### PR TITLE
fix(tests): update tests to reflect fixed bugs and corrected routes

### DIFF
--- a/API/src/modules/users/services/permissions.py
+++ b/API/src/modules/users/services/permissions.py
@@ -231,7 +231,7 @@ def require_oauth_token(f):
 
             return f(*args, **kwargs)
 
-        except (MissingParameterError, MissingJsonBodyError):
+        except (SecOpsException, MissingParameterError, MissingJsonBodyError):
             raise
         except Exception as exc:
             logger.exception("Error durante la autenticación")

--- a/API/tests/integration/test_acheron.py
+++ b/API/tests/integration/test_acheron.py
@@ -1,7 +1,4 @@
-"""Tests de integración del módulo Acheron (vaults de secretos).
-
-La ruta incluye el doble prefijo ``/acheron/acheron/vault`` (ver IMPROVEMENTS.md).
-"""
+"""Tests de integración del módulo Acheron (vaults de secretos)."""
 
 import pytest
 
@@ -9,30 +6,24 @@ pytestmark = pytest.mark.integration
 
 
 def test_get_vault_requires_authentication(client):
-    assert client.get("/acheron/acheron/vault").status_code == 401
+    assert client.get("/acheron/vault").status_code == 401
 
 
 def test_create_vault_requires_create_attribute(client, regular_user, auth_headers):
     # role_user tiene acheron_read pero no acheron_create.
-    resp = client.post("/acheron/acheron/vault", headers=auth_headers(regular_user),
+    resp = client.post("/acheron/vault", headers=auth_headers(regular_user),
                        json={"storables": []})
     assert resp.status_code == 403
 
 
-@pytest.mark.xfail(
-    reason="require_attributes captura la excepción de dominio y devuelve 500 "
-           "en lugar de 404; además VaultNotFoundError() se invoca sin vault_id. "
-           "Ver IMPROVEMENTS.md.",
-    strict=True,
-)
 def test_get_vault_empty_returns_404(client, regular_user, auth_headers):
     # El usuario tiene acheron_read (baseline) pero no tiene vault creado.
-    resp = client.get("/acheron/acheron/vault", headers=auth_headers(regular_user))
+    resp = client.get("/acheron/vault", headers=auth_headers(regular_user))
     assert resp.status_code == 404
 
 
 def test_add_storable_requires_create_attribute(client, regular_user, auth_headers):
-    resp = client.post("/acheron/vaults/storables", headers=auth_headers(regular_user), json={
+    resp = client.post("/acheron/storables", headers=auth_headers(regular_user), json={
         "kind": "account",
         "username": "u",
         "domain": "d",

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -22,11 +22,6 @@ def test_list_results_empty(client, regular_user, auth_headers):
     assert resp.get_json()["total"] == 0
 
 
-@pytest.mark.xfail(
-    reason="require_attributes captura la excepción de dominio y devuelve 500 "
-           "en lugar de 404. Ver IMPROVEMENTS.md.",
-    strict=True,
-)
 def test_status_unknown_analysis_returns_404(client, regular_user, auth_headers):
     resp = client.get("/iris/status?id=999999", headers=auth_headers(regular_user))
     assert resp.status_code == 404

--- a/API/tests/integration/test_pages.py
+++ b/API/tests/integration/test_pages.py
@@ -1,22 +1,23 @@
-"""Tests de integración del blueprint de páginas.
-
-Nota: ``serve_page`` NO aplica autenticación pese a documentarlo (ver
-IMPROVEMENTS.md); estos tests fijan el comportamiento real actual.
-"""
+"""Tests de integración del blueprint de páginas."""
 
 import pytest
 
 pytestmark = pytest.mark.integration
 
 
-def test_unknown_page_returns_404(client):
+def test_unknown_page_requires_authentication(client):
+    # serve_page exige token; sin él devuelve 401 antes de comprobar si existe.
     resp = client.get("/pages/pagina-que-no-existe")
+    assert resp.status_code == 401
+
+
+def test_unknown_page_returns_404_when_authenticated(client, regular_user, auth_headers):
+    resp = client.get("/pages/pagina-que-no-existe", headers=auth_headers(regular_user))
     assert resp.status_code == 404
     assert resp.get_json()["error"] == "not_found"
 
 
 def test_login_page_served_or_missing(client):
-    # Según el entorno, login.html puede existir (200) o no (404), pero
-    # nunca debe exigir autenticación.
+    # /pages/login es público; nunca debe exigir autenticación.
     resp = client.get("/pages/login")
     assert resp.status_code in (200, 404)

--- a/API/tests/integration/test_sentinel.py
+++ b/API/tests/integration/test_sentinel.py
@@ -38,11 +38,6 @@ def test_stats_for_new_user(client, regular_user, auth_headers):
     assert resp.status_code == 200
 
 
-@pytest.mark.xfail(
-    reason="require_attributes captura ScanNotFoundError y devuelve 500 en lugar "
-           "de 404. Ver IMPROVEMENTS.md.",
-    strict=True,
-)
 def test_scan_detail_not_found(client, regular_user, auth_headers):
     resp = client.get("/sentinel/results/999999", headers=auth_headers(regular_user))
     assert resp.status_code == 404
@@ -71,11 +66,6 @@ def test_folder_crud_roundtrip(client, regular_user, auth_headers):
     assert deleted.status_code == 200
 
 
-@pytest.mark.xfail(
-    reason="require_attributes captura FolderNotFoundError y devuelve 500 en lugar "
-           "de 404 al acceder a una carpeta ajena. Ver IMPROVEMENTS.md.",
-    strict=True,
-)
 def test_folder_isolation_between_users(client, make_user, auth_headers):
     owner = make_user(role="role_user")
     other = make_user(role="role_user")

--- a/API/tests/unit/test_config_reading.py
+++ b/API/tests/unit/test_config_reading.py
@@ -54,13 +54,10 @@ def test_get_app_context_happy_path(monkeypatch):
     assert ctx.port == 5000
 
 
-def test_get_app_context_bug_with_default_booleans(monkeypatch):
-    """Documenta el bug de get_app_context (ver IMPROVEMENTS.md).
-
-    Con DEBUG sin definir, el default es el bool ``False``, que ``all([...])``
-    interpreta como "ausente" y provoca un ``ValueError`` espurio.
-    """
+def test_get_app_context_uses_false_defaults_when_envs_absent(monkeypatch):
+    """Con DEBUG y CREATE_DATABASE sin definir, get_app_context() usa False por defecto."""
     monkeypatch.delenv("DEBUG", raising=False)
     monkeypatch.delenv("CREATE_DATABASE", raising=False)
-    with pytest.raises(ValueError):
-        CR.get_app_context()
+    ctx = CR.get_app_context()
+    assert ctx.debug is False
+    assert ctx.create_database is False

--- a/API/tests/unit/test_permissions.py
+++ b/API/tests/unit/test_permissions.py
@@ -25,11 +25,11 @@ def test_attribute_db_name():
     assert AttributeType.IRIS_DELETE.db_name == "iris_delete"
 
 
-def test_attribute_db_description_is_currently_broken():
-    """Documenta un bug: ``db_description`` referencia ``self._DESCRIPTIONS``,
-    que dentro del Enum no resuelve al dict esperado (ver IMPROVEMENTS.md)."""
-    with pytest.raises(AttributeError):
-        _ = AttributeType.SENTINEL_READ.db_description
+def test_attribute_db_description_returns_non_empty_string():
+    """db_description devuelve una descripción legible para cada miembro del Enum."""
+    assert AttributeType.SENTINEL_READ.db_description == "Read access for Sentinel security scans"
+    assert AttributeType.ACHERON_READ.db_description == "Read access for Acheron vault secrets"
+    assert AttributeType.IRIS_DELETE.db_description == "Delete access for Iris email header analysis"
 
 
 def test_user_role_includes_read_baseline():

--- a/API/tests/unit/test_secrets.py
+++ b/API/tests/unit/test_secrets.py
@@ -3,8 +3,8 @@
 import pytest
 
 from src.modules.users.services.secrets import (
-    encode_sha256,
     generate_salt,
+    hash_password,
     hash_password_with_salt,
     verify_password,
 )
@@ -12,31 +12,55 @@ from src.modules.users.services.secrets import (
 pytestmark = pytest.mark.unit
 
 
-def test_salt_is_random_and_hex():
-    s1, s2 = generate_salt(), generate_salt()
-    assert s1 != s2
-    assert len(s1) == 32
-    int(s1, 16)  # no lanza: es hexadecimal válido
+def test_generate_salt_is_legacy_stub():
+    """generate_salt() es un stub de compatibilidad; Argon2 gestiona el salt internamente."""
+    assert generate_salt() == ""
 
 
-def test_hash_is_deterministic_for_same_salt():
+def test_hash_password_produces_argon2_hash():
+    h = hash_password("mypassword")
+    assert h.startswith("$argon2")
+
+
+def test_verify_password_roundtrip_argon2():
+    h = hash_password("MyP@ssw0rd")
+    valid, needs_rehash = verify_password(h, "MyP@ssw0rd")
+    assert valid is True
+    assert needs_rehash is False  # hash recién generado, no necesita rehash
+
+    invalid, _ = verify_password(h, "wrong")
+    assert invalid is False
+
+
+def test_verify_password_wrong_password_returns_false():
+    h = hash_password("correct")
+    valid, _ = verify_password(h, "incorrect")
+    assert valid is False
+
+
+# ---------------------------------------------------------------------------
+# Ruta de compatibilidad SHA-256 (hashes heredados)
+# ---------------------------------------------------------------------------
+
+def test_hash_password_with_salt_is_deterministic():
     salt = "abc123"
     assert hash_password_with_salt("secret", salt) == hash_password_with_salt("secret", salt)
 
 
-def test_hash_changes_with_salt():
+def test_hash_password_with_salt_differs_with_different_salt():
     assert hash_password_with_salt("secret", "salt1") != hash_password_with_salt("secret", "salt2")
 
 
-def test_verify_password_roundtrip():
-    salt = generate_salt()
-    stored = hash_password_with_salt("MyP@ssw0rd", salt)
-    assert verify_password(stored, "MyP@ssw0rd", salt) is True
-    assert verify_password(stored, "wrong", salt) is False
+def test_verify_legacy_sha256_hash_valid():
+    salt = "abc123"
+    stored = hash_password_with_salt("legacy_password", salt)
+    valid, needs_rehash = verify_password(stored, "legacy_password", legacy_salt=salt)
+    assert valid is True
+    assert needs_rehash is True  # hash antiguo debe migrar a Argon2
 
 
-def test_encode_sha256_known_value():
-    # SHA-256 de la cadena vacía.
-    assert encode_sha256("") == (
-        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    )
+def test_verify_legacy_sha256_hash_invalid():
+    salt = "abc123"
+    stored = hash_password_with_salt("legacy_password", salt)
+    valid, _ = verify_password(stored, "wrong", legacy_salt=salt)
+    assert valid is False


### PR DESCRIPTION
- Remove xfail markers from 5 tests: bugs now fixed (require_attributes, VaultNotFoundError, FolderNotFoundError, ScanNotFoundError, IrisNotFound)
- Fix acheron test URLs: /acheron/acheron/ → /acheron/ (double prefix removed)
- Fix storable URL: /acheron/vaults/storables → /acheron/storables
- Fix test_pages: unauthenticated unknown page now returns 401 (auth enforced)
- Fix test_config_reading: get_app_context no longer raises ValueError with defaults
- Fix test_permissions: db_description now returns correct string (not AttributeError)
- Rewrite test_secrets: cover Argon2 roundtrip + legacy SHA-256 compatibility path
- Also fix require_oauth_token: re-raise SecOpsException (same pattern as require_attributes)