### PR TITLE
feat(hygeia): activos que se apagan a proposito no abren host_down

### DIFF
--- a/API/alembic/versions/a6b7c8d9e0f1_hygeia_asset_is_persistent.py
+++ b/API/alembic/versions/a6b7c8d9e0f1_hygeia_asset_is_persistent.py
@@ -1,0 +1,47 @@
+"""hygeia: activos que se apagan a proposito (is_persistent)
+
+Hasta ahora todo silencio era una incidencia: el detector de presencia abria
+``host_down`` critica y mandaba correo en cuanto un activo dejaba de reportar.
+Correcto para un servidor 24/7, ruido puro para un portatil que se suspende de
+noche — y una alerta que suena cada noche por algo esperado es una alerta que
+su dueño aprende a ignorar.
+
+``is_persistent`` marca esa expectativa por activo. ``False`` no cambia la
+transicion de estado (el activo sigue pasando a ``offline``: el estado es un
+hecho observado, no una opinion), solo suprime la anomalia y, con ella, el
+correo.
+
+NOT NULL con ``server_default=true``: a diferencia de ``inventory``, aqui no
+hay un tercer significado que un NULL pudiera representar — un activo o se
+espera encendido o no — y el default rellena las filas existentes con el
+comportamiento que ya tenian.
+
+Revision ID: a6b7c8d9e0f1
+Revises: f5e6f7a8b9c0
+Create Date: 2026-08-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a6b7c8d9e0f1"
+down_revision: Union[str, Sequence[str], None] = "f5e6f7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "MonitoredAsset",
+        sa.Column("is_persistent", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("MonitoredAsset", "is_persistent")

--- a/API/src/modules/features/hygeia/endpoints.py
+++ b/API/src/modules/features/hygeia/endpoints.py
@@ -42,6 +42,7 @@ from .schemas import (
     AssetMetricsQuerySchema,
     AssetMetricsResponseSchema,
     AssetSchema,
+    AssetUpdateRequestSchema,
     IngestRequestSchema,
     IngestResponseSchema,
     InventoryAnalysisSummarySchema,
@@ -77,6 +78,7 @@ def create_asset(data):
         hostname=data["hostname"],
         os_name=data["os"],
         labels=data["labels"],
+        is_persistent=data["isPersistent"],
     )
     logger.info(f"Activo Hygeia creado | user={current_actor()} hostname={data['hostname']}")
     return result
@@ -198,6 +200,27 @@ def get_asset_analysis(asset_id):
     user = get_current_user()
     manager = HygeiaAssetManager(user)
     return manager.get_analysis_summary(asset_id)
+
+
+@hygeia_blp.patch("/assets/<int:asset_id>")
+@hygeia_blp.arguments(AssetUpdateRequestSchema)
+@hygeia_blp.response(200, AssetSchema, description="Activo actualizado")
+@hygeia_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@hygeia_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@hygeia_blp.alt_response(404, schema=ErrorSchema, description="Asset not found")
+@limiter.limit("30 per hour")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.HYGEIA_UPDATE])
+@handle_exceptions(default_exception=AssetNotFoundError, logger=logger)
+def update_asset(data, asset_id):
+    """Marcar si un activo debería estar siempre encendido o se apaga a propósito"""
+    user = get_current_user()
+    manager = HygeiaAssetManager(user)
+    result = manager.set_persistence(asset_id, data["isPersistent"])
+    logger.info(
+        f"Persistencia del activo {asset_id} = {data['isPersistent']} | user={current_actor()}"
+    )
+    return result
 
 
 @hygeia_blp.delete("/assets/<int:asset_id>")

--- a/API/src/modules/features/hygeia/managers.py
+++ b/API/src/modules/features/hygeia/managers.py
@@ -55,6 +55,23 @@ from src.modules.features.themis.managers import LybraEngineManager
 logger = logging.getLogger(__name__)
 
 
+def _resolve_host_down_if_open(uow: UnitOfWork, asset_id: int) -> None:
+    """Cierra una anomalía ``host_down`` abierta de este activo, si la había.
+
+    Dos caminos la resuelven, y por eso vive aquí y no dentro de un manager:
+    recibir un heartbeat **es** la condición de resolución para este tipo
+    concreto de anomalía (§7.2, no hace falta mirar las métricas del
+    payload), y marcar el activo como no persistente también — silenciar un
+    host mientras su aviso sigue sonando no silenciaría nada.
+    """
+    anomaly_repo = AnomalyRepository(uow)
+    open_host_down = anomaly_repo.get_active(asset_id, "host_down")
+    if open_host_down is not None:
+        open_host_down.state = "resolved"
+        open_host_down.resolved_at = utcnow_naive()
+        anomaly_repo.update(open_host_down)
+
+
 class HygeiaAssetManager:
     """
     Gestiona el alta, consulta, baja y credenciales de los activos
@@ -100,7 +117,9 @@ class HygeiaAssetManager:
         repo = build_repository(MonitoredAssetRepository)
         return any(asset.inventory for asset in repo.get_by_user(user_id))
 
-    def create_asset(self, hostname: str, os_name: Optional[str], labels: dict) -> dict:
+    def create_asset(
+        self, hostname: str, os_name: Optional[str], labels: dict, is_persistent: bool = True,
+    ) -> dict:
         """
         Da de alta un nuevo activo y emite su clave de agente.
 
@@ -112,6 +131,9 @@ class HygeiaAssetManager:
             hostname: Nombre del host que reportará el agente.
             os_name: Sistema operativo del host, si se conoce de antemano.
             labels: Etiquetas libres del activo (entorno, rol, ubicación...).
+            is_persistent: Si se espera que el host esté siempre encendido.
+                ``False`` para un host que se apaga a propósito: su caída no
+                abrirá anomalía ni disparará correo.
 
         Returns:
             Diccionario con ``asset`` (vista serializada del activo) y
@@ -144,6 +166,7 @@ class HygeiaAssetManager:
                 agent_key_id=key_id,
                 agent_key_hash=secret_hash,
                 heartbeat_interval_sec=CR.hygeia_config().heartbeat_interval_sec,
+                is_persistent=is_persistent,
                 user_id=self.user.id,
             )
             saved = repo.save(asset)
@@ -399,6 +422,39 @@ class HygeiaAssetManager:
             )
             MonitoredAssetRepository(uow).delete(asset)
 
+    def set_persistence(self, asset_id: int, is_persistent: bool) -> dict:
+        """
+        Cambia la expectativa de encendido de un activo.
+
+        Al marcarlo como no persistente se resuelve además su ``host_down``
+        abierto, si lo hay: quien silencia un host caído está silenciando ese
+        aviso concreto, no solo los futuros.
+
+        Args:
+            asset_id: Activo a modificar.
+            is_persistent: ``True`` si el host debería estar siempre
+                encendido; ``False`` si se apaga a propósito.
+
+        Returns:
+            La vista serializada del activo ya actualizado.
+
+        Raises:
+            AssetNotFoundError: Si el activo no existe o pertenece a otro usuario.
+        """
+        with UnitOfWork() as uow:
+            asset = assert_owned(
+                MonitoredAssetRepository, asset_id, self.user.id,
+                AssetNotFoundError, uow=uow,
+            )
+
+            asset.is_persistent = is_persistent
+            if not is_persistent:
+                _resolve_host_down_if_open(uow, asset.id)
+            MonitoredAssetRepository(uow).update(asset)
+
+            # Serializado dentro del bloque: fuera, la instancia queda detached.
+            return asset.to_dict()
+
     def rotate_key(self, asset_id: int) -> dict:
         """
         Regenera la clave de agente de un activo, invalidando la anterior.
@@ -499,7 +555,7 @@ class HygeiaIngestManager:
                 asset.inventory_collected_at = now
             asset_repo.update(asset)
 
-            self._resolve_host_down_if_open(uow, asset.id)
+            _resolve_host_down_if_open(uow, asset.id)
 
             metrics = payload["metrics"]
             # La forma del payload la conocen el schema de ingesta y
@@ -549,21 +605,6 @@ class HygeiaIngestManager:
         elapsed = (now - asset.last_seen_at).total_seconds()
         if elapsed < min_interval:
             raise IngestTooFrequentError(min_interval)
-
-    @staticmethod
-    def _resolve_host_down_if_open(uow: UnitOfWork, asset_id: int) -> None:
-        """Cierra una anomalía ``host_down`` abierta de este activo, si la había.
-
-        Recibir el heartbeat **es** la condición de resolución para este
-        tipo concreto de anomalía (§7.2) — no hace falta ninguna otra
-        comprobación sobre las métricas del payload.
-        """
-        anomaly_repo = AnomalyRepository(uow)
-        open_host_down = anomaly_repo.get_active(asset_id, "host_down")
-        if open_host_down is not None:
-            open_host_down.state = "resolved"
-            open_host_down.resolved_at = utcnow_naive()
-            anomaly_repo.update(open_host_down)
 
     @staticmethod
     def _evaluate_thresholds(uow: UnitOfWork, asset: MonitoredAsset, metrics: dict) -> list[int]:
@@ -733,8 +774,13 @@ class HygeiaMaintenanceManager:
            señal visual en el listado de activos, no abre ninguna incidencia.
         2. ``stale`` → ``offline`` en un segundo corte más permisivo
            (``offlineAfterMissed`` heartbeats perdidos): solo esta segunda
-           transición abre ``Anomaly(kind="host_down")``, y solo si no había
-           ya una abierta (apertura idempotente).
+           transición abre ``Anomaly(kind="host_down")``, y solo si el activo
+           es persistente y no había ya una abierta (apertura idempotente).
+
+        Un activo no persistente (``is_persistent=False``: un host que se
+        apaga a propósito) transiciona igual — su estado es un hecho
+        observado y la lista debe mostrarlo — pero no abre anomalía, y al no
+        haber anomalía tampoco hay correo.
 
         Cada activo se compara contra su propio ``heartbeat_interval_sec``
         (el que tiene configurado, tras un posible auto-ajuste), no contra
@@ -774,7 +820,11 @@ class HygeiaMaintenanceManager:
                     transitioned = asset_repo.transition_status_if_still_silent(
                         asset.id, offline_cutoff, "stale", "offline",
                     )
-                    if transitioned and anomaly_repo.get_active(asset.id, "host_down") is None:
+                    if (
+                        transitioned
+                        and asset.is_persistent
+                        and anomaly_repo.get_active(asset.id, "host_down") is None
+                    ):
                         saved = anomaly_repo.save(Anomaly(
                             asset_id=asset.id, kind="host_down", severity="critical",
                         ))

--- a/API/src/modules/features/hygeia/model.py
+++ b/API/src/modules/features/hygeia/model.py
@@ -21,6 +21,7 @@ Example:
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     Column,
     DateTime,
     Float,
@@ -28,6 +29,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    true,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
@@ -75,6 +77,14 @@ class MonitoredAsset(Base):
             tras el último heartbeat evaluado. Es la memoria que necesita
             la histéresis de ``services/detection.py`` para decidir cuándo
             abrir una anomalía sin tener que releer snapshots históricos.
+        is_persistent: Si el host debería estar encendido siempre. ``True``
+            (por defecto) es el comportamiento de un servidor 24/7: quedarse
+            callado es una incidencia y el detector de presencia abre
+            ``host_down``. ``False`` marca un host que se apaga a propósito
+            (un portátil, un sobremesa que se suspende de noche): sigue
+            transicionando a ``offline`` porque el estado es un hecho, pero
+            no abre anomalía ni dispara correo — una caída esperada avisando
+            cada noche solo entrena al dueño a ignorar los avisos de verdad.
         thresholds: Umbrales específicos de este activo, en el mismo formato
             que el bloque ``features.hygeia.thresholds`` de la configuración global.
             Si una métrica no aparece aquí, se usa el umbral global.
@@ -115,6 +125,7 @@ class MonitoredAsset(Base):
     heartbeat_interval_sec = Column(Integer, nullable=True)
     breach_counters        = Column(JSONB, nullable=True)
     thresholds             = Column(JSONB, nullable=True)
+    is_persistent          = Column(Boolean, nullable=False, default=True, server_default=true())
 
     inventory               = Column(JSONB, nullable=True)
     inventory_collected_at  = Column(DateTime, nullable=True)
@@ -143,7 +154,7 @@ class MonitoredAsset(Base):
 
         Returns:
             Diccionario con id, hostname, os, kernel, labels, status,
-            lastSeenAt, uptimeSec, agentVersion y createdAt.
+            isPersistent, lastSeenAt, uptimeSec, agentVersion y createdAt.
         """
         return {
             "id":           self.id,
@@ -152,6 +163,7 @@ class MonitoredAsset(Base):
             "kernel":       self.kernel,
             "labels":       self.labels or {},
             "status":       self.status,
+            "isPersistent": self.is_persistent,
             "lastSeenAt":   self.last_seen_at,
             "uptimeSec":    self.uptime_sec,
             "agentVersion": self.agent_version,

--- a/API/src/modules/features/hygeia/schemas.py
+++ b/API/src/modules/features/hygeia/schemas.py
@@ -16,6 +16,14 @@ class AssetCreateRequestSchema(Schema):
     hostname = fields.String(required=True, validate=validate.Length(min=1, max=255))
     os = fields.String(load_default=None, validate=validate.Length(max=64))
     labels = fields.Dict(load_default=dict)
+    # Por defecto se espera un host siempre encendido: es el comportamiento
+    # que tenía todo activo antes de que existiera esta propiedad.
+    isPersistent = fields.Boolean(load_default=True)
+
+
+class AssetUpdateRequestSchema(Schema):
+    """Modificación de un activo. Solo la expectativa de encendido es editable."""
+    isPersistent = fields.Boolean(required=True)
 
 
 class AssetSchema(Schema):
@@ -26,6 +34,7 @@ class AssetSchema(Schema):
     kernel = fields.String(allow_none=True)
     labels = fields.Dict()
     status = fields.String()
+    isPersistent = fields.Boolean()
     lastSeenAt = UTCDateTime(allow_none=True)
     uptimeSec = fields.Integer(allow_none=True)
     agentVersion = fields.String(allow_none=True)

--- a/API/tests/integration/test_hygeia_persistence.py
+++ b/API/tests/integration/test_hygeia_persistence.py
@@ -1,0 +1,156 @@
+"""
+Tests de integración HTTP de la persistencia de un activo de Hygeia.
+
+``isPersistent`` marca si se espera que el host esté siempre encendido. Aquí
+se cubre el ciclo por HTTP (alta, lectura y ``PATCH``) y el efecto lateral de
+desmarcarlo: un ``host_down`` abierto se resuelve, porque silenciar un host
+mientras su aviso sigue sonando no silenciaría nada.
+
+El efecto sobre el detector de presencia (no abrir anomalía ni encolar
+correo) vive en ``test_hygeia_scheduling.py``, junto al resto del ciclo de
+vida de la presencia.
+"""
+
+import secrets
+
+import pytest
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared import utcnow_naive
+from src.modules.features.hygeia.model import Anomaly, MonitoredAsset
+from src.modules.features.hygeia.repositories import (
+    AnomalyRepository,
+    MonitoredAssetRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _create_asset(app, user_id: int, is_persistent: bool = True) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            asset = MonitoredAsset(
+                hostname="persistence-test",
+                agent_key_id=secrets.token_hex(8),
+                agent_key_hash="dummy",
+                heartbeat_interval_sec=15,
+                status="offline",
+                last_seen_at=utcnow_naive(),
+                is_persistent=is_persistent,
+                user_id=user_id,
+            )
+            MonitoredAssetRepository(uow).save(asset)
+            return asset.id
+
+
+def _open_host_down(app, asset_id: int) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            anomaly = Anomaly(
+                asset_id=asset_id, kind="host_down", severity="critical", state="open",
+            )
+            AnomalyRepository(uow).save(anomaly)
+            return anomaly.id
+
+
+def _anomaly_state(app, anomaly_id: int) -> str:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return AnomalyRepository(uow).get_by_id(anomaly_id).state
+
+
+def test_new_asset_is_persistent_by_default(client, regular_user, auth_headers):
+    resp = client.post(
+        "/hygeia/assets",
+        json={"hostname": "default-test"},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 201
+    assert resp.get_json()["asset"]["isPersistent"] is True
+
+
+def test_asset_can_be_created_as_non_persistent(client, regular_user, auth_headers):
+    resp = client.post(
+        "/hygeia/assets",
+        json={"hostname": "portatil", "isPersistent": False},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 201
+    assert resp.get_json()["asset"]["isPersistent"] is False
+
+
+def test_patch_marks_asset_as_non_persistent(client, app, regular_user, auth_headers):
+    asset_id = _create_asset(app, regular_user.id)
+
+    resp = client.patch(
+        f"/hygeia/assets/{asset_id}",
+        json={"isPersistent": False},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["isPersistent"] is False
+
+    detail = client.get(f"/hygeia/assets/{asset_id}", headers=auth_headers(regular_user))
+    assert detail.get_json()["isPersistent"] is False
+
+
+def test_marking_non_persistent_resolves_an_open_host_down(
+    client, app, regular_user, auth_headers,
+):
+    asset_id = _create_asset(app, regular_user.id)
+    anomaly_id = _open_host_down(app, asset_id)
+
+    resp = client.patch(
+        f"/hygeia/assets/{asset_id}",
+        json={"isPersistent": False},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 200
+    assert _anomaly_state(app, anomaly_id) == "resolved"
+
+
+def test_marking_persistent_again_leaves_anomalies_untouched(
+    client, app, regular_user, auth_headers,
+):
+    """Volver a marcarlo como persistente no resuelve nada: solo reactiva el aviso."""
+    asset_id = _create_asset(app, regular_user.id, is_persistent=False)
+    anomaly_id = _open_host_down(app, asset_id)
+
+    resp = client.patch(
+        f"/hygeia/assets/{asset_id}",
+        json={"isPersistent": True},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["isPersistent"] is True
+    assert _anomaly_state(app, anomaly_id) == "open"
+
+
+def test_patch_on_another_users_asset_returns_404(
+    client, app, regular_user, make_user, auth_headers,
+):
+    intruder = make_user()
+    asset_id = _create_asset(app, regular_user.id)
+
+    resp = client.patch(
+        f"/hygeia/assets/{asset_id}",
+        json={"isPersistent": False},
+        headers=auth_headers(intruder),
+    )
+
+    assert resp.status_code == 404
+
+
+def test_patch_requires_the_field(client, app, regular_user, auth_headers):
+    asset_id = _create_asset(app, regular_user.id)
+
+    resp = client.patch(
+        f"/hygeia/assets/{asset_id}", json={}, headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 422

--- a/API/tests/integration/test_hygeia_scheduling.py
+++ b/API/tests/integration/test_hygeia_scheduling.py
@@ -37,20 +37,29 @@ class _FakeTaskQueue:
     transiciona a offline; este banco solo verifica la transición y la
     apertura de la anomalía, no el envío async, así que el submit se
     descarta sin tocar TaskQueue/Redis (mismo patrón que test_traceroute.py
-    y test_iris_documents.py).
+    y test_iris_documents.py). Se anotan las llamadas para poder afirmar que
+    un activo no persistente tampoco encola correo.
     """
 
+    def __init__(self):
+        self.submissions = []
+
     def submit(self, **kwargs):
+        self.submissions.append(kwargs)
         return None
 
 
 @pytest.fixture(autouse=True)
-def _fake_task_queue():
-    with mock.patch.object(hygeia_managers.TaskQueue, "get_instance", return_value=_FakeTaskQueue()):
-        yield
+def fake_task_queue():
+    fake = _FakeTaskQueue()
+    with mock.patch.object(hygeia_managers.TaskQueue, "get_instance", return_value=fake):
+        yield fake
 
 
-def _create_asset(app, user_id: int, status: str, last_seen_at, interval: int = _INTERVAL) -> int:
+def _create_asset(
+    app, user_id: int, status: str, last_seen_at,
+    interval: int = _INTERVAL, is_persistent: bool = True,
+) -> int:
     with app.app_context():
         with UnitOfWork() as uow:
             asset = MonitoredAsset(
@@ -60,6 +69,7 @@ def _create_asset(app, user_id: int, status: str, last_seen_at, interval: int = 
                 heartbeat_interval_sec=interval,
                 status=status,
                 last_seen_at=last_seen_at,
+                is_persistent=is_persistent,
                 user_id=user_id,
             )
             MonitoredAssetRepository(uow).save(asset)
@@ -125,6 +135,21 @@ def test_stale_asset_past_offline_cutoff_transitions_and_opens_host_down(app, re
     assert len(anomalies) == 1
     assert anomalies[0].severity == "critical"
     assert anomalies[0].state == "open"
+
+
+def test_non_persistent_asset_goes_offline_without_anomaly_or_email(
+    app, regular_user, fake_task_queue,
+):
+    """Un host que se apaga a propósito transiciona igual, pero en silencio."""
+    last_seen = utcnow_naive() - timedelta(seconds=_INTERVAL * _OFFLINE_AFTER_MISSED + 5)
+    asset_id = _create_asset(app, regular_user.id, "stale", last_seen, is_persistent=False)
+
+    with app.app_context():
+        HygeiaMaintenanceManager.execute_presence_check()
+
+    assert _fetch_asset(app, asset_id).status == "offline", "el estado sigue siendo un hecho"
+    assert _open_anomalies(app, asset_id) == []
+    assert fake_task_queue.submissions == [], "una caída esperada no manda correo"
 
 
 def test_offline_asset_is_excluded_from_presence_check(app, regular_user):

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Aegis combines AI-generated awareness content with current CVE alerts from INCIB
 | `GET` | `/hygeia/assets/<id>/metrics?from=&to=` | `HYGEIA_READ` | CPU/memory time series for the asset's chart |
 | `GET` | `/hygeia/assets/<id>/inventory` | `HYGEIA_READ` | Last known installed-software inventory |
 | `POST/GET` | `/hygeia/assets/<id>/analyze` / `/analysis` | `HYGEIA_UPDATE` + `THEMIS_CREATE` | Run/read a Lybra-powered analysis of the asset's software inventory |
+| `PATCH` | `/hygeia/assets/<id>` | `HYGEIA_UPDATE` | Set `isPersistent` — `false` marks a host that powers off on purpose, so its downtime opens no anomaly and sends no email |
 | `DELETE` | `/hygeia/assets/<id>` | `HYGEIA_DELETE` | Deregister an asset, revoking its agent key |
 | `POST` | `/hygeia/assets/<id>/rotate-key` | `HYGEIA_UPDATE` | Rotate the agent key, invalidating the previous one |
 | `GET` | `/hygeia/alerts?state=&severity=&assetId=` | `HYGEIA_READ` | List anomalies for the user's assets |

--- a/plans/feature/hygeia/hygeia-backend.md
+++ b/plans/feature/hygeia/hygeia-backend.md
@@ -358,7 +358,15 @@ métricas, solo silencio:
 3. **Apertura idempotente.** Antes de crear la `Anomaly`, comprobar que no exista ya una
    `open` del mismo `kind="host_down"` para ese activo. Un job que corre cada minuto no debe
    abrir una anomalía nueva cada vez que se ejecuta mientras el activo sigue caído.
-4. **A salvo de la carrera con un heartbeat que llega a la vez.** No hagas "leer
+4. **Activos que se apagan a propósito.** `MonitoredAsset.is_persistent` (`isPersistent` en la
+   API, `true` por defecto) dice si se espera que el host esté siempre encendido. Un activo no
+   persistente — un portátil, un equipo que se suspende de noche — transiciona exactamente
+   igual, porque su estado es un hecho observado y el listado debe mostrarlo, pero **no abre
+   `Anomaly(kind="host_down")`**, y al no haber anomalía tampoco hay correo (§8): el aviso
+   viaja siempre colgado de una anomalía, nunca por su cuenta. Se marca en el alta o con
+   `PATCH /hygeia/assets/<id>`; desmarcar la persistencia resuelve además el `host_down`
+   abierto que hubiera, porque silenciar un host mientras su aviso suena no silenciaría nada.
+5. **A salvo de la carrera con un heartbeat que llega a la vez.** No hagas "leer
    `last_seen_at`, decidir en Python, escribir" en dos pasos: si un heartbeat entra justo
    cuando el job está evaluando, esa lectura pudo quedar obsoleta un instante después. Haz el
    corte con una escritura condicional atómica (`UPDATE ... WHERE last_seen_at < :umbral AND

--- a/web/app/src/components/hygeia/AssetList.vue
+++ b/web/app/src/components/hygeia/AssetList.vue
@@ -45,14 +45,24 @@
     <ul v-else class="rows">
       <li v-for="asset in assets" :key="asset.id" class="row" :class="{ 'row--selected': asset.id === selectedId }">
         <button class="row-select" :aria-pressed="asset.id === selectedId" @click="$emit('select', asset.id)">
-          <span class="pulse" :class="`pulse--${asset.status}`" aria-hidden="true"></span>
+          <span class="pulse" :class="pulseClass(asset)" aria-hidden="true"></span>
           <span class="row-text">
             <span class="row-host">{{ asset.hostname }}</span>
-            <span class="row-meta">{{ statusLabel(asset.status) }} · {{ timeAgo(asset.lastSeenAt) }}</span>
+            <span class="row-meta">{{ statusLabel(asset) }} · {{ timeAgo(asset.lastSeenAt) }}</span>
           </span>
         </button>
 
         <span class="row-actions">
+          <button class="btn-icon" :class="{ 'btn-icon--muted': !asset.isPersistent }"
+            :title="asset.isPersistent ? 'Marcar como host que se apaga a propósito' : 'Marcar como host siempre encendido'"
+            :aria-pressed="!asset.isPersistent"
+            :aria-label="`${asset.hostname}: ${asset.isPersistent ? 'dejar de avisar cuando esté caído' : 'volver a avisar cuando esté caído'}`"
+            @click="$emit('toggle-persistent', asset.id)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 3v9" />
+              <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+            </svg>
+          </button>
           <button class="btn-icon" title="Rotar clave" :aria-label="`Rotar la clave de ${asset.hostname}`"
             @click="$emit('rotate', asset.id)">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -81,13 +91,27 @@ defineProps({
   loading: { type: Boolean, default: false },
   error: { type: String, default: null },
 })
-defineEmits(['select', 'create', 'delete', 'rotate', 'refresh'])
+defineEmits(['select', 'create', 'delete', 'rotate', 'refresh', 'toggle-persistent'])
 
 /** Filas fantasma mientras carga: las que caben sin alargar el panel. */
 const SKELETON_ROWS = 4
 
 const STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inestable', offline: 'Caído' }
-function statusLabel(status) { return STATUS_LABELS[status] || status }
+
+/**
+ * Un activo que se apaga a propósito no está "caído": pintarlo en rojo sería
+ * exactamente el ruido que su marca elimina. El estado es el mismo (`offline`),
+ * solo cambia cómo se lee.
+ */
+function statusLabel(asset) {
+  if (asset.status === 'offline' && asset.isPersistent === false) return 'Apagado'
+  return STATUS_LABELS[asset.status] || asset.status
+}
+
+function pulseClass(asset) {
+  if (asset.status === 'offline' && asset.isPersistent === false) return 'pulse--dormant'
+  return `pulse--${asset.status}`
+}
 </script>
 
 <style scoped>
@@ -120,6 +144,8 @@ function statusLabel(status) { return STATUS_LABELS[status] || status }
 .btn-icon svg { width: 14px; height: 14px; }
 .btn-icon:hover { border-color: var(--accent); color: var(--accent-bright); }
 .btn-icon--danger:hover { border-color: var(--danger); color: var(--danger); }
+/* Interruptor pulsado: el activo está marcado como "se apaga a propósito". */
+.btn-icon--muted { border-style: dashed; opacity: 0.65; }
 
 /* ── Filas ── */
 .rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.3rem; }
@@ -159,6 +185,8 @@ function statusLabel(status) { return STATUS_LABELS[status] || status }
 .pulse--stale { background: var(--warn); }
 .pulse--offline { background: var(--danger); }
 .pulse--pending { background: var(--text-muted); box-shadow: inset 0 0 0 1px var(--border-med); }
+/* Caído a propósito: apagado, no en alarma. */
+.pulse--dormant { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-muted); }
 /* La fila fantasma repite el padding y el gap de .row-select. El min-height
    es el alto medido de una fila real (55px): las dos líneas del fantasma son
    algo más bajas que el hostname y su metadato, y sin esto la lista crecía

--- a/web/app/src/components/hygeia/CreateAssetModal.vue
+++ b/web/app/src/components/hygeia/CreateAssetModal.vue
@@ -22,6 +22,14 @@
               </select>
             </label>
 
+            <label class="check">
+              <input v-model="powersOff" type="checkbox" />
+              <span class="check-text">
+                Este host se apaga a propósito
+                <small>Un portátil o un equipo que se suspende. No se avisará cuando esté caído.</small>
+              </span>
+            </label>
+
             <p v-if="localError" class="error">{{ localError }}</p>
 
             <div class="modal-footer">
@@ -49,16 +57,19 @@ const emit = defineEmits(['submit', 'close'])
 
 const hostname = ref('')
 const os = ref(null)
+// Se pregunta en positivo ("se apaga") porque es la excepción; la API lo
+// recibe en negativo (`isPersistent`), que es lo que el detector consulta.
+const powersOff = ref(false)
 const localError = ref('')
 
 watch(() => props.show, (v) => {
-  if (v) { hostname.value = ''; os.value = null; localError.value = '' }
+  if (v) { hostname.value = ''; os.value = null; powersOff.value = false; localError.value = '' }
 })
 
 function submit() {
   if (!hostname.value) { localError.value = 'El hostname es obligatorio.'; return }
   localError.value = ''
-  emit('submit', { hostname: hostname.value, os: os.value })
+  emit('submit', { hostname: hostname.value, os: os.value, isPersistent: !powersOff.value })
 }
 </script>
 
@@ -77,6 +88,11 @@ function submit() {
   background: var(--bg); color: var(--text); font-size: var(--fs-md);
 }
 .field input:focus, .field select:focus { outline: none; border-color: var(--accent); }
+
+.check { display: flex; align-items: flex-start; gap: 0.5rem; margin-bottom: 0.85rem; cursor: pointer; }
+.check input { margin-top: 0.15rem; accent-color: var(--accent); }
+.check-text { display: flex; flex-direction: column; gap: 0.15rem; font-size: var(--fs-md); color: var(--text); }
+.check-text small { font-size: var(--fs-sm); color: var(--text-muted); }
 
 .error { color: var(--danger); font-size: var(--fs-sm); margin: 0 0 0.6rem; }
 

--- a/web/app/src/stores/hygeiaStore.js
+++ b/web/app/src/stores/hygeiaStore.js
@@ -47,11 +47,11 @@ export const useHygeiaStore = defineStore('hygeia', () => {
   }
 
   /** Da de alta un activo. La clave de agente queda en `state.lastAgentKey`, una única vez. */
-  async function createAsset({ hostname, os = null, labels = {} }) {
+  async function createAsset({ hostname, os = null, labels = {}, isPersistent = true }) {
     try {
       const res = await apiFetch('/hygeia/assets', {
         method: 'POST',
-        body: JSON.stringify({ hostname, os, labels }),
+        body: JSON.stringify({ hostname, os, labels, isPersistent }),
       })
       if (!res?.ok) { state.error = await apiError(res, 'No se pudo dar de alta el activo.'); return null }
       const data = await res.json()
@@ -81,6 +81,27 @@ export const useHygeiaStore = defineStore('hygeia', () => {
       state.lastAgentKey = data.agentKey
       return data.agentKey
     } catch { state.error = 'No se pudo conectar con la API.'; return null }
+  }
+
+  /**
+   * Marca si un activo debería estar siempre encendido o se apaga a propósito.
+   *
+   * La fila se reemplaza con la que devuelve la API en vez de esperar al
+   * siguiente sondeo de `fetchAssets` (uno de cada cuatro ticks): el estado del
+   * interruptor tiene que verse en el momento en que se pulsa.
+   */
+  async function setPersistence(id, isPersistent) {
+    try {
+      const res = await apiFetch(`/hygeia/assets/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ isPersistent }),
+      })
+      if (!res?.ok) { state.error = await apiError(res, 'No se pudo actualizar el activo.'); return false }
+      const asset = await res.json()
+      const index = state.assets.findIndex((a) => a.id === id)
+      if (index !== -1) state.assets[index] = asset
+      return true
+    } catch { state.error = 'No se pudo conectar con la API.'; return false }
   }
 
   /** Selecciona un activo para ver su detalle y carga sus métricas. */
@@ -229,7 +250,7 @@ export const useHygeiaStore = defineStore('hygeia', () => {
 
   return {
     state,
-    fetchAssets, createAsset, deleteAsset, rotateKey,
+    fetchAssets, createAsset, deleteAsset, rotateKey, setPersistence,
     selectAsset, fetchMetrics, fetchLatest, fetchInventory, clearAgentKey,
     fetchAnalysis, analyzeInventory,
     $reset,

--- a/web/app/src/views/HygeiaView.vue
+++ b/web/app/src/views/HygeiaView.vue
@@ -14,6 +14,7 @@
           @create="showCreateModal = true"
           @delete="handleDeleteRequest"
           @rotate="handleRotate"
+          @toggle-persistent="handleTogglePersistent"
           @refresh="refreshNow"
         />
       </section>
@@ -166,10 +167,10 @@ async function handleSelect(id) {
   await alerts.fetchAlerts({ assetId: id })
 }
 
-async function handleCreate({ hostname, os }) {
+async function handleCreate({ hostname, os, isPersistent }) {
   creating.value = true
   try {
-    const asset = await store.createAsset({ hostname, os })
+    const asset = await store.createAsset({ hostname, os, isPersistent })
     if (asset) {
       showCreateModal.value = false
       toast.show(`Activo «${asset.hostname}» dado de alta.`, 'success')
@@ -179,6 +180,27 @@ async function handleCreate({ hostname, os }) {
   } finally {
     creating.value = false
   }
+}
+
+/**
+ * Alterna si un activo debería estar siempre encendido. Sin confirmación: es
+ * reversible con el mismo botón y no destruye nada.
+ */
+async function handleTogglePersistent(id) {
+  const asset = store.state.assets.find((a) => a.id === id)
+  if (!asset) return
+  const next = !asset.isPersistent
+  const ok = await store.setPersistence(id, next)
+  if (!ok) {
+    toast.show(store.state.error || 'No se pudo actualizar el activo.', 'error')
+    return
+  }
+  toast.show(
+    next
+      ? `Se volverá a avisar cuando «${asset.hostname}» esté caído.`
+      : `«${asset.hostname}» se marca como host que se apaga a propósito: no se avisará de sus caídas.`,
+    'success',
+  )
 }
 
 function handleDeleteRequest(id) {


### PR DESCRIPTION
Hasta ahora todo silencio era una incidencia: el detector de presencia abria Anomaly(kind="host_down") critica y mandaba correo en cuanto un activo dejaba de reportar. Correcto para un servidor 24/7, ruido puro para un portatil que se suspende cada noche — y una alerta esperada que suena a diario es una alerta que su dueño aprende a ignorar.

MonitoredAsset.is_persistent (isPersistent en la API, true por defecto) marca esa expectativa por activo. Un activo no persistente transiciona igual a offline, porque su estado es un hecho observado y el listado debe mostrarlo, pero no abre anomalia; al viajar el correo siempre colgado de una anomalia, eso corta tambien el aviso.

Se marca en el alta o con el nuevo PATCH /hygeia/assets/<id>. Desmarcar la persistencia resuelve ademas el host_down abierto que hubiera: silenciar un host mientras su aviso suena no silenciaria nada. Para eso _resolve_host_down_if_open pasa de metodo privado de HygeiaIngestManager a funcion de modulo, ahora con dos caminos que la usan.

En la SPA, un interruptor por fila en la lista de activos y una casilla en el alta; un activo no persistente caido se lee "Apagado" con punto gris en vez de "Caido" en rojo.