### PR TITLE
fix(nginx): evitar 404 al recargar rutas de SPA bajo prefijos de la API

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "5.0.1",
+  "appVersion": "5.0.2",
   "general": {
     "directories": {
       "logdir": "..",

--- a/web/api-locations.conf
+++ b/web/api-locations.conf
@@ -34,3 +34,27 @@ location /acheron/        { proxy_pass http://Ellysia-API:5000/acheron/;       i
 location /hygeia/         { proxy_pass http://Ellysia-API:5000/hygeia/;        include /etc/nginx/conf.d/proxy-common.conf; }
 location /plans/          { proxy_pass http://Ellysia-API:5000/plans/;         include /etc/nginx/conf.d/proxy-common.conf; }
 location /organizations/  { proxy_pass http://Ellysia-API:5000/organizations/; include /etc/nginx/conf.d/proxy-common.conf; }
+
+# Rutas de la SPA (Vue Router) que cuelgan de los MISMOS prefijos que la API
+# de arriba: el hub de cada modulo (con barra final: /acheron/, /hygeia/...
+# los usuarios la escriben o la pegan a mano) y sus subrutas de trabajo
+# (/acheron/boveda, /hygeia/activos...). Sin esto, al recargar la pagina o
+# escribir la URL a mano el prefijo de proxy de arriba se la lleva entera a
+# Flask, que no tiene esa ruta, y devuelve 404 en vez de servir el SPA.
+#
+# `location =` exacto gana siempre sobre el `location /x/` de prefijo, sin
+# importar el orden en el fichero. Tiene que seguir a `routes` en
+# web/app/src/router/index.js igual que el bloque de arriba sigue a
+# `run.py`: al anadir una ruta de Vue bajo un prefijo de modulo, aqui hay
+# que anadir su forma exacta.
+location = /themis/          { try_files $uri /index.html; }
+location = /themis/escaneos  { try_files $uri /index.html; }
+location = /aegis/           { try_files $uri /index.html; }
+location = /aegis/generador  { try_files $uri /index.html; }
+location = /iris/            { try_files $uri /index.html; }
+location = /iris/analisis    { try_files $uri /index.html; }
+location = /iris/conexiones  { try_files $uri /index.html; }
+location = /acheron/         { try_files $uri /index.html; }
+location = /acheron/boveda   { try_files $uri /index.html; }
+location = /hygeia/          { try_files $uri /index.html; }
+location = /hygeia/activos   { try_files $uri /index.html; }


### PR DESCRIPTION
Prefijos como /acheron/ o /hygeia/ se reenvian enteros a Flask, asi que el hub (con barra final) y las subrutas de trabajo de cada modulo (boveda, activos, escaneos, generador, analisis, conexiones) devolvian 404 al recargar la pagina o escribir la URL a mano en vez de servir el SPA. Se anaden locations exactas que ganan sobre el prefijo de proxy.

Incluye tambien el bump de appVersion a 5.0.2.