### PR TITLE
feat(hygeia): etiquetado de agentes con catálogo común y personal

### DIFF
--- a/API/alembic/versions/b7c8d9e0f1a2_hygeia_tags.py
+++ b/API/alembic/versions/b7c8d9e0f1a2_hygeia_tags.py
@@ -1,0 +1,131 @@
+"""hygeia: etiquetas de activos (HygeiaTag + AssetTag)
+
+Hygeia listaba los activos como una tira plana ordenada por fecha de alta.
+Con media docena de agentes eso basta; con treinta no hay forma de agrupar
+"los de produccion", "los que dan la cara a Internet" o "los que puedo apagar
+sin avisar a nadie". La columna ``labels`` (JSONB) prometia eso y nunca lo
+cumplio: se acepta en el alta, se serializa, y ningun endpoint la escribe ni
+ninguna consulta la lee. Se deja donde esta, intacta; esto no la sustituye ni
+la migra, la ignora.
+
+``HygeiaTag`` es una etiqueta de verdad: una entidad compartida entre activos.
+Hay dos clases y comparten tabla (herencia *single-table*, discriminada por
+``tag_type``), porque desde el punto de vista de un activo son la misma cosa,
+un nombre y un color que se le cuelgan. Lo unico que las distingue es de
+quien son:
+
+  - ``system``: catalogo comun. ``user_id`` es NULL, todo el mundo las ve y
+    nadie las crea ni las borra. Son las 12 filas que siembra esta revision.
+  - ``user``: repositorio personal. ``user_id`` es obligatorio y solo su
+    dueño la ve, la asigna y la borra.
+
+El ``CheckConstraint`` impone esa regla en la base de datos y no solo en el
+manager: ni una migracion torcida ni un INSERT a mano pueden dejar una
+etiqueta personal huerfana ni una de sistema con dueño.
+
+Los dos ``ondelete="CASCADE"`` de ``AssetTag`` son la garantia que pide el
+producto: borrar una etiqueta borra sus asociaciones, **nunca los activos**
+que la llevaban.
+
+La siembra va aqui y no en ``_init_db()`` porque ``_init_db()`` es destructivo
+y no se puede ejecutar en un entorno con datos: el catalogo tiene que llegar
+por ``alembic upgrade head``. Las instalaciones nuevas lo reciben igual, ya
+que ``_init_db()`` ejecuta las migraciones.
+
+Revision ID: b7c8d9e0f1a2
+Revises: a6b7c8d9e0f1
+Create Date: 2026-08-12 00:00:00.000000
+
+"""
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = "a6b7c8d9e0f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Catalogo comun, en cuatro ejes: entorno, rol, criticidad/exposicion y
+# ubicacion. El color se comparte dentro de cada eje para que una tira de
+# badges se lea de un vistazo sin tener que descifrar doce tonos distintos.
+# No hay "Windows" ni "Linux": eso ya es ``MonitoredAsset.os``.
+_SYSTEM_TAGS = [
+    ("Producción",           "red"),
+    ("Preproducción",        "amber"),
+    ("Desarrollo",           "blue"),
+    ("Servidor web",         "violet"),
+    ("Base de datos",        "violet"),
+    ("Workstation",          "violet"),
+    ("Crítico",              "red"),
+    ("Expuesto a Internet",  "pink"),
+    ("Cloud",                "teal"),
+    ("On-premise",           "teal"),
+    ("Contenedor",           "green"),
+    ("Backup",               "slate"),
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    hygeia_tag = op.create_table(
+        "HygeiaTag",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=48), nullable=False),
+        sa.Column("color", sa.String(length=16), nullable=False, server_default="slate"),
+        sa.Column("tag_type", sa.String(length=16), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["User.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        # Un usuario no repite nombre. Las de sistema quedan fuera (en Postgres
+        # los NULL son distintos entre si) y no hace falta mas: su unico
+        # escritor es esta migracion.
+        sa.UniqueConstraint("user_id", "name", name="uq_hygeiatag_user_name"),
+        sa.CheckConstraint(
+            "(tag_type = 'system' AND user_id IS NULL) OR "
+            "(tag_type = 'user' AND user_id IS NOT NULL)",
+            name="ck_hygeiatag_owner",
+        ),
+    )
+    op.create_index("ix_hygeiatag_user", "HygeiaTag", ["user_id"])
+
+    op.create_table(
+        "AssetTag",
+        sa.Column("asset_id", sa.Integer(), nullable=False),
+        sa.Column("tag_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["asset_id"], ["MonitoredAsset.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tag_id"], ["HygeiaTag.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("asset_id", "tag_id"),
+    )
+
+    # `created_at` va como valor de Python y no como `sa.func.now()`: los
+    # valores de `bulk_insert` viajan como parametros bindeados, y una funcion
+    # SQL ahi se enviaria como literal en vez de ejecutarse.
+    seeded_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    op.bulk_insert(
+        hygeia_tag,
+        [
+            {
+                "name": name,
+                "color": color,
+                "tag_type": "system",
+                "user_id": None,
+                "created_at": seeded_at,
+            }
+            for name, color in _SYSTEM_TAGS
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Primero las asociaciones: sus FK apuntan a la tabla de etiquetas.
+    op.drop_table("AssetTag")
+    op.drop_index("ix_hygeiatag_user", table_name="HygeiaTag")
+    op.drop_table("HygeiaTag")

--- a/API/src/modules/features/hygeia/__init__.py
+++ b/API/src/modules/features/hygeia/__init__.py
@@ -3,14 +3,15 @@ src.modules.features.hygeia - Monitorización de activos (agente Hygeia)
 
 Exponente:
     - HygeiaAssetManager: alta, consulta y credenciales de activos monitorizados.
-    - Modelos: MonitoredAsset, AssetSnapshot, Anomaly.
+    - HygeiaTagManager: catálogo de etiquetas y su asignación a los activos.
+    - Modelos: MonitoredAsset, AssetSnapshot, Anomaly, HygeiaTag (SystemTag, UserTag).
     - Endpoints: hygeia_blp.
 """
 
 from src.modules.system.taskqueue import QueueRegistry
 
-from .model import Anomaly, AssetSnapshot, MonitoredAsset
-from .managers import HygeiaAssetManager
+from .model import Anomaly, AssetSnapshot, AssetTag, HygeiaTag, MonitoredAsset, SystemTag, UserTag
+from .managers import HygeiaAssetManager, HygeiaTagManager
 from .endpoints import hygeia_blp
 
 # Registro de las categorías de cola de este módulo (OCP). Los jobs de
@@ -24,6 +25,11 @@ __all__ = [
     "MonitoredAsset",
     "AssetSnapshot",
     "Anomaly",
+    "AssetTag",
+    "HygeiaTag",
+    "SystemTag",
+    "UserTag",
     "HygeiaAssetManager",
+    "HygeiaTagManager",
     "hygeia_blp",
 ]

--- a/API/src/modules/features/hygeia/endpoints.py
+++ b/API/src/modules/features/hygeia/endpoints.py
@@ -7,7 +7,8 @@ repositorio (regla del repo).
 
 Dos superficies separadas:
     - Usuario (``@require_oauth_token``): alta, listado, detalle, baja y
-      rotación de clave de los activos monitorizados.
+      rotación de clave de los activos monitorizados, más el catálogo de
+      etiquetas con el que se agrupan.
     - Agente (``@require_agent_key``): la ruta caliente de ingesta de
       heartbeats (``POST /hygeia/ingest``).
 """
@@ -27,8 +28,11 @@ from .exceptions import (
     AnomalyNotFoundError,
     AssetNotFoundError,
     HygeiaError,
+    TagNotFoundError,
 )
-from .managers import HygeiaAlertManager, HygeiaAssetManager, HygeiaIngestManager
+from .managers import (
+    HygeiaAlertManager, HygeiaAssetManager, HygeiaIngestManager, HygeiaTagManager,
+)
 from .schemas import (
     AnalyzeInventoryResponseSchema,
     AnomalyListResponseSchema,
@@ -42,11 +46,15 @@ from .schemas import (
     AssetMetricsQuerySchema,
     AssetMetricsResponseSchema,
     AssetSchema,
+    AssetTagsRequestSchema,
     AssetUpdateRequestSchema,
     IngestRequestSchema,
     IngestResponseSchema,
     InventoryAnalysisSummarySchema,
     RotateKeyResponseSchema,
+    TagCreateRequestSchema,
+    TagListResponseSchema,
+    TagSchema,
 )
 from .services import agent_key_id_from_request, enforce_ingest_limits, require_agent_key
 
@@ -238,6 +246,87 @@ def delete_asset(asset_id):
     manager = HygeiaAssetManager(user)
     manager.delete_asset(asset_id)
     logger.info(f"Activo Hygeia {asset_id} eliminado | user={current_actor()}")
+
+
+# =============================================================================
+# ETIQUETAS — catálogo común + repositorio personal, y su asignación a activos.
+#
+# No estrenan atributos propios: una etiqueta es una propiedad de los activos
+# de Hygeia, no un recurso aparte, así que reutilizan los HYGEIA_* que ya
+# gobiernan el módulo.
+# =============================================================================
+
+
+@hygeia_blp.get("/tags")
+@hygeia_blp.response(200, TagListResponseSchema, description="Etiquetas visibles para el usuario")
+@hygeia_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@hygeia_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@limiter.limit("600 per hour")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.HYGEIA_READ])
+@handle_exceptions(default_exception=HygeiaError, logger=logger)
+def list_tags():
+    """Listar el catálogo de etiquetas del usuario con el recuento de activos de cada una"""
+    user = get_current_user()
+    manager = HygeiaTagManager(user)
+    return {"tags": manager.list_tags()}
+
+
+@hygeia_blp.post("/tags")
+@hygeia_blp.arguments(TagCreateRequestSchema)
+@hygeia_blp.response(201, TagSchema, description="Etiqueta personal creada")
+@hygeia_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@hygeia_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@hygeia_blp.alt_response(409, schema=ErrorSchema, description="Tag name taken or quota exceeded")
+@limiter.limit("60 per hour")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.HYGEIA_CREATE])
+@handle_exceptions(default_exception=HygeiaError, logger=logger)
+def create_tag(data):
+    """Añadir una etiqueta al repositorio personal del usuario"""
+    user = get_current_user()
+    manager = HygeiaTagManager(user)
+    result = manager.create_tag(name=data["name"], color=data["color"])
+    logger.info(f"Etiqueta Hygeia creada | user={current_actor()} name={data['name']}")
+    return result
+
+
+@hygeia_blp.delete("/tags/<int:tag_id>")
+@hygeia_blp.response(200, description="Etiqueta eliminada")
+@hygeia_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@hygeia_blp.alt_response(403, schema=ErrorSchema, description="System tags cannot be deleted")
+@hygeia_blp.alt_response(404, schema=ErrorSchema, description="Tag not found")
+@limiter.limit("60 per hour")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.HYGEIA_DELETE])
+@handle_exceptions(default_exception=TagNotFoundError, logger=logger)
+def delete_tag(tag_id):
+    """Borrar una etiqueta personal, quitándola de todos los activos que la llevaran"""
+    user = get_current_user()
+    manager = HygeiaTagManager(user)
+    manager.delete_tag(tag_id)
+    logger.info(f"Etiqueta Hygeia {tag_id} eliminada | user={current_actor()}")
+
+
+@hygeia_blp.put("/assets/<int:asset_id>/tags")
+@hygeia_blp.arguments(AssetTagsRequestSchema)
+@hygeia_blp.response(200, AssetSchema, description="Activo con sus etiquetas actualizadas")
+@hygeia_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@hygeia_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@hygeia_blp.alt_response(404, schema=ErrorSchema, description="Asset or tag not found")
+@limiter.limit("120 per hour")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.HYGEIA_UPDATE])
+@handle_exceptions(default_exception=AssetNotFoundError, logger=logger)
+def set_asset_tags(data, asset_id):
+    """Fijar el conjunto completo de etiquetas de un activo"""
+    user = get_current_user()
+    manager = HygeiaTagManager(user)
+    result = manager.set_asset_tags(asset_id, data["tagIds"])
+    logger.info(
+        f"Etiquetas del activo {asset_id} = {data['tagIds']} | user={current_actor()}"
+    )
+    return result
     return {"message": "Asset eliminado correctamente"}
 
 

--- a/API/src/modules/features/hygeia/exceptions.py
+++ b/API/src/modules/features/hygeia/exceptions.py
@@ -10,7 +10,11 @@ Hierarchy:
     ├── IngestTooFrequentError    (429)
     ├── AnomalyNotFoundError      (404)
     ├── AnomalyStillOpenError     (409)
-    └── InventoryNotAvailableError (409)
+    ├── InventoryNotAvailableError (409)
+    ├── TagNotFoundError          (404)
+    ├── TagAlreadyExistsError     (409)
+    ├── TagQuotaExceededError     (409)
+    └── SystemTagImmutableError   (403)
 """
 
 from __future__ import annotations
@@ -133,4 +137,60 @@ class InventoryNotAvailableError(HygeiaError):
             message=f"El activo {asset_id} no tiene inventario de software que analizar",
             details={"asset_id": asset_id},
             user_message="Este activo aún no ha reportado un inventario de software.",
+        )
+
+
+class TagNotFoundError(EntityNotFoundError, HygeiaError):
+    """Se lanza cuando una etiqueta no existe o no es visible para el usuario.
+
+    Igual que con los activos: una etiqueta personal de otro usuario da el
+    mismo 404 que una inexistente, para no permitir enumerar el catálogo
+    ajeno por diferencia de respuesta.
+    """
+    entity_label = "Etiqueta"
+    entity_is_feminine = True
+    id_field = "tag_id"
+
+
+class TagAlreadyExistsError(HygeiaError):
+    """El usuario ya tiene (o el catálogo común ya trae) una etiqueta con ese nombre."""
+    default_code = ErrorCode.CONSTRAINT_VIOLATION
+    default_status_code = 409
+
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            message=f"Ya existe una etiqueta llamada {name!r}",
+            details={"name": name},
+            user_message=f"Ya existe una etiqueta «{name}».",
+        )
+
+
+class TagQuotaExceededError(HygeiaError):
+    """El usuario ha llegado al tope de etiquetas personales."""
+    default_code = ErrorCode.CONSTRAINT_VIOLATION
+    default_status_code = 409
+
+    def __init__(self, max_tags: int) -> None:
+        super().__init__(
+            message=f"Tope de etiquetas personales superado (máximo {max_tags})",
+            details={"max_tags": max_tags},
+            user_message=f"Has alcanzado el máximo de {max_tags} etiquetas personales.",
+        )
+
+
+class SystemTagImmutableError(HygeiaError):
+    """Se intenta borrar una etiqueta del catálogo común.
+
+    No es un 404 a propósito: la etiqueta existe y el usuario la ve, así que
+    fingir que no está sería confuso. Lo que no puede es tocarla — el
+    catálogo es común, y borrarla se la quitaría a todo el mundo.
+    """
+    default_code = ErrorCode.AUTHORIZATION_ERROR
+    default_status_code = 403
+
+    def __init__(self, tag_id: int) -> None:
+        super().__init__(
+            message=f"La etiqueta {tag_id} es del catálogo común y no se puede borrar",
+            details={"tag_id": tag_id},
+            user_message="Las etiquetas del catálogo común no se pueden borrar.",
         )

--- a/API/src/modules/features/hygeia/managers.py
+++ b/API/src/modules/features/hygeia/managers.py
@@ -31,9 +31,18 @@ from .exceptions import (
     AssetQuotaExceededError,
     IngestTooFrequentError,
     InventoryNotAvailableError,
+    SystemTagImmutableError,
+    TagAlreadyExistsError,
+    TagNotFoundError,
+    TagQuotaExceededError,
 )
-from .model import Anomaly, MonitoredAsset, AssetSnapshot
-from .repositories import AnomalyRepository, AssetSnapshotRepository, MonitoredAssetRepository
+from .model import Anomaly, MonitoredAsset, AssetSnapshot, UserTag
+from .repositories import (
+    AnomalyRepository,
+    AssetSnapshotRepository,
+    HygeiaTagRepository,
+    MonitoredAssetRepository,
+)
 from .services import check_clock_skew, denormalize, evaluate, generate_agent_key, services_from_inventory
 
 # ---------------------------------------------------------------------------
@@ -481,6 +490,157 @@ class HygeiaAssetManager:
             MonitoredAssetRepository(uow).update(asset)
 
         return {"agentKey": full_key}
+
+
+#: Tope de etiquetas personales por usuario.
+#:
+#: Es una constante de módulo y no un valor de ``SecOpsConfig.json`` a
+#: propósito: nadie va a querer ajustar este número, y llevarlo a la
+#: configuración obligaría a tocar ``config_reading.py``, el JSON, la vista de
+#: configuración de la SPA y ``test_config_shape.py`` para algo que solo existe
+#: para que la tabla no crezca sin fondo si alguien automatiza el alta.
+MAX_TAGS_PER_USER = 50
+
+
+class HygeiaTagManager:
+    """
+    Gestiona el catálogo de etiquetas de un usuario y su asignación a activos.
+
+    Un usuario ve dos cosas como si fueran una: el catálogo común
+    (``SystemTag``, sembrado por migración) y su repositorio personal
+    (``UserTag``). Puede asignar cualquiera de las dos a sus activos, pero
+    solo crear y borrar las suyas.
+    """
+
+    def __init__(self, user: User) -> None:
+        self.user = user
+
+    def list_tags(self) -> list[dict]:
+        """
+        Devuelve el catálogo visible con el recuento de activos de cada etiqueta.
+
+        Returns:
+            Lista de diccionarios ``{id, name, color, tagType, assetCount}``,
+            las de sistema primero y por nombre dentro de cada grupo.
+        """
+        tag_repository = build_repository(HygeiaTagRepository)
+        counts = tag_repository.count_assets_per_tag(self.user.id)
+
+        return [
+            {**tag.to_dict(), "assetCount": counts.get(tag.id, 0)}
+            for tag in tag_repository.get_visible_for_user(self.user.id)
+        ]
+
+    def create_tag(self, name: str, color: str) -> dict:
+        """
+        Crea una etiqueta personal.
+
+        El nombre se normaliza (espacios de sobra colapsados y recortados)
+        antes de comprobar duplicados: «  Base   de datos » y «Base de datos»
+        son la misma etiqueta escrita con menos cuidado, no dos.
+
+        Args:
+            name: Texto de la etiqueta.
+            color: Nombre del color, ya validado contra ``TAG_COLORS`` por el schema.
+
+        Returns:
+            La vista serializada de la etiqueta creada, con ``assetCount`` a 0.
+
+        Raises:
+            TagAlreadyExistsError: Si ya existe una con ese nombre (sin
+                distinguir mayúsculas), sea del catálogo común o suya.
+            TagQuotaExceededError: Si ya tiene ``MAX_TAGS_PER_USER`` etiquetas.
+        """
+        normalized_name = " ".join(name.split())
+
+        with UnitOfWork() as uow:
+            tag_repository = HygeiaTagRepository(uow)
+
+            if tag_repository.count_user_tags(self.user.id) >= MAX_TAGS_PER_USER:
+                raise TagQuotaExceededError(MAX_TAGS_PER_USER)
+            if tag_repository.get_by_name_for_user(self.user.id, normalized_name) is not None:
+                raise TagAlreadyExistsError(normalized_name)
+
+            tag = UserTag(name=normalized_name, color=color, user_id=self.user.id)
+            tag_repository.save(tag)
+
+            # Serializado dentro del bloque: fuera, la instancia queda detached.
+            return {**tag.to_dict(), "assetCount": 0}
+
+    def delete_tag(self, tag_id: int) -> None:
+        """
+        Borra una etiqueta personal del usuario.
+
+        Se lleva por delante sus asociaciones con los activos —esa es la
+        operación—, pero **ningún activo**: quitar la etiqueta «Producción»
+        del catálogo no borra los servidores de producción. De la limpieza se
+        encargan el ORM (que vacía la tabla de asociación al borrar el padre)
+        y el ``ondelete="CASCADE"`` de ``AssetTag``.
+
+        Args:
+            tag_id: Etiqueta a borrar.
+
+        Raises:
+            TagNotFoundError: Si no existe o es de otro usuario.
+            SystemTagImmutableError: Si es del catálogo común.
+        """
+        with UnitOfWork() as uow:
+            tag_repository = HygeiaTagRepository(uow)
+            tag = tag_repository.get_by_id(tag_id)
+
+            # Una etiqueta de sistema sí existe y sí se ve, así que decir "no
+            # existe" sería mentir; una de otro usuario, en cambio, no debe
+            # distinguirse de una inexistente.
+            if tag is not None and tag.user_id is None:
+                raise SystemTagImmutableError(tag_id)
+            if tag is None or tag.user_id != self.user.id:
+                raise TagNotFoundError(tag_id)
+
+            tag_repository.delete(tag)
+
+    def set_asset_tags(self, asset_id: int, tag_ids: list[int]) -> dict:
+        """
+        Reemplaza el conjunto de etiquetas de un activo.
+
+        Es un reemplazo y no un añadido: llega la lista definitiva, y lo que
+        no aparezca se quita. Así poner y quitar son la misma operación y el
+        cliente no tiene que calcular diferencias ni encadenar llamadas.
+
+        Args:
+            asset_id: Activo a etiquetar.
+            tag_ids: Ids de las etiquetas que debe llevar al terminar.
+
+        Returns:
+            La vista serializada del activo ya actualizado.
+
+        Raises:
+            AssetNotFoundError: Si el activo no existe o es de otro usuario.
+            TagNotFoundError: Si alguna etiqueta no existe o no es visible
+                para el usuario.
+        """
+        requested_ids = set(tag_ids)
+
+        with UnitOfWork() as uow:
+            asset = assert_owned(
+                MonitoredAssetRepository, asset_id, self.user.id,
+                AssetNotFoundError, uow=uow,
+            )
+
+            # Se resuelven contra las visibles, no por id suelto: así una
+            # etiqueta personal ajena da el mismo 404 que una inexistente y no
+            # se puede colar en un activo propio.
+            visible = {
+                tag.id: tag
+                for tag in HygeiaTagRepository(uow).get_visible_for_user(self.user.id)
+            }
+            unknown_ids = requested_ids - visible.keys()
+            if unknown_ids:
+                raise TagNotFoundError(min(unknown_ids))
+
+            asset.tags = [visible[tag_id] for tag_id in requested_ids]
+            MonitoredAssetRepository(uow).update(asset)
+
+            return asset.to_dict()
 
 
 class HygeiaIngestManager:

--- a/API/src/modules/features/hygeia/model.py
+++ b/API/src/modules/features/hygeia/model.py
@@ -10,6 +10,9 @@ Classes:
     MonitoredAsset: Activo (host/máquina) vigilado por un agente Hygeia.
     AssetSnapshot: Instantánea de métricas de un activo en un heartbeat.
     Anomaly: Incidencia abierta por la detección de umbrales.
+    HygeiaTag: Etiqueta con la que agrupar activos (base polimórfica).
+    SystemTag: Etiqueta del catálogo común, sembrada por migración.
+    UserTag: Etiqueta personal, siempre asociada a su dueño.
 
 Example:
     >>> from src.modules.features.hygeia.model import MonitoredAsset
@@ -22,6 +25,7 @@ Example:
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     Float,
@@ -29,12 +33,39 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Table,
+    UniqueConstraint,
     true,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from src.modules.shared import Base, utcnow_naive
+
+
+# =========================================================================
+# ASSOCIATION TABLES
+# =========================================================================
+
+AssetTag = Table(
+    "AssetTag",
+    Base.metadata,
+    Column(
+        "asset_id", Integer,
+        ForeignKey("MonitoredAsset.id", ondelete="CASCADE"), primary_key=True,
+    ),
+    Column(
+        "tag_id", Integer,
+        ForeignKey("HygeiaTag.id", ondelete="CASCADE"), primary_key=True,
+    ),
+)
+"""Qué etiquetas lleva cada activo.
+
+Los dos ``ondelete="CASCADE"`` son la mitad de la garantía que pide el
+producto: borrar una etiqueta borra sus asociaciones, **nunca los activos**
+que la llevaban. La otra mitad la pone el ORM, que limpia la tabla de
+asociación al borrar cualquiera de los dos extremos de la relación.
+"""
 
 
 class MonitoredAsset(Base):
@@ -105,6 +136,7 @@ class MonitoredAsset(Base):
         created_at: Instante de alta del activo.
         snapshots: Heartbeats recibidos de este activo.
         anomalies: Anomalías (abiertas o resueltas) de este activo.
+        tags: Etiquetas con las que el dueño agrupa este activo.
     """
 
     __tablename__ = "MonitoredAsset"
@@ -139,6 +171,12 @@ class MonitoredAsset(Base):
     anomalies = relationship(
         "Anomaly", back_populates="asset", cascade="all, delete-orphan",
     )
+    # `selectin` y no lazy por defecto: `list_assets()` serializa todos los
+    # activos del usuario y la SPA sondea ese endpoint cada minuto. Con carga
+    # perezosa serían N+1 consultas por listado; así son dos.
+    tags = relationship(
+        "HygeiaTag", secondary=AssetTag, back_populates="assets", lazy="selectin",
+    )
 
     def to_dict(self) -> dict:
         """
@@ -153,7 +191,7 @@ class MonitoredAsset(Base):
         con sufijo de zona horaria, igual que en el resto de módulos.
 
         Returns:
-            Diccionario con id, hostname, os, kernel, labels, status,
+            Diccionario con id, hostname, os, kernel, labels, tags, status,
             isPersistent, lastSeenAt, uptimeSec, agentVersion y createdAt.
         """
         return {
@@ -162,6 +200,7 @@ class MonitoredAsset(Base):
             "os":           self.os,
             "kernel":       self.kernel,
             "labels":       self.labels or {},
+            "tags":         [tag.to_dict() for tag in self.tags],
             "status":       self.status,
             "isPersistent": self.is_persistent,
             "lastSeenAt":   self.last_seen_at,
@@ -362,3 +401,97 @@ class Anomaly(Base):
             f"<Anomaly(id={self.id}, asset={self.asset_id}, "
             f"kind='{self.kind}', state='{self.state}')>"
         )
+
+
+class HygeiaTag(Base):
+    """
+    Etiqueta con la que agrupar activos monitorizados.
+
+    Hay dos clases de etiqueta y comparten tabla (herencia *single-table*,
+    discriminada por ``tag_type``), porque son la misma cosa desde el punto
+    de vista de un activo: un nombre y un color que se le cuelgan. Lo único
+    que las distingue es de quién son.
+
+    - ``SystemTag``: catálogo común, sembrado por migración. ``user_id`` es
+      ``NULL``, todo el mundo las ve y nadie las crea ni las borra.
+    - ``UserTag``: repositorio personal. ``user_id`` es obligatorio y solo
+      su dueño la ve, la asigna y la borra.
+
+    Esa regla no vive solo en el manager: el ``CheckConstraint`` de más
+    abajo la impone en la base de datos, así que ni una migración torcida
+    ni un ``INSERT`` a mano pueden dejar una etiqueta personal huérfana ni
+    una de sistema con dueño.
+
+    Attributes:
+        id: Clave primaria, autoincremental.
+        name: Texto de la etiqueta, tal como se pinta en el badge.
+        color: Nombre del color de la paleta cerrada (ver ``TAG_COLORS`` en
+            ``schemas.py``). No es un valor CSS: el frontend lo traduce, para
+            que un cambio de tema no obligue a reescribir filas.
+        tag_type: Discriminador ("system" | "user").
+        user_id: Dueño de la etiqueta; ``NULL`` en las de sistema.
+        created_at: Instante de alta de la etiqueta.
+        assets: Activos que llevan esta etiqueta.
+    """
+
+    __tablename__ = "HygeiaTag"
+
+    id         = Column(Integer, primary_key=True, autoincrement=True)
+    name       = Column(String(48), nullable=False)
+    color      = Column(String(16), nullable=False, default="slate")
+    tag_type   = Column(String(16), nullable=False)
+    user_id    = Column(Integer, ForeignKey("User.id", ondelete="CASCADE"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+
+    assets = relationship("MonitoredAsset", secondary=AssetTag, back_populates="tags")
+
+    # Sin `polymorphic_identity` en la base a propósito: toda fila es de un
+    # tipo concreto, `HygeiaTag` nunca se instancia directamente.
+    __mapper_args__ = {"polymorphic_on": tag_type}
+
+    __table_args__ = (
+        # Un usuario no repite nombre. Las de sistema quedan fuera (en
+        # Postgres los NULL son distintos entre sí) y no hace falta más: su
+        # único escritor es la migración de siembra.
+        UniqueConstraint("user_id", "name", name="uq_hygeiatag_user_name"),
+        CheckConstraint(
+            "(tag_type = 'system' AND user_id IS NULL) OR "
+            "(tag_type = 'user' AND user_id IS NOT NULL)",
+            name="ck_hygeiatag_owner",
+        ),
+        Index("ix_hygeiatag_user", "user_id"),
+    )
+
+    def to_dict(self) -> dict:
+        """
+        Serializa la etiqueta para respuestas de API.
+
+        No incluye ``userId``: quien la recibe es siempre su dueño (o el de
+        una etiqueta de sistema, que no tiene), así que el dato no añade
+        nada y sí revela la forma interna del modelo.
+
+        Returns:
+            Diccionario con id, name, color y tagType.
+        """
+        return {
+            "id":      self.id,
+            "name":    self.name,
+            "color":   self.color,
+            "tagType": self.tag_type,
+        }
+
+    def __repr__(self) -> str:
+        """Representación de depuración con id, nombre y tipo."""
+        return f"<HygeiaTag(id={self.id}, name='{self.name}', type='{self.tag_type}')>"
+
+
+class SystemTag(HygeiaTag):
+    """Etiqueta del catálogo común: sin dueño, visible para todos, inmutable."""
+
+    __mapper_args__ = {"polymorphic_identity": "system"}
+
+
+class UserTag(HygeiaTag):
+    """Etiqueta personal: siempre con dueño, y solo su dueño la usa."""
+
+    __mapper_args__ = {"polymorphic_identity": "user"}

--- a/API/src/modules/features/hygeia/repositories.py
+++ b/API/src/modules/features/hygeia/repositories.py
@@ -1,22 +1,22 @@
 """
 Acceso a datos del módulo Hygeia.
 
-Extiende BaseRepository para CRUD tipado sobre MonitoredAsset, AssetSnapshot
-y Anomaly. Las lecturas se construyen con ``build_repository`` (sesión
-ambiental, sin demarcar transacción); las escrituras, dentro de un
+Extiende BaseRepository para CRUD tipado sobre MonitoredAsset, AssetSnapshot,
+Anomaly y HygeiaTag. Las lecturas se construyen con ``build_repository``
+(sesión ambiental, sin demarcar transacción); las escrituras, dentro de un
 ``UnitOfWork``. Ningún método de este módulo crea ni cierra sesiones.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
-from sqlalchemy import update
+from sqlalchemy import func, update
 
 from src.modules.infrastructure import BaseRepository
 
-from .model import Anomaly, AssetSnapshot, MonitoredAsset
+from .model import Anomaly, AssetSnapshot, AssetTag, HygeiaTag, MonitoredAsset
 
 
 class MonitoredAssetRepository(BaseRepository[MonitoredAsset]):
@@ -253,3 +253,67 @@ class AnomalyRepository(BaseRepository[Anomaly]):
         if asset_id is not None:
             query = query.filter(Anomaly.asset_id == asset_id)
         return query.order_by(Anomaly.opened_at.desc()).all()
+
+
+class HygeiaTagRepository(BaseRepository[HygeiaTag]):
+    """Acceso a datos de HygeiaTag (etiquetas de sistema y personales)."""
+
+    _MODEL = HygeiaTag
+
+    def get_visible_for_user(self, user_id: int) -> List[HygeiaTag]:
+        """Catálogo de sistema más el repositorio personal de un usuario.
+
+        Es el conjunto que el usuario puede ver y asignar; cualquier otra
+        etiqueta le es invisible. Ordenado primero por tipo (``system``
+        antes que ``user``) y luego por nombre, para que la lista salga ya
+        agrupada de la base de datos y el frontend no tenga que reordenarla.
+        """
+        return (
+            self._session.query(HygeiaTag)
+            .filter(
+                (HygeiaTag.user_id.is_(None)) | (HygeiaTag.user_id == user_id)
+            )
+            .order_by(HygeiaTag.tag_type.asc(), HygeiaTag.name.asc())
+            .all()
+        )
+
+    def count_assets_per_tag(self, user_id: int) -> Dict[int, int]:
+        """Cuántos activos **del usuario** lleva cada etiqueta.
+
+        El filtro por dueño no es cosmético: una etiqueta de sistema la usa
+        todo el mundo, y contar sus asociaciones sin filtrar delataría
+        cuántos activos ajenos hay. Las etiquetas sin activos no aparecen en
+        el diccionario; el manager las completa con 0.
+        """
+        rows = (
+            self._session.query(AssetTag.c.tag_id, func.count(AssetTag.c.asset_id))
+            .join(MonitoredAsset, MonitoredAsset.id == AssetTag.c.asset_id)
+            .filter(MonitoredAsset.user_id == user_id)
+            .group_by(AssetTag.c.tag_id)
+            .all()
+        )
+        return dict(rows)
+
+    def get_by_name_for_user(self, user_id: int, name: str) -> Optional[HygeiaTag]:
+        """Busca una etiqueta visible para el usuario por nombre, sin distinguir mayúsculas.
+
+        Se compara en minúsculas porque «Producción» y «producción» son la
+        misma etiqueta para quien la lee: permitir ambas llenaría el catálogo
+        de duplicados que solo se distinguen mirándolos con lupa.
+        """
+        return (
+            self._session.query(HygeiaTag)
+            .filter(
+                (HygeiaTag.user_id.is_(None)) | (HygeiaTag.user_id == user_id),
+                func.lower(HygeiaTag.name) == name.lower(),
+            )
+            .first()
+        )
+
+    def count_user_tags(self, user_id: int) -> int:
+        """Cuántas etiquetas personales tiene ya creadas un usuario (tope §MAX_TAGS_PER_USER)."""
+        return (
+            self._session.query(HygeiaTag)
+            .filter(HygeiaTag.user_id == user_id)
+            .count()
+        )

--- a/API/src/modules/features/hygeia/schemas.py
+++ b/API/src/modules/features/hygeia/schemas.py
@@ -11,6 +11,50 @@ import src.modules.system.config_reading as CR
 from src.modules.shared.schemas import UTCDateTime
 
 
+TAG_COLORS = ("slate", "green", "teal", "blue", "violet", "amber", "red", "pink")
+"""Paleta cerrada de colores de etiqueta.
+
+Se guarda el **nombre** del color, no un valor CSS: el frontend lo traduce a
+la variable que toque, así que cambiar el tema (o el matiz exacto de "amber")
+no obliga a reescribir ninguna fila. Cerrada, además, porque una paleta libre
+acaba siendo diez tonos de gris indistinguibles en un badge de 11px.
+"""
+
+
+class TagSchema(Schema):
+    """Vista de una etiqueta.
+
+    ``assetCount`` solo lo rellena el listado del catálogo; las etiquetas
+    anidadas dentro de un activo lo omiten (allí no significaría nada).
+    """
+    id = fields.Integer()
+    name = fields.String()
+    color = fields.String()
+    tagType = fields.String()
+    assetCount = fields.Integer()
+
+
+class TagCreateRequestSchema(Schema):
+    """Alta de una etiqueta personal."""
+    name = fields.String(required=True, validate=validate.Length(min=1, max=48))
+    color = fields.String(load_default="slate", validate=validate.OneOf(TAG_COLORS))
+
+
+class TagListResponseSchema(Schema):
+    """Catálogo visible para el usuario: las de sistema más las suyas."""
+    tags = fields.List(fields.Nested(TagSchema))
+
+
+class AssetTagsRequestSchema(Schema):
+    """Conjunto completo de etiquetas de un activo.
+
+    Es un reemplazo, no un añadido: lo que llega es la lista definitiva, y
+    las que no aparezcan se quitan. Una sola operación cubre poner, quitar y
+    reordenar sin que el cliente tenga que calcular diferencias.
+    """
+    tagIds = fields.List(fields.Integer(), required=True)
+
+
 class AssetCreateRequestSchema(Schema):
     """Alta de un nuevo activo a monitorizar."""
     hostname = fields.String(required=True, validate=validate.Length(min=1, max=255))
@@ -33,6 +77,7 @@ class AssetSchema(Schema):
     os = fields.String(allow_none=True)
     kernel = fields.String(allow_none=True)
     labels = fields.Dict()
+    tags = fields.List(fields.Nested(TagSchema))
     status = fields.String()
     isPersistent = fields.Boolean()
     lastSeenAt = UTCDateTime(allow_none=True)

--- a/API/tests/integration/test_hygeia_tags.py
+++ b/API/tests/integration/test_hygeia_tags.py
@@ -1,0 +1,285 @@
+"""
+Tests de integración HTTP del etiquetado de activos de Hygeia.
+
+Cubre lo que de verdad puede romperse en un sistema de etiquetas con dos
+dueños distintos:
+
+- que el catálogo común y el repositorio personal se vean como una sola lista,
+  pero solo las propias se puedan borrar;
+- que una etiqueta personal de otro usuario sea indistinguible de una
+  inexistente (misma respuesta, sin enumerar catálogos ajenos);
+- y sobre todo, que **borrar una etiqueta no borre los activos que la
+  llevaban**, que es la garantía explícita del producto.
+
+Los tests siembran sus propias ``SystemTag``: la suite crea el esquema con
+``Base.metadata.create_all()`` y no pasa por Alembic, así que las 12 filas
+que siembra la migración no existen aquí.
+"""
+
+import secrets
+
+import pytest
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.features.hygeia.model import MonitoredAsset, SystemTag, UserTag
+from src.modules.features.hygeia.repositories import (
+    HygeiaTagRepository,
+    MonitoredAssetRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _create_asset(app, user_id: int, hostname: str = "tag-test") -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            asset = MonitoredAsset(
+                hostname=hostname,
+                agent_key_id=secrets.token_hex(8),
+                agent_key_hash="dummy",
+                heartbeat_interval_sec=15,
+                status="pending",
+                user_id=user_id,
+            )
+            MonitoredAssetRepository(uow).save(asset)
+            return asset.id
+
+
+def _create_system_tag(app, name: str = "Producción", color: str = "red") -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            tag = SystemTag(name=name, color=color)
+            HygeiaTagRepository(uow).save(tag)
+            return tag.id
+
+
+def _create_user_tag(app, user_id: int, name: str, color: str = "slate") -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            tag = UserTag(name=name, color=color, user_id=user_id)
+            HygeiaTagRepository(uow).save(tag)
+            return tag.id
+
+
+def _asset_exists(app, asset_id: int) -> bool:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return MonitoredAssetRepository(uow).get_by_id(asset_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Catálogo: qué ve cada usuario
+# ---------------------------------------------------------------------------
+
+def test_catalog_mixes_system_and_own_tags(app, client, regular_user, auth_headers):
+    _create_system_tag(app)
+
+    created = client.post(
+        "/hygeia/tags",
+        json={"name": "Mi etiqueta", "color": "blue"},
+        headers=auth_headers(regular_user),
+    )
+    assert created.status_code == 201
+    assert created.get_json()["tagType"] == "user"
+
+    listed = client.get("/hygeia/tags", headers=auth_headers(regular_user))
+    assert listed.status_code == 200
+
+    tags = listed.get_json()["tags"]
+    assert {tag["name"] for tag in tags} == {"Producción", "Mi etiqueta"}
+    # Las de sistema primero: la lista sale ya agrupada de la base de datos.
+    assert [tag["tagType"] for tag in tags] == ["system", "user"]
+
+
+def test_personal_tags_of_other_users_are_invisible(app, client, make_user, auth_headers):
+    owner = make_user()
+    stranger = make_user()
+    _create_user_tag(app, owner.id, "Solo mía")
+
+    resp = client.get("/hygeia/tags", headers=auth_headers(stranger))
+
+    assert resp.status_code == 200
+    assert resp.get_json()["tags"] == []
+
+
+def test_duplicate_name_is_rejected_ignoring_case(app, client, regular_user, auth_headers):
+    client.post(
+        "/hygeia/tags",
+        json={"name": "Cocina", "color": "green"},
+        headers=auth_headers(regular_user),
+    )
+
+    resp = client.post(
+        "/hygeia/tags",
+        json={"name": "  cocina  ", "color": "red"},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 409
+
+
+def test_cannot_shadow_a_system_tag_name(app, client, regular_user, auth_headers):
+    _create_system_tag(app, "Backup", "slate")
+
+    resp = client.post(
+        "/hygeia/tags",
+        json={"name": "backup"},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 409
+
+
+def test_color_outside_the_palette_is_rejected(client, regular_user, auth_headers):
+    resp = client.post(
+        "/hygeia/tags",
+        json={"name": "Fucsia", "color": "#ff00ff"},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Borrado: quién puede, y qué se lleva por delante
+# ---------------------------------------------------------------------------
+
+def test_system_tags_cannot_be_deleted(app, client, regular_user, auth_headers):
+    tag_id = _create_system_tag(app)
+
+    resp = client.delete(f"/hygeia/tags/{tag_id}", headers=auth_headers(regular_user))
+
+    # 403 y no 404: la etiqueta existe y el usuario la ve, lo que no puede es
+    # tocarla — el catálogo es común.
+    assert resp.status_code == 403
+
+
+def test_deleting_another_users_tag_is_indistinguishable_from_missing(
+    app, client, make_user, auth_headers,
+):
+    owner = make_user()
+    stranger = make_user()
+    tag_id = _create_user_tag(app, owner.id, "Ajena")
+
+    existing = client.delete(f"/hygeia/tags/{tag_id}", headers=auth_headers(stranger))
+    missing = client.delete("/hygeia/tags/999999", headers=auth_headers(stranger))
+
+    assert existing.status_code == 404
+    assert missing.status_code == 404
+
+
+def test_deleting_a_tag_keeps_the_assets_that_carried_it(
+    app, client, regular_user, auth_headers,
+):
+    """La garantía explícita del producto: se van las asociaciones, no los activos."""
+    asset_id = _create_asset(app, regular_user.id)
+    tag_id = _create_user_tag(app, regular_user.id, "Efímera")
+
+    assigned = client.put(
+        f"/hygeia/assets/{asset_id}/tags",
+        json={"tagIds": [tag_id]},
+        headers=auth_headers(regular_user),
+    )
+    assert assigned.status_code == 200
+    assert [tag["id"] for tag in assigned.get_json()["tags"]] == [tag_id]
+
+    deleted = client.delete(f"/hygeia/tags/{tag_id}", headers=auth_headers(regular_user))
+    assert deleted.status_code == 200
+
+    assert _asset_exists(app, asset_id)
+    asset = client.get(f"/hygeia/assets/{asset_id}", headers=auth_headers(regular_user))
+    assert asset.status_code == 200
+    assert asset.get_json()["tags"] == []
+
+
+# ---------------------------------------------------------------------------
+# Asignación
+# ---------------------------------------------------------------------------
+
+def test_assigning_tags_replaces_the_whole_set(app, client, regular_user, auth_headers):
+    asset_id = _create_asset(app, regular_user.id)
+    first = _create_user_tag(app, regular_user.id, "Primera")
+    second = _create_user_tag(app, regular_user.id, "Segunda")
+
+    client.put(
+        f"/hygeia/assets/{asset_id}/tags",
+        json={"tagIds": [first, second]},
+        headers=auth_headers(regular_user),
+    )
+    resp = client.put(
+        f"/hygeia/assets/{asset_id}/tags",
+        json={"tagIds": [second]},
+        headers=auth_headers(regular_user),
+    )
+
+    assert resp.status_code == 200
+    assert [tag["id"] for tag in resp.get_json()["tags"]] == [second]
+
+
+def test_cannot_assign_a_tag_owned_by_someone_else(app, client, make_user, auth_headers):
+    owner = make_user()
+    stranger = make_user()
+    stranger_asset = _create_asset(app, stranger.id)
+    owner_tag = _create_user_tag(app, owner.id, "Ajena")
+
+    resp = client.put(
+        f"/hygeia/assets/{stranger_asset}/tags",
+        json={"tagIds": [owner_tag]},
+        headers=auth_headers(stranger),
+    )
+
+    assert resp.status_code == 404
+
+
+def test_cannot_tag_an_asset_owned_by_someone_else(app, client, make_user, auth_headers):
+    owner = make_user()
+    stranger = make_user()
+    owner_asset = _create_asset(app, owner.id)
+    stranger_tag = _create_user_tag(app, stranger.id, "Suya")
+
+    resp = client.put(
+        f"/hygeia/assets/{owner_asset}/tags",
+        json={"tagIds": [stranger_tag]},
+        headers=auth_headers(stranger),
+    )
+
+    assert resp.status_code == 404
+
+
+def test_asset_count_only_counts_your_own_assets(app, client, make_user, auth_headers):
+    owner = make_user()
+    stranger = make_user()
+    shared_tag = _create_system_tag(app, "Cloud", "teal")
+
+    for user in (owner, stranger):
+        asset_id = _create_asset(app, user.id, hostname=f"host-{user.id}")
+        client.put(
+            f"/hygeia/assets/{asset_id}/tags",
+            json={"tagIds": [shared_tag]},
+            headers=auth_headers(user),
+        )
+
+    resp = client.get("/hygeia/tags", headers=auth_headers(owner))
+
+    # Uno, no dos: el recuento de una etiqueta compartida no puede delatar
+    # cuántos activos ajenos la llevan.
+    assert resp.get_json()["tags"][0]["assetCount"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Invariante de modelo
+# ---------------------------------------------------------------------------
+
+def test_a_personal_tag_without_an_owner_is_rejected_by_the_database(app):
+    """El CheckConstraint, no el manager: la regla vive en el esquema.
+
+    Se espera ``SQLAlchemyError`` y no ``IntegrityError`` porque
+    ``BaseRepository.save`` reenvuelve el error del driver; lo que importa
+    aquí es que el ``INSERT`` no pasa, y el mensaje nombra la constraint.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
+    with app.app_context():
+        with pytest.raises(SQLAlchemyError, match="ck_hygeiatag_owner"):
+            with UnitOfWork() as uow:
+                HygeiaTagRepository(uow).save(UserTag(name="Huérfana", color="slate"))

--- a/web/app/src/components/hygeia/AssetList.vue
+++ b/web/app/src/components/hygeia/AssetList.vue
@@ -3,6 +3,12 @@
     <header class="toolbar">
       <h3 class="toolbar-title">Activos</h3>
       <div class="toolbar-actions">
+        <RouterLink class="btn-icon" to="/hygeia/etiquetas" title="Gestionar etiquetas" aria-label="Gestionar etiquetas">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+            <path d="M7 7h.01" />
+          </svg>
+        </RouterLink>
         <button class="btn-icon" title="Recargar" aria-label="Recargar activos" @click="$emit('refresh')">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path d="M23 4v6h-6M1 20v-6h6" />
@@ -12,6 +18,22 @@
         <button class="btn-new" @click="$emit('create')">Nuevo activo</button>
       </div>
     </header>
+
+    <!-- Filtro por etiqueta. Solo se ofrecen las que alguien lleva: una tira de
+         chips con el catálogo entero sería casi todo ruido cuando la mitad no
+         está puesta en ningún sitio. -->
+    <div v-if="filterableTags.length" class="filter-bar">
+      <button
+        v-for="tag in filterableTags" :key="tag.id"
+        type="button" class="filter-chip" :class="{ 'filter-chip--on': activeTagIds.includes(tag.id) }"
+        :aria-pressed="activeTagIds.includes(tag.id)"
+        :style="{ '--tag-hue': hueOf(tag.color) }"
+        @click="toggleFilter(tag.id)"
+      >{{ tag.name }}</button>
+      <button v-if="activeTagIds.length" type="button" class="filter-clear" @click="activeTagIds = []">
+        Quitar filtros
+      </button>
+    </div>
 
     <!-- Sin <Transition mode="out-in"> a propósito: la transición de salida
          depende de requestAnimationFrame, que el navegador suspende en las
@@ -42,17 +64,38 @@
       <button class="btn-new" @click="$emit('create')">Nuevo activo</button>
     </div>
 
+    <div v-else-if="!visibleAssets.length" class="state-empty">
+      <p class="empty-title">Ningún activo con esas etiquetas</p>
+      <p class="empty-sub">Prueba a quitar algún filtro.</p>
+      <button class="btn-new" @click="activeTagIds = []">Quitar filtros</button>
+    </div>
+
     <ul v-else class="rows">
-      <li v-for="asset in assets" :key="asset.id" class="row" :class="{ 'row--selected': asset.id === selectedId }">
+      <li v-for="asset in visibleAssets" :key="asset.id" class="row" :class="{ 'row--selected': asset.id === selectedId }">
         <button class="row-select" :aria-pressed="asset.id === selectedId" @click="$emit('select', asset.id)">
           <span class="pulse" :class="pulseClass(asset)" aria-hidden="true"></span>
           <span class="row-text">
             <span class="row-host">{{ asset.hostname }}</span>
             <span class="row-meta">{{ statusLabel(asset) }} · {{ timeAgo(asset.lastSeenAt) }}</span>
+            <!-- Tira aparte y con salto de línea propio: `.row-host` y
+                 `.row-meta` son `nowrap` con elipsis y no sirven de molde. -->
+            <span v-if="asset.tags?.length" class="row-tags">
+              <TagBadge v-for="tag in shownTags(asset)" :key="tag.id" :tag="tag" small />
+              <span v-if="asset.tags.length > MAX_ROW_TAGS" class="row-tags-more">
+                +{{ asset.tags.length - MAX_ROW_TAGS }}
+              </span>
+            </span>
           </span>
         </button>
 
         <span class="row-actions">
+          <button class="btn-icon" title="Etiquetas" :aria-label="`Etiquetas de ${asset.hostname}`"
+            @click="$emit('tag', asset.id)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+              <path d="M7 7h.01" />
+            </svg>
+          </button>
           <button class="btn-icon" :class="{ 'btn-icon--muted': !asset.isPersistent }"
             :title="asset.isPersistent ? 'Marcar como host que se apaga a propósito' : 'Marcar como host siempre encendido'"
             :aria-pressed="!asset.isPersistent"
@@ -83,18 +126,64 @@
 </template>
 
 <script setup>
+import { computed, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import TagBadge from './TagBadge.vue'
+import { hueOf } from './tagColors'
 import { timeAgo } from './format'
 
-defineProps({
+const props = defineProps({
   assets: { type: Array, default: () => [] },
   selectedId: { type: [Number, null], default: null },
   loading: { type: Boolean, default: false },
   error: { type: String, default: null },
 })
-defineEmits(['select', 'create', 'delete', 'rotate', 'refresh', 'toggle-persistent'])
+defineEmits(['select', 'create', 'delete', 'rotate', 'refresh', 'toggle-persistent', 'tag'])
 
 /** Filas fantasma mientras carga: las que caben sin alargar el panel. */
 const SKELETON_ROWS = 4
+
+/** Badges que caben en una fila sin robarle el sitio al hostname. */
+const MAX_ROW_TAGS = 3
+
+/**
+ * Filtrado por etiqueta, en cliente y con estado local.
+ *
+ * La lista completa ya está en memoria —la vista la sondea entera cada
+ * minuto—, así que filtrar aquí es instantáneo y no gasta ni una petición.
+ * El estado no sube a la vista porque nadie más lo necesita: quien filtra la
+ * lista es la lista.
+ */
+const activeTagIds = ref([])
+
+/** Solo las etiquetas realmente puestas en algún activo: filtrar por una que
+ *  nadie lleva solo puede vaciar la lista. */
+const filterableTags = computed(() => {
+  const seen = new Map()
+  for (const asset of props.assets) {
+    for (const tag of asset.tags ?? []) seen.set(tag.id, tag)
+  }
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name))
+})
+
+/** Conjunción: al sumar etiquetas se estrecha la lista, no se ensancha. */
+const visibleAssets = computed(() => {
+  if (!activeTagIds.value.length) return props.assets
+  return props.assets.filter((asset) => {
+    const ids = (asset.tags ?? []).map((tag) => tag.id)
+    return activeTagIds.value.every((id) => ids.includes(id))
+  })
+})
+
+function toggleFilter(id) {
+  activeTagIds.value = activeTagIds.value.includes(id)
+    ? activeTagIds.value.filter((active) => active !== id)
+    : [...activeTagIds.value, id]
+}
+
+function shownTags(asset) {
+  return (asset.tags ?? []).slice(0, MAX_ROW_TAGS)
+}
 
 const STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inestable', offline: 'Caído' }
 
@@ -141,6 +230,9 @@ function pulseClass(asset) {
   color: var(--text-muted); cursor: pointer;
   transition: border-color var(--transition), color var(--transition);
 }
+/* El enlace a la vista de etiquetas comparte estilo con los botones de icono,
+   pero no hereda su reset de anclas. */
+a.btn-icon { text-decoration: none; }
 .btn-icon svg { width: 14px; height: 14px; }
 .btn-icon:hover { border-color: var(--accent); color: var(--accent-bright); }
 .btn-icon--danger:hover { border-color: var(--danger); color: var(--danger); }
@@ -174,6 +266,34 @@ function pulseClass(asset) {
   font-size: var(--fs-sm); color: var(--text-muted);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+.row-tags { display: flex; flex-wrap: wrap; gap: 0.2rem; margin-top: 0.2rem; }
+.row-tags-more { align-self: center; font-size: var(--fs-caption); color: var(--text-muted); }
+
+/* ── Filtro por etiqueta ── */
+.filter-bar { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+
+.filter-chip {
+  padding: 0.15rem 0.5rem;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--tag-hue) 38%, transparent);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: var(--fs-caption); cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+.filter-chip:hover { color: var(--text-dim); }
+.filter-chip--on {
+  background: color-mix(in srgb, var(--tag-hue) 22%, transparent);
+  color: var(--tag-hue);
+  font-weight: 600;
+}
+
+.filter-clear {
+  padding: 0.15rem 0.5rem;
+  background: none; border: 1px dashed var(--border-med); border-radius: 999px;
+  color: var(--text-muted); font-size: var(--fs-caption); cursor: pointer;
+}
+.filter-clear:hover { color: var(--text-dim); border-color: var(--text-muted); }
 
 .row-actions { display: flex; align-items: center; gap: 0.25rem; padding-right: 0.45rem; }
 
@@ -216,7 +336,8 @@ function pulseClass(asset) {
 .empty-title { margin: 0 0 0.25rem; font-size: var(--fs-lg); color: var(--text-dim); }
 .empty-sub { margin: 0 0 0.9rem; font-size: var(--fs-body); color: var(--text-muted); }
 
-.row-select:focus-visible, .btn-icon:focus-visible, .btn-new:focus-visible, .retry:focus-visible {
+.row-select:focus-visible, .btn-icon:focus-visible, .btn-new:focus-visible, .retry:focus-visible,
+.filter-chip:focus-visible, .filter-clear:focus-visible {
   outline: 2px solid var(--accent-bright); outline-offset: 2px;
 }
 

--- a/web/app/src/components/hygeia/AssetTagsModal.vue
+++ b/web/app/src/components/hygeia/AssetTagsModal.vue
@@ -1,0 +1,246 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <!-- `data-module` va en el overlay, no en la página: Teleport saca este
+           nodo de la raíz de la vista y sin esto el modal heredaría el acento
+           dorado por defecto en vez del verde de Hygeia. -->
+      <div v-if="show" class="modal-overlay" data-module="hygeia" @click.self="$emit('close')">
+        <div class="modal-box">
+          <div class="modal-header">
+            <h3>Etiquetas de {{ asset?.hostname }}</h3>
+            <button class="close-btn" @click="$emit('close')">&times;</button>
+          </div>
+
+          <div class="modal-body">
+            <input
+              ref="searchInput"
+              v-model.trim="search"
+              type="search"
+              class="search-input"
+              placeholder="Buscar o crear una etiqueta…"
+              @keydown.enter.prevent="onEnter"
+            />
+
+            <div v-if="chosen.length" class="chosen">
+              <TagBadge
+                v-for="tag in chosen" :key="tagKey(tag)"
+                :tag="tag" removable
+                @remove="toggle(tag)"
+              />
+            </div>
+
+            <div class="groups">
+              <template v-for="group in groups" :key="group.title">
+                <p v-if="group.tags.length" class="group-title">{{ group.title }}</p>
+                <label v-for="tag in group.tags" :key="tag.id" class="option">
+                  <input type="checkbox" :checked="isSelected(tag.id)" @change="toggle(tag)" />
+                  <TagBadge :tag="tag" />
+                  <span class="option-count">{{ countLabel(tag) }}</span>
+                </label>
+              </template>
+
+              <p v-if="!hasVisibleTags && !canCreate" class="empty">
+                No hay ninguna etiqueta que coincida.
+              </p>
+            </div>
+
+            <!-- Crear desde aquí: lo que se escriba y no exista se puede añadir
+                 al repositorio personal y queda marcado en el acto. Se guarda
+                 con el resto al aceptar, en una sola operación. -->
+            <div v-if="canCreate" class="create">
+              <button type="button" class="create-btn" @click="stageNewTag">
+                Crear «{{ search }}»
+              </button>
+              <span class="swatches">
+                <button
+                  v-for="color in TAG_COLOR_NAMES" :key="color"
+                  type="button" class="swatch" :class="{ 'swatch--on': color === newColor }"
+                  :style="{ background: hueOf(color) }"
+                  :aria-label="`Color ${color}`" :aria-pressed="color === newColor"
+                  @click="newColor = color"
+                ></button>
+              </span>
+            </div>
+
+            <p v-if="error" class="error">{{ error }}</p>
+
+            <div class="modal-footer">
+              <button type="button" class="btn-secondary" @click="$emit('close')">Cancelar</button>
+              <button type="button" class="btn-primary" :disabled="submitting" @click="submit">
+                {{ submitting ? 'Guardando…' : 'Guardar' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, nextTick, ref, watch } from 'vue'
+import TagBadge from './TagBadge.vue'
+import { TAG_COLOR_NAMES, hueOf } from './tagColors'
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+  /** Activo que se está etiquetando; sus `tags` son el estado de partida. */
+  asset: { type: Object, default: null },
+  /** Catálogo visible: las de sistema más las del usuario. */
+  tags: { type: Array, default: () => [] },
+  submitting: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+})
+const emit = defineEmits(['submit', 'close'])
+
+const search = ref('')
+const selectedIds = ref([])
+/** Etiquetas escritas aquí que aún no existen en el servidor. */
+const pendingNew = ref([])
+const newColor = ref('slate')
+const searchInput = ref(null)
+
+// Al abrir se parte de lo que el activo ya lleva; al cerrar no se limpia nada,
+// porque el siguiente `show` lo vuelve a hacer.
+watch(() => props.show, (visible) => {
+  if (!visible) return
+  search.value = ''
+  pendingNew.value = []
+  newColor.value = 'slate'
+  selectedIds.value = (props.asset?.tags ?? []).map((tag) => tag.id)
+  nextTick(() => searchInput.value?.focus())
+})
+
+const normalizedSearch = computed(() => search.value.trim().toLowerCase())
+
+function matches(tag) {
+  return !normalizedSearch.value || tag.name.toLowerCase().includes(normalizedSearch.value)
+}
+
+const groups = computed(() => [
+  { title: 'Catálogo común', tags: props.tags.filter((t) => t.tagType === 'system' && matches(t)) },
+  { title: 'Mis etiquetas', tags: props.tags.filter((t) => t.tagType === 'user' && matches(t)) },
+])
+
+const hasVisibleTags = computed(() => groups.value.some((group) => group.tags.length))
+
+/** Solo se ofrece crear si lo escrito no existe ya, ni en el catálogo ni entre las pendientes. */
+const canCreate = computed(() => {
+  if (!normalizedSearch.value) return false
+  const taken = [...props.tags, ...pendingNew.value]
+    .some((tag) => tag.name.toLowerCase() === normalizedSearch.value)
+  return !taken
+})
+
+/** Las pendientes aún no tienen id, así que la clave de lista es su nombre. */
+function tagKey(tag) { return tag.id ?? `new:${tag.name}` }
+
+function isSelected(id) { return selectedIds.value.includes(id) }
+
+const chosen = computed(() => [
+  ...props.tags.filter((tag) => selectedIds.value.includes(tag.id)),
+  ...pendingNew.value,
+])
+
+function toggle(tag) {
+  if (tag.id == null) {
+    pendingNew.value = pendingNew.value.filter((pending) => pending.name !== tag.name)
+    return
+  }
+  selectedIds.value = isSelected(tag.id)
+    ? selectedIds.value.filter((id) => id !== tag.id)
+    : [...selectedIds.value, tag.id]
+}
+
+function countLabel(tag) {
+  const count = tag.assetCount ?? 0
+  return count === 1 ? '1 activo' : `${count} activos`
+}
+
+function stageNewTag() {
+  if (!canCreate.value) return
+  pendingNew.value = [...pendingNew.value, { name: search.value.trim(), color: newColor.value }]
+  search.value = ''
+}
+
+/** Enter crea si lo escrito es nuevo; si ya existe, lo marca. */
+function onEnter() {
+  if (canCreate.value) { stageNewTag(); return }
+  const match = props.tags.find((tag) => tag.name.toLowerCase() === normalizedSearch.value)
+  if (match) { toggle(match); search.value = '' }
+}
+
+function submit() {
+  emit('submit', { tagIds: [...selectedIds.value], newTags: [...pendingNew.value] })
+}
+</script>
+
+<style scoped>
+.modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 1rem; }
+.modal-box { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; width: 100%; max-width: 460px; box-shadow: 0 10px 30px rgba(0,0,0,0.5); }
+.modal-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; padding: 0.85rem 1.1rem; border-bottom: 1px solid var(--border); }
+.modal-header h3 { margin: 0; font-size: var(--fs-xl); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.close-btn { background: none; border: none; color: var(--text-muted); font-size: var(--fs-xl); cursor: pointer; }
+.modal-body { padding: 1rem 1.1rem; }
+
+.search-input {
+  width: 100%; padding: 0.45rem 0.6rem;
+  background: var(--bg); border: 1px solid var(--border-med); border-radius: 6px;
+  color: var(--text); font-size: var(--fs-md);
+}
+.search-input:focus { outline: none; border-color: var(--accent); }
+
+.chosen { display: flex; flex-wrap: wrap; gap: 0.3rem; margin-top: 0.7rem; }
+
+/* Alto acotado: con el catálogo común más el personal la lista puede pasarse
+   de largo, y el botón de guardar tiene que seguir a la vista. */
+.groups { max-height: 240px; overflow-y: auto; margin-top: 0.7rem; }
+
+.group-title {
+  margin: 0.6rem 0 0.3rem;
+  font-size: var(--fs-caption); font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.05em; color: var(--text-muted);
+}
+
+.option {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.28rem 0.35rem; border-radius: 6px; cursor: pointer;
+}
+.option:hover { background: var(--surface-2); }
+.option input { accent-color: var(--accent); flex-shrink: 0; }
+.option-count { margin-left: auto; font-size: var(--fs-caption); color: var(--text-muted); white-space: nowrap; }
+
+.empty { margin: 0.8rem 0; text-align: center; color: var(--text-muted); font-size: var(--fs-sm); }
+
+.create {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; flex-wrap: wrap;
+  margin-top: 0.7rem; padding-top: 0.7rem; border-top: 1px dashed var(--border-med);
+}
+.create-btn {
+  padding: 0.35rem 0.7rem;
+  background: var(--accent-dim); border: 1px solid var(--accent); border-radius: 6px;
+  color: var(--accent-bright); font-size: var(--fs-sm); font-weight: 600; cursor: pointer;
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.create-btn:hover { background: var(--accent); color: var(--on-accent); }
+
+.swatches { display: flex; gap: 0.25rem; }
+.swatch {
+  width: 16px; height: 16px; border-radius: 50%;
+  border: 1px solid var(--border-med); cursor: pointer;
+}
+.swatch--on { box-shadow: 0 0 0 2px var(--surface), 0 0 0 3px var(--text-dim); }
+
+.error { color: var(--danger); font-size: var(--fs-sm); margin: 0.7rem 0 0; }
+
+.modal-footer { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 1rem; }
+.btn-secondary, .btn-primary { padding: 0.45rem 0.9rem; border-radius: 6px; font-size: var(--fs-md); font-weight: 600; cursor: pointer; }
+.btn-secondary { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim); }
+.btn-secondary:hover { border-color: var(--text-muted); color: var(--text); }
+.btn-primary { background: var(--accent); border: 1px solid var(--accent); color: var(--on-accent); }
+.btn-primary:hover:not(:disabled) { background: var(--accent-bright); }
+.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.modal-enter-active, .modal-leave-active { transition: opacity 0.2s ease; }
+.modal-enter-from, .modal-leave-to { opacity: 0; }
+</style>

--- a/web/app/src/components/hygeia/TagBadge.vue
+++ b/web/app/src/components/hygeia/TagBadge.vue
@@ -1,0 +1,63 @@
+<template>
+  <span class="tag-badge" :class="{ 'tag-badge--sm': small }" :style="{ '--tag-hue': hueOf(tag.color) }">
+    <span class="tag-name">{{ tag.name }}</span>
+    <button
+      v-if="removable"
+      type="button"
+      class="tag-remove"
+      :aria-label="`Quitar la etiqueta ${tag.name}`"
+      @click.stop="$emit('remove', tag.id)"
+    >&times;</button>
+  </span>
+</template>
+
+<script setup>
+import { hueOf } from './tagColors'
+
+defineProps({
+  tag: { type: Object, required: true },
+  /** Muestra la aspa para quitarla. Presentacional: quien decide es el padre. */
+  removable: { type: Boolean, default: false },
+  /** Versión compacta, para las tiras de las filas de la lista. */
+  small: { type: Boolean, default: false },
+})
+defineEmits(['remove'])
+</script>
+
+<style scoped>
+/* Un solo bloque para los ocho colores: el matiz entra por `--tag-hue` desde
+   JS, así que la paleta vive en un sitio (tagColors.js) y no en ocho reglas
+   CSS que habría que mantener en paralelo. */
+.tag-badge {
+  display: inline-flex; align-items: center; gap: 0.25rem;
+  max-width: 100%;
+  padding: 0.15rem 0.45rem;
+  background: color-mix(in srgb, var(--tag-hue) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--tag-hue) 38%, transparent);
+  border-radius: 999px;
+  color: var(--tag-hue);
+  font-size: var(--fs-sm); font-weight: 500; line-height: 1.4;
+}
+
+.tag-badge--sm { padding: 0.05rem 0.35rem; font-size: var(--fs-caption); }
+
+.tag-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.tag-remove {
+  flex-shrink: 0;
+  padding: 0 0.1rem;
+  background: none; border: none;
+  color: inherit; opacity: 0.65;
+  font-size: 1em; line-height: 1; cursor: pointer;
+}
+.tag-remove:hover { opacity: 1; }
+.tag-remove:focus-visible { outline: 1px solid currentColor; outline-offset: 1px; }
+
+/* Sobre fondo claro los mismos matices quedan lavados: el texto se oscurece y
+   el relleno se aclara para conservar el contraste sin cambiar la paleta. */
+[data-theme="dawn"] .tag-badge {
+  background: color-mix(in srgb, var(--tag-hue) 12%, white);
+  border-color: color-mix(in srgb, var(--tag-hue) 45%, transparent);
+  color: color-mix(in srgb, var(--tag-hue) 72%, black);
+}
+</style>

--- a/web/app/src/components/hygeia/tagColors.js
+++ b/web/app/src/components/hygeia/tagColors.js
@@ -1,0 +1,30 @@
+/**
+ * Traducción de los nombres de color que guarda la API (`TAG_COLORS` en
+ * `schemas.py`) al matiz que se pinta.
+ *
+ * La base de datos guarda «amber», no `#d9a441`: así el matiz exacto se puede
+ * retocar aquí sin reescribir una sola fila, y un cambio de tema no obliga a
+ * migrar nada. Un único mapa para las dos cosas que necesitan color —el badge
+ * y el selector de swatches—, para que no puedan desincronizarse.
+ *
+ * Los matices están elegidos para leerse sobre el fondo oscuro por defecto; el
+ * tema claro los oscurece en el propio badge, no aquí.
+ */
+export const TAG_HUES = {
+  slate:  '#8a93a6',
+  green:  '#5a8f6d',
+  teal:   '#3fa39b',
+  blue:   '#5b8fd6',
+  violet: '#9b7bd4',
+  amber:  '#d9a441',
+  red:    '#d2603f',
+  pink:   '#d46fa0',
+}
+
+/** Nombres de la paleta, en el orden en que se ofrecen al elegir. */
+export const TAG_COLOR_NAMES = Object.keys(TAG_HUES)
+
+/** Matiz de un color, con «slate» como red de seguridad si llega uno desconocido. */
+export function hueOf(color) {
+  return TAG_HUES[color] || TAG_HUES.slate
+}

--- a/web/app/src/router/index.js
+++ b/web/app/src/router/index.js
@@ -99,6 +99,12 @@ const routes = [
     component: () => import('@/views/HygeiaView.vue'),
     meta: { requiresAuth: true },
   },
+  {
+    path: '/hygeia/etiquetas',
+    name: 'HygeiaTags',
+    component: () => import('@/views/HygeiaTagsView.vue'),
+    meta: { requiresAuth: true },
+  },
   // Capa comercial: planes, plan propio y organización.
   {
     // Pública: es la tabla de precios, la ve quien todavía no tiene cuenta.

--- a/web/app/src/stores/hygeiaStore.js
+++ b/web/app/src/stores/hygeiaStore.js
@@ -104,6 +104,48 @@ export const useHygeiaStore = defineStore('hygeia', () => {
     } catch { state.error = 'No se pudo conectar con la API.'; return false }
   }
 
+  /**
+   * Fija el conjunto completo de etiquetas de un activo.
+   *
+   * La lista que se manda es la definitiva: lo que no vaya en `tagIds` se
+   * quita. Igual que `setPersistence`, reemplaza la fila con la que devuelve
+   * la API en vez de esperar al siguiente sondeo — los badges tienen que
+   * aparecer en el momento en que se guarda, no un minuto después.
+   *
+   * @param {number} id - Id del activo.
+   * @param {number[]} tagIds - Etiquetas que debe llevar al terminar.
+   */
+  async function setAssetTags(id, tagIds) {
+    try {
+      const res = await apiFetch(`/hygeia/assets/${id}/tags`, {
+        method: 'PUT',
+        body: JSON.stringify({ tagIds }),
+      })
+      if (!res?.ok) { state.error = await apiError(res, 'No se pudieron guardar las etiquetas.'); return false }
+      const asset = await res.json()
+      const index = state.assets.findIndex((a) => a.id === id)
+      if (index !== -1) state.assets[index] = asset
+      return true
+    } catch { state.error = 'No se pudo conectar con la API.'; return false }
+  }
+
+  /**
+   * Quita una etiqueta de todos los activos que la llevaban, en local.
+   *
+   * La borra el backend (con sus asociaciones), pero la lista de activos ya
+   * está en memoria y volver a pedirla entera por una etiqueta menos sería
+   * una petición de más para un cambio que el cliente ya sabe hacer.
+   *
+   * @param {number} tagId - Etiqueta recién borrada.
+   */
+  function dropTagFromAssets(tagId) {
+    for (const asset of state.assets) {
+      if (asset.tags?.some((tag) => tag.id === tagId)) {
+        asset.tags = asset.tags.filter((tag) => tag.id !== tagId)
+      }
+    }
+  }
+
   /** Selecciona un activo para ver su detalle y carga sus métricas. */
   function selectAsset(id) {
     state.selectedId = id
@@ -251,6 +293,7 @@ export const useHygeiaStore = defineStore('hygeia', () => {
   return {
     state,
     fetchAssets, createAsset, deleteAsset, rotateKey, setPersistence,
+    setAssetTags, dropTagFromAssets,
     selectAsset, fetchMetrics, fetchLatest, fetchInventory, clearAgentKey,
     fetchAnalysis, analyzeInventory,
     $reset,

--- a/web/app/src/stores/hygeiaTagsStore.js
+++ b/web/app/src/stores/hygeiaTagsStore.js
@@ -1,0 +1,106 @@
+import { defineStore } from 'pinia'
+import { reactive } from 'vue'
+import { useApi } from '@/composables/useApi'
+
+/**
+ * Store del catálogo de etiquetas de Hygeia.
+ *
+ * Guarda las dos clases juntas, tal como llegan de la API: las de sistema
+ * (`tagType: 'system'`, comunes a todo el mundo) y las personales
+ * (`tagType: 'user'`). Para asignarlas son intercambiables; solo se
+ * distinguen al crear y al borrar, que es cosa exclusiva de las propias.
+ *
+ * El dueño de los activos sigue siendo `hygeiaStore`: aquí vive el catálogo,
+ * allí a qué activo se le ha puesto qué.
+ */
+export const useHygeiaTagsStore = defineStore('hygeiaTags', () => {
+  const { apiFetch, apiError } = useApi()
+
+  const state = reactive({
+    tags: [], loading: false, error: null,
+  })
+
+  /**
+   * Carga el catálogo visible: las de sistema más las del usuario.
+   *
+   * @param {object} [opts]
+   * @param {boolean} [opts.silent=false] - No levanta el flag de carga, para
+   *   los refrescos que siguen a una escritura (el catálogo ya está pintado y
+   *   no debe parpadear).
+   */
+  async function fetchTags({ silent = false } = {}) {
+    if (!silent) state.loading = true
+    try {
+      const res = await apiFetch('/hygeia/tags')
+      if (!res?.ok) { state.error = await apiError(res, 'No se pudieron cargar las etiquetas.'); return }
+      const data = await res.json()
+      state.tags = data.tags ?? []
+      state.error = null
+    } catch { state.error = 'No se pudo conectar con la API.' }
+    finally { if (!silent) state.loading = false }
+  }
+
+  /**
+   * Añade una etiqueta al repositorio personal del usuario.
+   *
+   * @param {object} tag
+   * @param {string} tag.name - Texto de la etiqueta.
+   * @param {string} tag.color - Nombre de color de la paleta (ver `tagColors.js`).
+   * @returns {Promise<object|null>} La etiqueta creada, o null si falló.
+   */
+  async function createTag({ name, color = 'slate' }) {
+    try {
+      const res = await apiFetch('/hygeia/tags', {
+        method: 'POST',
+        body: JSON.stringify({ name, color }),
+      })
+      if (!res?.ok) { state.error = await apiError(res, 'No se pudo crear la etiqueta.'); return null }
+      const tag = await res.json()
+      state.tags.push(tag)
+      state.error = null
+      return tag
+    } catch { state.error = 'No se pudo conectar con la API.'; return null }
+  }
+
+  /**
+   * Borra una etiqueta personal.
+   *
+   * Se lleva sus asociaciones con los activos, nunca los activos: quien la
+   * llevaba se queda, sin ella. De reflejarlo en la lista de activos ya
+   * cargada se encarga `hygeiaStore.dropTagFromAssets`.
+   *
+   * @param {number} id - Id de la etiqueta.
+   */
+  async function deleteTag(id) {
+    try {
+      const res = await apiFetch(`/hygeia/tags/${id}`, { method: 'DELETE' })
+      if (!res?.ok) { state.error = await apiError(res, 'No se pudo borrar la etiqueta.'); return false }
+      state.tags = state.tags.filter((tag) => tag.id !== id)
+      state.error = null
+      return true
+    } catch { state.error = 'No se pudo conectar con la API.'; return false }
+  }
+
+  /**
+   * Ajusta en local el recuento de activos de una etiqueta.
+   *
+   * Lo llama la vista tras guardar las etiquetas de un activo, para no tener
+   * que recargar el catálogo entero por un número que ya se conoce.
+   *
+   * @param {number[]} added - Etiquetas que el activo acaba de ganar.
+   * @param {number[]} removed - Etiquetas que acaba de perder.
+   */
+  function adjustCounts(added, removed) {
+    for (const tag of state.tags) {
+      if (added.includes(tag.id)) tag.assetCount = (tag.assetCount ?? 0) + 1
+      if (removed.includes(tag.id)) tag.assetCount = Math.max(0, (tag.assetCount ?? 0) - 1)
+    }
+  }
+
+  /** Limpia el estado (logout SPA sin recarga dura). */
+  function $reset() {
+    Object.assign(state, { tags: [], loading: false, error: null })
+  }
+
+  return { state, fetchTags, createTag, deleteTag, adjustCounts, $reset }
+})

--- a/web/app/src/views/HygeiaHubView.vue
+++ b/web/app/src/views/HygeiaHubView.vue
@@ -10,6 +10,7 @@
     claim="Vigila el pulso de cada activo"
     tool-route="/hygeia/activos"
     tool-label="Ver mis activos"
+    :shortcuts="[{ label: 'Etiquetas', to: '/hygeia/etiquetas' }]"
     :highlight="highlight"
     :features="features"
     :resources="resources"

--- a/web/app/src/views/HygeiaTagsView.vue
+++ b/web/app/src/views/HygeiaTagsView.vue
@@ -1,0 +1,380 @@
+<template>
+  <div class="tags-page" data-module="hygeia">
+    <StarBackground />
+    <Topbar title="Hygeia" badge="Etiquetas" back-to="/hygeia/activos" back-label="Activos" />
+
+    <main class="tags-layout">
+      <header class="head">
+        <div class="head-text">
+          <h2 class="head-title">Etiquetas</h2>
+          <p class="head-sub">
+            El catálogo común lo comparte todo el mundo; las tuyas solo las ves tú.
+            Borrar una la quita de los activos que la llevaban — los activos se quedan.
+          </p>
+        </div>
+        <button class="btn-new" @click="startCreating">Nueva etiqueta</button>
+      </header>
+
+      <div class="controls">
+        <input
+          v-model.trim="search"
+          type="search"
+          class="search-input"
+          placeholder="Buscar una etiqueta…"
+        />
+        <div class="scope">
+          <button
+            v-for="option in SCOPES" :key="option.value"
+            type="button" class="scope-btn" :class="{ 'scope-btn--on': scope === option.value }"
+            :aria-pressed="scope === option.value"
+            @click="scope = option.value"
+          >{{ option.label }}</button>
+        </div>
+      </div>
+
+      <!-- Alta en línea, no en modal: es un nombre y un color, y el catálogo de
+           al lado es justo lo que hay que mirar para no repetir una. -->
+      <form v-if="creating" class="create-row" @submit.prevent="submitNewTag">
+        <input
+          ref="newNameInput"
+          v-model.trim="newName"
+          type="text" class="search-input"
+          placeholder="Nombre de la etiqueta" maxlength="48" required
+        />
+        <span class="swatches">
+          <button
+            v-for="color in TAG_COLOR_NAMES" :key="color"
+            type="button" class="swatch" :class="{ 'swatch--on': color === newColor }"
+            :style="{ background: hueOf(color) }"
+            :aria-label="`Color ${color}`" :aria-pressed="color === newColor"
+            @click="newColor = color"
+          ></button>
+        </span>
+        <button type="submit" class="btn-primary" :disabled="saving">
+          {{ saving ? 'Creando…' : 'Crear' }}
+        </button>
+        <button type="button" class="btn-secondary" @click="creating = false">Cancelar</button>
+      </form>
+
+      <p v-if="tagsStore.state.loading" class="state-msg">Cargando etiquetas…</p>
+
+      <p v-else-if="tagsStore.state.error" class="state-msg state-msg--error">
+        {{ tagsStore.state.error }}
+        <button type="button" class="retry" @click="tagsStore.fetchTags()">Reintentar</button>
+      </p>
+
+      <div v-else-if="!filteredTags.length" class="state-empty">
+        <p class="empty-title">Ninguna etiqueta que coincida</p>
+        <p class="empty-sub">Prueba con otra búsqueda, o crea una nueva.</p>
+      </div>
+
+      <ul v-else class="tag-grid">
+        <li
+          v-for="tag in filteredTags" :key="tag.id"
+          class="tag-card" :class="{ 'tag-card--selected': tag.id === selectedId }"
+        >
+          <button class="tag-main" :aria-pressed="tag.id === selectedId" @click="toggleSelected(tag.id)">
+            <TagBadge :tag="tag" />
+            <span class="tag-meta">
+              {{ tag.tagType === 'system' ? 'Catálogo común' : 'Personal' }}
+              · {{ countLabel(tag) }}
+            </span>
+          </button>
+
+          <button
+            v-if="tag.tagType === 'user'"
+            class="btn-icon btn-icon--danger"
+            title="Borrar etiqueta" :aria-label="`Borrar la etiqueta ${tag.name}`"
+            @click="pendingDelete = tag"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" />
+            </svg>
+          </button>
+        </li>
+      </ul>
+
+      <!-- Al elegir una etiqueta se ve quién la lleva: es la pregunta que trae
+           a alguien a esta pantalla. -->
+      <section v-if="selectedTag" class="carriers">
+        <h3 class="carriers-title">
+          Activos con «{{ selectedTag.name }}»
+        </h3>
+        <p v-if="!carriers.length" class="carriers-empty">
+          Ningún activo lleva esta etiqueta todavía.
+        </p>
+        <ul v-else class="carriers-list">
+          <li v-for="asset in carriers" :key="asset.id">
+            <RouterLink class="carrier" to="/hygeia/activos">
+              <span class="pulse" :class="`pulse--${asset.status}`" aria-hidden="true"></span>
+              {{ asset.hostname }}
+            </RouterLink>
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <ConfirmModal
+      :show="!!pendingDelete"
+      title="Borrar etiqueta"
+      :message="deleteMessage"
+      confirm-label="Borrar"
+      danger
+      @confirm="confirmDelete"
+      @cancel="pendingDelete = null"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import Topbar from '@/components/shared/Topbar.vue'
+import StarBackground from '@/components/shared/StarBackground.vue'
+import ConfirmModal from '@/components/shared/ConfirmModal.vue'
+import TagBadge from '@/components/hygeia/TagBadge.vue'
+import { TAG_COLOR_NAMES, hueOf } from '@/components/hygeia/tagColors'
+import { useHygeiaStore } from '@/stores/hygeiaStore'
+import { useHygeiaTagsStore } from '@/stores/hygeiaTagsStore'
+import { useToastStore } from '@/stores/toastStore'
+
+const store = useHygeiaStore()
+const tagsStore = useHygeiaTagsStore()
+const toast = useToastStore()
+
+const SCOPES = [
+  { value: 'all', label: 'Todas' },
+  { value: 'system', label: 'Catálogo común' },
+  { value: 'user', label: 'Mías' },
+]
+
+const search = ref('')
+const scope = ref('all')
+const selectedId = ref(null)
+const pendingDelete = ref(null)
+
+const creating = ref(false)
+const newName = ref('')
+const newColor = ref('slate')
+const newNameInput = ref(null)
+const saving = ref(false)
+
+const filteredTags = computed(() => {
+  const needle = search.value.toLowerCase()
+  return tagsStore.state.tags.filter((tag) => {
+    if (scope.value !== 'all' && tag.tagType !== scope.value) return false
+    return !needle || tag.name.toLowerCase().includes(needle)
+  })
+})
+
+const selectedTag = computed(() =>
+  tagsStore.state.tags.find((tag) => tag.id === selectedId.value) || null
+)
+
+const carriers = computed(() => {
+  if (!selectedTag.value) return []
+  return store.state.assets.filter(
+    (asset) => (asset.tags ?? []).some((tag) => tag.id === selectedId.value),
+  )
+})
+
+const deleteMessage = computed(() => {
+  const count = pendingDelete.value?.assetCount ?? 0
+  const carried = count === 1 ? 'del activo que la lleva' : `de los ${count} activos que la llevan`
+  return count
+    ? `Se quitará «${pendingDelete.value.name}» ${carried}. Los activos no se borran.`
+    : `Se borrará la etiqueta «${pendingDelete.value?.name}». No la lleva ningún activo.`
+})
+
+function countLabel(tag) {
+  const count = tag.assetCount ?? 0
+  return count === 1 ? '1 activo' : `${count} activos`
+}
+
+function toggleSelected(id) {
+  selectedId.value = selectedId.value === id ? null : id
+}
+
+function startCreating() {
+  creating.value = true
+  newName.value = ''
+  newColor.value = 'slate'
+  nextTick(() => newNameInput.value?.focus())
+}
+
+async function submitNewTag() {
+  if (!newName.value) return
+  saving.value = true
+  try {
+    const tag = await tagsStore.createTag({ name: newName.value, color: newColor.value })
+    if (!tag) {
+      toast.show(tagsStore.state.error || 'No se pudo crear la etiqueta.', 'error')
+      return
+    }
+    creating.value = false
+    toast.show(`Etiqueta «${tag.name}» creada.`, 'success')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDelete() {
+  const tag = pendingDelete.value
+  pendingDelete.value = null
+  if (!tag) return
+
+  const ok = await tagsStore.deleteTag(tag.id)
+  if (!ok) {
+    toast.show(tagsStore.state.error || 'No se pudo borrar la etiqueta.', 'error')
+    return
+  }
+  // La lista de activos ya está en memoria: quitarle la etiqueta aquí evita
+  // volver a pedirla entera por un cambio que el cliente ya sabe hacer.
+  store.dropTagFromAssets(tag.id)
+  if (selectedId.value === tag.id) selectedId.value = null
+  toast.show(`Etiqueta «${tag.name}» borrada.`, 'success')
+}
+
+onMounted(() => {
+  // Los activos hacen falta para el recuento por etiqueta y para la lista de
+  // quién la lleva; si se llega aquí directo por URL, aún no están cargados.
+  tagsStore.fetchTags()
+  if (!store.state.assets.length) store.fetchAssets()
+})
+</script>
+
+<style scoped>
+.tags-page {
+  min-height: 100vh;
+  background: var(--bg);
+  padding-top: var(--topbar-h);
+  position: relative;
+}
+
+.tags-layout {
+  position: relative;
+  z-index: 1;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 3rem;
+}
+
+.head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.head-title { margin: 0 0 0.3rem; font-size: var(--fs-2xl); font-weight: 600; color: var(--text); }
+.head-sub { margin: 0; max-width: 56ch; font-size: var(--fs-md); color: var(--text-muted); line-height: 1.5; }
+
+.btn-new {
+  padding: 0.45rem 0.9rem; flex-shrink: 0;
+  background: var(--accent-dim); border: 1px solid var(--accent); border-radius: 6px;
+  color: var(--accent-bright); font-size: var(--fs-body); font-weight: 600; cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+.btn-new:hover { background: var(--accent); color: var(--on-accent); }
+
+.controls { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin: 1.2rem 0 0.9rem; }
+
+.search-input {
+  flex: 1; min-width: 180px;
+  padding: 0.45rem 0.6rem;
+  background: var(--surface); border: 1px solid var(--border-med); border-radius: 6px;
+  color: var(--text); font-size: var(--fs-md);
+}
+.search-input:focus { outline: none; border-color: var(--accent); }
+
+.scope { display: flex; gap: 0.25rem; }
+.scope-btn {
+  padding: 0.35rem 0.7rem;
+  background: transparent; border: 1px solid var(--border-med); border-radius: 999px;
+  color: var(--text-muted); font-size: var(--fs-sm); cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+.scope-btn:hover { color: var(--text-dim); }
+.scope-btn--on { background: var(--accent-dim); border-color: var(--accent); color: var(--accent-bright); font-weight: 600; }
+
+.create-row {
+  display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+  margin-bottom: 0.9rem; padding: 0.7rem;
+  background: var(--surface); border: 1px dashed var(--accent); border-radius: 8px;
+}
+
+.swatches { display: flex; gap: 0.25rem; }
+.swatch { width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--border-med); cursor: pointer; }
+.swatch--on { box-shadow: 0 0 0 2px var(--surface), 0 0 0 3px var(--text-dim); }
+
+.btn-secondary, .btn-primary { padding: 0.4rem 0.85rem; border-radius: 6px; font-size: var(--fs-md); font-weight: 600; cursor: pointer; }
+.btn-secondary { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim); }
+.btn-secondary:hover { border-color: var(--text-muted); color: var(--text); }
+.btn-primary { background: var(--accent); border: 1px solid var(--accent); color: var(--on-accent); }
+.btn-primary:hover:not(:disabled) { background: var(--accent-bright); }
+.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* ── Catálogo ── */
+.tag-grid {
+  list-style: none; margin: 0; padding: 0;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 0.5rem;
+}
+
+.tag-card {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.55rem 0.6rem;
+  background: var(--surface); border: 1px solid var(--border-med); border-radius: 8px;
+  transition: border-color var(--transition), background var(--transition);
+}
+.tag-card:hover { border-color: var(--accent); }
+.tag-card--selected { background: var(--accent-dim); border-color: var(--accent); }
+
+.tag-main {
+  flex: 1; min-width: 0;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 0.25rem;
+  background: none; border: none; text-align: left; cursor: pointer;
+}
+.tag-meta { font-size: var(--fs-caption); color: var(--text-muted); }
+
+.btn-icon {
+  width: 28px; height: 28px; flex-shrink: 0;
+  display: grid; place-items: center;
+  background: transparent; border: 1px solid var(--border-med); border-radius: 6px;
+  color: var(--text-muted); cursor: pointer;
+  transition: border-color var(--transition), color var(--transition);
+}
+.btn-icon svg { width: 14px; height: 14px; }
+.btn-icon--danger:hover { border-color: var(--danger); color: var(--danger); }
+
+/* ── Quién la lleva ── */
+.carriers { margin-top: 1.6rem; padding-top: 1.1rem; border-top: 1px solid var(--border-med); }
+.carriers-title { margin: 0 0 0.6rem; font-size: var(--fs-lg); font-weight: 600; color: var(--text); }
+.carriers-empty { margin: 0; font-size: var(--fs-md); color: var(--text-muted); }
+.carriers-list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 0.4rem; }
+
+.carrier {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.3rem 0.6rem;
+  background: var(--surface); border: 1px solid var(--border-med); border-radius: 6px;
+  color: var(--text-dim); font-size: var(--fs-sm); text-decoration: none;
+  transition: border-color var(--transition), color var(--transition);
+}
+.carrier:hover { border-color: var(--accent); color: var(--text); }
+
+.pulse { width: 8px; height: 8px; flex-shrink: 0; border-radius: 50%; background: var(--text-muted); }
+.pulse--online { background: var(--success); }
+.pulse--stale { background: var(--warn); }
+.pulse--offline { background: var(--danger); }
+
+/* ── Estados ── */
+.state-msg { margin: 2rem 0; text-align: center; color: var(--text-muted); font-size: var(--fs-body); }
+.state-msg--error { color: var(--danger); }
+.retry {
+  margin-left: 0.5rem; padding: 0.2rem 0.6rem;
+  background: transparent; border: 1px solid var(--danger); border-radius: 6px;
+  color: var(--danger); font-size: var(--fs-sm); cursor: pointer;
+}
+
+.state-empty { padding: 2.4rem 1rem; text-align: center; border: 1px dashed var(--border-med); border-radius: 8px; }
+.empty-title { margin: 0 0 0.25rem; font-size: var(--fs-lg); color: var(--text-dim); }
+.empty-sub { margin: 0; font-size: var(--fs-body); color: var(--text-muted); }
+
+.tag-main:focus-visible, .btn-icon:focus-visible, .btn-new:focus-visible,
+.scope-btn:focus-visible, .swatch:focus-visible, .carrier:focus-visible {
+  outline: 2px solid var(--accent-bright); outline-offset: 2px;
+}
+</style>

--- a/web/app/src/views/HygeiaView.vue
+++ b/web/app/src/views/HygeiaView.vue
@@ -15,6 +15,7 @@
           @delete="handleDeleteRequest"
           @rotate="handleRotate"
           @toggle-persistent="handleTogglePersistent"
+          @tag="handleTagRequest"
           @refresh="refreshNow"
         />
       </section>
@@ -60,6 +61,16 @@
       :show="!!store.state.lastAgentKey"
       :agent-key="store.state.lastAgentKey || ''"
       @close="store.clearAgentKey()"
+    />
+
+    <AssetTagsModal
+      :show="!!taggingAsset"
+      :asset="taggingAsset"
+      :tags="tagsStore.state.tags"
+      :submitting="savingTags"
+      :error="tagsError"
+      @submit="handleTagsSubmit"
+      @close="closeTagsModal"
     />
 
     <ConfirmModal
@@ -125,14 +136,17 @@ import AssetList from '@/components/hygeia/AssetList.vue'
 import AssetDetail from '@/components/hygeia/AssetDetail.vue'
 import CreateAssetModal from '@/components/hygeia/CreateAssetModal.vue'
 import AgentKeyModal from '@/components/hygeia/AgentKeyModal.vue'
+import AssetTagsModal from '@/components/hygeia/AssetTagsModal.vue'
 import InventoryAnalysisModal from '@/components/hygeia/InventoryAnalysisModal.vue'
 import { usePolling } from '@/composables/usePolling'
 import { useHygeiaStore } from '@/stores/hygeiaStore'
 import { useHygeiaAlertsStore } from '@/stores/hygeiaAlertsStore'
+import { useHygeiaTagsStore } from '@/stores/hygeiaTagsStore'
 import { useToastStore } from '@/stores/toastStore'
 
 const store = useHygeiaStore()
 const alerts = useHygeiaAlertsStore()
+const tagsStore = useHygeiaTagsStore()
 const toast = useToastStore()
 const router = useRouter()
 
@@ -143,6 +157,9 @@ const pendingRotateId = ref(null)
 const pendingDeleteAnomalyId = ref(null)
 const pendingReanalyze = ref(false)
 const showAnalysisModal = ref(false)
+const taggingAssetId = ref(null)
+const savingTags = ref(false)
+const tagsError = ref('')
 
 const selectedAsset = computed(() =>
   store.state.assets.find((a) => a.id === store.state.selectedId) || null
@@ -150,6 +167,12 @@ const selectedAsset = computed(() =>
 
 const assetAnomalies = computed(() =>
   alerts.state.anomalies.filter((a) => a.assetId === store.state.selectedId)
+)
+
+// Se resuelve contra la lista en vez de guardar el objeto: así el modal ve las
+// etiquetas actualizadas después de guardar, sin tener que refrescarlo a mano.
+const taggingAsset = computed(() =>
+  store.state.assets.find((a) => a.id === taggingAssetId.value) || null
 )
 
 /**
@@ -201,6 +224,62 @@ async function handleTogglePersistent(id) {
       : `«${asset.hostname}» se marca como host que se apaga a propósito: no se avisará de sus caídas.`,
     'success',
   )
+}
+
+/* ── Etiquetas ── */
+
+function handleTagRequest(id) {
+  tagsError.value = ''
+  taggingAssetId.value = id
+}
+
+function closeTagsModal() {
+  taggingAssetId.value = null
+  tagsError.value = ''
+}
+
+/**
+ * Guarda las etiquetas de un activo en una sola pasada.
+ *
+ * Lo escrito en el modal y no existente se crea antes en el repositorio
+ * personal; después va un único `PUT` con el conjunto definitivo. Si falla
+ * el alta de alguna, se para ahí: asignar un conjunto incompleto sería peor
+ * que no asignar nada, porque el `PUT` reemplaza y se llevaría por delante
+ * las que sí estaban.
+ */
+async function handleTagsSubmit({ tagIds, newTags }) {
+  const assetId = taggingAssetId.value
+  if (!assetId) return
+
+  savingTags.value = true
+  tagsError.value = ''
+  try {
+    const finalIds = [...tagIds]
+    for (const pending of newTags) {
+      const created = await tagsStore.createTag(pending)
+      if (!created) {
+        tagsError.value = tagsStore.state.error || 'No se pudo crear la etiqueta.'
+        return
+      }
+      finalIds.push(created.id)
+    }
+
+    const before = (taggingAsset.value?.tags ?? []).map((tag) => tag.id)
+    const ok = await store.setAssetTags(assetId, finalIds)
+    if (!ok) {
+      tagsError.value = store.state.error || 'No se pudieron guardar las etiquetas.'
+      return
+    }
+
+    tagsStore.adjustCounts(
+      finalIds.filter((id) => !before.includes(id)),
+      before.filter((id) => !finalIds.includes(id)),
+    )
+    closeTagsModal()
+    toast.show('Etiquetas actualizadas.', 'success')
+  } finally {
+    savingTags.value = false
+  }
 }
 
 function handleDeleteRequest(id) {
@@ -353,7 +432,9 @@ async function poll() {
 const poller = usePolling(poll, { intervalMs: POLL_MS, immediate: false })
 
 onMounted(async () => {
-  await store.fetchAssets()
+  // El catálogo no entra en el sondeo: solo cambia cuando el propio usuario
+  // crea o borra una etiqueta, y de eso ya se entera el store en el momento.
+  await Promise.all([store.fetchAssets(), tagsStore.fetchTags()])
   if (store.state.assets.length) {
     await handleSelect(store.state.assets[0].id)
   }

--- a/web/app/vite.config.js
+++ b/web/app/vite.config.js
@@ -70,6 +70,7 @@ const FRONTEND_SUBROUTES = new Set([
   '/iris/conexiones',
   '/acheron/boveda',
   '/hygeia/activos',
+  '/hygeia/etiquetas',
 ])
 
 function proxyBypass(req) {


### PR DESCRIPTION
Hygeia listaba los activos como una tira plana ordenada por fecha de alta. Con media docena de agentes basta; con treinta no hay forma de agrupar «los de producción» o «los que dan la cara a Internet». La columna `labels` (JSONB) prometía eso y nunca lo cumplió: se acepta en el alta y no la escribe ni la lee nadie. Se deja intacta; esto no la sustituye, la ignora.

`HygeiaTag` es una etiqueta de verdad, compartida entre activos. Dos clases en una sola tabla (herencia single-table por `tag_type`), porque para un activo son la misma cosa —un nombre y un color— y lo único que las distingue es de quién son:

  - SystemTag: catálogo común sin dueño, sembrado por la migración.
  - UserTag: repositorio personal, siempre con dueño y solo para él.

Esa regla vive en el esquema, no solo en el manager: un CheckConstraint impide una etiqueta personal huérfana o una de sistema con dueño. Los dos ondelete CASCADE de `AssetTag` garantizan lo que pide el producto —borrar una etiqueta se lleva sus asociaciones, nunca los activos que la llevaban.

La siembra de las 12 etiquetas va en la migración y no en `_init_db()`, que es destructivo y no se puede ejecutar sobre datos reales: el catálogo tiene que llegar por `alembic upgrade head`.

En la SPA: badges en las filas de activos, filtro conjuntivo por chips, modal para etiquetar un agente (con alta en línea de etiquetas personales, que se crean y se asignan en la misma pasada) y una vista global en /hygeia/etiquetas para buscar, filtrar, crear y borrar.

Sin AttributeType nuevos: una etiqueta es una propiedad de los activos de Hygeia, no un recurso con permiso propio, así que reutilizan los HYGEIA_*.

De paso, `/hygeia/etiquetas` se añade a FRONTEND_SUBROUTES de vite.config: sin eso una carga directa de la URL en desarrollo caía en el proxy hacia Flask en vez de en el SPA.