### PR TITLE
fix(web): el toast se apagaba a los 0.42 s por un bloque CSS legacy

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "test:acheron": "node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
     "test:hygeia": "node test/hygeia.format.test.mjs && node test/hygeia.chartMath.test.mjs",
     "test:polling": "node test/usePolling.test.mjs",
+    "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs"
   },

--- a/web/app/src/assets/css/shared.css
+++ b/web/app/src/assets/css/shared.css
@@ -425,21 +425,14 @@ select option { background: var(--surface); color: var(--text); }
 .btn.loading .btn-spin  { display: inline-block; }
 .btn.loading .btn-label { display: none; }
 
-.toast {
-  position: fixed; bottom: 24px; left: 50%;
-  transform: translateX(-50%) translateY(16px);
-  background: var(--surface-3); border: 1px solid var(--border-med);
-  color: var(--text); font-family: var(--font-body); font-size-adjust: var(--fsa-body); font-size: var(--fs-md);
-  padding: 10px 18px; border-radius: var(--radius);
-  opacity: 0; pointer-events: none;
-  transition: opacity 0.22s ease, transform 0.22s ease;
-  z-index: 9999; white-space: nowrap;
-}
-.toast.visible         { opacity: 1; transform: translateX(-50%) translateY(0); }
-.toast--error    { border-color: var(--danger);  color: var(--danger);  }
-.toast--success  { border-color: var(--success); color: var(--success); }
-.toast--warn     { border-color: var(--warn);    color: var(--warn);    }
-.toast--info     { border-color: var(--accent);  color: var(--accent);  }
+/* Aquí vivían los estilos del `SeqToast` legacy (`.toast`, `.toast.visible`,
+   `.toast--*`). El toast lo renderiza AppToast.vue desde la migración a Vue
+   (cdf50d35) con sus propios estilos scoped, y nada volvió a poner la clase
+   `visible`, así que este bloque quedó muerto — pero no inerte: al ser global
+   seguía ganando en toda propiedad que el bloque scoped no declarase. Su
+   `opacity: 0` volvía el toast invisible en cuanto Vue retiraba
+   `.toast-enter-active` al acabar la animación de entrada (0.42 s), y su
+   `left: 50%` + `transform: translateX(-50%)` lo descolocaban. Ver #127. */
 
 .badge {
   display: inline-block; padding: 2px 7px; border-radius: 4px;

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -94,6 +94,13 @@ const toast = useToastStore()
   animation: toast-out 0.22s ease-in both;
 }
 
+/* Estado inicial de la entrada y final de la salida. En el caso normal los
+   `@keyframes` lo pisan, pero son lo único que queda cuando reduced-motion
+   anula la animación: sin estas dos reglas ahí no había nada que transicionar
+   y el fundido declarado más abajo era un corte seco. */
+.toast-enter-from,
+.toast-leave-to { opacity: 0; }
+
 @keyframes toast-in {
   0% { opacity: 0; transform: translate3d(0, 1.2rem, 0) scale(0.96); filter: blur(4px); }
   65% { opacity: 1; transform: translate3d(0, -0.15rem, 0) scale(1.005); filter: blur(0); }

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -46,7 +46,6 @@ const toast = useToastStore()
   position: fixed; bottom: 2rem; right: 2rem;
   z-index: 9999;
   pointer-events: none;
-  max-width: min(460px, calc(100vw - 2rem));
 }
 
 .toast {
@@ -56,7 +55,10 @@ const toast = useToastStore()
   font-size: var(--fs-body); font-weight: 500; line-height: 1.35;
   background: var(--surface-3); border: 1px solid var(--border);
   color: var(--text);
-  max-width: 100%; max-height: 7.5rem; overflow-y: auto;
+  /* El tope va aquí y no en la región: la región es `position: fixed` sin
+     ancho, o sea shrink-to-fit, y un `max-width: 100%` del hijo contra eso es
+     circular — el navegador lo ignora y el toast se estira más de la cuenta. */
+  max-width: min(460px, calc(100vw - 2rem)); max-height: 7.5rem; overflow-y: auto;
   overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap;
   backdrop-filter: blur(12px);
   box-shadow: 0 12px 32px rgba(0,0,0,0.34);
@@ -118,11 +120,8 @@ const toast = useToastStore()
 }
 
 @media (max-width: 560px) {
-  .toast-region {
-    right: 1rem; bottom: 1rem;
-    max-width: calc(100vw - 2rem);
-  }
-  .toast { align-items: flex-start; }
+  .toast-region { right: 1rem; bottom: 1rem; }
+  .toast { align-items: flex-start; max-width: calc(100vw - 2rem); }
   .toast__action { white-space: normal; }
 }
 

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -5,31 +5,53 @@ const toast = useToastStore()
 
 <template>
   <Teleport to="body">
-    <Transition name="toast">
-      <div v-if="toast.visible" :key="toast.id" class="toast"
-           :class="toast.type ? `toast--${toast.type}` : ''"
-           role="alert" aria-live="assertive">
-        <span class="toast__message">{{ toast.message }}</span>
-        <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
-                    @click="toast.dismiss">
-          {{ toast.action.label }}
-        </RouterLink>
-        <button type="button" class="toast__close" aria-label="Cerrar notificación"
-                @click="toast.dismiss">&times;</button>
-      </div>
-    </Transition>
+    <!--
+      La región live está siempre montada, aunque no haya toast. Un `aria-live`
+      solo se anuncia si ya existía en el DOM antes de que cambie su contenido;
+      cuando el `role="alert"` iba en el <div> del toast, que nace y muere con
+      el v-if, los lectores de pantalla no decían nada.
+
+      El toast tampoco lleva ya `:key`: con un único elemento bajo `v-if` la
+      clave es redundante (el <div> se crea de cero al pasar de oculto a
+      visible, y la animación de entrada corre igual), y cambiarla mientras la
+      salida seguía animando metía el entrante y el saliente a la vez en el DOM
+      — dos toasts `position: fixed` superpuestos en el mismo píxel.
+    -->
+    <div class="toast-region" role="alert" aria-live="assertive" aria-atomic="true">
+      <Transition name="toast">
+        <div v-if="toast.visible" class="toast"
+             :class="toast.type ? `toast--${toast.type}` : ''">
+          <span class="toast__message">{{ toast.message }}</span>
+          <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
+                      @click="toast.dismiss">
+            {{ toast.action.label }}
+          </RouterLink>
+          <button type="button" class="toast__close" aria-label="Cerrar notificación"
+                  @click="toast.dismiss">&times;</button>
+        </div>
+      </Transition>
+    </div>
   </Teleport>
 </template>
 
 <style scoped>
-.toast {
+/* El posicionamiento vive en la región, no en el toast: la región está montada
+   siempre, así que no debe interceptar clics cuando está vacía. */
+.toast-region {
   position: fixed; bottom: 2rem; right: 2rem;
+  z-index: 9999;
+  pointer-events: none;
+  max-width: min(460px, calc(100vw - 2rem));
+}
+
+.toast {
+  pointer-events: auto;
   display: flex; align-items: center; gap: 0.75rem;
   padding: 0.8rem 0.8rem 0.8rem 1.1rem; border-radius: 8px;
   font-size: var(--fs-body); font-weight: 500; line-height: 1.35;
   background: var(--surface-3); border: 1px solid var(--border);
-  color: var(--text); z-index: 9999;
-  max-width: min(460px, calc(100vw - 2rem)); max-height: 7.5rem; overflow-y: auto;
+  color: var(--text);
+  max-width: 100%; max-height: 7.5rem; overflow-y: auto;
   overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap;
   backdrop-filter: blur(12px);
   box-shadow: 0 12px 32px rgba(0,0,0,0.34);
@@ -84,11 +106,11 @@ const toast = useToastStore()
 }
 
 @media (max-width: 560px) {
-  .toast {
+  .toast-region {
     right: 1rem; bottom: 1rem;
-    align-items: flex-start;
     max-width: calc(100vw - 2rem);
   }
+  .toast { align-items: flex-start; }
   .toast__action { white-space: normal; }
 }
 

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -19,8 +19,13 @@ const toast = useToastStore()
     -->
     <div class="toast-region" role="alert" aria-live="assertive" aria-atomic="true">
       <Transition name="toast">
+        <!-- La cuenta atrás se congela mientras el toast se lee o se recorre
+             con el teclado; `focusin`/`focusout` burbujean, así que cubren
+             también el enlace de acción y el botón de cerrar. -->
         <div v-if="toast.visible" class="toast"
-             :class="toast.type ? `toast--${toast.type}` : ''">
+             :class="toast.type ? `toast--${toast.type}` : ''"
+             @mouseenter="toast.pause" @mouseleave="toast.resume"
+             @focusin="toast.pause" @focusout="toast.resume">
           <span class="toast__message">{{ toast.message }}</span>
           <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
                       @click="toast.dismiss">

--- a/web/app/src/stores/toastStore.js
+++ b/web/app/src/stores/toastStore.js
@@ -26,8 +26,6 @@ export const useToastStore = defineStore('toast', () => {
   const visible = ref(false)
   /** @type {import('vue').Ref<{label: string, to: string}|null>} Acción opcional */
   const action = ref(null)
-  /** Clave para reanudar la animación de entrada entre toasts distintos. */
-  const id = ref(0)
 
   /** @type {number|null} Referencia al timeout de auto-ocultación */
   let timer = null
@@ -46,11 +44,10 @@ export const useToastStore = defineStore('toast', () => {
     message.value = msg
     type.value = variant || ''
     action.value = nextAction
-    // Solo se anima la entrada cuando el toast no está visible. Si ya hay uno
-    // mostrándose, se actualiza en el sitio: cambiar `id` reemplazaría el
-    // elemento y `mode="out-in"` haría la animación de salida+entrada
-    // (doble amago de aparecer) aunque sea el mismo aviso.
-    if (!visible.value) id.value += 1
+    // Si ya hay un toast mostrándose se actualiza en el sitio, sin reanimar:
+    // `visible` no cambia, así que Vue no recrea el elemento. Cuando no lo
+    // hay, el `v-if` del componente crea el <div> de cero y la animación de
+    // entrada corre sola — no hace falta ninguna clave que la fuerce.
     visible.value = true
     timer = setTimeout(dismiss, duration)
   }
@@ -62,5 +59,5 @@ export const useToastStore = defineStore('toast', () => {
     visible.value = false
   }
 
-  return { message, type, visible, action, id, show, dismiss }
+  return { message, type, visible, action, show, dismiss }
 })

--- a/web/app/src/stores/toastStore.js
+++ b/web/app/src/stores/toastStore.js
@@ -1,5 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { readonly, ref } from 'vue'
+
+/** Milisegundos que dura un toast si no se pide otra cosa. */
+const DEFAULT_DURATION_MS = 7000
 
 /**
  * Store de notificaciones toast — mensajes temporales no bloqueantes.
@@ -13,6 +16,7 @@ import { ref } from 'vue'
  * const toast = useToastStore()
  * toast.show('Escaneo completado', 'success')
  * toast.show('Error de conexión', 'error', 5000)
+ * toast.show('Revisa esto antes de seguir', 'warn', 0)  // no se cierra solo
  */
 export const useToastStore = defineStore('toast', () => {
   /** @type {import('vue').Ref<string>} Texto del mensaje */
@@ -27,20 +31,42 @@ export const useToastStore = defineStore('toast', () => {
   /** @type {import('vue').Ref<{label: string, to: string}|null>} Acción opcional */
   const action = ref(null)
 
-  /** @type {number|null} Referencia al timeout de auto-ocultación */
+  /** @type {number|null} Timeout de auto-ocultación; `null` si no hay cuenta atrás. */
   let timer = null
+  /** Milisegundos que le quedaban al toast la última vez que se armó el timeout. */
+  let remainingMs = 0
+  /** `Date.now()` de ese último armado, para saber cuánto se ha consumido. */
+  let startedAt = 0
+
+  /**
+   * Arranca la cuenta atrás de cierre. Se mide contra el reloj de pared en vez
+   * de fiarse del timeout, porque `pause()` puede pararla a mitad y hay que
+   * saber exactamente cuánto quedaba.
+   *
+   * @param {number} durationMs - `<= 0` (o no numérico) deja el toast fijo.
+   */
+  function armTimer(durationMs) {
+    clearTimeout(timer)
+    timer = null
+    remainingMs = durationMs
+    // Un toast persistente es una petición legítima (un aviso que el usuario
+    // debe cerrar a mano). Antes `duration = 0` se traducía en
+    // `setTimeout(dismiss, 0)`, o sea desaparecía en el mismo frame.
+    if (!(durationMs > 0)) return
+    startedAt = Date.now()
+    timer = setTimeout(dismiss, durationMs)
+  }
 
   /**
    * Muestra un toast con el mensaje y tipo especificados.
    * Si ya hay otro toast visible, lo reemplaza (resetea el temporizador).
    *
    * @param {string} msg - Texto a mostrar
-   * @param {'success'|'error'|'warn'|'info'|''} [type='success'] - Variante visual
-   * @param {number} [duration=7000] - Milisegundos antes de ocultarse
+   * @param {'success'|'error'|'warn'|'info'|''} [variant='success'] - Variante visual
+   * @param {number} [duration=7000] - Milisegundos antes de ocultarse; `<= 0` lo deja fijo
    * @param {{label: string, to: string}|null} [nextAction=null] - Acción interna opcional
    */
-  function show(msg, variant = 'success', duration = 7000, nextAction = null) {
-    clearTimeout(timer)
+  function show(msg, variant = 'success', duration = DEFAULT_DURATION_MS, nextAction = null) {
     message.value = msg
     type.value = variant || ''
     action.value = nextAction
@@ -49,15 +75,55 @@ export const useToastStore = defineStore('toast', () => {
     // hay, el `v-if` del componente crea el <div> de cero y la animación de
     // entrada corre sola — no hace falta ninguna clave que la fuerce.
     visible.value = true
-    timer = setTimeout(dismiss, duration)
+    armTimer(duration)
+  }
+
+  /**
+   * Congela la cuenta atrás guardando lo que quedaba. Se llama al pasar el
+   * ratón o el foco por encima: el toast puede traer un error de validación
+   * largo (con scroll propio, ver `max-height` en AppToast.vue) y cerrarlo a
+   * los 7 s mientras se lee lo deja irrecuperable.
+   */
+  function pause() {
+    // Sin timeout no hay nada que congelar: o ya está pausado, o es persistente.
+    if (!timer) return
+    clearTimeout(timer)
+    timer = null
+    const pending = remainingMs - (Date.now() - startedAt)
+    // Si el navegador estranguló el timeout y el tiempo ya se había agotado, se
+    // cierra en vez de guardar un cero: `remainingMs === 0` significa "toast
+    // persistente", y confundir ambos casos dejaría el toast fijo para siempre.
+    if (pending <= 0) { dismiss(); return }
+    remainingMs = pending
+  }
+
+  /** Reanuda la cuenta atrás con el tiempo que quedaba al pausar. */
+  function resume() {
+    // Sin toast, con cuenta atrás ya corriendo, o persistente (`remainingMs`
+    // en 0): no hay nada que reanudar.
+    if (timer || !visible.value || remainingMs <= 0) return
+    armTimer(remainingMs)
   }
 
   /** Oculta el toast inmediatamente y cancela su cierre automático. */
   function dismiss() {
     clearTimeout(timer)
     timer = null
+    remainingMs = 0
     visible.value = false
   }
 
-  return { message, type, visible, action, show, dismiss }
+  // Solo lectura hacia fuera: el estado se cambia por `show`/`dismiss`, que son
+  // quienes mantienen el timeout en sincronía. Un `toast.visible = false` suelto
+  // dejaba un `setTimeout` huérfano que cerraba el toast siguiente antes de tiempo.
+  return {
+    message: readonly(message),
+    type: readonly(type),
+    visible: readonly(visible),
+    action: readonly(action),
+    show,
+    pause,
+    resume,
+    dismiss,
+  }
 })

--- a/web/app/test/toastStore.test.mjs
+++ b/web/app/test/toastStore.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Tests de `toastStore` — la cuenta atrás del toast (#127).
+ *
+ * Node puro, sin framework, misma convención que el resto de `test/`.
+ * Con timers reales y duraciones cortas, como en `usePolling.test.mjs`.
+ *
+ * Lo que se comprueba es justo lo que el store hacía mal:
+ *   - que `duration <= 0` sea un toast persistente y no uno que desaparece
+ *     en el mismo frame (`setTimeout(dismiss, 0)`);
+ *   - que `pause()`/`resume()` conserven el tiempo que quedaba en vez de
+ *     reiniciarlo o perderlo;
+ *   - que `dismiss()` no deje un timeout huérfano capaz de cerrar el toast
+ *     siguiente antes de tiempo.
+ */
+
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { useToastStore } = await import('../src/stores/toastStore.js')
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms))
+
+let failures = 0
+async function test(name, fn) {
+  setActivePinia(createPinia())   // store limpio por test
+  try { await fn(); console.log(`  ok   ${name}`) }
+  catch (err) { failures++; console.error(`  FAIL ${name}\n       ${err.message}`) }
+}
+
+console.log('toastStore')
+
+await test('duration <= 0 deja el toast fijo', async () => {
+  const toast = useToastStore()
+  toast.show('persistente', 'warn', 0)
+  assert.equal(toast.visible, true)
+  await sleep(80)
+  assert.equal(toast.visible, true, 'se cerro solo pese a pedir duracion 0')
+  toast.dismiss()
+  assert.equal(toast.visible, false, 'dismiss() no cierra el toast persistente')
+})
+
+await test('se cierra solo al agotar su duracion', async () => {
+  const toast = useToastStore()
+  toast.show('efimero', 'info', 60)
+  await sleep(30)
+  assert.equal(toast.visible, true, 'se cerro antes de tiempo')
+  await sleep(60)
+  assert.equal(toast.visible, false, 'no se cerro al agotarse')
+})
+
+await test('pause() congela la cuenta atras', async () => {
+  const toast = useToastStore()
+  toast.show('leyendome', 'error', 60)
+  await sleep(30)
+  toast.pause()
+  await sleep(120)              // el doble de su duracion, en pausa
+  assert.equal(toast.visible, true, 'se cerro estando pausado')
+})
+
+await test('resume() reanuda con lo que quedaba, no con la duracion entera', async () => {
+  const toast = useToastStore()
+  toast.show('leyendome', 'error', 100)
+  await sleep(70)              // consumidos ~70, quedan ~30
+  toast.pause()
+  await sleep(50)
+  toast.resume()
+  await sleep(10)
+  assert.equal(toast.visible, true, 'se cerro antes de agotar lo que quedaba')
+  await sleep(60)              // sobrado para esos ~30 restantes
+  assert.equal(toast.visible, false, 'reanudo con la duracion entera en vez de con el resto')
+})
+
+await test('resume() no revive un toast ya cerrado', async () => {
+  const toast = useToastStore()
+  toast.show('efimero', 'info', 30)
+  await sleep(60)
+  assert.equal(toast.visible, false)
+  toast.resume()
+  assert.equal(toast.visible, false, 'resume() reabrio un toast cerrado')
+})
+
+await test('dismiss() no deja un timeout que cierre el toast siguiente', async () => {
+  const toast = useToastStore()
+  toast.show('primero', 'success', 40)
+  await sleep(10)
+  toast.dismiss()              // quedaban ~30 ms del primero
+  toast.show('segundo', 'success', 120)
+  await sleep(60)              // el timeout huerfano ya habria disparado
+  assert.equal(toast.visible, true, 'el timeout del primer toast cerro al segundo')
+  assert.equal(toast.message, 'segundo')
+})
+
+await test('un show() sobre un toast visible reinicia la cuenta atras', async () => {
+  const toast = useToastStore()
+  toast.show('primero', 'success', 60)
+  await sleep(45)
+  toast.show('segundo', 'error', 60)
+  await sleep(40)              // el primero ya habria expirado
+  assert.equal(toast.visible, true, 'el reemplazo heredo la cuenta atras del anterior')
+  assert.equal(toast.message, 'segundo')
+  assert.equal(toast.type, 'error')
+})
+
+console.log(failures ? `\n${failures} test(s) fallaron` : '\nTodos los tests de toastStore pasaron')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
Cierra #127.

El toast entraba con su animación y **se apagaba a los 0.42 s**, mientras el store lo daba por visible 7 s. Cinco commits, uno por fase.

## La causa raíz no estaba en `AppToast.vue`

`shared.css` seguía llevando el bloque `.toast` del `SeqToast` legacy, de antes de la migración a Vue (`cdf50d35`). Nada volvió a poner la clase `visible` que lo activaba, así que era código muerto — pero no inerte: al ser **global** ganaba en toda propiedad que el `<style scoped>` de `AppToast.vue` no declarase, y ese bloque scoped nunca declaró `opacity`, `left` ni `transform`.

```css
.toast { ...; opacity: 0; pointer-events: none; left: 50%; transform: translateX(-50%) translateY(16px); }
.toast.visible { opacity: 1; ... }   /* clase que ya nadie pone */
```

En cuanto Vue retiraba `.toast-enter-active` al acabar la animación de entrada, el `opacity: 0` global tomaba el control. Salió al verificar en el navegador, no del análisis estático: leyendo sólo el `<style scoped>` no se ve.

## Fases

| Commit | Qué |
|---|---|
| `2f5e7396` | Región `aria-live` permanente; fuera `:key` e `id` |
| `5cb7242b` | `.toast-enter-from` / `.toast-leave-to`, que no existían |
| `dd4985d4` | `duration <= 0` persistente; pausa al hover/foco; refs `readonly` |
| `2450362a` | `test/toastStore.test.mjs` |
| `f6cc33db` | Borrado del bloque legacy de `shared.css` |

**Región live permanente.** El `role="alert"` iba en el `<div>` que nace y muere con el `v-if`. Un `aria-live` sólo se anuncia si ya existía en el DOM antes de que cambie su contenido, así que ningún lector de pantalla decía nada. La región ahora vive siempre montada, 0×0 y con `pointer-events: none` cuando está vacía (verificado: no intercepta clics).

**Fuera `:key`.** Con un único elemento bajo `v-if` la clave es redundante — el `<div>` se crea de cero al pasar de oculto a visible y la animación corre igual — pero sí hacía daño: un `show()` durante los 0.22 s de la salida veía `visible` en `false`, incrementaba `id` y ponía `visible` a `true` a la vez, y sin `mode` (retirado en `05c362c2`) entrante y saliente coexistían como dos toasts superpuestos en el mismo píxel. Es el mismo "doble amago" que `05c362c2` creía cerrar, sólo que movido a la ventana de salida.

**`-from` / `-to`.** El bloque `prefers-reduced-motion` anulaba `animation` y declaraba `transition: opacity 0.12s`, pero esas dos clases no existían en todo `src/`: la animación vivía entera en los `@keyframes`. La opacidad nunca cambiaba, así que el fallback era un corte seco.

**Persistente y pausa.** `duration = 0` era `setTimeout(dismiss, 0)`: desaparecía en el mismo frame. Ahora `<= 0` deja el toast fijo. `pause()`/`resume()` congelan la cuenta atrás con el ratón o el foco encima — el toast declara `max-height: 7.5rem; overflow-y: auto` porque los mensajes de `apiError` propagan errores de validación 422, que son largos, y cerrarlo a los 7 s mientras se lee dejaba el mensaje irrecuperable. El tiempo restante se mide con `Date.now()`, no con el timeout, para que pausar y reanudar no derive.

**Las 181 llamadas a `toast.show()` de los 24 archivos consumidores no se tocan**: la firma no cambia.

## Verificación

- `npm run build` limpio.
- `npm run test:toast` (nuevo, script añadido): 7 tests en verde. Contra el store previo al arreglo fallan 4 de los 7; los otros 3 son guardas de regresión.
- Dev server + DOM real: `opacity` computada tras retirar las clases de entrada pasa de `0` a `1`; región vacía 0×0 sin interceptar clics; toast en flujo dentro de la región a 460×90 px, topado en 460 y a 2 rem del borde; borde `--danger` en la variante `error`; pausa/reanudación probada con eventos `mouseenter`/`mouseleave` reales.

Sin capturas: el panel del navegador no compone frames en esta sesión, así que las comprobaciones son de DOM y estilo computado, no visuales. Merece un vistazo a ojo antes de mergear.

## Fuera de alcance

**Cola real de toasts.** Un `show()` sobre un toast visible sustituye el texto in situ, así que dos avisos seguidos se comen entre sí — reproducible en `QueueView.vue:96`, que lanza `loadStatus()` y `loadTasks()` y con la API caída emite dos toasts de error de los que sólo se ve uno. Pide `<TransitionGroup>` sobre un array y layout apilado; lo suyo es medirlo con esto ya arreglado y abrirlo aparte si sigue molestando.

Dos detalles menores del #127 se quedan sin tocar a propósito, ambos cosméticos y sin efecto visible: el autocierre llama a la función local en vez de a la acción envuelta por Pinia (arreglarlo pide una autorreferencia al store para ganar sólo `$onAction` en devtools), y `setTimeout` sigue estrangulándose en pestañas en segundo plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
