### PR TITLE
feat(aegis): modal dedicado para los productos vigilados

### DIFF
--- a/web/app/src/components/aegis/OrgProfilePanel.vue
+++ b/web/app/src/components/aegis/OrgProfilePanel.vue
@@ -11,11 +11,8 @@
     </button>
 
     <p v-if="!expanded" class="op-summary">
-      {{ store.tweaks.company || "Sin configurar todavía" }}
-      <span v-if="usingInventory"> · productos de mis agentes</span>
-      <span v-else-if="store.trackedProducts.length">
-        · {{ store.trackedProducts.length }} producto(s)</span
-      >
+      {{ store.tweaks.company || "Sin configurar todavía" }} ·
+      {{ productsSummary }}
     </p>
 
     <div class="op-collapse" :class="{ expanded }">
@@ -140,71 +137,20 @@
             </div>
           </div>
 
-          <!-- Solo se ofrece si hay algún agente que haya reportado
-               inventario; si no, la preferencia queda latente. -->
-          <div class="form-group" v-if="store.hygeiaInventoryAvailable">
-            <label class="switch-row">
-              <input type="checkbox" v-model="store.useHygeiaInventory" />
-              <span>
-                Deducir los productos de mis agentes
-                <small
-                  >Usa el software que Hygeia inventaría en tus activos en
-                  lugar de la lista de abajo.</small
-                >
-              </span>
-            </label>
-          </div>
-
-          <div class="form-group" :class="{ 'form-group--muted': usingInventory }">
-            <label for="op-products">Productos vigilados</label>
-            <p class="field-hint" v-if="usingInventory">
-              Ahora mismo se usan los de tus agentes. Esta lista queda como
-              alternativa si desactivas la opción de arriba.
-            </p>
-
-            <div class="selected-brands" v-if="store.trackedProducts.length">
-              <span
-                v-for="p in store.trackedProducts"
-                :key="`${p.vendor}:${p.product}`"
-                class="brand-tag"
-              >
-                {{ p.vendor }}<template v-if="p.product"> · {{ p.product }}</template>
-                <button
-                  type="button"
-                  class="brand-remove"
-                  :aria-label="`Quitar ${p.vendor} ${p.product}`"
-                  @click="store.removeTrackedProduct(p)"
-                >
-                  &times;
-                </button>
-              </span>
-            </div>
-
-            <input
-              id="op-products"
-              v-model="productQuery"
-              type="search"
-              class="input"
-              placeholder="Busca un producto: windows, firefox, apache…"
-              autocomplete="off"
-              @input="onProductQuery"
-            />
-            <p class="field-hint" v-if="store.searchingProducts">Buscando…</p>
-            <p
-              class="field-hint"
-              v-else-if="productQuery.trim().length >= 2 && !store.productResults.length"
+          <!-- El buscador y el interruptor de inventario viven ahora en su
+               propio modal: en 400 px de panel no cabían. La lista de
+               seleccionados crecía sin tope y empujaba el buscador, y la de
+               resultados desplazaba al botón de guardar. -->
+          <div class="form-group">
+            <label>Productos vigilados</label>
+            <button
+              type="button"
+              class="products-btn"
+              @click="productsModalOpen = true"
             >
-              Sin coincidencias en el catálogo de vulnerabilidades.
-            </p>
-
-            <ul class="product-results" v-if="store.productResults.length">
-              <li v-for="p in store.productResults" :key="`${p.vendor}:${p.product}`">
-                <button type="button" @click="pickProduct(p)">
-                  <span class="product-name">{{ p.displayName }}</span>
-                  <span class="product-cpe">{{ p.vendor }}:{{ p.product }}</span>
-                </button>
-              </li>
-            </ul>
+              <span>Gestionar productos</span>
+              <span class="products-count">{{ productsSummary }}</span>
+            </button>
           </div>
 
           <button
@@ -225,12 +171,18 @@
         </div>
       </div>
     </div>
+
+    <TrackedProductsModal
+      :show="productsModalOpen"
+      @close="productsModalOpen = false"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useAegisStore } from "@/stores/aegisStore";
+import TrackedProductsModal from "./TrackedProductsModal.vue";
 
 const store = useAegisStore();
 
@@ -238,28 +190,24 @@ const store = useAegisStore();
 // mes); expandido si es la primera vez. Se ajusta tras cargar el perfil.
 const expanded = ref(true);
 
-const productQuery = ref("");
+const productsModalOpen = ref(false);
 
 /** Origen efectivo de los productos: los agentes mandan cuando están activos. */
 const usingInventory = computed(
   () => store.hygeiaInventoryAvailable && store.useHygeiaInventory,
 );
 
-// Debounce: cada pulsación consultaría el índice CPE, y el endpoint está
-// limitado a 120 peticiones/hora.
-let queryTimer = null;
-function onProductQuery() {
-  clearTimeout(queryTimer);
-  const term = productQuery.value;
-  queryTimer = setTimeout(() => store.searchProducts(term), 250);
-}
-
-function pickProduct(product) {
-  store.addTrackedProduct(product);
-  productQuery.value = "";
-}
-
-onUnmounted(() => clearTimeout(queryTimer));
+/**
+ * Qué se está vigilando, en una línea. Lo usan el resumen del acordeón
+ * colapsado y el botón que abre el modal: antes cada uno lo calculaba por su
+ * cuenta en el template.
+ */
+const productsSummary = computed(() => {
+  if (usingInventory.value) return "productos de mis agentes";
+  const count = store.trackedProducts.length;
+  if (!count) return "sin productos";
+  return count === 1 ? "1 producto" : `${count} productos`;
+});
 
 async function handleSave() {
   const ok = await store.saveOrgProfile();
@@ -377,103 +325,31 @@ onMounted(async () => {
 .input[type="number"] {
   -moz-appearance: textfield;
 }
-.selected-brands {
+/* ── Acceso al modal de productos vigilados ── */
+.products-btn {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  margin-bottom: 0.3rem;
-}
-.brand-tag {
-  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.15rem 0.4rem;
-  font-size: var(--fs-md);
-  font-weight: 600;
-  background: var(--accent);
-  color: var(--on-accent);
-  border-radius: 4px;
-}
-.brand-remove {
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font-size: var(--fs-xl);
-  padding: 0;
-  line-height: 1;
-  opacity: 0.7;
-}
-.brand-remove:hover {
-  opacity: 1;
-}
-
-/* ── Buscador de productos (índice CPE) ── */
-.field-hint {
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-  margin: 0.2rem 0;
-}
-.form-group--muted .selected-brands,
-.form-group--muted .input {
-  opacity: 0.6;
-}
-.switch-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-.switch-row input {
-  margin-top: 0.25rem;
-  accent-color: var(--accent);
-  flex: 0 0 auto;
-}
-.switch-row small {
-  display: block;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-  font-weight: 400;
-}
-.product-results {
-  list-style: none;
-  margin: 0.3rem 0 0;
-  padding: 0;
-  max-height: 11rem;
-  overflow-y: auto;
-  border: 1px solid var(--border-med);
-  border-radius: var(--radius-sm);
-  background: var(--bg);
-}
-.product-results button {
-  display: flex;
   justify-content: space-between;
-  align-items: baseline;
   gap: 0.5rem;
   width: 100%;
-  padding: 0.4rem 0.55rem;
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  font-family: inherit;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-solid);
+  background: var(--bg);
   color: var(--text);
+  font-family: inherit;
+  font-size: var(--fs-input);
+  cursor: pointer;
+  transition: border-color 0.2s;
 }
-.product-results button:hover {
-  background: var(--accent-dim);
+.products-btn:hover {
+  border-color: var(--accent);
 }
-.product-results button:focus-visible {
-  outline: 2px solid var(--accent-bright);
-  outline-offset: -2px;
-}
-.product-name {
-  font-size: var(--fs-md);
-}
-.product-cpe {
-  font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  flex-shrink: 0;
+.products-count {
+  flex: 0 0 auto;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--accent-bright);
 }
 .btn-save-profile {
   margin-top: 0.2rem;

--- a/web/app/src/components/aegis/TrackedProductsModal.vue
+++ b/web/app/src/components/aegis/TrackedProductsModal.vue
@@ -1,0 +1,513 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <!-- `data-module` va en el overlay, no en la página: Teleport saca este
+           nodo de la raíz de la vista y sin esto el modal heredaría el acento
+           dorado por defecto en vez del de Aegis. -->
+      <div
+        v-if="show"
+        class="tp-overlay"
+        data-module="aegis"
+        @click.self="close"
+      >
+        <!-- Prefijo `tp-` en vez de `modal-`: shared.css define `.modal`,
+             `.modal-header` y compañía de forma global (restos del legacy), y
+             un bloque scoped solo gana en las propiedades que declara — el
+             global se cuela en todas las demás. IrisArchiveModal escapa igual
+             con `archive-`. -->
+        <div
+          ref="boxRef"
+          class="tp-box"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="tp-title"
+        >
+          <div class="tp-header">
+            <h3 id="tp-title">Productos vigilados</h3>
+            <button
+              type="button"
+              class="tp-close"
+              aria-label="Cerrar"
+              title="Cerrar (Esc)"
+              @click="close"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="tp-body">
+            <!-- Solo se ofrece si hay algún agente que haya reportado
+                 inventario; si no, la preferencia queda latente. -->
+            <label v-if="store.hygeiaInventoryAvailable" class="tp-switch">
+              <input type="checkbox" v-model="store.useHygeiaInventory" />
+              <span>
+                Deducir los productos de mis agentes
+                <small
+                  >Usa el software que Hygeia inventaría en tus activos en lugar
+                  de la lista de abajo.</small
+                >
+              </span>
+            </label>
+
+            <p v-if="usingInventory" class="tp-hint">
+              Ahora mismo se usan los de tus agentes. Esta lista queda como
+              alternativa si desactivas la opción de arriba.
+            </p>
+
+            <input
+              id="tp-search"
+              ref="searchRef"
+              v-model="productQuery"
+              type="search"
+              class="tp-search"
+              placeholder="Busca un producto: windows, firefox, apache…"
+              autocomplete="off"
+              @input="onProductQuery"
+            />
+
+            <!-- Un solo hueco para todos los estados, encadenados por
+                 prioridad: lo que esté pasando ahora manda sobre lo anterior. -->
+            <p class="tp-hint" aria-live="polite">
+              <template v-if="store.searchingProducts">Buscando…</template>
+              <template v-else-if="store.productSearchError">{{
+                store.productSearchError
+              }}</template>
+              <template v-else-if="trimmedQuery.length === 1"
+                >Escribe al menos 2 caracteres.</template
+              >
+              <template
+                v-else-if="trimmedQuery.length >= 2 && !store.productResults.length"
+                >Sin coincidencias en el catálogo de vulnerabilidades.</template
+              >
+            </p>
+
+            <ul v-if="store.productResults.length" class="tp-results">
+              <li
+                v-for="p in store.productResults"
+                :key="`${p.vendor}:${p.product}`"
+              >
+                <button type="button" @click="pickProduct(p)">
+                  <span class="tp-name">{{ p.displayName }}</span>
+                  <span class="tp-cpe">{{ p.vendor }}:{{ p.product }}</span>
+                </button>
+              </li>
+            </ul>
+
+            <!-- Los seleccionados van DEBAJO de los resultados, al revés que en
+                 AssetTagsModal: así el buscador y la lista no se desplazan
+                 hacia abajo cada vez que se añade uno, que es justo donde está
+                 mirando el usuario mientras escribe. -->
+            <div class="tp-chosen" :class="{ 'tp-chosen--muted': usingInventory }">
+              <p class="tp-chosen-title">
+                {{ countLabel }}
+              </p>
+              <div v-if="store.trackedProducts.length" class="tp-chips">
+                <span
+                  v-for="p in store.trackedProducts"
+                  :key="`${p.vendor}:${p.product}`"
+                  class="tp-chip"
+                >
+                  {{ p.vendor
+                  }}<template v-if="p.product"> · {{ p.product }}</template>
+                  <button
+                    type="button"
+                    class="tp-chip-remove"
+                    :aria-label="`Quitar ${p.vendor} ${p.product}`"
+                    @click="store.removeTrackedProduct(p)"
+                  >
+                    &times;
+                  </button>
+                </span>
+              </div>
+              <p v-else class="empty-state">Aún no vigilas ningún producto.</p>
+            </div>
+          </div>
+
+          <!-- El pie es hermano de `.tp-body`, no hijo: así queda fuera del
+               scroll y el botón no se mueve por muchos resultados que haya. -->
+          <div class="tp-footer">
+            <p class="tp-save-note">
+              Los cambios se guardan con «Guardar perfil».
+            </p>
+            <button type="button" class="tp-done" @click="close">Listo</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { useAegisStore } from "@/stores/aegisStore";
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+});
+const emit = defineEmits(["close"]);
+
+const store = useAegisStore();
+
+const productQuery = ref("");
+const searchRef = ref(null);
+const boxRef = ref(null);
+
+const trimmedQuery = computed(() => productQuery.value.trim());
+
+/** Origen efectivo de los productos: los agentes mandan cuando están activos. */
+const usingInventory = computed(
+  () => store.hygeiaInventoryAvailable && store.useHygeiaInventory,
+);
+
+const countLabel = computed(() => {
+  const count = store.trackedProducts.length;
+  if (!count) return "Seleccionados";
+  return count === 1 ? "1 producto vigilado" : `${count} productos vigilados`;
+});
+
+// Debounce: cada pulsación consultaría el índice CPE, y el endpoint está
+// limitado a 120 peticiones/hora.
+let queryTimer = null;
+function onProductQuery() {
+  clearTimeout(queryTimer);
+  const term = productQuery.value;
+  queryTimer = setTimeout(() => store.searchProducts(term), 250);
+}
+
+function pickProduct(product) {
+  store.addTrackedProduct(product);
+  productQuery.value = "";
+}
+
+function close() {
+  emit("close");
+}
+
+// Al abrir se parte de cero; al cerrar se sueltan el bloqueo del scroll y el
+// listener global.
+watch(
+  () => props.show,
+  (visible) => {
+    if (visible) {
+      productQuery.value = "";
+      // Con menos de 2 caracteres esto solo limpia resultados y error, sin
+      // llegar a pedir nada. Evita tocar el estado del store a mano.
+      store.searchProducts("");
+      document.body.style.overflow = "hidden";
+      nextTick(() => searchRef.value?.focus());
+      window.addEventListener("keydown", onGlobalKeydown);
+    } else {
+      clearTimeout(queryTimer);
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onGlobalKeydown);
+    }
+  },
+);
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = "";
+  window.removeEventListener("keydown", onGlobalKeydown);
+  clearTimeout(queryTimer);
+});
+
+/**
+ * Escape cierra y Tab queda atrapado dentro del modal. El listener va en
+ * `window` y no como `@keydown.esc` en el overlay: sobre un div solo dispara
+ * si el foco está dentro, que es el fallo que arrastran CampaignModal y
+ * DistributionListsModal.
+ */
+function onGlobalKeydown(e) {
+  if (e.key === "Escape") {
+    close();
+    return;
+  }
+  if (e.key === "Tab") trapFocus(e);
+}
+
+function trapFocus(e) {
+  const root = boxRef.value;
+  if (!root) return;
+  const focusables = Array.from(
+    root.querySelectorAll(
+      'button:not(:disabled), input, [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+<style scoped>
+.tp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+/* `min-height: 0` en toda la cadena flex: sin él un hijo no se encoge por
+   debajo de su contenido y ninguno de los `max-height` de abajo recorta nada
+   — que es exactamente lo que le pasaba al panel. */
+.tp-box {
+  display: flex;
+  flex-direction: column;
+  width: min(560px, 100%);
+  max-height: 85vh;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+.tp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+.tp-header h3 {
+  margin: 0;
+  font-size: var(--fs-xl);
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size-adjust: var(--fsa-display);
+}
+.tp-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--fs-xl);
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+.tp-close:hover {
+  color: var(--text);
+}
+
+.tp-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 0;
+  overflow: hidden;
+  padding: 1rem 1.1rem;
+}
+
+.tp-switch {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text-dim);
+  flex: 0 0 auto;
+}
+.tp-switch input {
+  margin-top: 0.25rem;
+  accent-color: var(--accent);
+  flex: 0 0 auto;
+}
+.tp-switch small {
+  display: block;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.tp-hint {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin: 0;
+  min-height: 1.2em;
+  flex: 0 0 auto;
+}
+
+.tp-search {
+  background: var(--bg);
+  border: 1px solid var(--border-solid);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: var(--text);
+  font-size: var(--fs-input);
+  font-family: inherit;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+  flex: 0 0 auto;
+}
+.tp-search:focus {
+  border-color: var(--accent);
+}
+
+/* Deja de ser in-flow sin tope real: aquí se queda con su alto y hace scroll,
+   en vez de empujar el botón de guardar fuera de la vista. */
+.tp-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 20rem;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-med);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.tp-results button {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  width: 100%;
+  min-width: 0;
+  padding: 0.4rem 0.55rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--text);
+}
+.tp-results button:hover {
+  background: var(--accent-dim);
+}
+.tp-results button:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: -2px;
+}
+/* El `min-width: 0` es lo que permite que el ellipsis funcione dentro de flex:
+   sin él un hijo no baja de su ancho de contenido y el nombre desborda. */
+.tp-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+}
+.tp-cpe {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size-adjust: var(--fsa-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+.tp-chosen {
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: 7.5rem;
+  overflow-y: auto;
+  padding-top: 0.6rem;
+  border-top: 1px dashed var(--border-med);
+}
+.tp-chosen--muted {
+  opacity: 0.6;
+}
+.tp-chosen-title {
+  margin: 0 0 0.4rem;
+  font-size: var(--fs-caption);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+.tp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.tp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.4rem;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--on-accent);
+  border-radius: 4px;
+}
+.tp-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: var(--fs-xl);
+  padding: 0;
+  line-height: 1;
+  opacity: 0.7;
+}
+.tp-chip-remove:hover {
+  opacity: 1;
+}
+
+.tp-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  padding: 0.75rem 1.1rem;
+  border-top: 1px solid var(--border);
+}
+.tp-save-note {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+.tp-done {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-family: inherit;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+.tp-done:hover {
+  background: var(--accent-bright);
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 560px) {
+  .tp-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tp-done {
+    width: 100%;
+  }
+}
+</style>

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -41,6 +41,11 @@ export const useAegisStore = defineStore('aegis', () => {
   const productResults = ref([])
   /** Búsqueda de productos en curso */
   const searchingProducts = ref(false)
+  /**
+   * Motivo por el que la última búsqueda no devolvió nada, cuando no fue
+   * porque el catálogo no tuviera coincidencias. Cadena vacía si fue bien.
+   */
+  const productSearchError = ref('')
   /** Generación en curso */
   const generating = ref(false)
   /** Último fallo de generación, para pintarlo donde ocurrió y no solo en un
@@ -141,14 +146,31 @@ export const useAegisStore = defineStore('aegis', () => {
    */
   async function searchProducts(term) {
     const query = (term || '').trim()
+    productSearchError.value = ''
     if (query.length < 2) { productResults.value = []; return }
     searchingProducts.value = true
     try {
       const res = await apiFetch(`/aegis/products?q=${encodeURIComponent(query)}`)
-      if (!res?.ok) { productResults.value = []; return }
+      if (!res?.ok) {
+        productResults.value = []
+        // Un fallo vaciaba `productResults` igual que una búsqueda sin
+        // coincidencias, así que la UI no podía distinguirlos y enseñaba "sin
+        // coincidencias en el catálogo" — al usuario le decía que su producto
+        // no existe cuando lo que pasa es que no hemos podido preguntarlo.
+        // El 429 además tiene su propio aviso porque el endpoint está limitado
+        // a 120 peticiones/hora; useApi ya lanza un toast, pero el toast se va
+        // a los pocos segundos y esto se queda junto a la lista vacía.
+        productSearchError.value = res?.status === 429
+          ? 'Has agotado las búsquedas por ahora. Inténtalo de nuevo en unos minutos.'
+          : 'No se pudo consultar el catálogo de vulnerabilidades.'
+        return
+      }
       const data = await res.json()
       productResults.value = data.products ?? []
-    } catch { productResults.value = [] }
+    } catch {
+      productResults.value = []
+      productSearchError.value = 'No se pudo conectar con el catálogo de vulnerabilidades.'
+    }
     finally { searchingProducts.value = false }
   }
 
@@ -664,6 +686,7 @@ export const useAegisStore = defineStore('aegis', () => {
     hygeiaInventoryAvailable.value = false
     productResults.value = []
     searchingProducts.value = false
+    productSearchError.value = ''
     generating.value = false
     loading.value = false
     editing.value = false
@@ -695,7 +718,7 @@ export const useAegisStore = defineStore('aegis', () => {
   return {
     topics, documents, listError, selectedTopicId, currentDocId, sortMode,
     trackedProducts, useHygeiaInventory, hygeiaInventoryAvailable,
-    productResults, searchingProducts,
+    productResults, searchingProducts, productSearchError,
     generating, generateError, loading, editing, saving, tweaks, viewerDoc,
     loadingOrgProfile, savingOrgProfile, orgProfileConfigured,
     searchProducts, addTrackedProduct, removeTrackedProduct,

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -168,8 +168,11 @@ export const useAegisStore = defineStore('aegis', () => {
       const data = await res.json()
       productResults.value = data.products ?? []
     } catch {
+      // Aquí solo se llega si `res.json()` no puede parsear el cuerpo: los
+      // fallos de red los absorbe `apiFetch`, que devuelve `null` y entra por
+      // la rama de arriba. Mismo mensaje: para el usuario es el mismo problema.
       productResults.value = []
-      productSearchError.value = 'No se pudo conectar con el catálogo de vulnerabilidades.'
+      productSearchError.value = 'No se pudo consultar el catálogo de vulnerabilidades.'
     }
     finally { searchingProducts.value = false }
   }


### PR DESCRIPTION
Cierra #119.

## Resumen

El buscador de "Productos vigilados" pasa a un modal dedicado. En el panel *Perfil de la organización* queda un botón compacto con el recuento, y el interruptor "Deducir los productos de mis agentes" se va al modal con él.

**Aviso de terminología:** el Issue habla de "pestaña Empresa" y "buscador de inventario". No hay tabs en `AegisView.vue`, y el único selector es el de Productos vigilados (catálogo CPE de NVD). Confirmado con el autor antes de empezar; el alcance es ése.

## El problema real

Todo vivía en un panel de 400 px fijos (`AegisView.vue:109`):

- `.selected-brands` **sin `max-height`**: N chips crecían sin tope y empujaban el buscador fuera de vista.
- `.product-results` tenía `max-height: 11rem` pero era **in-flow**: al abrirse desplazaba el botón "Guardar perfil" hacia abajo.
- `.op-collapse-inner { overflow: hidden }` habría recortado cualquier dropdown absoluto, así que un parche de CSS no era salida: hacía falta un nodo teleportado.

## Implementación

| Commit | Fase |
|---|---|
| `0282814f` | `productSearchError` en el store |
| `9e8dce11` | `TrackedProductsModal.vue` |
| `9fa55122` | Sustitución en `OrgProfilePanel.vue` |
| `1b41d22a` | Unificar el mensaje de fallo |

**Store.** `searchProducts` vaciaba `productResults` tanto si no había coincidencias como si la petición fallaba, así que la UI enseñaba "Sin coincidencias en el catálogo" ante cualquier error: le decía al usuario que su producto no existe cuando lo que pasa es que no hemos podido preguntarlo. Ahora hay un `productSearchError` con texto propio para el 429 — el endpoint está limitado a 120 req/h. Complementa al toast que `useApi` ya lanza en ese caso: el toast se va a los pocos segundos, este mensaje se queda junto a la lista vacía.

**Modal.** Los topes de alto son el arreglo de fondo. Los resultados y los seleccionados tienen cada uno su `max-height` y su scroll, y el pie es hermano del cuerpo, no hijo, así que el botón no se va de la vista. El `min-height: 0` en toda la cadena flex es imprescindible: sin él un hijo no se encoge por debajo de su contenido y ningún `max-height` recorta nada.

Los chips van **debajo** de los resultados, al revés que en `AssetTagsModal`: así el buscador y la lista no se desplazan cada vez que se añade uno, que es donde está la mirada mientras se escribe.

Accesibilidad al nivel de `IrisArchiveModal`, el único modal del repo que la tiene completa: `role="dialog"`, Escape con listener en `window` (no `@keydown.esc` sobre el div, que sólo dispara si el foco ya está dentro — el fallo que arrastran `CampaignModal` y `DistributionListsModal`), focus trap, scroll-lock y autofocus.

Dos trampas del repo aplicadas: `data-module="aegis"` va en el overlay porque Teleport saca el nodo de la raíz de la vista, y las clases llevan prefijo `tp-` porque `shared.css` define `.modal-*` globalmente y un scoped sólo gana en lo que declara.

**Panel.** El recuento se consolida en un computed `productsSummary` que usan el botón y el resumen del acordeón; antes cada uno lo calculaba por su cuenta. Nueve clases CSS quedan sin uso y se borran, comprobado con grep sobre el template resultante. Diff neto: **-175 líneas** en `OrgProfilePanel.vue`.

## Validación

`npm run build` limpio. Los cinco suites de `web/app/test/` en verde (toast, polling, hygeia, quiz, logs) — ninguno cubre esto, se corren como guarda de no-regresión.

Verificado en el navegador con el dev server. Como Docker está parado y `/aegis/generador` exige sesión, sembré sesión en `localStorage` y stubbeé `fetch` **desde la consola** — sin tocar el código:

- `data-module` efectivo: `--accent` resuelve a `#6fa3c7` (Aegis), no al oro por defecto.
- `role="dialog"`, `aria-modal`, `aria-labelledby`, foco inicial en el buscador, scroll-lock activo al abrir y liberado al cerrar.
- Focus trap en ambos sentidos (Tab desde el último vuelve al primero, Shift+Tab al revés).
- Cadena de hints completa: 1 carácter → "Escribe al menos 2 caracteres"; sin resultados → "Sin coincidencias"; fallo → "No se pudo consultar el catálogo"; 429 → mensaje de cupo.
- **El caso del Issue**: con 40 productos y 25 resultados, la caja se topa en 612 px (85vh), resultados y seleccionados hacen scroll cada uno en el suyo, el pie sigue visible y el cuerpo no desborda. Pasar de 12 a 50 resultados **no mueve el pie** (508 → 508).
- Nombre largo truncado con elipsis.
- Móvil 375×812: caja de 343 px, pie apilado, "Listo" a ancho completo, sin scroll horizontal.

## Notas

**Sin test automático, a propósito.** Los tests del repo son node puro sin DOM y sólo alcanzan lógica sin dependencias. El modal es template, CSS y orden del foco, y no hay montaje de componentes (ni vitest ni `@vue/test-utils`); el store sí es lógica, pero `aegisStore` construye `useApi()` en su setup y arrastra router y sesión, así que habría más andamio que código bajo prueba. Los dos caminos de error se verificaron a mano en el navegador, que es donde estaría el valor.

**Cambio de comportamiento menor:** el resumen del acordeón colapsado ahora dice "sin productos" cuando no hay ninguno, donde antes callaba.

**Coste aceptado:** el interruptor de inventario deja de verse sin abrir el modal. Confirmado con el autor; mitigado porque el botón y el resumen dicen "productos de mis agentes" cuando está activo.

## Fuera de alcance

- Extraer un `useModalA11y` compartido (Escape + focus trap + scroll-lock) y adoptarlo en los 19 modales ad-hoc del repo. Hoy está inline en `IrisArchiveModal` y a medias en `PromptField`; esto sería el tercer duplicado. Merece Issue propio.
- Limpiar el bloque `.modal` legacy de `shared.css:565-607`, hermano del `.toast` legacy que causaba el bug de #127. Issue aparte.
- Paginación o virtualización: el backend ya topa en 50 resultados por búsqueda.
- Cualquier cambio en la API o en el modelo de datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
