### PR TITLE
test(hygeia): corregir test de métricas intermitente por dependencia del reloj real

### DIFF
--- a/API/tests/integration/test_hygeia_metrics_api.py
+++ b/API/tests/integration/test_hygeia_metrics_api.py
@@ -346,15 +346,25 @@ def test_series_bucketed_one_point_per_bucket_with_max(client, app, regular_user
 
 
 def test_series_bucketed_points_are_bucket_starts_and_ordered(client, app, regular_user, auth_headers):
-    """El instante del punto es el inicio del cubo, y la serie va en orden."""
+    """El instante del punto es el inicio del cubo, y la serie va en orden.
+
+    La alineación de los cubos depende del segundo exacto del reloj en el
+    momento de sembrar (ver test_series_bucketed_one_point_per_bucket_with_max),
+    así que el recuento esperado se calcula contra los propios ``received_at``
+    sembrados, no contra una constante.
+    """
     asset_id = _create_asset(app, regular_user.id)
-    stamps = _seed_snapshots(app, asset_id, 10)  # 10 × 15 s = 2,5 min → 3 cubos
+    stamps = _seed_snapshots(app, asset_id, 10)  # 10 × 15 s = 2,5 min
 
     snapshots = client.get(
         f"/hygeia/assets/{asset_id}/metrics?bucket=60", headers=auth_headers(regular_user)
     ).get_json()["snapshots"]
 
-    assert len(snapshots) == 3
+    def utc_epoch(t):
+        return t.replace(tzinfo=timezone.utc).timestamp()
+
+    expected = int(utc_epoch(stamps[-1]) // 60) - int(utc_epoch(stamps[0]) // 60) + 1
+    assert len(snapshots) == expected
     received = [datetime.fromisoformat(s["receivedAt"]).replace(tzinfo=None) for s in snapshots]
     collected = [datetime.fromisoformat(s["collectedAt"]).replace(tzinfo=None) for s in snapshots]
 


### PR DESCRIPTION
## Summary
- `test_series_bucketed_points_are_bucket_starts_and_ordered` calculaba mal el número esperado de cubos: asumía que un span de 135s (10 snapshots × 15s) siempre cae en 3 cubos de 60s, pero eso depende de la fase del reloj real en el momento de sembrar.
- El conteo esperado ahora se deriva de los propios `stamps` sembrados (mismo patrón que ya usan los tests hermanos `test_series_bucketed_one_point_per_bucket_with_max` y `test_series_bucketed_respects_from`), en vez de una constante.

## Related Issue
Fixes ProjectEllysia/EllysiaServer#132

## Implementation
- Único cambio en `API/tests/integration/test_hygeia_metrics_api.py`: se reemplaza `assert len(snapshots) == 3` por un cálculo `floor(epoch/60)` sobre el primer y último `stamp` sembrado, y se documenta la razón en el docstring del test.
- No se tocó `src/` — la lógica de bucketing en `AssetSnapshotRepository.get_series_bucketed` es correcta; el bug era solo del test.

## Validation
- `pytest tests/integration/test_hygeia_metrics_api.py -v --no-cov` → 26/26 passed.
- Verificación manual forzando ambas ramas del reloj (monkeypatch de `utcnow_naive` con segundo `<15` y `>=15`) para confirmar que el test ya no depende de la fase; código de verificación retirado antes del commit final.
- Suite completa (`pytest`) → exit code 0, sin regresiones.

## Notes
Ninguna. Cambio acotado a un test, sin impacto en producto.