### PR TITLE
fix(web): corregir tema claro en la vista de logs del sistema

### DIFF
--- a/web/app/src/views/LogsView.vue
+++ b/web/app/src/views/LogsView.vue
@@ -221,7 +221,7 @@ onMounted(() => applyFilters())
 }
 .page-header h1 { margin: 0.35rem 0 0; color: var(--text); font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-3xl); font-weight: 800; }
 .subtitle { margin: 0.35rem 0 0; color: var(--text-dim); font-size: var(--fs-lg); }
-.filter-panel, .log-card { background: rgba(15, 19, 28, 0.72); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 18px 50px rgba(0,0,0,0.18); }
+.filter-panel, .log-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 18px 50px rgba(0,0,0,0.18); }
 .filter-panel { padding: 1.15rem; margin-bottom: 1.1rem; }
 .filter-heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; padding-bottom: 0.9rem; border-bottom: 1px solid var(--border); }
 .filter-heading h2, .log-card-head h2 { margin: 0.25rem 0 0; color: var(--text); font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-xl); }
@@ -242,8 +242,8 @@ onMounted(() => applyFilters())
 .log-card-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; padding: 1.1rem 1.15rem; border-bottom: 1px solid var(--border); }
 .log-stats { display: flex; gap: 0.85rem; color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); text-align: right; }
 .notice { padding: 0.6rem 1.15rem; background: var(--warn-dim); color: var(--warn); border-bottom: 1px solid var(--border); font-size: var(--fs-md); }
-.log-window { max-height: 62vh; overflow: auto; background: #090c12; }
-.log-window pre { min-width: max-content; margin: 0; padding: 1rem 1.15rem 1.25rem; color: #d9e2ed; font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); line-height: 1.65; tab-size: 4; }
+.log-window { max-height: 62vh; overflow: auto; background: var(--bg); }
+.log-window pre { min-width: max-content; margin: 0; padding: 1rem 1.15rem 1.25rem; color: var(--text); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); line-height: 1.65; tab-size: 4; }
 .log-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.85rem 1.15rem; border-top: 1px solid var(--border); }
 .line-range, .page-status { color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); }
 .pagination { display: flex; align-items: center; gap: 0.65rem; }


### PR DESCRIPTION
## Summary
- `.filter-panel` y `.log-card` usaban `background: rgba(15, 19, 28, 0.72)` fijo -> ahora `var(--surface)`.
- `.log-window` usaba `background: #090c12` fijo -> ahora `var(--bg)`.
- `.log-window pre` usaba `color: #d9e2ed` fijo -> ahora `var(--text)`.

Estos eran los unicos elementos de `LogsView.vue` que no seguian el sistema de variables de tema ya usado en el resto de la vista, provocando una mezcla de colores oscuros y claros al activar el tema claro.

## Related Issue
Closes #126

## Implementation
Cambio de una sola fase: reemplazo de valores hardcodeados por variables de tema existentes (`--surface`, `--bg`, `--text`) en `web/app/src/views/LogsView.vue`. Sin cambios de logica ni de markup.

## Validation
- [x] `npm run build` en `web/app` completa sin errores.
- [ ] Verificacion visual manual en navegador con backend + login (no ejecutada en este entorno; se recomienda revisar el toggle de tema claro/oscuro en la pantalla de Logs antes de mergear).

## Notes
La apariencia del tema oscuro no deberia cambiar, ya que las variables usadas resuelven a los mismos valores que antes bajo `data-theme="dark"`.
