### PR TITLE
fix(web): evitar el salto de scroll en Aegis al añadir el logo de white-labeling

### DIFF
--- a/web/app/src/views/AegisView.vue
+++ b/web/app/src/views/AegisView.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onBeforeUnmount } from 'vue'
 import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
 import { useAegisStore } from '@/stores/aegisStore'
@@ -109,11 +109,37 @@ const { collapsed: rightCollapsed, toggle: toggleRight } = usePanelCollapse('aeg
 const leftWidth = computed(() => (leftCollapsed.value ? '48px' : '400px'))
 const rightWidth = computed(() => (rightCollapsed.value ? '48px' : '320px'))
 
-onMounted(async () => { await store.loadTopics(); await store.loadHistory() })
+// El layout de escritorio es de una sola pantalla (.app-layout mide
+// calc(100vh - topbar) con overflow:hidden) y cada panel scrollea por su
+// cuenta en .panel-content. Pero `html` sí puede desplazarse (overflow-x
+// hidden fuerza overflow-y:auto, ver comentario en shared.css) y Chromium,
+// al devolver el foco al <input type="file"> oculto de WhiteLabelFields tras
+// cerrar el diálogo nativo, se salta `.app-layout` (overflow:hidden no cuenta
+// como contenedor de scroll) y desplaza `html` en su lugar — aunque el input
+// ya era visible. Como la página mide justo 100vh, ese scroll no revela más
+// contenido: revela hueco, con el fondo fijo de StarBackground asomando.
+// Bloquear el scroll de html en este rango de anchura (el mismo en el que
+// .app-layout es de una sola pantalla) impide que ese salto tenga adónde ir,
+// sin tocar el modo apilado por debajo de 1200px, donde sí debe desplazarse.
+onMounted(async () => {
+  document.documentElement.classList.add('aegis-scroll-lock')
+  await store.loadTopics()
+  await store.loadHistory()
+})
+onBeforeUnmount(() => {
+  document.documentElement.classList.remove('aegis-scroll-lock')
+})
 </script>
 
 <style scoped>
 .aegis-page { min-height: 100vh; background: var(--bg); padding-top: var(--topbar-h); position: relative; }
+
+/* Ver el porqué en el onMounted de <script setup>. Acotado al mismo ancho en
+   el que .app-layout es de una sola pantalla (media query de más abajo
+   apila los paneles y necesita que la página SÍ pueda desplazarse). */
+@media (min-width: 1201px) {
+  :global(html.aegis-scroll-lock) { overflow-y: hidden; }
+}
 
 /* Flex, no grid: el ancho de cada barra llega por :style inline (calculado
    en leftWidth/rightWidth) y se anima con "transition: width". */


### PR DESCRIPTION
## Summary
- El `<input type="file">` oculto de `WhiteLabelFields.vue` recupera el foco al cerrar el diálogo nativo de selección de imagen. El navegador intenta llevar ese input a la vista, pero `.app-layout` (el contenedor real de la vista de Aegis) usa `overflow: hidden` y no cuenta como destino válido para ese scroll-into-view, así que el navegador termina desplazando `html` en su lugar.
- Como la vista mide exactamente `100vh`, ese desplazamiento no revela más contenido: deja un hueco vacío al fondo de la ventana con el fondo decorativo fijo (`StarBackground`) asomando, y el contenido visible parece subir. Confirmado con la captura del issue (el patrón hexagonal del fondo decorativo se ve justo debajo del botón "Actualizar perfil").
- El fix bloquea el scroll de `html` mientras la vista de escritorio de Aegis está montada, en el mismo rango de anchura (`≥1201px`) en el que `.app-layout` es de una sola pantalla — sin tocar el modo apilado por debajo de 1200px, que sí necesita que la página se desplace (comportamiento intencional ya documentado en el propio CSS).

## Related Issue
Closes #135

## Implementation
- [AegisView.vue](web/app/src/views/AegisView.vue): añade la clase `aegis-scroll-lock` a `document.documentElement` en `onMounted` y la retira en `onBeforeUnmount`; una regla `@media (min-width: 1201px)` con `:global(html.aegis-scroll-lock) { overflow-y: hidden }` aplica el bloqueo solo en el layout de escritorio.

## Validation
- `npm run dev` en `web/app` (sin backend, API mockeada con un JWT falso en `localStorage` para saltar el login) para comprobar que la vista compila y renderiza sin errores.
- A ≥1201px: `getComputedStyle(document.documentElement).overflowY` es `hidden` mientras Aegis está montado, y `window.scrollTo(0, 300)` ya no mueve `document.documentElement.scrollTop`.
- A <1200px: `overflowY` vuelve a `auto` — el modo apilado conserva el scroll de página.
- Al navegar fuera de Aegis, la clase `aegis-scroll-lock` se retira correctamente (sin fuga a otras vistas).

## Notes
- No se ha podido probar el flujo completo con el diálogo nativo real del SO (requiere backend en WSL/Docker para autenticar); la validación se hizo simulando las condiciones exactas que causaban el bug (bloqueo de scroll de `html` en el layout de escritorio).