### PR TITLE
fix(themis): evitar peticiones sobredimensionadas a OpenAI en escaneos con muchos hallazgos

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -53,6 +53,7 @@
   "tools": {
     "scribe": {
       "defaultStrategy": "openai",
+      "maxInputTokens": 24000,
       "modules": {
         "aegis": "openai",
         "themis": "openai"

--- a/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
+++ b/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
@@ -1,0 +1,30 @@
+"""cpe match and finding required_os
+
+Revision ID: 4fe4383a5085
+Revises: a1b2c3d4e5f7
+Create Date: 2026-08-28 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4fe4383a5085'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('CpeMatch', sa.Column('required_os', sa.String(length=64), nullable=True))
+    op.add_column('Finding', sa.Column('required_os', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('Finding', 'required_os')
+    op.drop_column('CpeMatch', 'required_os')

--- a/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
+++ b/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
@@ -1,7 +1,7 @@
 """cpe match and finding required_os
 
 Revision ID: 4fe4383a5085
-Revises: a1b2c3d4e5f7
+Revises: baf6f0e7fd8c
 Create Date: 2026-08-28 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '4fe4383a5085'
-down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f7'
+down_revision: Union[str, Sequence[str], None] = 'baf6f0e7fd8c'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/API/alembic/versions/baf6f0e7fd8c_merge_white_labeling_migration_heads.py
+++ b/API/alembic/versions/baf6f0e7fd8c_merge_white_labeling_migration_heads.py
@@ -1,0 +1,28 @@
+"""merge white-labeling migration heads
+
+Revision ID: baf6f0e7fd8c
+Revises: a1b2c3d4e5f7, b2c3d4e5f6a7
+Create Date: 2026-08-27 21:12:52.808729
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'baf6f0e7fd8c'
+down_revision: Union[str, Sequence[str], None] = ('a1b2c3d4e5f7', 'b2c3d4e5f6a7')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/API/src/modules/features/themis/lybra/adapters.py
+++ b/API/src/modules/features/themis/lybra/adapters.py
@@ -222,7 +222,8 @@ def finding_to_json(f: dict, exposure: str) -> dict:
     """
     priority = score_finding(
         {"cvss_score": f.get("cvss_score"), "in_kev": f.get("in_kev"),
-         "epss_score": f.get("epss_score"), "confirmed": f.get("confirmed")},
+         "epss_score": f.get("epss_score"), "confirmed": f.get("confirmed"),
+         "required_os": f.get("required_os")},
         exposure,
     )
     return {
@@ -243,4 +244,5 @@ def finding_to_json(f: dict, exposure: str) -> dict:
         "state":       f.get("state"),
         "dedupKey":    f.get("dedup_key"),
         "priority":    priority,
+        "requiredOs":  f.get("required_os"),
     }

--- a/API/src/modules/features/themis/lybra/correlation.py
+++ b/API/src/modules/features/themis/lybra/correlation.py
@@ -254,12 +254,20 @@ def score_finding(finding: dict, exposure: str) -> str:
       least 0.5 — pushes the priority up one band.
     * An actively-confirmed finding with no CVSS (e.g. an exposed path) is floored
       at MEDIUM, so a confirmed issue never reads as merely informational.
+    * An unconfirmed match whose CVE only applies on a specific platform
+      (``required_os`` set — see ``CpeMatch.required_os``) is capped at
+      MEDIUM: Lybra has no OS-detection signal, so it cannot verify that
+      precondition, and treating an unverifiable "on Windows"-type CVE as
+      CRITICAL against every banner-matched host — regardless of its actual
+      OS — is exactly the false-positive pattern this cap closes. A
+      confirmed finding (Hygeia inventory, where the host's own OS is already
+      known) is exempt.
     * A private-LAN target caps the priority at HIGH, since it is not exposed to
       the internet.
 
     Args:
         finding: A finding dict, read for ``cvss_score`` / ``in_kev`` /
-            ``epss_score`` / ``confirmed``.
+            ``epss_score`` / ``confirmed`` / ``required_os``.
         exposure: ``"private"`` or ``"public"``, as returned by
             :func:`classify_exposure`.
 
@@ -274,6 +282,9 @@ def score_finding(finding: dict, exposure: str) -> str:
 
     if finding.get("confirmed") and cvss == 0.0:
         band = max(band, PRIORITY_LADDER.index("MEDIUM"))
+
+    if finding.get("required_os") and not finding.get("confirmed"):
+        band = min(band, PRIORITY_LADDER.index("MEDIUM"))
 
     if exposure == "private":
         band = min(band, PRIORITY_LADDER.index("HIGH"))

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -118,7 +118,9 @@ class LybraEngine:
 
     Args:
         cve_lookup: A callable ``(vendor, product, version) -> iterable`` of CVE
-            rows, each exposing ``cve_id`` / ``cvss_score`` / ``cvss_vector``.
+            rows, each exposing ``cve_id`` / ``cvss_score`` / ``cvss_vector``
+            and, optionally, ``required_os`` (the platform the match is gated
+            behind, or ``None`` — see ``KbRepository.cves_for_cpe``).
             Passing ``None`` disables version detection, leaving only the
             informational findings.
         kev_lookup: A callable ``(cve_id) -> bool`` telling whether the CVE is in
@@ -206,6 +208,7 @@ class LybraEngine:
             "cvss_vector":  cve.cvss_vector,
             "epss_score":   self._epss_lookup(cve_id) if self._epss_lookup else None,
             "in_kev":       self._kev_lookup(cve_id) if self._kev_lookup else False,
+            "required_os":  getattr(cve, "required_os", None),
             "source":       "lybra",
             "check_id":     "lybra:version-match@1",
             "feed_version": self.FEED_VERSION,

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -328,13 +328,22 @@ def parse_cpe23(cpe: str) -> Optional[dict]:
         cpe: A CPE string in 2.2 or 2.3 form.
 
     Returns:
-        A dict with ``"part"``, ``"vendor"``, ``"product"`` and ``"version"``, or
-        ``None`` if the string is not a recognisable CPE.
+        A dict with ``"part"``, ``"vendor"``, ``"product"``, ``"version"`` and
+        ``"target_sw"``, or ``None`` if the string is not a recognisable CPE.
+        ``target_sw`` is the CPE 2.3 form's 11th field (index 10) — the
+        platform a CVE's applicability rule requires (e.g. ``"windows"``)
+        when NVD encodes it directly on the software's own CPE rather than as
+        a sibling platform CPE in the same configuration node. Missing on a
+        2.2-form or short string, in which case it is ``None``.
     """
     parts = normalize_cpe_to_23(cpe).split(":")
     if len(parts) < 6 or parts[0] != "cpe" or parts[1] != "2.3":
         return None
-    return {"part": parts[2], "vendor": parts[3], "product": parts[4], "version": parts[5]}
+    target_sw = parts[10] if len(parts) > 10 else None
+    return {
+        "part": parts[2], "vendor": parts[3], "product": parts[4], "version": parts[5],
+        "target_sw": target_sw if target_sw not in (None, "*", "-") else None,
+    }
 
 
 # The curated product-name -> (vendor, product) alias feed (Fase I-b, paso 3),
@@ -473,17 +482,56 @@ def ingest_nvd_cve(item: dict) -> Optional[Tuple[dict, List[dict]]]:
     matches: List[dict] = []
     for config in cve.get("configurations", []):
         for node in config.get("nodes", []):
+            node_os = _node_required_os(node)
             for cm in node.get("cpeMatch", []):
                 if not cm.get("vulnerable"):
                     continue
-                row = _cpe_match_row(cm)
+                row = _cpe_match_row(cm, node_required_os=node_os)
                 if row:
                     matches.append(row)
 
     return cve_row, matches
 
 
-def _cpe_match_row(cm: dict) -> Optional[dict]:
+def _node_required_os(node: dict) -> Optional[str]:
+    """Derive the platform an NVD configuration node's software match requires.
+
+    NVD sometimes expresses "product X, but only when running on Windows" as
+    two sibling ``cpeMatch`` entries in the same node — one ``part="a"`` (the
+    software) and one ``part="o"`` (the operating system) — joined by
+    ``operator: "AND"``. Flattening every ``cpeMatch`` in a node into
+    independent rows (as this module used to) loses that joint condition
+    entirely, so a Windows-only CVE ends up matched against the same software
+    regardless of OS. This walks one node's siblings and, when exactly the
+    "AND with a single platform CPE" shape holds, returns that platform's CPE
+    ``product`` token (e.g. ``"windows_10"``) so the caller can tag the
+    software row with it.
+
+    Deliberately conservative: a node with ``operator != "AND"``, no platform
+    CPE, or more than one distinct platform product (an "OR" of platforms,
+    which would need real node-tree semantics to resolve exactly) returns
+    ``None`` rather than guess — the same "no OS gate" behaviour the matcher
+    already had before this existed.
+
+    Args:
+        node: One NVD configuration node.
+
+    Returns:
+        The single required platform's CPE ``product`` token, or ``None``.
+    """
+    if node.get("operator") != "AND" or node.get("negate"):
+        return None
+    platforms = set()
+    for cm in node.get("cpeMatch", []):
+        if not cm.get("vulnerable"):
+            continue
+        parsed = parse_cpe23(cm.get("criteria", ""))
+        if parsed and parsed["part"] == "o":
+            platforms.add(parsed["product"])
+    return next(iter(platforms)) if len(platforms) == 1 else None
+
+
+def _cpe_match_row(cm: dict, node_required_os: Optional[str] = None) -> Optional[dict]:
     """Turn one NVD ``cpeMatch`` object into a ``CpeMatch`` row dict.
 
     A CPE that pins a concrete version (not ``*`` or ``-``) becomes an
@@ -491,15 +539,23 @@ def _cpe_match_row(cm: dict) -> Optional[dict]:
     bounds, in which case the range takes precedence and the pinned version is
     ignored.
 
+    A platform-only entry (``part="o"``, e.g. ``cpe:2.3:o:microsoft:windows_10:...``)
+    is not itself a matchable product — no scanner ever reports "Windows 10"
+    as a network service — so it produces no row of its own; it only exists to
+    gate its AND-sibling software row via ``node_required_os``
+    (see :func:`_node_required_os`).
+
     Args:
         cm: One ``cpeMatch`` object from an NVD configuration node.
+        node_required_os: The platform this match's sibling ``AND`` condition
+            requires, from :func:`_node_required_os`, or ``None``.
 
     Returns:
         A dict of ``CpeMatch`` column values, or ``None`` if the object's CPE
-        string cannot be parsed.
+        string cannot be parsed or is a platform-only entry.
     """
     parsed = parse_cpe23(cm.get("criteria", ""))
-    if not parsed:
+    if not parsed or parsed["part"] == "o":
         return None
     bounds = (
         cm.get("versionStartIncluding"), cm.get("versionStartExcluding"),
@@ -514,6 +570,10 @@ def _cpe_match_row(cm: dict) -> Optional[dict]:
         "version_end_including":   cm.get("versionEndIncluding"),
         "version_end_excluding":   cm.get("versionEndExcluding"),
         "exact_version":           None if any(bounds) else pinned,
+        # The software's own CPE can encode the platform directly
+        # (target_sw), or it can come from an AND-sibling platform CPE in the
+        # same node; either is a genuine applicability gate NVD intends.
+        "required_os": parsed["target_sw"] or node_required_os,
     }
 
 

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -826,7 +826,7 @@ class Finding(Base):
     epss_score       = Column(Float)
     in_kev           = Column(Boolean, default=False)
     exploit_maturity = Column(String(16))   # none|poc|functional|weaponized|in_the_wild
-    required_os      = Column(String(64))   # CPE platform token this finding's CVE match is gated behind (see CpeMatch.required_os), or None
+    required_os      = Column(String(64))   # Platform this finding's CVE match is gated behind (see CpeMatch.required_os), or None
 
     # Quality / provenance
     source       = Column(String(32), index=True)
@@ -922,7 +922,7 @@ class CpeMatch(Base):
     version_end_including   = Column(String(64))
     version_end_excluding   = Column(String(64))
     exact_version           = Column(String(64))  # set when the CPE pins a single version
-    required_os             = Column(String(64))  # CPE product token of an AND-linked platform gate (see lybra/kb.py::_node_required_os), or None
+    required_os             = Column(String(64))  # AND-linked platform gate (lybra/kb.py::_node_required_os), or None
 
     cve = relationship("CveEntry", back_populates="cpe_matches")
 

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -785,6 +785,11 @@ class Finding(Base):
             collide the two.
         cve_ids / cvss_score / cvss_vector / epss_score / in_kev /
             exploit_maturity: Vulnerability correlation (filled from Fase 1 on).
+        required_os: CPE platform token (e.g. "windows_10") this finding's CVE
+            match is gated behind, or None if unconditional. Set from
+            ``CpeMatch.required_os`` at correlation time; used by
+            ``score_finding`` to avoid treating an unverifiable platform
+            precondition as a confirmed risk.
         source: Which scanner produced it ("lybra" | "nikto" | "nuclei" | "nmap",
             or historically "openvas" — that scanner no longer runs).
         check_id: Which own check produced it ("lybra:git-config-exposure@3").
@@ -821,6 +826,7 @@ class Finding(Base):
     epss_score       = Column(Float)
     in_kev           = Column(Boolean, default=False)
     exploit_maturity = Column(String(16))   # none|poc|functional|weaponized|in_the_wild
+    required_os      = Column(String(64))   # CPE platform token this finding's CVE match is gated behind (see CpeMatch.required_os), or None
 
     # Quality / provenance
     source       = Column(String(32), index=True)
@@ -849,9 +855,10 @@ class Finding(Base):
             "cve_ids": self.cve_ids,
             "cvss_score": self.cvss_score, 
             "cvss_vector": self.cvss_vector,
-            "epss_score": self.epss_score, 
+            "epss_score": self.epss_score,
             "in_kev": self.in_kev,
-            "exploit_maturity": self.exploit_maturity, 
+            "exploit_maturity": self.exploit_maturity,
+            "required_os": self.required_os,
             "source": self.source,
             "check_id": self.check_id, 
             "feed_version": self.feed_version,
@@ -915,6 +922,7 @@ class CpeMatch(Base):
     version_end_including   = Column(String(64))
     version_end_excluding   = Column(String(64))
     exact_version           = Column(String(64))  # set when the CPE pins a single version
+    required_os             = Column(String(64))  # CPE product token of an AND-linked platform gate (see lybra/kb.py::_node_required_os), or None
 
     cve = relationship("CveEntry", back_populates="cpe_matches")
 

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -888,7 +888,16 @@ class KbRepository(BaseRepository[CveEntry]):
 
         Filters candidate applicability rows by (vendor, product) in SQL, then
         applies the version-range logic in Python (see ``lybra.kb``). Results
-        are de-duplicated by CVE.
+        are de-duplicated by CVE — a CVE can have several ``CpeMatch`` rows for
+        the same product (different ranges, some OS-gated and some not); when
+        that happens the *least* restrictive rule wins, since an unconditional
+        applicability rule proves the CVE genuinely applies here regardless of
+        any other, narrower rule that also happens to match.
+
+        Each returned ``CveEntry`` carries a transient ``required_os``
+        attribute (not a mapped column — set on this query's result objects
+        only) telling the caller which platform, if any, every contributing
+        match required. ``None`` means unconditional.
         """
         from .lybra import version_in_range
 
@@ -898,12 +907,24 @@ class KbRepository(BaseRepository[CveEntry]):
             .options(joinedload(CpeMatch.cve))
             .all()
         )
-        seen: set[int] = set()
-        result: List[CveEntry] = []
+        order: List[int] = []
+        entries: Dict[int, CveEntry] = {}
+        required_os: Dict[int, Optional[str]] = {}
         for match in candidates:
-            if version_in_range(version, match) and match.cve_id not in seen:
-                seen.add(match.cve_id)
-                result.append(match.cve)
+            if not version_in_range(version, match):
+                continue
+            cve_id = match.cve_id
+            if cve_id not in entries:
+                order.append(cve_id)
+                entries[cve_id] = match.cve
+                required_os[cve_id] = match.required_os
+            elif required_os[cve_id] and not match.required_os:
+                required_os[cve_id] = None
+        result: List[CveEntry] = []
+        for cve_id in order:
+            entry = entries[cve_id]
+            entry.required_os = required_os[cve_id]  # type: ignore[attr-defined]
+            result.append(entry)
         return result
 
     def resolve_product_alias(self, normalized_name: str) -> Optional[Tuple[str, str]]:

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -48,6 +48,13 @@ class NmapAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
+    # Tope de puertos detallados que viajan al prompt (#118): un host con
+    # cientos de puertos abiertos (mala configuración, o un rango escaneado
+    # como si fuera un solo host) podía generar un 'ports_json' sin límite.
+    # '{{total_ports}}' sigue reportando el recuento real (no el recortado),
+    # así que el modelo nunca lee "hay menos puertos de los que realmente hay".
+    _MAX_PORTS = 60
+
     def __init__(self, generator: Optional[AIGenerator] = None) -> None:
         """Initialize Nmap AI writer.
 
@@ -129,6 +136,9 @@ class NmapAIWriter:
                 "categoria_funcional": self._infer_functional_category(service, port_num)
             })
 
+        total_ports = len(ports_info)
+        ports_info = ports_info[:self._MAX_PORTS]
+
         prompts_config = CR.get_prompts_config()
         template = prompts_config.get("nmap", {}).get("userTemplate", "")
 
@@ -140,7 +150,7 @@ class NmapAIWriter:
 
         rendered = template.replace("{{target}}", str(target)) \
                         .replace("{{started}}", str(started)) \
-                        .replace("{{total_ports}}", str(len(ports_info))) \
+                        .replace("{{total_ports}}", str(total_ports)) \
                         .replace("{{distribution}}", str(analysis_context["distribution"])) \
                         .replace("{{profile_type}}", str(analysis_context["profile_type"])) \
                         .replace("{{ports_json}}", json.dumps(ports_info, indent=2, ensure_ascii=False))
@@ -504,12 +514,21 @@ class LybraAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
-    # Tope de hallazgos detallados que viajan al prompt. Los confirmados y los
-    # de KEV nunca se recortan; el tope sólo acota la cola ordenada por
-    # prioridad. El rollup por servicio cubre igualmente los que no entran, así
-    # que un host con cientos de CVEs sigue describiéndose entero.
+    # Tope de hallazgos detallados que viajan al prompt. Se aplica al conjunto
+    # completo (confirmados + KEV + cola), no solo a la cola: un scan con más
+    # de _MAX_HIGHLIGHTED_FINDINGS hallazgos confirmados/KEV podía generar un
+    # payload sin límite real pese a este tope, porque antes solo recortaba
+    # "rest" (Issue #118). El rollup por servicio cubre igualmente los que no
+    # entran, así que un host con cientos de CVEs sigue describiéndose entero.
     _MAX_HIGHLIGHTED_FINDINGS = 25
     _MAX_DESCRIPTION_CHARS = 300
+
+    # Tope de grupos del rollup por servicio (#118): un objetivo con muchos
+    # productos/puertos distintos (un rango de red, no un solo host) podía
+    # generar un 'services_json' sin límite pese a que ya es una compresión
+    # de los hallazgos. Ordenado por severidad (ver _build_service_rollup),
+    # así que un recorte siempre descarta primero los grupos menos graves.
+    _MAX_SERVICE_GROUPS = 40
 
     # Mismo orden que FindingsPrintingStrategy._PRIORITY_ORDER: el informe y el
     # análisis deben priorizar igual o se contradicen entre páginas.
@@ -614,7 +633,8 @@ class LybraAIWriter:
             del group["cves"]
             rollup.append(group)
 
-        return sorted(rollup, key=lambda group: -(group["max_cvss"] or 0))
+        rollup.sort(key=lambda group: -(group["max_cvss"] or 0))
+        return rollup[:self._MAX_SERVICE_GROUPS]
 
     @staticmethod
     def _version_key(version: str) -> tuple:
@@ -639,18 +659,24 @@ class LybraAIWriter:
         started = scan_data.get("started_at", "N/A")
         exposure = scan_data.get("exposure", "unknown")
 
-        confirmed = [finding for finding in findings if finding.get("confirmed")]
-        kev = [finding for finding in findings if finding.get("in_kev")]
+        # Confirmados y KEV se priorizan siempre por delante de la cola, y se
+        # deduplican por identidad antes de ordenar: un hallazgo puede ser
+        # confirmado Y estar en KEV a la vez, y una concatenación ingenua lo
+        # metía dos veces. Se ordenan por prioridad real (no por orden de
+        # repositorio) para que, al recortar, sobrevivan los más graves —
+        # y se recortan igual que la cola: antes solo _rest_ tenía tope, así
+        # que un scan con más de _MAX_HIGHLIGHTED_FINDINGS confirmados/KEV
+        # generaba un payload sin límite real pese a la constante (#118).
+        priority = list({id(finding): finding for finding in findings
+                          if finding.get("confirmed") or finding.get("in_kev")}.values())
+        priority.sort(key=self._sort_key)
 
-        # Confirmados y KEV van siempre; la cola se ordena por prioridad real
-        # (no por orden de repositorio) antes de recortarse, para que los
-        # hallazgos destacados sean los mismos que encabezan el informe.
-        priority_ids = {id(finding) for finding in confirmed} | {id(finding) for finding in kev}
+        priority_ids = {id(finding) for finding in priority}
         rest = sorted(
             (finding for finding in findings if id(finding) not in priority_ids),
             key=self._sort_key,
         )
-        highlighted = (confirmed + kev + rest)[:self._MAX_HIGHLIGHTED_FINDINGS]
+        highlighted = (priority + rest)[:self._MAX_HIGHLIGHTED_FINDINGS]
 
         findings_for_ai = [{
             "titulo": finding.get("title", "")[:160],
@@ -677,8 +703,8 @@ class LybraAIWriter:
                     .replace("{{started}}", str(started)) \
                     .replace("{{exposure}}", str(exposure)) \
                     .replace("{{total_findings}}", str(len(findings))) \
-                    .replace("{{confirmed_count}}", str(len(confirmed))) \
-                    .replace("{{kev_count}}", str(len(kev))) \
+                    .replace("{{confirmed_count}}", str(sum(1 for finding in findings if finding.get("confirmed")))) \
+                    .replace("{{kev_count}}", str(sum(1 for finding in findings if finding.get("in_kev")))) \
                     .replace("{{services_json}}", json.dumps(self._build_service_rollup(findings), indent=2, ensure_ascii=False)) \
                     .replace("{{findings_json}}", json.dumps(findings_for_ai, indent=2, ensure_ascii=False))
 

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -667,6 +667,7 @@ class LybraAIWriter:
             "estado": finding.get("state", "open"),
             "corregido_en": finding.get("fixed_version"),
             "descripcion": (finding.get("description") or "")[:self._MAX_DESCRIPTION_CHARS],
+            "requiere_so": finding.get("required_os"),
         } for finding in highlighted]
 
         prompts_config = CR.get_prompts_config()
@@ -725,6 +726,7 @@ class LybraAIWriter:
                 "service": row.service, "cpe": row.cpe, "cve_ids": row.cve_ids,
                 "cvss_score": row.cvss_score, "epss_score": row.epss_score, "in_kev": row.in_kev,
                 "confirmed": row.confirmed, "qod": row.qod, "state": row.state,
+                "required_os": row.required_os,
             } for row in rows]
 
         for finding in findings:

--- a/API/src/modules/features/themis/services/reports/base.py
+++ b/API/src/modules/features/themis/services/reports/base.py
@@ -20,6 +20,7 @@ from reportlab.platypus import PageBreak, Paragraph, Spacer, Table, TableStyle
 import src.modules.system.config_reading as CR
 
 from src.modules.shared._exceptions import IllegalStateError, ValidationError
+from src.modules.tools.scribe import AIPayloadTooLargeError
 from ...model import Scan, ScanType
 from src.modules.shared.report_theme import ColorType, ReportTheme, safe_markup
 
@@ -134,6 +135,16 @@ class PrintingStrategy(ABC):
                 raise IllegalStateError("Writer detectado como None")
 
             ai_analysis = self.writer.generate(self.scan, **writer_kwargs)
+        except AIPayloadTooLargeError as e:
+            logger.warning(f"[IA] Payload demasiado grande para scan {self.scan.id}: {e}")
+            elements.append(PageBreak())
+            elements.extend(theme.section_header("Análisis de Seguridad IA", "INTELIGENCIA ARTIFICIAL"))
+            elements.append(Paragraph(
+                "Este escaneo tiene demasiados hallazgos para generar un análisis de IA completo. "
+                "Consulta el detalle técnico del informe: contiene la misma información, sin resumir.",
+                theme.body,
+            ))
+            return
         except Exception as e:
             logger.error(f"[IA] Excepción: {e}", exc_info=True)
             ai_analysis = {}

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -118,6 +118,7 @@ class FindingsPrintingStrategy(PrintingStrategy):
             "cpe": row.cpe, "cve_ids": row.cve_ids or [], "cvss_score": row.cvss_score,
             "epss_score": row.epss_score, "in_kev": row.in_kev, "qod": row.qod, "confirmed": row.confirmed,
             "source": row.source, "state": row.state, "cpe_resolved": row.cpe_resolved,
+            "required_os": row.required_os,
         } for row in rows]
         for f in findings:
             f["priority"] = score_finding(f, exposure)
@@ -374,6 +375,8 @@ class FindingsPrintingStrategy(PrintingStrategy):
             details.append(["EPSS (30 días):", f"{finding['epss_score'] * 100:.1f}%"])
         if finding.get("in_kev"):
             details.append(["CISA KEV:", "Sí — explotada activamente"])
+        if finding.get("required_os") and not finding.get("confirmed"):
+            details.append(["Requiere SO:", f"{finding['required_os']} (no verificado en este escaneo)"])
         if finding.get("fixed_version"):
             details.append(["Corregido en:", f"{finding['fixed_version']} o superior"])
         if finding.get("state") and finding["state"] != "open":

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -575,6 +575,20 @@ class ScribeConfig(_StrategySelection):
 
     default_strategy: str = "ollama"
 
+    max_input_tokens: int = 24000
+    """Tope de tokens estimados del prompt (system + examples + user) que
+    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia (Issue
+    #118).
+
+    Sin esto, un writer de dominio (p.ej. ``LybraAIWriter`` con un scan de
+    muchos hallazgos) podía generar un payload que OpenAI rechazaba con un
+    429 'Request too large' — tras haber quemado ``max_retries`` reintentos
+    con backoff, porque el mismo prompt sobredimensionado vuelve a fallar en
+    cada intento. 24000 deja margen bajo el límite TPM de 30000 observado en
+    el error original, incluso en la organización más ajustada; se aplica al
+    total estimado (no solo al último mensaje) e independientemente del
+    backend, ya que un contexto local también tiene un tope real."""
+
 
 @config_block("tools.herald")
 @dataclass(frozen=True)

--- a/API/src/modules/tools/scribe/__init__.py
+++ b/API/src/modules/tools/scribe/__init__.py
@@ -14,7 +14,7 @@ Uso típico:
     >>> data = result.parse_json()
 """
 
-from .inputs import AIInput, AIResult, Example
+from .inputs import AIInput, AIResult, Example, estimate_tokens
 from .strategies import ModelStrategy, OllamaStrategy, OpenAIStrategy, GoogleStrategy, ToolExecutor
 from .generator import AIGenerator
 from .factory import build_generator
@@ -23,6 +23,7 @@ from .exceptions import (
     AIConnectionError,
     AIResponseError,
     AIFallbackExhaustedError,
+    AIPayloadTooLargeError,
     CircuitBreakerOpenError,
     AIStrategyConfigurationError,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "AIInput",
     "AIResult",
     "Example",
+    "estimate_tokens",
     "ModelStrategy",
     "OllamaStrategy",
     "OpenAIStrategy",
@@ -43,6 +45,7 @@ __all__ = [
     "AIConnectionError",
     "AIResponseError",
     "AIFallbackExhaustedError",
+    "AIPayloadTooLargeError",
     "CircuitBreakerOpenError",
     "AIStrategyConfigurationError",
 ]

--- a/API/src/modules/tools/scribe/exceptions.py
+++ b/API/src/modules/tools/scribe/exceptions.py
@@ -45,6 +45,29 @@ class AIResponseError(EllysiaException):
         )
 
 
+class AIPayloadTooLargeError(EllysiaException):
+    """El prompt estimado supera el tope de tokens configurado (Issue #118).
+
+    Se lanza *antes* de invocar la estrategia — nunca es transitorio (el mismo
+    prompt sobredimensionado fallaría igual en cada reintento), así que
+    ``AIGenerator.digest`` no la reintenta como hace con el resto de errores.
+    """
+
+    default_code = ErrorCode.VALIDATION_ERROR
+    default_status_code = 422
+    default_severity = ErrorSeverity.MEDIUM
+
+    def __init__(self, estimated_tokens: int, max_tokens: int):
+        super().__init__(
+            message=(
+                f"Prompt de ~{estimated_tokens} tokens estimados supera el "
+                f"límite configurado de {max_tokens}."
+            ),
+            details={"estimated_tokens": estimated_tokens, "max_tokens": max_tokens},
+            user_message="El escaneo es demasiado grande para generar un análisis de IA completo.",
+        )
+
+
 class AIFallbackExhaustedError(EllysiaException):
     """Se agotaron todos los reintentos sin obtener una respuesta válida."""
 

--- a/API/src/modules/tools/scribe/generator.py
+++ b/API/src/modules/tools/scribe/generator.py
@@ -23,7 +23,7 @@ import threading
 import time
 from typing import Optional
 
-from .exceptions import AIFallbackExhaustedError, CircuitBreakerOpenError
+from .exceptions import AIFallbackExhaustedError, AIPayloadTooLargeError, CircuitBreakerOpenError
 from .inputs import AIInput, AIResult
 from .strategies import ModelStrategy, ToolExecutor
 from .tools import web_search
@@ -85,6 +85,29 @@ class AIGenerator:
             self._failures += 1
             self._last_failure_time = time.time()
 
+    # ── Guardarraíl de tamaño (Issue #118) ──────────────────────────────────
+
+    @staticmethod
+    def _check_payload_size(ai_input: AIInput) -> None:
+        """Rechaza un prompt sobredimensionado antes de llamar al backend.
+
+        Registra el tamaño estimado incluso cuando no excede el límite —
+        observabilidad para diagnosticar el próximo 429 sin depender de que
+        el backend lo reporte, que es exactamente lo que faltó para
+        diagnosticar el caso original de este issue.
+        """
+        import src.modules.system.config_reading as CR
+
+        estimated = ai_input.estimated_tokens()
+        limit = CR.scribe_config().max_input_tokens
+        logger.info("[scribe] prompt estimado: %d tokens (límite: %d)", estimated, limit)
+        if estimated > limit:
+            logger.warning(
+                "[scribe] prompt de ~%d tokens supera el límite de %d — rechazado sin llamar al backend",
+                estimated, limit,
+            )
+            raise AIPayloadTooLargeError(estimated, limit)
+
     # ── API pública ──────────────────────────────────────────────────────────
 
     def digest(
@@ -106,9 +129,15 @@ class AIGenerator:
 
         Raises:
             CircuitBreakerOpenError: Si el breaker del backend está abierto.
+            AIPayloadTooLargeError: Si el prompt estimado supera el tope
+                configurado — se comprueba antes de llamar a la estrategia y
+                no se reintenta (Issue #118): un prompt sobredimensionado
+                falla igual en cada intento, así que reintentarlo solo
+                desperdicia llamadas y tiempo.
             AIFallbackExhaustedError: Si se agotan los reintentos.
         """
         self._check_breaker()
+        self._check_payload_size(ai_input)
         executor = tool_executor or _default_tool_executor
 
         last_error: str = ""

--- a/API/src/modules/tools/scribe/inputs.py
+++ b/API/src/modules/tools/scribe/inputs.py
@@ -22,6 +22,29 @@ from .exceptions import AIResponseError
 
 logger = logging.getLogger(__name__)
 
+# Caracteres por token, aproximación heurística (sin dependencia nueva tipo
+# tiktoken, que además tokeniza distinto por modelo/backend). ~4 es la cifra
+# que la propia documentación de OpenAI da como regla general para texto en
+# inglés/español; de sobra para un guardarraín de "no mandes un payload
+# disparatado" — no hace falta precisión exacta para eso (Issue #118).
+_CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimación heurística y barata del número de tokens de ``text``.
+
+    No es un tokenizador real: es la aproximación mínima necesaria para
+    detectar un prompt varias veces más grande que el límite configurado
+    antes de gastar una llamada de red en descubrirlo por el 429 del backend.
+
+    Args:
+        text: El texto a estimar.
+
+    Returns:
+        Una cota aproximada del número de tokens.
+    """
+    return (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN
+
 
 @dataclass(frozen=True)
 class Example:
@@ -70,6 +93,15 @@ class AIInput:
             messages.append({"role": "assistant", "content": ex.assistant})
         messages.append({"role": "user", "content": self.user_prompt})
         return messages
+
+    def estimated_tokens(self) -> int:
+        """Estimación heurística del tamaño del prompt completo (Issue #118).
+
+        Suma sobre todos los mensajes que ``to_messages`` enviaría — no solo
+        el último — porque es el total lo que un backend factura contra su
+        límite de tokens, no un mensaje aislado.
+        """
+        return sum(estimate_tokens(message["content"]) for message in self.to_messages())
 
 
 @dataclass

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -41,6 +41,50 @@ def test_cves_for_cpe_respects_version_range(app):
     assert wrong_product == []
 
 
+def test_cves_for_cpe_tags_result_with_required_os(app):
+    """#118: a match gated behind a platform (CpeMatch.required_os) must
+    surface on the returned CveEntry so the caller (LybraEngine) can avoid
+    treating an unverifiable OS precondition as a confirmed risk."""
+    match = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.59",
+             "version_start_including": None, "version_start_excluding": None,
+             "version_end_including": None, "version_end_excluding": None,
+             "required_os": "windows_10"}
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [match])
+
+        with UnitOfWork() as uow:
+            hit = KbRepository(uow).cves_for_cpe("apache", "http_server", "2.4.59")
+
+    assert [c.cve_id for c in hit] == ["CVE-2021-41773"]
+    assert hit[0].required_os == "windows_10"
+
+
+def test_cves_for_cpe_unconditional_rule_wins_over_os_gated_one(app):
+    """The same CVE can have several applicability rows for the same product
+    (different ranges from different NVD configuration nodes). If even one of
+    the rows matching this version is unconditional, the CVE genuinely
+    applies regardless of platform — the OS gate from the other row must not
+    leak into the result."""
+    windows_only = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.59",
+                     "version_start_including": None, "version_start_excluding": None,
+                     "version_end_including": None, "version_end_excluding": None,
+                     "required_os": "windows_10"}
+    unconditional = {"vendor": "apache", "product": "http_server",
+                      "version_start_including": "2.4.0", "version_end_excluding": "2.4.60",
+                      "version_start_excluding": None, "version_end_including": None,
+                      "exact_version": None, "required_os": None}
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [windows_only, unconditional])
+
+        with UnitOfWork() as uow:
+            hit = KbRepository(uow).cves_for_cpe("apache", "http_server", "2.4.59")
+
+    assert [c.cve_id for c in hit] == ["CVE-2021-41773"]
+    assert hit[0].required_os is None
+
+
 def test_upsert_cve_is_idempotent_and_replaces_matches(app):
     m1 = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.49",
           "version_start_including": None, "version_start_excluding": None,

--- a/API/tests/unit/test_lybra_correlation.py
+++ b/API/tests/unit/test_lybra_correlation.py
@@ -144,6 +144,16 @@ def test_lifecycle_does_not_recarry_already_fixed():
     ({"cvss_score": 5.0, "epss_score": 0.6}, "public", "HIGH"),     # high EPSS escalates
     ({"cvss_score": 0.0, "confirmed": True}, "public", "MEDIUM"),   # confirmed w/o CVSS floors
     ({"cvss_score": 0.0}, "public", "INFO"),
+    # required_os (#118): an unconfirmed, platform-gated CVSS 9.8 match cannot
+    # be verified without OS-detection, so it is capped at MEDIUM instead of
+    # reading as CRITICAL.
+    ({"cvss_score": 9.8, "required_os": "windows_10"}, "public", "MEDIUM"),
+    ({"cvss_score": 9.8, "required_os": "windows_10", "in_kev": True}, "public", "MEDIUM"),  # cap wins over the KEV boost
+    # A confirmed finding (Hygeia inventory, host OS already known) is exempt
+    # from the cap — the platform precondition isn't a guess in that case.
+    ({"cvss_score": 9.8, "required_os": "windows_10", "confirmed": True}, "public", "CRITICAL"),
+    # required_os alongside a private-LAN target: both caps apply, smallest wins.
+    ({"cvss_score": 9.8, "required_os": "windows_10"}, "private", "MEDIUM"),
 ])
 def test_score_finding(finding, exposure, expected):
     assert score_finding(finding, exposure) == expected

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -127,9 +127,10 @@ def test_nmap_processor_keeps_cpe_in_ports_data():
 
 # ------------------------------------------------ version matcher (Fase 1)
 
-def _fake_cve(cve_id="CVE-2021-41773"):
+def _fake_cve(cve_id="CVE-2021-41773", required_os=None):
     return types.SimpleNamespace(
         cve_id=cve_id, cvss_score=7.5, cvss_vector="CVSS:3.1/AV:N", severity="HIGH",
+        required_os=required_os,
     )
 
 
@@ -176,6 +177,33 @@ def test_version_finding_from_nmap_cpe():
     assert vuln["epss_score"] == 0.97
     assert vuln["check_id"] == "lybra:version-match@1"
     assert vuln["cpe"] == "cpe:2.3:a:apache:http_server:2.4.49:*:*:*:*:*:*:*"
+
+
+def test_version_finding_carries_required_os_from_the_cve_lookup():
+    """#118: a cve_lookup result flagged with a platform gate (KbRepository's
+    transient CveEntry.required_os) must reach the finding dict, so
+    score_finding can avoid crowning an unverifiable platform hypothesis as
+    CRITICAL."""
+    engine = LybraEngine(cve_lookup=lambda *a: [_fake_cve(required_os="windows_10")])
+    service = Service(80, "tcp", "http", "Apache httpd", "2.4.59",
+                      "cpe:/a:apache:http_server:2.4.59")
+
+    findings = engine.analyze([service])
+
+    vuln = findings[1]
+    assert vuln["required_os"] == "windows_10"
+
+
+def test_version_finding_required_os_defaults_to_none():
+    """A cve_lookup result with no required_os attribute at all (a stub, or a
+    genuinely unconditional match) must not blow up — getattr defaults it."""
+    engine = LybraEngine(cve_lookup=_lookup_for(("apache", "http_server")))
+    service = Service(80, "tcp", "http", "Apache httpd", "2.4.49",
+                      "cpe:/a:apache:http_server:2.4.49")
+
+    findings = engine.analyze([service])
+
+    assert findings[1]["required_os"] is None
 
 
 def test_version_finding_via_override_when_no_cpe():

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -93,7 +93,24 @@ def test_normalize_cpe_23_passthrough():
 
 def test_parse_cpe23_extracts_fields():
     parsed = parse_cpe23("cpe:/a:apache:http_server:2.4.49")
-    assert parsed == {"part": "a", "vendor": "apache", "product": "http_server", "version": "2.4.49"}
+    assert parsed == {
+        "part": "a", "vendor": "apache", "product": "http_server", "version": "2.4.49",
+        "target_sw": None,
+    }
+
+
+def test_parse_cpe23_extracts_target_sw():
+    parsed = parse_cpe23("cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:windows:*:*")
+    assert parsed["target_sw"] == "windows"
+
+
+@pytest.mark.parametrize("cpe", [
+    "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*",   # wildcard
+    "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:-:*",   # not-applicable marker
+    "cpe:/a:apache:http_server:2.4.49",                     # 2.2 form has no target_sw field at all
+])
+def test_parse_cpe23_target_sw_none_when_unset(cpe):
+    assert parse_cpe23(cpe)["target_sw"] is None
 
 
 # ---------------------------------------------------------------- NVD ingest
@@ -158,6 +175,83 @@ def test_ingest_nvd_cve_range_beats_pinned_version():
 
 def test_ingest_nvd_cve_malformed_returns_none():
     assert ingest_nvd_cve({"cve": {}}) is None
+
+
+# ------------------------------------------------- platform-gated CVEs (#118)
+
+def _and_node_item(platform_cpe: str) -> dict:
+    """One CVE whose only applicability node ANDs an Apache match with a
+    platform-only CPE — the shape NVD uses for "product X, but only on
+    OS Y" CVEs."""
+    return {"cve": {
+        "id": "CVE-2024-00001",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{
+            "operator": "AND",
+            "cpeMatch": [
+                {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": platform_cpe},
+            ],
+        }]}],
+    }}
+
+
+def test_ingest_nvd_cve_and_node_tags_software_match_with_platform():
+    """NVD's 'product AND platform' node shape must gate the software row
+    with the platform's product token — the mechanism behind CVE-2024-38472-
+    style ("...on Windows") false positives reported against non-Windows
+    hosts (Issue #118)."""
+    item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
+    _cve, matches = ingest_nvd_cve(item)
+    assert len(matches) == 1  # the platform-only cpeMatch produces no row of its own
+    assert matches[0]["product"] == "http_server"
+    assert matches[0]["required_os"] == "windows_10"
+
+
+def test_ingest_nvd_cve_or_node_does_not_gate():
+    """An 'OR' node is not the 'product AND this one platform' shape — must
+    not guess a required_os from it."""
+    item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
+    item["cve"]["configurations"][0]["nodes"][0]["operator"] = "OR"
+    _cve, matches = ingest_nvd_cve(item)
+    # Both entries survive as independent rows once there is no AND to fold.
+    assert {m["product"] for m in matches} == {"http_server"}
+    assert matches[0]["required_os"] is None
+
+
+def test_ingest_nvd_cve_multiple_platforms_in_and_node_does_not_gate():
+    """Two distinct platform products under the same AND node is a shape this
+    module does not attempt to resolve (would need real node-tree/OR
+    semantics) — conservatively leaves required_os unset rather than
+    guessing either platform."""
+    item = {"cve": {
+        "id": "CVE-2024-00002",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{
+            "operator": "AND",
+            "cpeMatch": [
+                {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": "cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": "cpe:2.3:o:microsoft:windows_11:*:*:*:*:*:*:*:*"},
+            ],
+        }]}],
+    }}
+    _cve, matches = ingest_nvd_cve(item)
+    assert matches[0]["required_os"] is None
+
+
+def test_ingest_nvd_cve_target_sw_on_software_cpe_gates_directly():
+    """When NVD encodes the platform on the software's own CPE (target_sw)
+    rather than via a sibling AND node, that must gate the match too."""
+    item = {"cve": {
+        "id": "CVE-2024-00003",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{"cpeMatch": [
+            {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:windows:*:*"},
+        ]}]}],
+    }}
+    _cve, matches = ingest_nvd_cve(item)
+    assert matches[0]["required_os"] == "windows"
 
 
 # --------------------------------------------------------------- KEV / EPSS

--- a/API/tests/unit/test_nuclei_adapter.py
+++ b/API/tests/unit/test_nuclei_adapter.py
@@ -5,7 +5,7 @@ Pure functions over dicts (one decoded JSONL line) — no DB, no subprocess.
 
 import pytest
 
-from src.modules.features.themis.lybra.adapters import nuclei_result_to_finding, QOD_NUCLEI_MATCH
+from src.modules.features.themis.lybra.adapters import nuclei_result_to_finding, finding_to_json, QOD_NUCLEI_MATCH
 
 pytestmark = pytest.mark.unit
 
@@ -168,3 +168,22 @@ def test_cpe_and_cvss_vector_read_from_classification():
     }))
     assert f["cpe"] == "cpe:2.3:a:apache:http_server:2.4.49"
     assert f["cvss_vector"] == "CVSS:3.1/x"
+
+
+# ------------------------------------------------------- finding_to_json (#118)
+
+def test_finding_to_json_exposes_required_os_and_feeds_the_cap_into_priority():
+    """An unconfirmed, platform-gated CVSS 9.8 finding must serialize its
+    required_os and, via score_finding, read as MEDIUM rather than CRITICAL —
+    the same cap the PDF report and the AI writer apply."""
+    f = {"cvss_score": 9.8, "confirmed": False, "required_os": "windows_10"}
+    out = finding_to_json(f, exposure="public")
+    assert out["requiredOs"] == "windows_10"
+    assert out["priority"] == "MEDIUM"
+
+
+def test_finding_to_json_required_os_absent_is_none():
+    f = {"cvss_score": 9.8, "confirmed": False}
+    out = finding_to_json(f, exposure="public")
+    assert out["requiredOs"] is None
+    assert out["priority"] == "CRITICAL"

--- a/API/tests/unit/test_scribe_generator.py
+++ b/API/tests/unit/test_scribe_generator.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Scribe payload-size guardrail (Issue #118).
+
+Covers the heuristic token estimate (``estimate_tokens`` / ``AIInput.estimated_tokens``)
+and ``AIGenerator``'s pre-flight check: an oversized prompt must be rejected
+with ``AIPayloadTooLargeError`` *before* the strategy is ever called, and
+without burning a retry.
+"""
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.tools.scribe import AIInput, AIGenerator, AIPayloadTooLargeError, estimate_tokens
+from src.modules.tools.scribe.inputs import Example
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------- estimate_tokens
+
+def test_estimate_tokens_roughly_four_chars_per_token():
+    assert estimate_tokens("a" * 400) == 100
+
+
+def test_estimate_tokens_empty_string_is_zero():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_rounds_up_partial_token():
+    assert estimate_tokens("abc") == 1  # 3 chars, 1 token, not 0
+
+
+# ------------------------------------------------------- AIInput.estimated_tokens
+
+def test_ai_input_estimated_tokens_sums_all_messages():
+    ai_input = AIInput(system_prompt="s" * 40, user_prompt="u" * 40)
+    # system + user = 80 chars = 20 tokens
+    assert ai_input.estimated_tokens() == 20
+
+
+def test_ai_input_estimated_tokens_includes_examples():
+    ai_input = AIInput(
+        system_prompt="s" * 40,
+        user_prompt="u" * 40,
+        examples=[Example(user="e" * 40, assistant="a" * 40)],
+    )
+    # 40*4 chars = 160 chars = 40 tokens
+    assert ai_input.estimated_tokens() == 40
+
+
+# ------------------------------------------------------------------ AIGenerator
+
+class _FakeStrategy:
+    """A strategy stub that records whether it was ever called."""
+
+    name = "fake"
+
+    def __init__(self, response: str = "ok"):
+        self._response = response
+        self.calls = 0
+
+    def complete(self, ai_input, tool_executor=None):
+        self.calls += 1
+        return self._response
+
+
+def test_digest_rejects_oversized_prompt_without_calling_strategy(monkeypatch):
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=10))
+    strategy = _FakeStrategy()
+    generator = AIGenerator(strategy)
+    ai_input = AIInput(system_prompt="x" * 1000, user_prompt="y")  # far over 10 tokens
+
+    with pytest.raises(AIPayloadTooLargeError):
+        generator.digest(ai_input)
+
+    assert strategy.calls == 0  # never reached the backend — no wasted retry
+
+
+def test_digest_allows_prompt_within_limit(monkeypatch):
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=1000))
+    strategy = _FakeStrategy(response="respuesta")
+    generator = AIGenerator(strategy)
+    ai_input = AIInput(system_prompt="hola", user_prompt="mundo")
+
+    result = generator.digest(ai_input)
+
+    assert result.text == "respuesta"
+    assert strategy.calls == 1
+
+
+def test_ai_payload_too_large_error_is_not_retried(monkeypatch):
+    """Distinguishes the size guardrail from a normal transient failure: a
+    normal exception is retried up to max_retries times, but a payload that's
+    too large must fail on the very first check, every time, so retrying it
+    would be pure waste."""
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=1))
+    strategy = _FakeStrategy()
+    generator = AIGenerator(strategy, max_retries=3)
+    ai_input = AIInput(system_prompt="way too long for the limit", user_prompt="y")
+
+    with pytest.raises(AIPayloadTooLargeError):
+        generator.digest(ai_input)
+
+    assert strategy.calls == 0

--- a/API/tests/unit/test_themis_ai_analysis_error_message.py
+++ b/API/tests/unit/test_themis_ai_analysis_error_message.py
@@ -1,0 +1,91 @@
+"""Unit tests for how the PDF report reacts when the AI writer fails (#118).
+
+``PrintingStrategy._append_ai_analysis`` used to catch every exception the
+same way, rendering a generic "No se pudo generar análisis IA" paragraph
+regardless of cause. A scan too large for the configured token budget now
+gets its own, specific message instead of that generic fallback.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from reportlab.lib.styles import getSampleStyleSheet
+
+import src.modules.system.config_reading as CR
+from src.modules.features.themis.services.reports.base import PrintingStrategy
+from src.modules.shared.report_theme import ColorType, ReportTheme
+from src.modules.tools.scribe import AIPayloadTooLargeError
+
+pytestmark = pytest.mark.unit
+
+_PALETTE = {
+    ColorType.BLACK: "#121212", ColorType.DARK: "#333333", ColorType.MAIN: "#014f86",
+    ColorType.SECONDARY: "#555b6e", ColorType.LIGHT: "#4a90e2", ColorType.WHITE: "#f5f5f5",
+}
+_FAKE_PROMPTS = {"nmap": {"system": "Eres un analista.", "userTemplate": "x"}}
+
+
+class _FakeWriter:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def generate(self, scan, **kwargs):
+        raise self._exc
+
+
+class _MinimalPrintingStrategy(PrintingStrategy):
+    """The smallest concrete subclass that satisfies the ABC — only
+    ``_append_ai_analysis`` (inherited, not overridden) is under test."""
+
+    def append_body(self, theme, elements, ai_report=False):
+        raise NotImplementedError
+
+    def get_filename_suffix(self) -> str:
+        return "_Test.pdf"
+
+    def get_picture_name(self, dark: bool = True) -> str:
+        return "Test"
+
+    def get_report_title(self) -> str:
+        return "Test"
+
+
+def _strategy(exc: Exception) -> _MinimalPrintingStrategy:
+    scan = types.SimpleNamespace(id=1, scan_type="nmap")
+    strategy = _MinimalPrintingStrategy(scan=scan)
+    strategy.writer = _FakeWriter(exc)
+    return strategy
+
+
+def _theme() -> ReportTheme:
+    return ReportTheme(getSampleStyleSheet(), _PALETTE)
+
+
+def _rendered_text(elements: list) -> str:
+    return " ".join(el.getPlainText() for el in elements if hasattr(el, "getPlainText"))
+
+
+def test_payload_too_large_gets_a_specific_message(monkeypatch):
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_PROMPTS)
+    strategy = _strategy(AIPayloadTooLargeError(estimated_tokens=99999, max_tokens=24000))
+    elements: list = []
+
+    strategy._append_ai_analysis(elements, _theme())
+
+    text = _rendered_text(elements)
+    assert "demasiados hallazgos" in text
+    assert "No se pudo generar análisis IA" not in text
+
+
+def test_other_failures_keep_the_generic_message(monkeypatch):
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_PROMPTS)
+    strategy = _strategy(RuntimeError("boom"))
+    elements: list = []
+
+    strategy._append_ai_analysis(elements, _theme())
+
+    text = _rendered_text(elements)
+    assert "No se pudo generar análisis IA" in text
+    assert "demasiados hallazgos" not in text

--- a/API/tests/unit/test_themis_ai_writer.py
+++ b/API/tests/unit/test_themis_ai_writer.py
@@ -20,7 +20,7 @@ import json
 import pytest
 
 import src.modules.system.config_reading as CR
-from src.modules.features.themis.services.analyzers import LybraAIWriter
+from src.modules.features.themis.services.analyzers import LybraAIWriter, NmapAIWriter
 
 pytestmark = pytest.mark.unit
 
@@ -150,3 +150,127 @@ def test_la_cola_se_recorta_por_prioridad_y_nunca_descarta_confirmados(monkeypat
     assert hallazgos[0]["confirmado"] is True
     # El recuento total sigue siendo el real aunque el detalle esté recortado.
     assert sum(group["total_hallazgos"] for group in payload["servicios"]) == len(ruido) + 1
+
+
+def test_confirmados_y_kev_tambien_se_recortan_al_tope(monkeypatch):
+    """#118: antes solo la cola ('rest') tenía tope — un scan con más
+    confirmados/KEV que _MAX_HIGHLIGHTED_FINDINGS generaba un payload sin
+    límite real pese a la constante. Deben recortarse igual, priorizando por
+    severidad."""
+    muchos_confirmados = [
+        _finding(
+            title=f"CVE-2021-{40000 + i}", cve_ids=[f"CVE-2021-{40000 + i}"],
+            confirmed=True, cvss_score=5.0 + (i % 5), priority="MEDIUM",
+            port=1000 + i,
+        )
+        for i in range(LybraAIWriter._MAX_HIGHLIGHTED_FINDINGS + 15)
+    ]
+    # El más grave del lote, al final de la lista de entrada — debe
+    # sobrevivir al recorte pese a no ser el primero en orden de repositorio.
+    muchos_confirmados[-1] = _finding(
+        title="El más grave", cve_ids=["CVE-2021-99999"],
+        confirmed=True, cvss_score=9.8, priority="CRITICAL", port=9999,
+    )
+
+    hallazgos = _build(muchos_confirmados, monkeypatch)["hallazgos"]
+
+    assert len(hallazgos) == LybraAIWriter._MAX_HIGHLIGHTED_FINDINGS
+    assert all(h["confirmado"] for h in hallazgos)
+    assert hallazgos[0]["titulo"] == "El más grave"
+
+
+def test_hallazgo_confirmado_y_en_kev_no_se_duplica_en_el_payload(monkeypatch):
+    """Antes de deduplicar, un hallazgo confirmado Y en KEV a la vez entraba
+    dos veces en la lista destacada (concatenación ingenua confirmed + kev)."""
+    doble = _finding(confirmed=True, in_kev=True)
+
+    hallazgos = _build([doble], monkeypatch)["hallazgos"]
+
+    assert len(hallazgos) == 1
+
+
+def test_rollup_de_servicios_se_recorta_al_tope_priorizando_severidad(monkeypatch):
+    """#118: un objetivo con muchos productos/puertos distintos (un rango de
+    red, no un solo host) podía generar un 'services_json' sin límite."""
+    muchos_servicios = [
+        _finding(
+            title=f"Servicio {i}", cve_ids=[f"CVE-2020-{10000 + i}"],
+            port=2000 + i, service=f"svc{i}",
+            cpe=f"cpe:2.3:a:vendor{i}:product{i}:1.0:*:*:*:*:*:*:*",
+            cvss_score=float(i % 10), priority="LOW",
+        )
+        for i in range(LybraAIWriter._MAX_SERVICE_GROUPS + 20)
+    ]
+    mas_grave = _finding(
+        title="El más grave", cve_ids=["CVE-2020-99999"],
+        port=9999, service="svc-critico",
+        cpe="cpe:2.3:a:vendor-critico:product-critico:1.0:*:*:*:*:*:*:*",
+        cvss_score=9.8, priority="CRITICAL",
+    )
+
+    servicios = _build(muchos_servicios + [mas_grave], monkeypatch)["servicios"]
+
+    assert len(servicios) == LybraAIWriter._MAX_SERVICE_GROUPS
+    assert servicios[0]["producto"] == "product-critico 1.0"
+
+
+# ------------------------------------------------------- NmapAIWriter (#118)
+
+_FAKE_NMAP_PROMPTS = {
+    "nmap": {
+        "system": "Eres un analista senior.",
+        "userTemplate": (
+            "Objetivo {{target}} inicio {{started}} total {{total_ports}} "
+            "distribucion {{distribution}} perfil {{profile_type}}\n"
+            "PUERTOS:\n{{ports_json}}"
+        ),
+    }
+}
+
+
+def _open_port(port: int, service: str = "http") -> dict:
+    return {
+        "port": {"port": port, "protocol": "tcp"},
+        "given_use": service,
+        "product": "Apache",
+        "version": "2.4.7",
+        "reason": "syn-ack",
+    }
+
+
+def _build_nmap(open_ports: list, monkeypatch) -> dict:
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_NMAP_PROMPTS)
+
+    writer = NmapAIWriter(generator=object())
+    network_ctx = {
+        "is_private": False, "network_type": "Red pública",
+        "max_risk_level": "CRÍTICO", "context_note": "CONTEXTO DE RED CONFIRMADO: público.",
+    }
+    prompt = writer._build_user_prompt(
+        {"target": "45.33.32.156", "started_at": "2026-08-11"}, open_ports, network_ctx,
+    )
+
+    header, _, ports_block = prompt.partition("PUERTOS:\n")
+    total_ports = int(header.split("total ")[1].split(" ")[0])
+    return {"total_ports": total_ports, "puertos": json.loads(ports_block)}
+
+
+def test_ports_se_recortan_al_tope_pero_total_ports_sigue_siendo_el_real(monkeypatch):
+    """#118: un host con muchos más puertos abiertos que el tope no debe
+    generar un 'ports_json' sin límite, pero '{{total_ports}}' debe seguir
+    reportando el recuento real — nunca menos puertos de los que hay."""
+    open_ports = [_open_port(1000 + i) for i in range(NmapAIWriter._MAX_PORTS + 25)]
+
+    payload = _build_nmap(open_ports, monkeypatch)
+
+    assert len(payload["puertos"]) == NmapAIWriter._MAX_PORTS
+    assert payload["total_ports"] == len(open_ports)
+
+
+def test_ports_bajo_el_tope_no_se_recortan(monkeypatch):
+    open_ports = [_open_port(80), _open_port(22, "ssh")]
+
+    payload = _build_nmap(open_ports, monkeypatch)
+
+    assert len(payload["puertos"]) == 2
+    assert payload["total_ports"] == 2


### PR DESCRIPTION
## Summary

Corrige el error `429 Request too large` de OpenAI al analizar con IA un scan de Themis con muchos hallazgos (Lybra/Nuclei), en tres capas complementarias:

1. **Causa raíz — precisión de correlación de CVEs (Lybra)**: `CpeMatch`/`Finding` ganan una columna `required_os`. `kb.py::ingest_nvd_cve` la deriva de los nodos `AND` de NVD (CPE de software + CPE de plataforma) o del `target_sw` embebido en la CPE. `score_finding` tapa a MEDIO cualquier hallazgo **no confirmado** cuya aplicabilidad dependa de un SO que Lybra no puede verificar, en vez de tratar un CVE "solo en Windows" como CRÍTICO contra cualquier host.
2. **Guardarraíl transversal en Scribe**: `AIGenerator.digest` estima el tamaño del prompt (heurística chars/4) y lanza `AIPayloadTooLargeError` si supera `ScribeConfig.max_input_tokens` — antes de llamar al backend y sin quemar los `max_retries` reintentos.
3. **Capado del payload en origen (Themis)**: `LybraAIWriter` aplica su tope de hallazgos destacados también a `confirmados + KEV` (antes solo a la cola) y acota el rollup por servicio; `NmapAIWriter` acota `ports_json` manteniendo el recuento real.

Además, un mensaje específico ("demasiados hallazgos para un análisis de IA completo") sustituye al genérico "No se pudo generar análisis IA" cuando la causa es el tamaño.

## Related Issue

Closes #118

## Implementation

- `fix(themis): filtrar hallazgos de Lybra/Nuclei gateados por SO no verificable` — causa raíz.
- `fix(scribe): rechazar prompts sobredimensionados antes de llamar al backend` — guardarraíl transversal.
- `fix(scribe): declarar maxInputTokens en SecOpsConfig.json` — fixup de forma de config.
- `fix(themis): acotar el payload de los AI writers de Themis` — defensa en profundidad.
- `fix(themis): mensaje específico cuando el escaneo es demasiado grande para IA`.
- `style(themis): acortar comentarios de required_os a <100 columnas`.
- `chore(db): merge white-labeling migration heads` (cherry-pick de `feat/aegis/white-labeling`, ver Notes).
- `chore(db): reencadenar la migración de required_os tras el merge de cabezas`.

Migración Alembic nueva (`4fe4383a5085`): añade `CpeMatch.required_os` y `Finding.required_os` (nullable, no destructiva). El `required_os` de los `CpeMatch` ya ingeridos queda en `NULL` hasta el próximo `sync_nvd` — no hace falta ningún backfill especial, solo un resync normal para que la precisión mejore también sobre CVEs ya en la base local.

## Validation

- `pytest -m unit` y `pytest tests/integration` — verdes, sin regresiones.
- `pylint` sobre todos los ficheros tocados — sin avisos nuevos más allá de deuda preexistente ya presente en esos mismos ficheros.
- Nuevos tests unitarios/integración cubriendo: derivación de `required_os` desde nodos `AND`/`target_sw` de NVD, el descuento de prioridad en `score_finding`, el guardarraíl de `AIGenerator.digest` (sin reintentos desperdiciados), el capado de confirmados+KEV/rollup/puertos, y el mensaje específico en el PDF.

## Notes

- Hallazgo colateral (comentado en el Issue #118): el informe real que motivó investigar esto (scan #256 contra `45.33.32.156`) tenía 151 hallazgos sobre solo 2 servicios, con 35 marcados CRÍTICA de los que solo 3 estaban confirmados — varios CVEs eran explícitamente "solo Windows" contra un host no-Windows. Ese caso queda cubierto por el fix de `required_os`.
- **Hallazgo nuevo, resuelto dentro de este mismo PR**: el repo tenía **dos cabezas de Alembic** sin fusionar (`a1b2c3d4e5f7` "aegis org profile" y `b2c3d4e5f6a7` "catalogo: tope de white-labeling por plan"), preexistentes en `develope` y sin relación con Themis/Scribe. `alembic upgrade head` (en singular) fallaba con "Multiple head revisions are present". La rama `feat/aegis/white-labeling` (aún no fusionada) ya había resuelto exactamente esto con `chore(db): merge white-labeling migration heads` (`baf6f0e7fd8c`) — en vez de escribir una migración de merge propia (que habría creado un segundo punto de fusión duplicado el día que ambas ramas conviven en `develope`), hice `cherry-pick` de ese commit tal cual y reencadené `4fe4383a5085` para que dependa de él. Así, fusione lo que fusione primero, el grafo de Alembic queda con una única cabeza sin duplicados.
- No se ha tocado el prompt de sistema de Lybra/Nuclei en `SecOpsConfig.json` para que el modelo "sepa" de `requiere_so` explícitamente (el campo ya viaja en el JSON del payload, pero el prompt no lo menciona) — evita el riesgo de reescribir un prompt ya afinado sin poder validar el resultado contra el modelo real en este entorno.

