### PR TITLE
fix(web): evitar que el hero recorte el desplegable de cuenta

### DIFF
--- a/web/app/src/components/shared/AccountMenu.vue
+++ b/web/app/src/components/shared/AccountMenu.vue
@@ -198,6 +198,8 @@ onUnmounted(() => {
 .drop {
   position: absolute; top: calc(100% + 0.7rem); right: 0; z-index: 60;
   width: 300px;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
   background: var(--surface);
   border: 1px solid var(--border-solid);
   border-radius: 10px;

--- a/web/app/src/views/LandingView.vue
+++ b/web/app/src/views/LandingView.vue
@@ -623,11 +623,15 @@ onUnmounted(() => {
 }
 
 /* ═══════════ HERO — la vista ═══════════ */
+/* Sin overflow:hidden aquí: `ElysianScene` ya se recorta a sí misma
+   (`.scene { overflow: hidden }`), así que este `overflow` no protegía nada
+   del fondo — solo recortaba, sin querer, cualquier desplegable de la
+   cabecera (AccountMenu, Herramientas, Documentación) que no cupiera en los
+   100vh del hero (issue #140). */
 .vista {
   position: relative;
   height: 100vh;
   min-height: 640px;
-  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Resumen

- `.vista` (la sección del hero de la portada) tenía `overflow: hidden` con altura fija (`100vh`/`min-height: 640px`). El `AccountMenu` se monta dentro de esa sección, así que cuando su panel desplegable no cabía en ese hueco recortado (rol admin/root con más entradas, y/o zoom alto del navegador), la parte inferior del menú quedaba invisible y sin poder pulsarse — daba la sensación de que el friso dorado del hero lo "tapaba".
- Se retira ese `overflow: hidden`: `ElysianScene` (el fondo animado) ya se recorta a sí misma con su propio `overflow: hidden`, así que el de `.vista` no protegía nada visualmente y solo recortaba, sin querer, cualquier desplegable de la cabecera (AccountMenu, y de paso los menús "Herramientas"/"Documentación", que comparten el mismo contenedor).
- Se añade `max-height` + `overflow-y: auto` al panel `.drop` del `AccountMenu`, para que un menú largo se pueda recorrer con scroll en vez de desbordar.

## Related Issue

Fixes ProjectEllysia/EllysiaServer#140

## Implementation

1. `web/app/src/views/LandingView.vue`: quitado `overflow: hidden` de `.vista`.
2. `web/app/src/components/shared/AccountMenu.vue`: `max-height: calc(100vh - 100px); overflow-y: auto;` en `.drop`.

## Validation

- `npm run build` en `web/app` — compila sin errores.
- Verificación en navegador (Vite dev server, sin API — la portada no requiere sesión para el menú "Herramientas"): se infló el panel `.nav-panel--tools` con elementos clonados para simular un contenido tan alto como el `AccountMenu` de un usuario root, y se confirmó mediante `getBoundingClientRect`/`elementFromPoint`:
  - Con `overflow: hidden` en `.vista`: el contenido que excede la caja del hero (390px en la prueba) queda fuera del área pintada — no es alcanzable con `elementFromPoint` aunque el punto esté dentro del viewport.
  - Tras el fix (`overflow: visible`): el mismo contenido es alcanzable en cuanto el viewport/scroll lo permite, como cualquier otro contenido en flujo normal.
- No se pudo hacer una pasada manual completa del `AccountMenu` real (con sesión root, para ver todas sus entradas) porque este entorno Windows no tiene la API corriendo (requiere WSL/Docker, no disponibles en este sandbox) — el razonamiento anterior aplica igual porque ambos desplegables comparten exactamente el mismo contenedor y la misma regla de `overflow`.

## Notes

- El `AccountMenu` que usa `SiteHeader.vue` (resto de la aplicación, fuera de la portada) no estaba afectado por este bug, y no ha cambiado.
- Pendiente de una verificación manual adicional en un entorno con la API disponible (WSL/Docker), idealmente con una cuenta root y zoom alto, para confirmar visualmente el `AccountMenu` real.
