### PR TITLE
fix(aegis): crear la columna brand_color y cerrar los hallazgos de la revisión

### DIFF
--- a/API/alembic/versions/c7d8e9f0a1b2_aegis_org_profile_brand_color.py
+++ b/API/alembic/versions/c7d8e9f0a1b2_aegis_org_profile_brand_color.py
@@ -1,0 +1,55 @@
+"""aegis org profile: la columna brand_color que falto en a1b2c3d4e5f7
+
+El mixin ``shared.WhiteLabelColumns`` declara tres columnas, pero la migracion
+que lo acompanyaba solo creo dos: ``brand_color`` se perdio al resolver un
+merge. En un despliegue real el esquema lo construye Alembic, asi que la
+columna no existia y cualquier lectura de AegisOrgProfile (perfil, envio de
+campanya, pagina publica del test) reventaba con UndefinedColumn. La suite no
+lo veia porque los tests crean el esquema con ``Base.metadata.create_all``.
+
+Va en una migracion nueva y no editando a1b2c3d4e5f7, que ya esta fusionada y
+puede haberse aplicado: reeditarla dejaria esas bases sin la columna para
+siempre. El ``IF NOT EXISTS`` la hace inocua alli donde a1b2c3d4e5f7 se
+aplicara con la version que si la creaba.
+
+Revision ID: c7d8e9f0a1b2
+Revises: 4fe4383a5085
+Create Date: 2026-08-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c7d8e9f0a1b2'
+down_revision: Union[str, Sequence[str], None] = '4fe4383a5085'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_COLUMN = sa.Column("brand_color", sa.String(length=7), nullable=True)
+
+
+def upgrade() -> None:
+    if not _has_brand_color():
+        op.add_column("AegisOrgProfile", _COLUMN)
+
+
+def downgrade() -> None:
+    if _has_brand_color():
+        op.drop_column("AegisOrgProfile", "brand_color")
+
+
+def _has_brand_color() -> bool:
+    """Si la columna ya esta, no se toca.
+
+    El inspector es portable (Postgres y SQLite); ``ADD COLUMN IF NOT EXISTS``
+    no lo es.
+    """
+    inspector = sa.inspect(op.get_bind())
+    return any(
+        column["name"] == "brand_color"
+        for column in inspector.get_columns("AegisOrgProfile")
+    )

--- a/API/src/modules/features/aegis/model.py
+++ b/API/src/modules/features/aegis/model.py
@@ -112,7 +112,8 @@ class AegisOrgProfile(WhiteLabelColumns, Base):
             registering a first agent starts paying off without extra setup;
             the UI only surfaces the control once such an agent exists.
         white_label_level: How much of the Ellysia brand the campaign
-            recipients see ('none' | 'logo' | 'full'). From WhiteLabelColumns.
+            recipients see ('none' | 'color' | 'logo' | 'full'). Each step adds
+            to the previous one. From WhiteLabelColumns.
         brand_logo: The organization's logo as a base64 data URI, shown in the
             campaign email. From WhiteLabelColumns.
         brand_color: The organization's accent colour ('#1a73e8'), replacing

--- a/API/src/modules/shared/_white_label.py
+++ b/API/src/modules/shared/_white_label.py
@@ -140,8 +140,13 @@ def validate_logo_data_uri(value: str) -> tuple[str, bytes]:
         allowed = ", ".join(sorted(ALLOWED_LOGO_MIMETYPES))
         raise ValueError(f"Formato de logo no admitido: '{mimetype}'. Admitidos: {allowed}.")
 
+    # Los espacios se quitan antes de decodificar, no después de rechazarlos:
+    # el regex los admite a propósito porque hay codificadores que parten el
+    # base64 en líneas de 76 caracteres (``base64.encodebytes``, RFC 2045), y
+    # ``validate=True`` los trata como alfabeto inválido.
+    payload = re.sub(r"\s+", "", match.group("payload"))
     try:
-        data = base64.b64decode(match.group("payload"), validate=True)
+        data = base64.b64decode(payload, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise ValueError("El logo no es base64 válido.") from exc
 

--- a/API/tests/unit/test_migration_column_coverage.py
+++ b/API/tests/unit/test_migration_column_coverage.py
@@ -1,0 +1,57 @@
+"""Que ninguna columna del modelo se quede sin migración.
+
+El esquema se construye de dos formas distintas y nadie las compara: los tests
+lo crean con ``Base.metadata.create_all`` (conftest.py) y el despliegue con
+``alembic upgrade head`` (run.py). Una columna declarada en el modelo y
+olvidada en la migración pasa la suite entera y revienta en producción con
+UndefinedColumn la primera vez que alguien lee esa tabla — que es justo lo que
+pasó con ``AegisOrgProfile.brand_color``.
+
+El test es textual a propósito: ejecutar la cadena de migraciones aquí exigiría
+un Postgres (hay JSONB, índices parciales y ARRAY por medio), y lo que se
+quiere cazar no es un fallo de SQL sino un descuido — el nombre de la columna
+no aparece en ninguna migración. Por eso solo busca el nombre, y por eso puede
+dar por buena una columna cuyo nombre coincida con el de otra tabla.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.modules.shared import Base
+
+# Los modelos tienen que estar importados para que estén en el metadata; el
+# paquete de cada módulo los arrastra.
+import src.modules.features.aegis.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.hygeia.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.iris.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.themis.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.accounts.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.users.model  # noqa: F401  pylint: disable=unused-import
+
+pytestmark = pytest.mark.unit
+
+
+VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+
+def _migration_sources() -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in VERSIONS_DIR.glob("*.py")
+    )
+
+
+def test_every_model_column_appears_in_some_migration():
+    sources = _migration_sources()
+    missing = {
+        f"{table.name}.{column.name}"
+        for table in Base.metadata.sorted_tables
+        for column in table.columns
+        if f'"{column.name}"' not in sources and f"'{column.name}'" not in sources
+    }
+    assert not missing, (
+        "Estas columnas están en el modelo y no las crea ninguna migración, así "
+        "que la suite pasa (crea el esquema con create_all) y el despliegue "
+        f"revienta con UndefinedColumn: {sorted(missing)}."
+    )

--- a/API/tests/unit/test_white_label.py
+++ b/API/tests/unit/test_white_label.py
@@ -75,6 +75,18 @@ def test_validate_logo_data_uri_rejects_invalid(value):
         validate_logo_data_uri(value)
 
 
+def test_validate_logo_data_uri_accepts_wrapped_base64():
+    """Base64 partido en líneas (RFC 2045) es válido y hay codificadores que lo
+    generan solos — ``base64.encodebytes``, sin ir más lejos. El regex ya lo
+    admitía; lo que fallaba era la decodificación con ``validate=True``."""
+    wrapped = "data:image/png;base64," + base64.encodebytes(_PNG_BYTES).decode()
+
+    mimetype, data = validate_logo_data_uri(wrapped)
+
+    assert mimetype == "image/png"
+    assert data == _PNG_BYTES
+
+
 def test_validate_logo_data_uri_rejects_oversized_logo():
     oversized = "data:image/png;base64," + base64.b64encode(b"\x00" * (MAX_LOGO_BYTES + 1)).decode()
     with pytest.raises(ValueError, match="máximo"):

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -39,11 +39,14 @@
         @input="update({ color: $event.target.value })"
       />
       <code class="wl-color-value">{{ modelValue.color || DEFAULT_COLOR }}</code>
+      <!-- "Restablecer" vuelve al acento del producto de forma explícita, no
+           vaciando el campo: un color vacío deja el nivel sin su dato y el
+           envío lo degradaría en silencio. -->
       <button
-        v-if="modelValue.color"
+        v-if="modelValue.color && modelValue.color !== DEFAULT_COLOR"
         type="button"
         class="wl-remove"
-        @click="update({ color: '' })"
+        @click="update({ color: DEFAULT_COLOR })"
       >
         Restablecer
       </button>
@@ -61,6 +64,10 @@
       </label>
 
       <p v-if="error" class="wl-error">{{ error }}</p>
+      <p v-else-if="!modelValue.logo" class="wl-warning">
+        Sin imagen este nivel no se aplica: los envíos saldrán con el escalón
+        anterior, «Aplicar color corporativo».
+      </p>
       <p v-else class="wl-hint">PNG, JPG o GIF, hasta {{ MAX_KB }} KB.</p>
     </div>
 
@@ -74,10 +81,11 @@
 
 <script setup>
 /**
- * Ajustes de white-labeling de un módulo: nivel y logo de la organización.
+ * Ajustes de white-labeling de un módulo: nivel, color y logo de la
+ * organización.
  *
  * No sabe de qué módulo son los ajustes ni cómo se guardan — se ata con
- * `v-model` a un objeto `{ level, logo }` y avisa de los cambios. El tope lo
+ * `v-model` a un objeto `{ level, color, logo }` y avisa de los cambios. El tope lo
  * decide el plan y llega en `maxLevel`; el servidor lo vuelve a comprobar al
  * guardar, así que aquí solo se evita ofrecer lo que se va a rechazar.
  *
@@ -88,7 +96,7 @@ import { computed, ref } from 'vue'
 
 const props = defineProps({
   modelValue: { type: Object, required: true },
-  /** Nivel máximo que concede el plan ('none' | 'logo' | 'full'). */
+  /** Nivel máximo que concede el plan ('none' | 'color' | 'logo' | 'full'). */
   maxLevel: { type: String, default: 'none' },
 })
 const emit = defineEmits(['update:modelValue'])
@@ -142,7 +150,13 @@ function update(patch) {
 
 function setLevel(level) {
   if (isLocked(level)) return
-  update({ level })
+  // El color del selector entra en el modelo en cuanto el nivel lo usa. Si no,
+  // se enseñaba DEFAULT_COLOR en la muestra y se guardaba una cadena vacía: el
+  // nivel quedaba sin su dato y el envío lo degradaba en silencio (el servidor
+  // acepta el guardado, así que no había ni error ni aviso).
+  const patch = { level }
+  if (level !== 'none' && !props.modelValue.color) patch.color = DEFAULT_COLOR
+  update(patch)
 }
 
 function clearLogo() {
@@ -238,6 +252,7 @@ function onFile(event) {
 .wl-file:focus-within { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 
 .wl-error { margin: 0; font-size: var(--fs-xs); color: var(--danger, #c2621d); }
+.wl-warning { margin: 0; font-size: var(--fs-sm); color: var(--warn, #a8842a); line-height: 1.35; }
 .wl-note {
   margin: 0.2rem 0 0; padding: 0.5rem 0.65rem; border-radius: 6px;
   background: var(--surface-2); border-left: 2px solid var(--border-med);

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -702,6 +702,11 @@ export const useAegisStore = defineStore('aegis', () => {
     trackedProducts.value = []
     useHygeiaInventory.value = true
     hygeiaInventoryAvailable.value = false
+    // El logo y el color son del usuario que se va: dejarlos aquí los enseña
+    // al siguiente que entre en la misma pestaña, y si su GET del perfil falla
+    // (loadOrgProfile no sobrescribe nada entonces) se los acabaría guardando.
+    whiteLabel.value = { level: 'none', logo: '', color: '' }
+    maxWhiteLabelLevel.value = 'none'
     productResults.value = []
     searchingProducts.value = false
     productSearchError.value = ''


### PR DESCRIPTION
## Resumen

Corrige los cinco hallazgos de la revisión del white-labeling ya fusionado en
`develope` (#143). El primero rompía el despliegue; los demás son fugas de
estado y fallos silenciosos.

## Hallazgos corregidos

**1. `AegisOrgProfile.brand_color` no la creaba ninguna migración** *(bloqueante)*

El mixin `WhiteLabelColumns` declara tres columnas y `a1b2c3d4e5f7` solo creaba
dos: `brand_color` se perdió al resolver un merge. Los tests construyen el
esquema con `Base.metadata.create_all` y el despliegue con `alembic upgrade
head`, así que la suite pasaba entera y en producción el primer `SELECT` sobre
`AegisOrgProfile` habría fallado con `UndefinedColumn` — perfil de organización,
envío de campañas y página pública del test, todo con 500.

La columna va en una **migración nueva** (`c7d8e9f0a1b2`), no editando la ya
fusionada: puede haberse aplicado, y reeditarla dejaría esas bases sin la
columna para siempre. Es idempotente (comprueba el inspector antes de añadirla),
así que no molesta donde `a1b2c3d4e5f7` se aplicara con la versión que sí la
creaba.

**Y el test que faltaba**: `test_migration_column_coverage.py` compara las
columnas del modelo con el texto de las migraciones. Verificado que falla con
`['AegisOrgProfile.brand_color']` si se retira la migración nueva.

**2. `$reset()` no limpiaba la marca del usuario saliente**

El logout SPA dejaba `whiteLabel` y `maxWhiteLabelLevel` en memoria. El
siguiente usuario en la misma pestaña veía el logo del anterior y, si su GET del
perfil fallaba (`loadOrgProfile` no sobrescribe nada entonces), podía guardarlo
como suyo.

**3. El selector de color enseñaba un color que no se guardaba**

Pintaba `DEFAULT_COLOR` con el modelo vacío: se guardaba nivel `color` con
`brandColor:""`, la API respondía 200 y el envío degradaba a "sin
white-labeling" sin decir nada. Ahora el color entra en el modelo al elegir el
nivel, «Restablecer» vuelve al acento del producto de forma explícita (vaciarlo
reintroducía el mismo fallo) y el nivel de logo avisa cuando falta la imagen.

**4. Base64 partido en líneas se rechazaba**

El regex admitía `\s` a propósito, pero `b64decode(validate=True)` lo trata como
alfabeto inválido: un PNG válido codificado con `base64.encodebytes` (RFC 2045,
líneas de 76 caracteres) se rechazaba con «El logo no es base64 válido». Se
limpian los espacios antes de decodificar.

**5. Docstrings sin el escalón `color`**

`model.py` y el prop `maxLevel` enumeraban tres niveles de cuatro, lo que induce
a repartir mal los ordinales de los planes.

## Validación

- Suite completa de la API: **0 fallos**.
- `test_migration_column_coverage.py` comprobado en los dos sentidos: falla sin
  la migración nueva, pasa con ella.
- Test nuevo del base64 con saltos de línea en `test_white_label.py`.
- Build del SPA sin errores.
- Verificación en navegador del componente: elegir «Aplicar color corporativo»
  deja `#d4a04a` en el modelo (lo que se ve es lo que se guarda), «Restablecer»
  vuelve a ese acento y desaparece, y el nivel de logo sin imagen muestra el
  aviso.

## Notas

- Los hallazgos 2 y 3 no llevan test automático: la cadena de imports de
  `aegisStore` llega a `@/router`, que arrastra todas las vistas `.vue`, y
  `web/app/test/` son tests de Node puro sin resolución de alias ni de SFC.
  Montar esa infraestructura era desproporcionado para el arreglo; ambos se
  verificaron en el navegador.
- Queda pendiente de la revisión, sin tocar aquí: la migración de merge
  `baf6f0e7fd8c` es un no-op y el encadenado quedaría más limpio si
  `b2c3d4e5f6a7` colgara de `a1b2c3d4e5f7`, pero no se reencadena por si ya se
  aplicó en alguna base local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
