### PR TITLE
fix(web): accesibilidad de teclado en modales (Escape/focus trap/scroll-lock)

### DIFF
--- a/web/app/src/components/aegis/CampaignModal.vue
+++ b/web/app/src/components/aegis/CampaignModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
-    <div class="modal-overlay" data-module="aegis" @click.self="close" @keydown.esc="close">
-      <div class="modal--campaign" role="dialog" aria-modal="true" aria-labelledby="campaign-modal-title">
+    <div class="modal-overlay" data-module="aegis" @click.self="close">
+      <div ref="boxRef" class="modal--campaign" role="dialog" aria-modal="true" aria-labelledby="campaign-modal-title" tabindex="-1">
         <header class="campaign-header">
           <div class="campaign-header-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
@@ -164,6 +164,7 @@ bob@empresa.com"
 import { computed, ref } from 'vue'
 import { useAegisStore } from '@/stores/aegisStore'
 import { useUtils } from '@/composables/useUtils'
+import { useModalA11y } from '@/composables/useModalA11y'
 import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const props = defineProps({ doc: { type: Object, required: true } })
@@ -171,6 +172,8 @@ const emit = defineEmits(['close'])
 
 const store = useAegisStore()
 const { formatDate, parseEmails } = useUtils()
+
+const boxRef = ref(null)
 
 function defaultCampaignName() {
   const title = props.doc?.subtitle || props.doc?.title || 'Píldora'
@@ -226,6 +229,8 @@ async function handleLaunch() {
 
 function close() { emit('close') }
 
+useModalA11y(() => true, { boxRef, onClose: close })
+
 const deleteTarget = ref(null)
 async function confirmDelete() {
   const campaign = deleteTarget.value
@@ -266,7 +271,7 @@ const stats = computed(() => {
 
 <style scoped>
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 1rem; }
-.modal--campaign { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; }
+.modal--campaign { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; outline: none; }
 
 .campaign-header { display: flex; align-items: flex-start; gap: 0.75rem; padding: 1.1rem 1.25rem 0.9rem; border-bottom: 1px solid var(--border); flex-shrink: 0; }
 .campaign-header-icon { width: 34px; height: 34px; border-radius: 9px; background: var(--accent-dim); color: var(--accent-bright); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }

--- a/web/app/src/components/aegis/DistributionListsModal.vue
+++ b/web/app/src/components/aegis/DistributionListsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
-    <div class="modal-overlay" data-module="aegis" @click.self="close" @keydown.esc="close">
-      <div class="modal--lists" role="dialog" aria-modal="true" aria-labelledby="lists-modal-title">
+    <div class="modal-overlay" data-module="aegis" @click.self="close">
+      <div ref="boxRef" class="modal--lists" role="dialog" aria-modal="true" aria-labelledby="lists-modal-title" tabindex="-1">
         <header class="lists-header">
           <div class="lists-header-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
@@ -127,12 +127,15 @@
 import { computed, ref, watch } from 'vue'
 import { useAegisStore } from '@/stores/aegisStore'
 import { useUtils } from '@/composables/useUtils'
+import { useModalA11y } from '@/composables/useModalA11y'
 import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const emit = defineEmits(['close'])
 
 const store = useAegisStore()
 const { parseEmails } = useUtils()
+
+const boxRef = ref(null)
 
 /* Una sola caja de "añadir": solo hay una lista desplegada a la vez. */
 const addRaw = ref('')
@@ -162,11 +165,13 @@ async function confirmDelete() {
 }
 
 function close() { emit('close') }
+
+useModalA11y(() => true, { boxRef, onClose: close })
 </script>
 
 <style scoped>
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 1rem; }
-.modal--lists { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; }
+.modal--lists { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; outline: none; }
 
 .lists-header { display: flex; align-items: flex-start; gap: 0.75rem; padding: 1.1rem 1.25rem 0.9rem; border-bottom: 1px solid var(--border); flex-shrink: 0; }
 .lists-header-icon { width: 34px; height: 34px; border-radius: 9px; background: var(--accent-dim); color: var(--accent-bright); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }

--- a/web/app/src/components/aegis/TrackedProductsModal.vue
+++ b/web/app/src/components/aegis/TrackedProductsModal.vue
@@ -138,8 +138,9 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useAegisStore } from "@/stores/aegisStore";
+import { useModalA11y } from "@/composables/useModalA11y";
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -183,8 +184,7 @@ function close() {
   emit("close");
 }
 
-// Al abrir se parte de cero; al cerrar se sueltan el bloqueo del scroll y el
-// listener global.
+// Al abrir se parte de cero; al cerrar se limpia el debounce pendiente.
 watch(
   () => props.show,
   (visible) => {
@@ -193,56 +193,13 @@ watch(
       // Con menos de 2 caracteres esto solo limpia resultados y error, sin
       // llegar a pedir nada. Evita tocar el estado del store a mano.
       store.searchProducts("");
-      document.body.style.overflow = "hidden";
-      nextTick(() => searchRef.value?.focus());
-      window.addEventListener("keydown", onGlobalKeydown);
     } else {
       clearTimeout(queryTimer);
-      document.body.style.overflow = "";
-      window.removeEventListener("keydown", onGlobalKeydown);
     }
   },
 );
 
-onBeforeUnmount(() => {
-  document.body.style.overflow = "";
-  window.removeEventListener("keydown", onGlobalKeydown);
-  clearTimeout(queryTimer);
-});
-
-/**
- * Escape cierra y Tab queda atrapado dentro del modal. El listener va en
- * `window` y no como `@keydown.esc` en el overlay: sobre un div solo dispara
- * si el foco está dentro, que es el fallo que arrastran CampaignModal y
- * DistributionListsModal.
- */
-function onGlobalKeydown(e) {
-  if (e.key === "Escape") {
-    close();
-    return;
-  }
-  if (e.key === "Tab") trapFocus(e);
-}
-
-function trapFocus(e) {
-  const root = boxRef.value;
-  if (!root) return;
-  const focusables = Array.from(
-    root.querySelectorAll(
-      'button:not(:disabled), input, [tabindex]:not([tabindex="-1"])',
-    ),
-  );
-  if (!focusables.length) return;
-  const first = focusables[0];
-  const last = focusables[focusables.length - 1];
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault();
-    last.focus();
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault();
-    first.focus();
-  }
-}
+useModalA11y(() => props.show, { boxRef, autofocusRef: searchRef, onClose: close });
 </script>
 
 <style scoped>

--- a/web/app/src/components/iris/IrisArchiveModal.vue
+++ b/web/app/src/components/iris/IrisArchiveModal.vue
@@ -158,9 +158,10 @@
  * campo — antes inexistentes (el "orden" de la tira solo reordenaba lo ya
  * cargado en cliente).
  */
-import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+import { ref, watch, onBeforeUnmount } from 'vue'
 import AppPagination from '@/components/shared/AppPagination.vue'
 import { useIrisStore } from '@/stores/irisStore'
+import { useModalA11y } from '@/composables/useModalA11y'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -214,22 +215,16 @@ watch(() => props.show, (visible) => {
   if (visible) {
     searchInput.value = store.archive.filters.search
     focusedIndex.value = -1
-    document.body.style.overflow = 'hidden'
     store.fetchArchive()
-    nextTick(() => searchRef.value?.focus())
-    window.addEventListener('keydown', onGlobalKeydown)
-  } else {
-    document.body.style.overflow = ''
-    window.removeEventListener('keydown', onGlobalKeydown)
   }
 })
 
 onBeforeUnmount(() => {
-  document.body.style.overflow = ''
-  window.removeEventListener('keydown', onGlobalKeydown)
   clearTimeout(searchDebounce)
   clearTimeout(loadingTimer)
 })
+
+useModalA11y(() => props.show, { boxRef, autofocusRef: searchRef, onClose: close, onKeydown: onExtraKeydown })
 
 function close() {
   emit('close')
@@ -278,13 +273,11 @@ function formatDate(iso) {
   catch { return iso }
 }
 
-/** Escape cierra; "/" enfoca la búsqueda; ↑/↓ recorren filas; Enter abre la
- * fila enfocada; Tab queda atrapado dentro del modal mientras está abierto —
- * ConfirmModal no hace ninguna de las dos últimas cosas, pero a esta escala
- * (una tabla completa) se echan en falta. */
-function onGlobalKeydown(e) {
-  if (e.key === 'Escape') { close(); return }
-
+/** "/" enfoca la búsqueda; ↑/↓ recorren filas; Enter abre la fila enfocada —
+ * Escape y Tab ya los cubre useModalA11y. ConfirmModal no hace ninguna de
+ * las dos cosas de aquí, pero a esta escala (una tabla completa) se echan en
+ * falta. */
+function onExtraKeydown(e) {
   if (e.key === '/' && document.activeElement !== searchRef.value) {
     e.preventDefault()
     searchRef.value?.focus()
@@ -305,28 +298,9 @@ function onGlobalKeydown(e) {
   if (e.key === 'Enter' && focusedIndex.value >= 0) {
     const item = items[focusedIndex.value]
     if (item) choose(item.analysisId)
-    return
-  }
-  if (e.key === 'Tab') {
-    trapFocus(e)
   }
 }
 
-function trapFocus(e) {
-  const root = boxRef.value
-  if (!root) return
-  const focusables = Array.from(root.querySelectorAll('button:not(:disabled), input, [tabindex]:not([tabindex="-1"])'))
-  if (!focusables.length) return
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
 </script>
 
 <style scoped>

--- a/web/app/src/composables/useModalA11y.js
+++ b/web/app/src/composables/useModalA11y.js
@@ -1,0 +1,75 @@
+import { nextTick, onBeforeUnmount, watch } from 'vue'
+
+/**
+ * Comportamiento de teclado y foco compartido por los modales: Escape cierra,
+ * Tab queda atrapado dentro de la caja, se bloquea el scroll del fondo
+ * mientras está abierto (con limpieza en onBeforeUnmount — si no, un
+ * desmontaje con el modal abierto deja el body bloqueado) y el foco vuelve al
+ * disparador al cerrar.
+ *
+ * El listener de Escape/Tab va en `window`, no como `@keydown.esc` sobre el
+ * div del overlay: sobre un div solo dispara si el foco ya está dentro, que
+ * es el fallo que arrastraban CampaignModal y DistributionListsModal.
+ *
+ * `isVisible` es un getter — reactivo para los modales que se quedan
+ * montados y alternan una prop `show` (p. ej. `() => props.show` en
+ * IrisArchiveModal), o `() => true` para los que el padre monta y desmonta
+ * con `v-if` (p. ej. CampaignModal) — ahí el `immediate: true` hace de
+ * "onMounted".
+ */
+export function useModalA11y(isVisible, { boxRef, autofocusRef, onClose, onKeydown } = {}) {
+  let previouslyFocused = null
+
+  function trapFocus(e) {
+    const root = boxRef?.value
+    if (!root) return
+    const focusables = Array.from(
+      root.querySelectorAll(
+        'button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])',
+      ),
+    )
+    if (!focusables.length) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Escape') {
+      onClose?.()
+      return
+    }
+    if (e.key === 'Tab') trapFocus(e)
+    onKeydown?.(e)
+  }
+
+  function cleanup() {
+    document.body.style.overflow = ''
+    window.removeEventListener('keydown', handleKeydown)
+    previouslyFocused?.focus?.()
+    previouslyFocused = null
+  }
+
+  watch(
+    isVisible,
+    (visible) => {
+      if (visible) {
+        previouslyFocused = document.activeElement
+        document.body.style.overflow = 'hidden'
+        window.addEventListener('keydown', handleKeydown)
+        nextTick(() => (autofocusRef?.value ?? boxRef?.value)?.focus())
+      } else {
+        cleanup()
+      }
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(cleanup)
+}


### PR DESCRIPTION
## Summary
- Extrae `web/app/src/composables/useModalA11y.js`: Escape cierra, Tab queda atrapado en la caja, scroll-lock del body (con limpieza en `onBeforeUnmount`) y devuelve el foco al disparador al cerrar. El listener va en `window`, no `@keydown.esc` sobre un div, para que Escape funcione aunque el foco no esté dentro del modal.
- Lo adopta en `IrisArchiveModal.vue` y `TrackedProductsModal.vue` (ya tenían el comportamiento — sirven de red de seguridad para verificar que el composable es equivalente).
- Arregla el `@keydown.esc` roto de `CampaignModal.vue` y `DistributionListsModal.vue`, que solo disparaba si el foco ya estaba dentro del modal.

## Related Issue
Fixes #130

## Implementation
1. `useModalA11y.js` — acepta un getter reactivo (`() => props.show`) para modales que se quedan montados y alternan una prop `show`, o `() => true` para los que el padre monta/desmonta con `v-if` (CampaignModal, DistributionListsModal), donde el `immediate: true` del watch hace de "onMounted".
2. `IrisArchiveModal.vue` / `TrackedProductsModal.vue`: sustituyen su `watch`/`onBeforeUnmount`/listener manual por una llamada al composable, dejando solo sus atajos propios (`/`, flechas, Enter) como callback `onKeydown`.
3. `CampaignModal.vue` / `DistributionListsModal.vue`: quitan el `@keydown.esc` del overlay, añaden `ref="boxRef"` + `tabindex="-1"` a la caja del diálogo y llaman al composable.

Fases 3 y 4 del issue original (ConfirmModal, 17 consumidores; el resto de módulos) quedan fuera de este PR, tal como el propio issue las deja para commits separados.

## Validation
- `npm run build` (Vite) sin errores tras cada fase.
- Verificación manual en el navegador (sesión sembrada en `localStorage`, sin backend, como en #119):
  - `TrackedProductsModal`: abrir bloquea el scroll del body y autoenfoca el buscador; Escape lo cierra, libera el scroll y devuelve el foco al botón que lo abrió.
  - `DistributionListsModal`: abrir sin tocar nada y pulsar Escape lo cierra (antes no hacía nada — el bug exacto del issue); libera el scroll.
  - `IrisArchiveModal`: mismo comportamiento tras la refactorización a composable — autoenfoque del buscador, Escape cierra y libera el scroll.
  - `CampaignModal` usa el mismo patrón que `DistributionListsModal` (mismo fix, mismo composable) — no se pudo abrir en vivo sin backend porque requiere un documento generado, pero comparte el código ya verificado.

## Notes
- No se probó `pytest`/backend porque este PR no toca `API/`.
- Alcance intencionadamente limitado a las fases 1 y 2 del issue (composable + red de seguridad + arreglo de Aegis); el resto de modales de la tabla del issue quedan para PRs posteriores.