### PR TITLE
fix(web): borra el bloque .modal legacy de shared.css

### DIFF
--- a/web/app/src/assets/css/shared.css
+++ b/web/app/src/assets/css/shared.css
@@ -562,12 +562,6 @@ select option { background: var(--surface); color: var(--text); }
   .card--interactive:hover { transform: none; }
 }
 
-.modal {
-  position: fixed; inset: 0; z-index: 1000;
-  display: none; align-items: center; justify-content: center;
-  padding: 1rem;
-}
-.modal.visible { display: flex; }
 .modal-backdrop {
   position: absolute; inset: 0;
   background: rgba(0,0,0,0.6);

--- a/web/app/src/components/iris/IrisDocumentsModal.vue
+++ b/web/app/src/components/iris/IrisDocumentsModal.vue
@@ -110,6 +110,22 @@ function verdictClass(v) {
 </script>
 
 <style scoped>
+/* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
+   (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
+   se borra (#131). */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.modal.visible {
+  display: flex;
+}
+
 .docs-modal-content {
   max-width: 560px;
 }

--- a/web/app/src/components/themis/ScanPreviewModal.vue
+++ b/web/app/src/components/themis/ScanPreviewModal.vue
@@ -127,6 +127,20 @@ function fmtDate(iso) { if (!iso) return ''; return new Date(iso).toLocaleDateSt
 </script>
 
 <style scoped>
+/* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
+   (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
+   se borra (#131). */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.modal.visible { display: flex; }
+
 .preview-modal { max-width: 520px; animation: none; }
 
 .modal-enter-active, .modal-leave-active { transition: opacity 0.2s ease; }


### PR DESCRIPTION
## Summary
Borra `.modal`/`.modal.visible` de `shared.css` (restos del patrón pre-Vue `display:none` + `.visible`, que ningún componente usa directamente — todos son `Teleport` + `Transition` + `v-if`).

**El issue original asumía 0 referencias a estas dos clases; no era así.** `ScanPreviewModal.vue` e `IrisDocumentsModal.vue` sí renderizan `class="modal visible"` y dependían enteramente de esta regla global para `position`, `inset`, `z-index`, `display` y el centrado — sin declarar nada de eso en su propio `<style scoped>`. Borrar el bloque a ciegas les habría roto el posicionamiento del overlay.

## Related Issue
Fixes #131

## Implementation
1. Se baja a `<style scoped>` de `ScanPreviewModal.vue` e `IrisDocumentsModal.vue` el bloque completo que hoy heredan del global (mismas propiedades, mismos valores).
2. Se borra `.modal`/`.modal.visible` de `shared.css`.
3. Las otras seis clases legacy (`.modal-header`, `.modal-body`, `.modal-footer`, `.modal-close`, `.modal-backdrop`, `.modal-content`) sí tienen consumidores reales hoy y quedan fuera de este PR — es la Fase 2 del issue original, auditar clase a clase antes de tocarlas.

## Validation
- `npm run build` (Vite) sin errores.
- Verificación en el navegador (sesión sembrada en `localStorage`, sin backend): inspeccioné `document.styleSheets` en las rutas que cargan cada componente (`/themis/escaneos`, `/iris/analisis`) y confirmé que la regla scoped `.modal[data-v-xxxx]` / `.modal.visible[data-v-xxxx]` de cada componente reproduce exactamente las propiedades que antes venían del global (`position: fixed; inset: 0; z-index: 1000; display: none/flex; align-items: center; justify-content: center; padding: 1rem`), y que ninguna hoja de estilos define ya `.modal` a secas.
- Grep de `class="modal visible"` en todo `web/app/src/components` confirma que no hay más consumidores fuera de estos dos.

## Notes
- No se probó `pytest`/backend porque este PR no toca `API/`.