### PR TITLE
ci(deploy): auto-deploy a producción en cada merge a main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,124 @@
+# Despliegue automático a producción.
+#
+# Se dispara cuando el workflow "API Tests" (tests.yml) termina con éxito tras
+# un push a `main` — es decir, cuando un pull request se ha aceptado y los
+# tests del commit mergeado han pasado. Decisiones de diseño, con su porqué:
+#
+# - Se usa `workflow_run` en vez de un simple `push: branches: [main]` para
+#   que el deploy sea estrictamente POSTERIOR a los tests del commit que se
+#   va a desplegar. Si algún día se quiere desplegar sin esperar al CI, basta
+#   con cambiar el trigger; el resto del workflow no cambia.
+# - El filtro `branches: [main]` del evento excluye las ejecuciones de
+#   tests.yml disparadas por pull requests (ahí `head_branch` es la rama de
+#   origen, no `main`): este workflow solo se lanza para el push del merge.
+# - El deploy va por SSH desde un runner de GitHub hacia la máquina objetivo
+#   (www.ellysia.es o la IP fija del VPS): la máquina no necesita un runner
+#   propio, y las credenciales viven como secretos del repositorio. El `.env`
+#   de producción —con las credenciales reales— nunca sale del servidor.
+# - `DEPLOY_HOST` debe ser el DOMINIO (www.ellysia.es), no la IP: Caddy no
+#   tiene bloque catch-all por IP, así que el smoke test de abajo contra la IP
+#   no encontraría sitio y fallaría. La IP del VPS solo la conoce la DNS.
+# - `StrictHostKeyChecking=accept-new` hace que la primera conexión a un VPS
+#   nuevo (IP nueva, host key nueva) se acepte automáticamente sin romper la
+#   verificación en las siguientes. Es lo único que hay que recordar el día
+#   que cambie la IP del VPS: la DNS y el secret `DEPLOY_HOST` deben apuntar
+#   a la nueva IP, y nada más.
+#
+# Preparación (una sola vez) — instrucciones completas en README.md
+# §"Continuous deployment (CI/CD)":
+#   1. En el servidor: checkout del repo en una ruta fija (p. ej. ~/ellysia),
+#      el `.env` con las credenciales reales, y el usuario SSH con permisos de
+#      `docker`.
+#   2. Generar un par de claves SSH dedicado al deploy y añadir la pública a
+#      ~/.ssh/authorized_keys del usuario del deploy:
+#        ssh-keygen -t ed25519 -a 100 -f deploy_key -N "" -C "github-actions-deploy@ellysia"
+#   3. Guardar como secretos del repositorio (Settings → Secrets and variables
+#      → Actions → New repository secret):
+#        DEPLOY_HOST  → www.ellysia.es   (o la IP fija del VPS)
+#        DEPLOY_USER  → usuario SSH del deploy
+#        DEPLOY_PATH  → ruta ABSOLUTA al checkout del servidor (p. ej. /home/<user>/ellysia)
+#        DEPLOY_KEY   → el contenido COMPLETO del fichero privado deploy_key
+name: Deploy to production
+
+on:
+  workflow_run:
+    workflows: ["API Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # El filtro `branches` del evento ya excluye las PRs; este `if` es la
+    # segunda red de seguridad y cubre también conclusiones distintas de
+    # success (failure, cancelled, skipped...). La rama manual
+    # (workflow_dispatch) se permite siempre: sirve para desplegar a mano
+    # sin esperar a un push a main (p. ej. un rollback).
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    steps:
+      - name: Check secrets
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          for var in DEPLOY_HOST DEPLOY_USER DEPLOY_KEY DEPLOY_PATH; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Falta el secreto ${var}. Configúralo en Settings → Secrets and variables → Actions (ver README.md §Continuous deployment)."
+              exit 1
+            fi
+          done
+
+      - name: Write SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          cat > ~/.ssh/deploy_key <<EOF
+          $DEPLOY_KEY
+          EOF
+          chmod 600 ~/.ssh/deploy_key
+          # Falla con un mensaje claro si el secret no es una clave legible.
+          ssh-keygen -y -f ~/.ssh/deploy_key >/dev/null
+
+      - name: Deploy via SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=15 \
+            -o ServerAliveInterval=30 \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "cd '${DEPLOY_PATH}' && \
+             git fetch origin && \
+             git reset --hard origin/main && \
+             git log -1 --oneline && \
+             docker compose --profile container up -d --build && \
+             docker image prune -f"
+
+      - name: Smoke test
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 10 "https://${DEPLOY_HOST}/system/say-hello" >/dev/null 2>&1; then
+              echo "::notice::Deploy verificado: la API responde en https://${DEPLOY_HOST}/system/say-hello"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::La API no respondió en https://${DEPLOY_HOST}/system/say-hello tras el deploy"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Ollama](https://img.shields.io/badge/Ollama-llama3.2-ff7000?style=flat-square&logo=ollama)](https://ollama.com)
 [![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=flat-square&logo=docker&logoColor=white)](https://www.docker.com)
 
-[Overview](#overview) · [Features](#features) · [Architecture](#architecture) · [Modules](#modules) · [Quick start](#quick-start) · [Authentication](#authentication) · [API reference](#api-reference) · [TaskQueue](#taskqueue-rq--redis) · [Testing](#testing) · [Database migrations](#database-migrations) · [Docker](#docker) · [AI & email](#ai-and-email-configuration) · [Technology stack](#technology-stack) · [Configuration](#configuration)
+[Overview](#overview) · [Features](#features) · [Architecture](#architecture) · [Modules](#modules) · [Quick start](#quick-start) · [Authentication](#authentication) · [API reference](#api-reference) · [TaskQueue](#taskqueue-rq--redis) · [Testing](#testing) · [Continuous deployment (CI/CD)](#continuous-deployment-cicd) · [Database migrations](#database-migrations) · [Docker](#docker) · [AI & email](#ai-and-email-configuration) · [Technology stack](#technology-stack) · [Configuration](#configuration)
 
 ---
 
@@ -406,7 +406,7 @@ pytest -m integration     # boots create_app() + test HTTP client
 pytest -m oracle          # differential-oracle bench against real Docker containers (skipped in CI by default)
 ```
 
-CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed.
+CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
 
 ### Web SPA (node, no framework)
 
@@ -418,6 +418,60 @@ npm run test:polling      # usePolling composable tests
 npm run test:quiz         # aegis quiz-shuffle permutation tests
 npm run test:logs         # gzip log-payload decoding tests
 ```
+
+## Continuous deployment (CI/CD)
+
+Every merge to `main` is deployed automatically to the production machine, **after** the CI tests of the merged commit pass. The pipeline lives in `.github/workflows/deploy.yml` and chains to `.github/workflows/tests.yml` via the `workflow_run` trigger: when the "API Tests" workflow completes with `success` on a push to `main`, the deploy job connects by SSH to the target host and runs:
+
+```bash
+cd <checkout> && \
+git fetch origin && \
+git reset --hard origin/main && \
+docker compose --profile container up -d --build && \
+docker image prune -f
+```
+
+Then it polls the public health endpoint `https://<host>/system/say-hello` as a smoke test and fails the run if the API does not answer within a few minutes.
+
+> The deploy is strictly *after* the tests: the `workflow_run` trigger fires on the `main`-push run of "API Tests", and its `branches: [main]` filter excludes the PR-triggered runs (there `head_branch` is the source branch). If the tests fail, the deploy is skipped. To deploy without waiting for CI, change the trigger to `push: branches: [main]`; nothing else needs to change.
+
+### One-time setup
+
+Before the first automatic deploy works:
+
+1. **On the server** — a checkout of this repo in a fixed path (e.g. `~/ellysia`), a root `.env` with the real credentials (start from `.env.example`), and a SSH user that can run Docker without `sudo` (`usermod -aG docker <user>`). The API applies Alembic migrations automatically on startup, and the existing volumes (`ellysia_caddy_data` included) are reused, so a redeploy never re-issues certificates or drops data.
+2. **First boot is manual** — a fresh server needs `CREATE_DATABASE=True` in the server's `.env` for the *very first* `docker compose --profile container up -d --build` (it seeds the root user, its ABAC attributes and the awareness topics — it is **destructive**, set it back to `False` afterwards). From then on, deploys are fully automatic.
+3. **The checkout that deploy targets** — pin `DEPLOY_PATH` to the checkout the running containers came from:
+   ```bash
+   docker inspect Ellysia-Web --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}'
+   ```
+   The compose file already pins the project name (`name: ellysia`) and names the critical volumes explicitly, so running from a different directory cannot orphan volumes — but `git reset --hard` must run in the checkout you keep as canonical, and `DEPLOY_PATH` must be that one.
+4. **Server → GitHub access** — the repository is private, so `git fetch` on the server needs credentials. The least-privilege option is a read-only deploy key:
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/ellysia_deploy -N "" -C "server@ellysia"
+   # add ~/.ssh/ellysia_deploy.pub to Repo → Settings → Deploy keys (read-only)
+   cd ~/ellysia && git config core.sshCommand "ssh -i ~/.ssh/ellysia_deploy"
+   ```
+5. **CI → server SSH key** — a dedicated key for the deploy job; the public half goes in the deploy user's `authorized_keys`:
+   ```bash
+   ssh-keygen -t ed25519 -a 100 -f deploy_key -N "" -C "github-actions-deploy@ellysia"
+   ```
+6. **Repository secrets** — Settings → Secrets and variables → Actions → New repository secret:
+
+   | Secret | Value |
+   |---|---|
+   | `DEPLOY_HOST` | `www.ellysia.es` — el **dominio**, no la IP del VPS (Caddy no tiene catch-all por IP, el smoke test fallaría contra la IP; la DNS ya apunta el dominio a la IP) |
+   | `DEPLOY_USER` | the SSH user on the server |
+   | `DEPLOY_PATH` | absolute path to the server checkout (e.g. `/home/deploy/ellysia`) |
+   | `DEPLOY_KEY` | the full contents of the private `deploy_key` file |
+
+### Notes
+
+- **The domain is the identity, not the IP.** The workflow connects to `DEPLOY_HOST`, so changing VPS only means pointing the DNS (and `DEPLOY_HOST`) at the new IP. The first connection to the new host key is accepted automatically (`StrictHostKeyChecking=accept-new`); nothing else changes.
+- **`git reset --hard origin/main`** makes the tracked files of the checkout exactly match `main`; any local modification to tracked files is discarded. The `.env` is gitignored and never touched.
+- **Rollback:** push a revert to `main` (or restore a previous commit) and the next green push deploys it. Data lives in the volumes, only the images are rebuilt.
+- **Manual deploy:** the workflow also has a manual trigger (Actions → "Deploy to production" → Run workflow) that deploys `main` on demand without waiting for a push — useful for a rollback or to re-run after fixing the server.
+- **Renaming the "API Tests" workflow breaks the trigger:** `deploy.yml` references it by name (`workflows: ["API Tests"]`).
 
 ## Database Migrations
 
@@ -465,6 +519,9 @@ alembic downgrade -1
 
 > [!NOTE]
 > Ollama is deliberately **not** part of the `container` profile — the shipped config uses OpenAI by default, and a local LLM reserves 4–8 GB of RAM. Include it explicitly with `--profile local-ai`.
+
+> [!NOTE]
+> Production deploys on every merge to `main` are automated — see [Continuous deployment](#continuous-deployment-cicd) for the exact command the pipeline runs and the one-time setup.
 
 ```bash
 # Infrastructure only (develop locally)


### PR DESCRIPTION
## Summary
- Añade `.github/workflows/deploy.yml`: se dispara con `workflow_run` al terminar con éxito "API Tests" sobre `main` (o manualmente vía `workflow_dispatch`), conecta por SSH al servidor de producción y ejecuta `git fetch && git reset --hard origin/main && docker compose --profile container up -d --build && docker image prune -f`, seguido de un smoke test contra `/system/say-hello`.
- Documenta en el README la sección "Continuous deployment (CI/CD)": el pipeline completo, la preparación de un solo uso (usuario `deploy` en el servidor, dos pares de claves SSH con direcciones cruzadas, los cuatro secretos del repo) y notas operativas (rollback, cambio de VPS, por qué `DEPLOY_HOST` debe ser el dominio y no la IP).

## Related work
Preparación de infraestructura hecha en el servidor de producción (`www.ellysia.es`) siguiendo el README de esta rama: usuario `deploy` dedicado (sin privilegios más allá de `docker`), Deploy Key de solo lectura para que el servidor lea del repo privado, y una segunda clave SSH exclusiva para que GitHub Actions entre al servidor. Los cuatro secretos (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`, `DEPLOY_KEY`) ya están configurados en Settings → Secrets and variables → Actions.

## Validation
- Los tests de este PR no tocan `API/` ni `web/`, solo el workflow y el README — no aplica `pytest`.
- El propio workflow se autovalida en el primer despliegue real: falla explícitamente si falta algún secreto ("Check secrets"), si la clave no es legible ("Write SSH key"), o si el smoke test no responde tras el deploy.

## Notes
- Este PR va a `develope`, siguiendo el flujo habitual del repo; de ahí pasará a `main` en un segundo PR, que es el que activa el workflow de verdad (`deploy.yml` solo se evalúa desde el commit desplegado en `main`).
- El primer arranque en el servidor necesita `CREATE_DATABASE=True` una sola vez en el `.env` de producción (siembra el usuario root y los topics) — hay que devolverlo a `False` en cuanto arranque bien, o el siguiente redeploy destruye datos.