### PR TITLE
White-labeling, accesibilidad de modales, CI de auto-deploy y varios fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,124 @@
+# Despliegue automático a producción.
+#
+# Se dispara cuando el workflow "API Tests" (tests.yml) termina con éxito tras
+# un push a `main` — es decir, cuando un pull request se ha aceptado y los
+# tests del commit mergeado han pasado. Decisiones de diseño, con su porqué:
+#
+# - Se usa `workflow_run` en vez de un simple `push: branches: [main]` para
+#   que el deploy sea estrictamente POSTERIOR a los tests del commit que se
+#   va a desplegar. Si algún día se quiere desplegar sin esperar al CI, basta
+#   con cambiar el trigger; el resto del workflow no cambia.
+# - El filtro `branches: [main]` del evento excluye las ejecuciones de
+#   tests.yml disparadas por pull requests (ahí `head_branch` es la rama de
+#   origen, no `main`): este workflow solo se lanza para el push del merge.
+# - El deploy va por SSH desde un runner de GitHub hacia la máquina objetivo
+#   (www.ellysia.es o la IP fija del VPS): la máquina no necesita un runner
+#   propio, y las credenciales viven como secretos del repositorio. El `.env`
+#   de producción —con las credenciales reales— nunca sale del servidor.
+# - `DEPLOY_HOST` debe ser el DOMINIO (www.ellysia.es), no la IP: Caddy no
+#   tiene bloque catch-all por IP, así que el smoke test de abajo contra la IP
+#   no encontraría sitio y fallaría. La IP del VPS solo la conoce la DNS.
+# - `StrictHostKeyChecking=accept-new` hace que la primera conexión a un VPS
+#   nuevo (IP nueva, host key nueva) se acepte automáticamente sin romper la
+#   verificación en las siguientes. Es lo único que hay que recordar el día
+#   que cambie la IP del VPS: la DNS y el secret `DEPLOY_HOST` deben apuntar
+#   a la nueva IP, y nada más.
+#
+# Preparación (una sola vez) — instrucciones completas en README.md
+# §"Continuous deployment (CI/CD)":
+#   1. En el servidor: checkout del repo en una ruta fija (p. ej. ~/ellysia),
+#      el `.env` con las credenciales reales, y el usuario SSH con permisos de
+#      `docker`.
+#   2. Generar un par de claves SSH dedicado al deploy y añadir la pública a
+#      ~/.ssh/authorized_keys del usuario del deploy:
+#        ssh-keygen -t ed25519 -a 100 -f deploy_key -N "" -C "github-actions-deploy@ellysia"
+#   3. Guardar como secretos del repositorio (Settings → Secrets and variables
+#      → Actions → New repository secret):
+#        DEPLOY_HOST  → www.ellysia.es   (o la IP fija del VPS)
+#        DEPLOY_USER  → usuario SSH del deploy
+#        DEPLOY_PATH  → ruta ABSOLUTA al checkout del servidor (p. ej. /home/<user>/ellysia)
+#        DEPLOY_KEY   → el contenido COMPLETO del fichero privado deploy_key
+name: Deploy to production
+
+on:
+  workflow_run:
+    workflows: ["API Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # El filtro `branches` del evento ya excluye las PRs; este `if` es la
+    # segunda red de seguridad y cubre también conclusiones distintas de
+    # success (failure, cancelled, skipped...). La rama manual
+    # (workflow_dispatch) se permite siempre: sirve para desplegar a mano
+    # sin esperar a un push a main (p. ej. un rollback).
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    steps:
+      - name: Check secrets
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          for var in DEPLOY_HOST DEPLOY_USER DEPLOY_KEY DEPLOY_PATH; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Falta el secreto ${var}. Configúralo en Settings → Secrets and variables → Actions (ver README.md §Continuous deployment)."
+              exit 1
+            fi
+          done
+
+      - name: Write SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          cat > ~/.ssh/deploy_key <<EOF
+          $DEPLOY_KEY
+          EOF
+          chmod 600 ~/.ssh/deploy_key
+          # Falla con un mensaje claro si el secret no es una clave legible.
+          ssh-keygen -y -f ~/.ssh/deploy_key >/dev/null
+
+      - name: Deploy via SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=15 \
+            -o ServerAliveInterval=30 \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "cd '${DEPLOY_PATH}' && \
+             git fetch origin && \
+             git reset --hard origin/main && \
+             git log -1 --oneline && \
+             docker compose --profile container up -d --build && \
+             docker image prune -f"
+
+      - name: Smoke test
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 10 "https://${DEPLOY_HOST}/system/say-hello" >/dev/null 2>&1; then
+              echo "::notice::Deploy verificado: la API responde en https://${DEPLOY_HOST}/system/say-hello"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::La API no respondió en https://${DEPLOY_HOST}/system/say-hello tras el deploy"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .env.local
 .agents
 skills-lock.json
+.mcp.json
 
 # ============================================
 # Datos y logs
@@ -40,23 +41,6 @@ docs/
 .vscode/
 .idea/
 *.iml
-
-# ============================================
-# Android / Gradle
-# ============================================
-.gradle
-/local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
-build/
-/captures
-.local.properties
-.externalNativeBuild
-.cxx
 
 # ============================================
 # Sistema operativo
@@ -98,3 +82,6 @@ API/src/tmp
 # Análisis interno
 # ============================================
 MEJORAS.md
+
+# ============================================
+.serena

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -84,8 +84,8 @@
       },
       "strategies": {
         "smtp": {
-          "fromAddress": "awareness@ellysia.es",
-          "fromName": "Ellysia Awareness",
+          "fromAddress": "herald@ellysia.es",
+          "fromName": "Ellysia Herald",
           "host": "smtp-relay.brevo.com",
           "port": 587,
           "useTls": true

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -53,6 +53,7 @@
   "tools": {
     "scribe": {
       "defaultStrategy": "openai",
+      "maxInputTokens": 24000,
       "modules": {
         "aegis": "openai",
         "themis": "openai"

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.7",
+  "appVersion": "0.5.8",
   "general": {
     "directories": {
       "logdir": "..",

--- a/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
+++ b/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
@@ -1,0 +1,30 @@
+"""cpe match and finding required_os
+
+Revision ID: 4fe4383a5085
+Revises: a1b2c3d4e5f7
+Create Date: 2026-08-28 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4fe4383a5085'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('CpeMatch', sa.Column('required_os', sa.String(length=64), nullable=True))
+    op.add_column('Finding', sa.Column('required_os', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('Finding', 'required_os')
+    op.drop_column('CpeMatch', 'required_os')

--- a/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
+++ b/API/alembic/versions/4fe4383a5085_cpe_match_and_finding_required_os.py
@@ -1,7 +1,7 @@
 """cpe match and finding required_os
 
 Revision ID: 4fe4383a5085
-Revises: a1b2c3d4e5f7
+Revises: baf6f0e7fd8c
 Create Date: 2026-08-28 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '4fe4383a5085'
-down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f7'
+down_revision: Union[str, Sequence[str], None] = 'baf6f0e7fd8c'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/API/alembic/versions/a1b2c3d4e5f6_aegis_org_profile_white_label.py
+++ b/API/alembic/versions/a1b2c3d4e5f6_aegis_org_profile_white_label.py
@@ -1,0 +1,39 @@
+"""aegis org profile: white-labeling de las campanyas
+
+Las dos columnas del mixin ``shared.WhiteLabelColumns``. El nivel por defecto
+es 'none', que reproduce exactamente el correo de antes: una organizacion que
+no toque nada no nota el cambio.
+
+Revision ID: a1b2c3d4e5f6
+Revises: e79879ec2b67
+Create Date: 2026-08-27
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = 'e79879ec2b67'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "AegisOrgProfile",
+        sa.Column(
+            "white_label_level",
+            sa.String(length=16),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column("AegisOrgProfile", sa.Column("brand_logo", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("AegisOrgProfile", "brand_logo")
+    op.drop_column("AegisOrgProfile", "white_label_level")

--- a/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
+++ b/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
@@ -1,6 +1,6 @@
 """aegis org profile: white-labeling de las campanyas
 
-Las dos columnas del mixin ``shared.WhiteLabelColumns``. El nivel por defecto
+Las columnas del mixin ``shared.WhiteLabelColumns``. El nivel por defecto
 es 'none', que reproduce exactamente el correo de antes: una organizacion que
 no toque nada no nota el cambio.
 
@@ -32,8 +32,10 @@ def upgrade() -> None:
         ),
     )
     op.add_column("AegisOrgProfile", sa.Column("brand_logo", sa.Text(), nullable=True))
+    op.add_column("AegisOrgProfile", sa.Column("brand_color", sa.String(length=7), nullable=True))
 
 
 def downgrade() -> None:
+    op.drop_column("AegisOrgProfile", "brand_color")
     op.drop_column("AegisOrgProfile", "brand_logo")
     op.drop_column("AegisOrgProfile", "white_label_level")

--- a/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
+++ b/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
@@ -15,7 +15,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = 'a1b2c3d4e5f6'
+revision: str = 'a1b2c3d4e5f7'
 down_revision: Union[str, Sequence[str], None] = 'e79879ec2b67'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
+++ b/API/alembic/versions/a1b2c3d4e5f7_aegis_org_profile_white_label.py
@@ -4,7 +4,7 @@ Las dos columnas del mixin ``shared.WhiteLabelColumns``. El nivel por defecto
 es 'none', que reproduce exactamente el correo de antes: una organizacion que
 no toque nada no nota el cambio.
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: a1b2c3d4e5f7
 Revises: e79879ec2b67
 Create Date: 2026-08-27
 

--- a/API/alembic/versions/b2c3d4e5f6a7_plan_limit_aegis_white_label.py
+++ b/API/alembic/versions/b2c3d4e5f6a7_plan_limit_aegis_white_label.py
@@ -6,7 +6,8 @@ inserta en las bases que ya estaban desplegadas, con los mismos valores que el
 literal congelado de la migracion de siembra.
 
 Su 'value' no es una cantidad sino el escalon concedido (LimitPeriod.TIER):
-0 ninguno, 1 logo propio, 2 sin rastro de la marca del producto.
+0 ninguno, 1 color de enfasis propio, 2 ademas el logo, 3 sin rastro de la
+marca del producto.
 
 Revision ID: b2c3d4e5f6a7
 Revises: a1b2c3d4e5f6
@@ -27,7 +28,7 @@ depends_on: Union[str, Sequence[str], None] = None
 _LIMIT_KEY = "aegis.white_label"
 
 #: Mismos valores que _HOLDER_LIMITS en la migracion de siembra.
-_VALUES: dict[str, int] = {"freemium": 0, "bronze": 1, "silver": 2, "gold": 2}
+_VALUES: dict[str, int] = {"freemium": 0, "bronze": 1, "silver": 2, "gold": 3}
 
 
 def upgrade() -> None:

--- a/API/alembic/versions/b2c3d4e5f6a7_plan_limit_aegis_white_label.py
+++ b/API/alembic/versions/b2c3d4e5f6a7_plan_limit_aegis_white_label.py
@@ -1,0 +1,54 @@
+"""catalogo: tope de white-labeling por plan
+
+La clave 'aegis.white_label' no existia cuando se sembro el catalogo, y una
+fila ausente vale 0 — o sea, sin white-labeling para nadie. Esta migracion la
+inserta en las bases que ya estaban desplegadas, con los mismos valores que el
+literal congelado de la migracion de siembra.
+
+Su 'value' no es una cantidad sino el escalon concedido (LimitPeriod.TIER):
+0 ninguno, 1 logo propio, 2 sin rastro de la marca del producto.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-27
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_LIMIT_KEY = "aegis.white_label"
+
+#: Mismos valores que _HOLDER_LIMITS en la migracion de siembra.
+_VALUES: dict[str, int] = {"freemium": 0, "bronze": 1, "silver": 2, "gold": 2}
+
+
+def upgrade() -> None:
+    # Idempotente: en una base recien creada la siembra ya puso la fila, y esta
+    # migracion corre despues sin duplicarla.
+    for code, value in _VALUES.items():
+        op.execute(
+            f"""
+            INSERT INTO "PlanLimit" (plan_id, limit_key, scope, value, period)
+            SELECT p.id, '{_LIMIT_KEY}', 'holder', {value}, 'tier'
+              FROM "Plan" p
+             WHERE p.code = '{code}'
+               AND NOT EXISTS (
+                   SELECT 1 FROM "PlanLimit" l
+                    WHERE l.plan_id = p.id
+                      AND l.limit_key = '{_LIMIT_KEY}'
+                      AND l.scope = 'holder'
+               )
+            """
+        )
+
+
+def downgrade() -> None:
+    op.execute(f"""DELETE FROM "PlanLimit" WHERE limit_key = '{_LIMIT_KEY}'""")

--- a/API/alembic/versions/baf6f0e7fd8c_merge_white_labeling_migration_heads.py
+++ b/API/alembic/versions/baf6f0e7fd8c_merge_white_labeling_migration_heads.py
@@ -1,0 +1,28 @@
+"""merge white-labeling migration heads
+
+Revision ID: baf6f0e7fd8c
+Revises: a1b2c3d4e5f7, b2c3d4e5f6a7
+Create Date: 2026-08-27 21:12:52.808729
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'baf6f0e7fd8c'
+down_revision: Union[str, Sequence[str], None] = ('a1b2c3d4e5f7', 'b2c3d4e5f6a7')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/API/alembic/versions/c7d8e9f0a1b2_aegis_org_profile_brand_color.py
+++ b/API/alembic/versions/c7d8e9f0a1b2_aegis_org_profile_brand_color.py
@@ -1,0 +1,55 @@
+"""aegis org profile: la columna brand_color que falto en a1b2c3d4e5f7
+
+El mixin ``shared.WhiteLabelColumns`` declara tres columnas, pero la migracion
+que lo acompanyaba solo creo dos: ``brand_color`` se perdio al resolver un
+merge. En un despliegue real el esquema lo construye Alembic, asi que la
+columna no existia y cualquier lectura de AegisOrgProfile (perfil, envio de
+campanya, pagina publica del test) reventaba con UndefinedColumn. La suite no
+lo veia porque los tests crean el esquema con ``Base.metadata.create_all``.
+
+Va en una migracion nueva y no editando a1b2c3d4e5f7, que ya esta fusionada y
+puede haberse aplicado: reeditarla dejaria esas bases sin la columna para
+siempre. El ``IF NOT EXISTS`` la hace inocua alli donde a1b2c3d4e5f7 se
+aplicara con la version que si la creaba.
+
+Revision ID: c7d8e9f0a1b2
+Revises: 4fe4383a5085
+Create Date: 2026-08-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c7d8e9f0a1b2'
+down_revision: Union[str, Sequence[str], None] = '4fe4383a5085'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_COLUMN = sa.Column("brand_color", sa.String(length=7), nullable=True)
+
+
+def upgrade() -> None:
+    if not _has_brand_color():
+        op.add_column("AegisOrgProfile", _COLUMN)
+
+
+def downgrade() -> None:
+    if _has_brand_color():
+        op.drop_column("AegisOrgProfile", "brand_color")
+
+
+def _has_brand_color() -> bool:
+    """Si la columna ya esta, no se toca.
+
+    El inspector es portable (Postgres y SQLite); ``ADD COLUMN IF NOT EXISTS``
+    no lo es.
+    """
+    inspector = sa.inspect(op.get_bind())
+    return any(
+        column["name"] == "brand_color"
+        for column in inspector.get_columns("AegisOrgProfile")
+    )

--- a/API/alembic/versions/f2b3c4d5e6f7_accounts_plans_and_organizations.py
+++ b/API/alembic/versions/f2b3c4d5e6f7_accounts_plans_and_organizations.py
@@ -46,7 +46,7 @@ _PLANS: tuple[tuple, ...] = (
 #: Topes del ambito "holder": lo que se lleva quien contrata el plan.
 #: limit_key -> (period, {code_de_plan: valor})
 #: None = ilimitado · 0 = no incluido.
-#: Las 15 claves aparecen para los 4 planes a proposito: una fila ausente se
+#: Todas las claves aparecen para los 4 planes a proposito: una fila ausente se
 #: leeria como 0 y desactivaria la caracteristica en silencio.
 _HOLDER_LIMITS: dict[str, tuple[str, dict[str, int | None]]] = {
     "themis.lybra.scans":       ("month", {"freemium":  3, "bronze":  25, "silver":  100, "gold":   400}),
@@ -56,6 +56,9 @@ _HOLDER_LIMITS: dict[str, tuple[str, dict[str, int | None]]] = {
     "aegis.pills":              ("month", {"freemium":  2, "bronze":  15, "silver":   60, "gold":   200}),
     "aegis.campaigns":          ("month", {"freemium":  0, "bronze":   2, "silver":   10, "gold":    40}),
     "aegis.recipients":         ("stock", {"freemium":  0, "bronze": 100, "silver":  500, "gold":  2000}),
+    # Nivel, no cantidad: 0 sin white-labeling, 1 logo propio, 2 sin rastro de
+    # la marca del producto. Ver WhiteLabelLevel.from_allowance.
+    "aegis.white_label":        ("tier",  {"freemium":  0, "bronze":   1, "silver":    2, "gold":     2}),
     "iris.analyses":            ("month", {"freemium": 10, "bronze": 100, "silver":  500, "gold":  None}),
     "iris.ai_summaries":        ("month", {"freemium":  2, "bronze":  25, "silver":  100, "gold":   400}),
     "iris.mailbox.connections": ("stock", {"freemium":  0, "bronze":   1, "silver":    3, "gold":    10}),

--- a/API/alembic/versions/f2b3c4d5e6f7_accounts_plans_and_organizations.py
+++ b/API/alembic/versions/f2b3c4d5e6f7_accounts_plans_and_organizations.py
@@ -56,9 +56,10 @@ _HOLDER_LIMITS: dict[str, tuple[str, dict[str, int | None]]] = {
     "aegis.pills":              ("month", {"freemium":  2, "bronze":  15, "silver":   60, "gold":   200}),
     "aegis.campaigns":          ("month", {"freemium":  0, "bronze":   2, "silver":   10, "gold":    40}),
     "aegis.recipients":         ("stock", {"freemium":  0, "bronze": 100, "silver":  500, "gold":  2000}),
-    # Nivel, no cantidad: 0 sin white-labeling, 1 logo propio, 2 sin rastro de
-    # la marca del producto. Ver WhiteLabelLevel.from_allowance.
-    "aegis.white_label":        ("tier",  {"freemium":  0, "bronze":   1, "silver":    2, "gold":     2}),
+    # Nivel, no cantidad: 0 sin white-labeling, 1 color de enfasis propio,
+    # 2 ademas el logo, 3 sin rastro de la marca del producto. Ver
+    # WhiteLabelLevel.from_allowance.
+    "aegis.white_label":        ("tier",  {"freemium":  0, "bronze":   1, "silver":    2, "gold":     3}),
     "iris.analyses":            ("month", {"freemium": 10, "bronze": 100, "silver":  500, "gold":  None}),
     "iris.ai_summaries":        ("month", {"freemium":  2, "bronze":  25, "silver":  100, "gold":   400}),
     "iris.mailbox.connections": ("stock", {"freemium":  0, "bronze":   1, "silver":    3, "gold":    10}),

--- a/API/src/modules/accounts/services/limits.py
+++ b/API/src/modules/accounts/services/limits.py
@@ -29,11 +29,17 @@ class LimitPeriod(str, Enum):
     - ``STOCK``: **existencias**. No hay contador: se cuenta la tabla real. Un
       contador de existencias se desincroniza en el primer borrado, y la base
       de datos ya sabe la respuesta.
+    - ``TIER``: **nivel**. Ni se consume ni se cuenta: el ``value`` de la fila
+      *es* el escalón que concede el plan (0 = ninguno, n = escalón n,
+      ``NULL`` = el más alto). Se lee con ``resolve_entitlement(...).limit`` y
+      no pasa por ``consume()``: no hay nada que gastar, solo un techo que
+      respetar.
     """
 
     MONTH = "month"
     DAY = "day"
     STOCK = "stock"
+    TIER = "tier"
 
 
 class LimitKey(Enum):
@@ -44,9 +50,10 @@ class LimitKey(Enum):
     THEMIS_SCHEDULED        = "themis.scheduled"
     THEMIS_REPORTS_AI       = "themis.reports.ai"
 
-    AEGIS_PILLS      = "aegis.pills"
-    AEGIS_CAMPAIGNS  = "aegis.campaigns"
-    AEGIS_RECIPIENTS = "aegis.recipients"
+    AEGIS_PILLS       = "aegis.pills"
+    AEGIS_CAMPAIGNS   = "aegis.campaigns"
+    AEGIS_RECIPIENTS  = "aegis.recipients"
+    AEGIS_WHITE_LABEL = "aegis.white_label"
 
     IRIS_ANALYSES            = "iris.analyses"
     IRIS_AI_SUMMARIES        = "iris.ai_summaries"
@@ -79,6 +86,9 @@ PERIODS: dict[LimitKey, LimitPeriod] = {
     LimitKey.AEGIS_PILLS:      LimitPeriod.MONTH,
     LimitKey.AEGIS_CAMPAIGNS:  LimitPeriod.MONTH,
     LimitKey.AEGIS_RECIPIENTS: LimitPeriod.STOCK,
+    # Nivel, no cantidad: hasta dónde puede llegar el white-labeling de sus
+    # campañas. Ver WhiteLabelLevel.from_allowance.
+    LimitKey.AEGIS_WHITE_LABEL: LimitPeriod.TIER,
 
     LimitKey.IRIS_ANALYSES:            LimitPeriod.MONTH,
     LimitKey.IRIS_AI_SUMMARIES:        LimitPeriod.MONTH,

--- a/API/src/modules/accounts/services/quotas.py
+++ b/API/src/modules/accounts/services/quotas.py
@@ -119,6 +119,12 @@ class QuotaManager:
             )
             raise PlanFeatureDisabledError(key.db_name, entitlement.plan_code)
 
+        if entitlement.period is LimitPeriod.TIER:
+            raise NotImplementedError(
+                f"'{key.db_name}' es una clave de nivel: no se consume. Su tope se "
+                f"lee con resolve_entitlement(...).limit y se respeta al aplicarlo."
+            )
+
         if entitlement.period is LimitPeriod.STOCK:
             self._consume_stock(entitlement, amount)
         else:
@@ -251,6 +257,11 @@ class QuotaManager:
             pass  # ya existía: seguimos al UPDATE.
 
     def _current_usage(self, entitlement: Entitlement) -> int:
+        # Un nivel no se gasta: lo consumido es siempre 0 y lo que importa es
+        # el tope. Así "Mi plan" puede pintarlo sin caso especial.
+        if entitlement.period is LimitPeriod.TIER:
+            return 0
+
         if entitlement.period is LimitPeriod.STOCK:
             return self._count_stock(entitlement)
 

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -9,7 +9,10 @@ tracking de apertura/finalización del quiz público, consumido por los
 endpoints sin autenticación.
 
 El envío de email delega en el módulo transversal ``herald``
-(``build_mailer("aegis").send(...)``): este manager no sabe nada de SMTP.
+(``build_mailer("aegis").send(...)``): este manager no sabe nada de SMTP —
+tampoco de cómo se pinta una marca: el white-labeling se resuelve con las
+piezas compartidas (``shared.WhiteLabel`` + ``herald.apply_white_label``) y
+aquí solo se leen los ajustes del perfil de la organización.
 """
 
 from __future__ import annotations
@@ -32,16 +35,24 @@ from src.modules.features.aegis.exceptions import (
 )
 import src.modules.system.config_reading as CR
 from src.modules.accounts import LimitKey, QuotaManager
-from src.modules.tools.herald import EmailMessage, Mailer, build_mailer, render_email
+from src.modules.tools.herald import (
+    EmailMessage,
+    Mailer,
+    apply_white_label,
+    build_mailer,
+    default_brand,
+    render_email,
+)
 from src.modules.users import User
 from src.modules.system.taskqueue import ITaskQueue, TaskTrackingMixin, job_context
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
-from src.modules.shared import assert_owned
+from src.modules.shared import WhiteLabel, assert_owned
 
 from ..model import Campaign, CampaignRecipient, DistributionList
 from ..repositories import (
     AegisDocumentRepository,
+    AegisOrgProfileRepository,
     CampaignRepository,
     DistributionListRepository,
 )
@@ -299,6 +310,19 @@ class CampaignManager(TaskTrackingMixin):
                 for alert in sorted(document.alerts, key=lambda a: a.position)
             ] if document else []
 
+            # White-labeling: los ajustes son del perfil de la organización y
+            # se leen una vez, no por destinatario — la marca es la misma para
+            # toda la campaña. El nombre con el que sustituir la del producto
+            # es el que el destinatario ya lee en el cuerpo ("Desde X, te
+            # hacemos llegar…"), para que cabecera y texto no se contradigan.
+            profile = build_repository(AegisOrgProfileRepository).get_by_user_id(self.user.id)
+            white_label = WhiteLabel.from_stored(
+                profile.white_label_level if profile else None,
+                profile.brand_logo if profile else None,
+                pill_company or (profile.company if profile else ""),
+            )
+            brand, brand_images = apply_white_label(default_brand(), white_label)
+
             sent_count = 0
             was_cancelled = False
             for i, recipient in enumerate(recipients):
@@ -313,6 +337,7 @@ class CampaignManager(TaskTrackingMixin):
                 link = f"{base_url}/quiz?t={recipient.token}"
                 html_body, text_body = render_email(
                     "campaign",
+                    brand=brand,
                     pill_title=pill_title,
                     link=link,
                     recipient_name=recipient.recipient_name,
@@ -330,6 +355,7 @@ class CampaignManager(TaskTrackingMixin):
                     subject=f"Formación de concienciación: {pill_title}",
                     html_body=html_body,
                     text_body=text_body,
+                    inline_images=brand_images,
                 )
                 try:
                     mailer.send(message)

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -49,6 +49,7 @@ from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
 from src.modules.shared import WhiteLabel, assert_owned
 
+from .org_profile import AegisOrgProfileManager
 from ..model import Campaign, CampaignRecipient, DistributionList
 from ..repositories import (
     AegisDocumentRepository,
@@ -320,6 +321,11 @@ class CampaignManager(TaskTrackingMixin):
                 profile.white_label_level if profile else None,
                 profile.brand_logo if profile else None,
                 pill_company or (profile.company if profile else ""),
+            )
+            # El tope del plan se vuelve a aplicar aquí: entre que se guardó el
+            # ajuste y se envía la campaña la suscripción puede haber bajado.
+            white_label = white_label.capped_to(
+                AegisOrgProfileManager.max_white_label_level(self.user.id)
             )
             brand, brand_images = apply_white_label(default_brand(), white_label)
 

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -47,7 +47,7 @@ from src.modules.users import User
 from src.modules.system.taskqueue import ITaskQueue, TaskTrackingMixin, job_context
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
-from src.modules.shared import WhiteLabel, assert_owned
+from src.modules.shared import WhiteLabel, WhiteLabelLevel, assert_owned
 
 from .org_profile import AegisOrgProfileManager
 from ..model import Campaign, CampaignRecipient, DistributionList
@@ -410,11 +410,14 @@ class CampaignManager(TaskTrackingMixin):
         campaign = recipient.campaign
         snapshot = campaign.questions_snapshot or []
 
+        white_label = CampaignManager._public_white_label(campaign)
+
         if recipient.status == "completed":
             return {
                 "status": "completed",
                 "score": recipient.score,
                 "total": len(snapshot),
+                "whiteLabel": white_label,
             }
 
         if recipient.status == "sent":
@@ -424,11 +427,42 @@ class CampaignManager(TaskTrackingMixin):
         document = campaign.document
         return {
             "status": "opened",
+            "whiteLabel": white_label,
             "pillTitle": (document.subtitle or document.title) if document else "",
             "questions": [
                 {"position": question["position"], "prompt": question["prompt"], "options": question["options"]}
                 for question in snapshot
             ],
+        }
+
+    @staticmethod
+    def _public_white_label(campaign: Campaign) -> dict:
+        """Marca que ve el destinatario en la página del test.
+
+        La misma que en el correo y resuelta igual (ajustes del perfil, topados
+        por el plan): el test es la segunda mitad de la campaña y sería raro
+        que la primera llegara sin marca del producto y la segunda con ella.
+
+        Se sirve por un endpoint sin autenticar, así que solo sale lo que ese
+        destinatario ya ha recibido en su correo — nombre y logo de su propia
+        organización, nada más.
+        """
+        document = campaign.document
+        if document is None:
+            return {"level": WhiteLabelLevel.NONE.value, "brandName": "", "brandLogo": ""}
+
+        profile = build_repository(AegisOrgProfileRepository).get_by_user_id(document.user_id)
+        white_label = WhiteLabel.from_stored(
+            profile.white_label_level if profile else None,
+            profile.brand_logo if profile else None,
+            document.company or (profile.company if profile else ""),
+        ).capped_to(AegisOrgProfileManager.max_white_label_level(document.user_id))
+
+        level = white_label.effective_level
+        return {
+            "level": level.value,
+            "brandName": white_label.brand_name if level is not WhiteLabelLevel.NONE else "",
+            "brandLogo": white_label.logo if level is not WhiteLabelLevel.NONE else "",
         }
 
     @staticmethod

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -320,6 +320,7 @@ class CampaignManager(TaskTrackingMixin):
             white_label = WhiteLabel.from_stored(
                 profile.white_label_level if profile else None,
                 profile.brand_logo if profile else None,
+                profile.brand_color if profile else None,
                 pill_company or (profile.company if profile else ""),
             )
             # El tope del plan se vuelve a aplicar aquí: entre que se guardó el
@@ -449,20 +450,30 @@ class CampaignManager(TaskTrackingMixin):
         """
         document = campaign.document
         if document is None:
-            return {"level": WhiteLabelLevel.NONE.value, "brandName": "", "brandLogo": ""}
+            return {
+                "level": WhiteLabelLevel.NONE.value,
+                "brandName": "", "brandLogo": "", "brandColor": "",
+            }
 
         profile = build_repository(AegisOrgProfileRepository).get_by_user_id(document.user_id)
         white_label = WhiteLabel.from_stored(
             profile.white_label_level if profile else None,
             profile.brand_logo if profile else None,
+            profile.brand_color if profile else None,
             document.company or (profile.company if profile else ""),
         ).capped_to(AegisOrgProfileManager.max_white_label_level(document.user_id))
 
         level = white_label.effective_level
+        if level is WhiteLabelLevel.NONE:
+            return {"level": level.value, "brandName": "", "brandLogo": "", "brandColor": ""}
+
         return {
             "level": level.value,
-            "brandName": white_label.brand_name if level is not WhiteLabelLevel.NONE else "",
-            "brandLogo": white_label.logo if level is not WhiteLabelLevel.NONE else "",
+            "brandName": white_label.brand_name,
+            # El logo solo se pinta desde el escalón que lo introduce; en COLOR
+            # el ajuste puede existir y no tocar todavía.
+            "brandLogo": white_label.logo if level.rank >= WhiteLabelLevel.LOGO.rank else "",
+            "brandColor": white_label.color,
         }
 
     @staticmethod

--- a/API/src/modules/features/aegis/managers/org_profile.py
+++ b/API/src/modules/features/aegis/managers/org_profile.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from src.modules.shared import WhiteLabelLevel
 from src.modules.users import User
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
@@ -38,6 +39,8 @@ _ORG_PROFILE_DEFAULTS: dict[str, Any] = {
     "employeeCount": None,
     "trackedProducts": [],
     "useHygeiaInventory": True,
+    "whiteLabelLevel": WhiteLabelLevel.NONE.value,
+    "brandLogo": "",
 }
 
 
@@ -111,6 +114,8 @@ class AegisOrgProfileManager:
             profile.employee_count = data["employeeCount"]
             profile.tracked_products = data["trackedProducts"]
             profile.use_hygeia_inventory = data["useHygeiaInventory"]
+            profile.white_label_level = data["whiteLabelLevel"]
+            profile.brand_logo = data["brandLogo"] or None
 
             saved = repo.save(profile)
             return saved.to_dict()

--- a/API/src/modules/features/aegis/managers/org_profile.py
+++ b/API/src/modules/features/aegis/managers/org_profile.py
@@ -13,6 +13,9 @@ import logging
 from typing import Any
 
 from src.modules.shared import WhiteLabelLevel
+from src.modules.accounts import LimitKey
+from src.modules.accounts.exceptions import PlanFeatureDisabledError
+from src.modules.accounts.services.entitlements import resolve_entitlement
 from src.modules.users import User
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
@@ -56,6 +59,19 @@ class AegisOrgProfileManager:
         self.user = user
 
     @staticmethod
+    def max_white_label_level(user_id: int) -> WhiteLabelLevel:
+        """Hasta dónde puede llegar el white-labeling de este usuario.
+
+        Lo decide el plan contratado, con la clave ``aegis.white_label``: su
+        tope no es una cantidad sino el escalón concedido (ver
+        ``LimitPeriod.TIER``). Una fila ausente vale 0, así que un plan al que
+        nadie se lo declare se queda sin white-labeling — fallo cerrado, que es
+        lo que se quiere de una característica que no debe llegar a todos.
+        """
+        entitlement = resolve_entitlement(user_id, LimitKey.AEGIS_WHITE_LABEL)
+        return WhiteLabelLevel.from_allowance(entitlement.limit)
+
+    @staticmethod
     def search_products(term: str, limit: int = 20) -> list[dict]:
         """Busca productos vigilables en el índice CPE del espejo local de NVD.
 
@@ -84,6 +100,10 @@ class AegisOrgProfileManager:
         profile = repo.get_by_user_id(self.user.id)
         result = dict(_ORG_PROFILE_DEFAULTS) if profile is None else profile.to_dict()
         result["hygeiaInventoryAvailable"] = self._hygeia_inventory_available()
+        # Igual que el anterior: no es un campo del perfil sino del entorno
+        # comercial. El frontend lo usa para no ofrecer niveles que el plan no
+        # concede, y el guardado lo vuelve a comprobar de todas formas.
+        result["maxWhiteLabelLevel"] = self.max_white_label_level(self.user.id).value
         return result
 
     def _hygeia_inventory_available(self) -> bool:
@@ -96,7 +116,14 @@ class AegisOrgProfileManager:
             return False
 
     def upsert(self, data: dict) -> dict:
-        """Crea o actualiza el perfil de organización del usuario actual."""
+        """Crea o actualiza el perfil de organización del usuario actual.
+
+        Raises:
+            PlanFeatureDisabledError: si se pide un nivel de white-labeling por
+                encima del que concede el plan (402).
+        """
+        self._assert_white_label_allowed(data["whiteLabelLevel"])
+
         with UnitOfWork() as uow:
             repo = AegisOrgProfileRepository(uow)
             profile = repo.get_by_user_id(self.user.id)
@@ -119,3 +146,23 @@ class AegisOrgProfileManager:
 
             saved = repo.save(profile)
             return saved.to_dict()
+
+    def _assert_white_label_allowed(self, requested: str) -> None:
+        """Corta si el plan no llega al nivel pedido.
+
+        Se comprueba al guardar para que el usuario se entere en el momento, y
+        otra vez al enviar (``WhiteLabel.capped_to``) para que una bajada de
+        plan posterior surta efecto sin tener que tocar lo ya guardado.
+        """
+        level = WhiteLabelLevel.coerce(requested)
+        maximum = self.max_white_label_level(self.user.id)
+        if level.rank > maximum.rank:
+            entitlement = resolve_entitlement(self.user.id, LimitKey.AEGIS_WHITE_LABEL)
+            logger.info(
+                "Corte por plan | user=%s key=%s plan=%s nivel_pedido=%s maximo=%s",
+                self.user.id, LimitKey.AEGIS_WHITE_LABEL.db_name,
+                entitlement.plan_code, level.value, maximum.value,
+            )
+            raise PlanFeatureDisabledError(
+                LimitKey.AEGIS_WHITE_LABEL.db_name, entitlement.plan_code
+            )

--- a/API/src/modules/features/aegis/managers/org_profile.py
+++ b/API/src/modules/features/aegis/managers/org_profile.py
@@ -44,6 +44,7 @@ _ORG_PROFILE_DEFAULTS: dict[str, Any] = {
     "useHygeiaInventory": True,
     "whiteLabelLevel": WhiteLabelLevel.NONE.value,
     "brandLogo": "",
+    "brandColor": "",
 }
 
 
@@ -143,6 +144,7 @@ class AegisOrgProfileManager:
             profile.use_hygeia_inventory = data["useHygeiaInventory"]
             profile.white_label_level = data["whiteLabelLevel"]
             profile.brand_logo = data["brandLogo"] or None
+            profile.brand_color = data["brandColor"] or None
 
             saved = repo.save(profile)
             return saved.to_dict()

--- a/API/src/modules/features/aegis/model.py
+++ b/API/src/modules/features/aegis/model.py
@@ -41,7 +41,14 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
-from src.modules.shared import Base, Document, utcnow_naive, isoformat_utc
+from src.modules.shared import (
+    Base,
+    Document,
+    WhiteLabelColumns,
+    WhiteLabelLevel,
+    utcnow_naive,
+    isoformat_utc,
+)
 
 
 # =========================================================================
@@ -71,7 +78,7 @@ class Topic(Base):
 # ORGANIZATION PROFILE
 # =========================================================================
 
-class AegisOrgProfile(Base):
+class AegisOrgProfile(WhiteLabelColumns, Base):
     """
     Stable per-user defaults for Aegis pill generation.
 
@@ -104,6 +111,10 @@ class AegisOrgProfile(Base):
             manual ``tracked_products`` list. Defaults to True so that
             registering a first agent starts paying off without extra setup;
             the UI only surfaces the control once such an agent exists.
+        white_label_level: How much of the Ellysia brand the campaign
+            recipients see ('none' | 'logo' | 'full'). From WhiteLabelColumns.
+        brand_logo: The organization's logo as a base64 data URI, shown in the
+            campaign email. From WhiteLabelColumns.
         created_at: Creation timestamp.
     """
 
@@ -147,6 +158,8 @@ class AegisOrgProfile(Base):
             "employeeCount":    self.employee_count,
             "trackedProducts":  self.tracked_products or [],
             "useHygeiaInventory": bool(self.use_hygeia_inventory),
+            "whiteLabelLevel":  self.white_label_level or WhiteLabelLevel.NONE.value,
+            "brandLogo":        self.brand_logo or "",
         }
 
     def __repr__(self) -> str:

--- a/API/src/modules/features/aegis/model.py
+++ b/API/src/modules/features/aegis/model.py
@@ -115,6 +115,8 @@ class AegisOrgProfile(WhiteLabelColumns, Base):
             recipients see ('none' | 'logo' | 'full'). From WhiteLabelColumns.
         brand_logo: The organization's logo as a base64 data URI, shown in the
             campaign email. From WhiteLabelColumns.
+        brand_color: The organization's accent colour ('#1a73e8'), replacing
+            the product's in the campaign email. From WhiteLabelColumns.
         created_at: Creation timestamp.
     """
 
@@ -160,6 +162,7 @@ class AegisOrgProfile(WhiteLabelColumns, Base):
             "useHygeiaInventory": bool(self.use_hygeia_inventory),
             "whiteLabelLevel":  self.white_label_level or WhiteLabelLevel.NONE.value,
             "brandLogo":        self.brand_logo or "",
+            "brandColor":       self.brand_color or "",
         }
 
     def __repr__(self) -> str:

--- a/API/src/modules/features/aegis/model.py
+++ b/API/src/modules/features/aegis/model.py
@@ -112,7 +112,8 @@ class AegisOrgProfile(WhiteLabelColumns, Base):
             registering a first agent starts paying off without extra setup;
             the UI only surfaces the control once such an agent exists.
         white_label_level: How much of the Ellysia brand the campaign
-            recipients see ('none' | 'logo' | 'full'). From WhiteLabelColumns.
+            recipients see ('none' | 'color' | 'logo' | 'full'). Each step adds
+            to the previous one. From WhiteLabelColumns.
         brand_logo: The organization's logo as a base64 data URI, shown in the
             campaign email. From WhiteLabelColumns.
         brand_color: The organization's accent colour ('#1a73e8'), replacing

--- a/API/src/modules/features/aegis/schemas.py
+++ b/API/src/modules/features/aegis/schemas.py
@@ -1,6 +1,7 @@
 from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 
 import src.modules.system.config_reading as CR
+from src.modules.shared import WhiteLabelSchemaMixin
 
 
 class TrackedProductSchema(Schema):
@@ -50,12 +51,15 @@ class AegisTweaksSchema(Schema):
     recentIncident    = fields.String(load_default="", validate=validate.Length(max=500))
 
 
-class AegisOrgProfileSchema(Schema):
+class AegisOrgProfileSchema(WhiteLabelSchemaMixin, Schema):
     """
     Perfil de organización de Aegis: valores estables que casi nunca cambian
     entre generaciones (empresa, contacto, tono, tamaño, jurisdicción, marcas
     habituales). Comparte nombres de campo con AegisTweaksSchema para que el
     frontend pueda precargar el formulario de generación sin traducirlos.
+
+    Los campos de white-labeling (``whiteLabelLevel``, ``brandLogo``) llegan
+    del mixin compartido, que es también quien valida el logo.
     """
     company           = fields.String(load_default="", validate=validate.Length(max=128))
     mentionContact    = fields.String(load_default="", validate=validate.Length(max=128))

--- a/API/src/modules/features/themis/lybra/adapters.py
+++ b/API/src/modules/features/themis/lybra/adapters.py
@@ -222,7 +222,8 @@ def finding_to_json(f: dict, exposure: str) -> dict:
     """
     priority = score_finding(
         {"cvss_score": f.get("cvss_score"), "in_kev": f.get("in_kev"),
-         "epss_score": f.get("epss_score"), "confirmed": f.get("confirmed")},
+         "epss_score": f.get("epss_score"), "confirmed": f.get("confirmed"),
+         "required_os": f.get("required_os")},
         exposure,
     )
     return {
@@ -243,4 +244,5 @@ def finding_to_json(f: dict, exposure: str) -> dict:
         "state":       f.get("state"),
         "dedupKey":    f.get("dedup_key"),
         "priority":    priority,
+        "requiredOs":  f.get("required_os"),
     }

--- a/API/src/modules/features/themis/lybra/correlation.py
+++ b/API/src/modules/features/themis/lybra/correlation.py
@@ -254,12 +254,20 @@ def score_finding(finding: dict, exposure: str) -> str:
       least 0.5 — pushes the priority up one band.
     * An actively-confirmed finding with no CVSS (e.g. an exposed path) is floored
       at MEDIUM, so a confirmed issue never reads as merely informational.
+    * An unconfirmed match whose CVE only applies on a specific platform
+      (``required_os`` set — see ``CpeMatch.required_os``) is capped at
+      MEDIUM: Lybra has no OS-detection signal, so it cannot verify that
+      precondition, and treating an unverifiable "on Windows"-type CVE as
+      CRITICAL against every banner-matched host — regardless of its actual
+      OS — is exactly the false-positive pattern this cap closes. A
+      confirmed finding (Hygeia inventory, where the host's own OS is already
+      known) is exempt.
     * A private-LAN target caps the priority at HIGH, since it is not exposed to
       the internet.
 
     Args:
         finding: A finding dict, read for ``cvss_score`` / ``in_kev`` /
-            ``epss_score`` / ``confirmed``.
+            ``epss_score`` / ``confirmed`` / ``required_os``.
         exposure: ``"private"`` or ``"public"``, as returned by
             :func:`classify_exposure`.
 
@@ -274,6 +282,9 @@ def score_finding(finding: dict, exposure: str) -> str:
 
     if finding.get("confirmed") and cvss == 0.0:
         band = max(band, PRIORITY_LADDER.index("MEDIUM"))
+
+    if finding.get("required_os") and not finding.get("confirmed"):
+        band = min(band, PRIORITY_LADDER.index("MEDIUM"))
 
     if exposure == "private":
         band = min(band, PRIORITY_LADDER.index("HIGH"))

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -118,7 +118,9 @@ class LybraEngine:
 
     Args:
         cve_lookup: A callable ``(vendor, product, version) -> iterable`` of CVE
-            rows, each exposing ``cve_id`` / ``cvss_score`` / ``cvss_vector``.
+            rows, each exposing ``cve_id`` / ``cvss_score`` / ``cvss_vector``
+            and, optionally, ``required_os`` (the platform the match is gated
+            behind, or ``None`` — see ``KbRepository.cves_for_cpe``).
             Passing ``None`` disables version detection, leaving only the
             informational findings.
         kev_lookup: A callable ``(cve_id) -> bool`` telling whether the CVE is in
@@ -206,6 +208,7 @@ class LybraEngine:
             "cvss_vector":  cve.cvss_vector,
             "epss_score":   self._epss_lookup(cve_id) if self._epss_lookup else None,
             "in_kev":       self._kev_lookup(cve_id) if self._kev_lookup else False,
+            "required_os":  getattr(cve, "required_os", None),
             "source":       "lybra",
             "check_id":     "lybra:version-match@1",
             "feed_version": self.FEED_VERSION,

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -328,13 +328,22 @@ def parse_cpe23(cpe: str) -> Optional[dict]:
         cpe: A CPE string in 2.2 or 2.3 form.
 
     Returns:
-        A dict with ``"part"``, ``"vendor"``, ``"product"`` and ``"version"``, or
-        ``None`` if the string is not a recognisable CPE.
+        A dict with ``"part"``, ``"vendor"``, ``"product"``, ``"version"`` and
+        ``"target_sw"``, or ``None`` if the string is not a recognisable CPE.
+        ``target_sw`` is the CPE 2.3 form's 11th field (index 10) — the
+        platform a CVE's applicability rule requires (e.g. ``"windows"``)
+        when NVD encodes it directly on the software's own CPE rather than as
+        a sibling platform CPE in the same configuration node. Missing on a
+        2.2-form or short string, in which case it is ``None``.
     """
     parts = normalize_cpe_to_23(cpe).split(":")
     if len(parts) < 6 or parts[0] != "cpe" or parts[1] != "2.3":
         return None
-    return {"part": parts[2], "vendor": parts[3], "product": parts[4], "version": parts[5]}
+    target_sw = parts[10] if len(parts) > 10 else None
+    return {
+        "part": parts[2], "vendor": parts[3], "product": parts[4], "version": parts[5],
+        "target_sw": target_sw if target_sw not in (None, "*", "-") else None,
+    }
 
 
 # The curated product-name -> (vendor, product) alias feed (Fase I-b, paso 3),
@@ -473,17 +482,56 @@ def ingest_nvd_cve(item: dict) -> Optional[Tuple[dict, List[dict]]]:
     matches: List[dict] = []
     for config in cve.get("configurations", []):
         for node in config.get("nodes", []):
+            node_os = _node_required_os(node)
             for cm in node.get("cpeMatch", []):
                 if not cm.get("vulnerable"):
                     continue
-                row = _cpe_match_row(cm)
+                row = _cpe_match_row(cm, node_required_os=node_os)
                 if row:
                     matches.append(row)
 
     return cve_row, matches
 
 
-def _cpe_match_row(cm: dict) -> Optional[dict]:
+def _node_required_os(node: dict) -> Optional[str]:
+    """Derive the platform an NVD configuration node's software match requires.
+
+    NVD sometimes expresses "product X, but only when running on Windows" as
+    two sibling ``cpeMatch`` entries in the same node — one ``part="a"`` (the
+    software) and one ``part="o"`` (the operating system) — joined by
+    ``operator: "AND"``. Flattening every ``cpeMatch`` in a node into
+    independent rows (as this module used to) loses that joint condition
+    entirely, so a Windows-only CVE ends up matched against the same software
+    regardless of OS. This walks one node's siblings and, when exactly the
+    "AND with a single platform CPE" shape holds, returns that platform's CPE
+    ``product`` token (e.g. ``"windows_10"``) so the caller can tag the
+    software row with it.
+
+    Deliberately conservative: a node with ``operator != "AND"``, no platform
+    CPE, or more than one distinct platform product (an "OR" of platforms,
+    which would need real node-tree semantics to resolve exactly) returns
+    ``None`` rather than guess — the same "no OS gate" behaviour the matcher
+    already had before this existed.
+
+    Args:
+        node: One NVD configuration node.
+
+    Returns:
+        The single required platform's CPE ``product`` token, or ``None``.
+    """
+    if node.get("operator") != "AND" or node.get("negate"):
+        return None
+    platforms = set()
+    for cm in node.get("cpeMatch", []):
+        if not cm.get("vulnerable"):
+            continue
+        parsed = parse_cpe23(cm.get("criteria", ""))
+        if parsed and parsed["part"] == "o":
+            platforms.add(parsed["product"])
+    return next(iter(platforms)) if len(platforms) == 1 else None
+
+
+def _cpe_match_row(cm: dict, node_required_os: Optional[str] = None) -> Optional[dict]:
     """Turn one NVD ``cpeMatch`` object into a ``CpeMatch`` row dict.
 
     A CPE that pins a concrete version (not ``*`` or ``-``) becomes an
@@ -491,15 +539,23 @@ def _cpe_match_row(cm: dict) -> Optional[dict]:
     bounds, in which case the range takes precedence and the pinned version is
     ignored.
 
+    A platform-only entry (``part="o"``, e.g. ``cpe:2.3:o:microsoft:windows_10:...``)
+    is not itself a matchable product — no scanner ever reports "Windows 10"
+    as a network service — so it produces no row of its own; it only exists to
+    gate its AND-sibling software row via ``node_required_os``
+    (see :func:`_node_required_os`).
+
     Args:
         cm: One ``cpeMatch`` object from an NVD configuration node.
+        node_required_os: The platform this match's sibling ``AND`` condition
+            requires, from :func:`_node_required_os`, or ``None``.
 
     Returns:
         A dict of ``CpeMatch`` column values, or ``None`` if the object's CPE
-        string cannot be parsed.
+        string cannot be parsed or is a platform-only entry.
     """
     parsed = parse_cpe23(cm.get("criteria", ""))
-    if not parsed:
+    if not parsed or parsed["part"] == "o":
         return None
     bounds = (
         cm.get("versionStartIncluding"), cm.get("versionStartExcluding"),
@@ -514,6 +570,10 @@ def _cpe_match_row(cm: dict) -> Optional[dict]:
         "version_end_including":   cm.get("versionEndIncluding"),
         "version_end_excluding":   cm.get("versionEndExcluding"),
         "exact_version":           None if any(bounds) else pinned,
+        # The software's own CPE can encode the platform directly
+        # (target_sw), or it can come from an AND-sibling platform CPE in the
+        # same node; either is a genuine applicability gate NVD intends.
+        "required_os": parsed["target_sw"] or node_required_os,
     }
 
 

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -826,7 +826,7 @@ class Finding(Base):
     epss_score       = Column(Float)
     in_kev           = Column(Boolean, default=False)
     exploit_maturity = Column(String(16))   # none|poc|functional|weaponized|in_the_wild
-    required_os      = Column(String(64))   # CPE platform token this finding's CVE match is gated behind (see CpeMatch.required_os), or None
+    required_os      = Column(String(64))   # Platform this finding's CVE match is gated behind (see CpeMatch.required_os), or None
 
     # Quality / provenance
     source       = Column(String(32), index=True)
@@ -922,7 +922,7 @@ class CpeMatch(Base):
     version_end_including   = Column(String(64))
     version_end_excluding   = Column(String(64))
     exact_version           = Column(String(64))  # set when the CPE pins a single version
-    required_os             = Column(String(64))  # CPE product token of an AND-linked platform gate (see lybra/kb.py::_node_required_os), or None
+    required_os             = Column(String(64))  # AND-linked platform gate (lybra/kb.py::_node_required_os), or None
 
     cve = relationship("CveEntry", back_populates="cpe_matches")
 

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -785,6 +785,11 @@ class Finding(Base):
             collide the two.
         cve_ids / cvss_score / cvss_vector / epss_score / in_kev /
             exploit_maturity: Vulnerability correlation (filled from Fase 1 on).
+        required_os: CPE platform token (e.g. "windows_10") this finding's CVE
+            match is gated behind, or None if unconditional. Set from
+            ``CpeMatch.required_os`` at correlation time; used by
+            ``score_finding`` to avoid treating an unverifiable platform
+            precondition as a confirmed risk.
         source: Which scanner produced it ("lybra" | "nikto" | "nuclei" | "nmap",
             or historically "openvas" — that scanner no longer runs).
         check_id: Which own check produced it ("lybra:git-config-exposure@3").
@@ -821,6 +826,7 @@ class Finding(Base):
     epss_score       = Column(Float)
     in_kev           = Column(Boolean, default=False)
     exploit_maturity = Column(String(16))   # none|poc|functional|weaponized|in_the_wild
+    required_os      = Column(String(64))   # CPE platform token this finding's CVE match is gated behind (see CpeMatch.required_os), or None
 
     # Quality / provenance
     source       = Column(String(32), index=True)
@@ -849,9 +855,10 @@ class Finding(Base):
             "cve_ids": self.cve_ids,
             "cvss_score": self.cvss_score, 
             "cvss_vector": self.cvss_vector,
-            "epss_score": self.epss_score, 
+            "epss_score": self.epss_score,
             "in_kev": self.in_kev,
-            "exploit_maturity": self.exploit_maturity, 
+            "exploit_maturity": self.exploit_maturity,
+            "required_os": self.required_os,
             "source": self.source,
             "check_id": self.check_id, 
             "feed_version": self.feed_version,
@@ -915,6 +922,7 @@ class CpeMatch(Base):
     version_end_including   = Column(String(64))
     version_end_excluding   = Column(String(64))
     exact_version           = Column(String(64))  # set when the CPE pins a single version
+    required_os             = Column(String(64))  # CPE product token of an AND-linked platform gate (see lybra/kb.py::_node_required_os), or None
 
     cve = relationship("CveEntry", back_populates="cpe_matches")
 

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -888,7 +888,16 @@ class KbRepository(BaseRepository[CveEntry]):
 
         Filters candidate applicability rows by (vendor, product) in SQL, then
         applies the version-range logic in Python (see ``lybra.kb``). Results
-        are de-duplicated by CVE.
+        are de-duplicated by CVE — a CVE can have several ``CpeMatch`` rows for
+        the same product (different ranges, some OS-gated and some not); when
+        that happens the *least* restrictive rule wins, since an unconditional
+        applicability rule proves the CVE genuinely applies here regardless of
+        any other, narrower rule that also happens to match.
+
+        Each returned ``CveEntry`` carries a transient ``required_os``
+        attribute (not a mapped column — set on this query's result objects
+        only) telling the caller which platform, if any, every contributing
+        match required. ``None`` means unconditional.
         """
         from .lybra import version_in_range
 
@@ -898,12 +907,24 @@ class KbRepository(BaseRepository[CveEntry]):
             .options(joinedload(CpeMatch.cve))
             .all()
         )
-        seen: set[int] = set()
-        result: List[CveEntry] = []
+        order: List[int] = []
+        entries: Dict[int, CveEntry] = {}
+        required_os: Dict[int, Optional[str]] = {}
         for match in candidates:
-            if version_in_range(version, match) and match.cve_id not in seen:
-                seen.add(match.cve_id)
-                result.append(match.cve)
+            if not version_in_range(version, match):
+                continue
+            cve_id = match.cve_id
+            if cve_id not in entries:
+                order.append(cve_id)
+                entries[cve_id] = match.cve
+                required_os[cve_id] = match.required_os
+            elif required_os[cve_id] and not match.required_os:
+                required_os[cve_id] = None
+        result: List[CveEntry] = []
+        for cve_id in order:
+            entry = entries[cve_id]
+            entry.required_os = required_os[cve_id]  # type: ignore[attr-defined]
+            result.append(entry)
         return result
 
     def resolve_product_alias(self, normalized_name: str) -> Optional[Tuple[str, str]]:

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -48,6 +48,13 @@ class NmapAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
+    # Tope de puertos detallados que viajan al prompt (#118): un host con
+    # cientos de puertos abiertos (mala configuración, o un rango escaneado
+    # como si fuera un solo host) podía generar un 'ports_json' sin límite.
+    # '{{total_ports}}' sigue reportando el recuento real (no el recortado),
+    # así que el modelo nunca lee "hay menos puertos de los que realmente hay".
+    _MAX_PORTS = 60
+
     def __init__(self, generator: Optional[AIGenerator] = None) -> None:
         """Initialize Nmap AI writer.
 
@@ -129,6 +136,9 @@ class NmapAIWriter:
                 "categoria_funcional": self._infer_functional_category(service, port_num)
             })
 
+        total_ports = len(ports_info)
+        ports_info = ports_info[:self._MAX_PORTS]
+
         prompts_config = CR.get_prompts_config()
         template = prompts_config.get("nmap", {}).get("userTemplate", "")
 
@@ -140,7 +150,7 @@ class NmapAIWriter:
 
         rendered = template.replace("{{target}}", str(target)) \
                         .replace("{{started}}", str(started)) \
-                        .replace("{{total_ports}}", str(len(ports_info))) \
+                        .replace("{{total_ports}}", str(total_ports)) \
                         .replace("{{distribution}}", str(analysis_context["distribution"])) \
                         .replace("{{profile_type}}", str(analysis_context["profile_type"])) \
                         .replace("{{ports_json}}", json.dumps(ports_info, indent=2, ensure_ascii=False))
@@ -504,12 +514,21 @@ class LybraAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
-    # Tope de hallazgos detallados que viajan al prompt. Los confirmados y los
-    # de KEV nunca se recortan; el tope sólo acota la cola ordenada por
-    # prioridad. El rollup por servicio cubre igualmente los que no entran, así
-    # que un host con cientos de CVEs sigue describiéndose entero.
+    # Tope de hallazgos detallados que viajan al prompt. Se aplica al conjunto
+    # completo (confirmados + KEV + cola), no solo a la cola: un scan con más
+    # de _MAX_HIGHLIGHTED_FINDINGS hallazgos confirmados/KEV podía generar un
+    # payload sin límite real pese a este tope, porque antes solo recortaba
+    # "rest" (Issue #118). El rollup por servicio cubre igualmente los que no
+    # entran, así que un host con cientos de CVEs sigue describiéndose entero.
     _MAX_HIGHLIGHTED_FINDINGS = 25
     _MAX_DESCRIPTION_CHARS = 300
+
+    # Tope de grupos del rollup por servicio (#118): un objetivo con muchos
+    # productos/puertos distintos (un rango de red, no un solo host) podía
+    # generar un 'services_json' sin límite pese a que ya es una compresión
+    # de los hallazgos. Ordenado por severidad (ver _build_service_rollup),
+    # así que un recorte siempre descarta primero los grupos menos graves.
+    _MAX_SERVICE_GROUPS = 40
 
     # Mismo orden que FindingsPrintingStrategy._PRIORITY_ORDER: el informe y el
     # análisis deben priorizar igual o se contradicen entre páginas.
@@ -614,7 +633,8 @@ class LybraAIWriter:
             del group["cves"]
             rollup.append(group)
 
-        return sorted(rollup, key=lambda group: -(group["max_cvss"] or 0))
+        rollup.sort(key=lambda group: -(group["max_cvss"] or 0))
+        return rollup[:self._MAX_SERVICE_GROUPS]
 
     @staticmethod
     def _version_key(version: str) -> tuple:
@@ -639,18 +659,24 @@ class LybraAIWriter:
         started = scan_data.get("started_at", "N/A")
         exposure = scan_data.get("exposure", "unknown")
 
-        confirmed = [finding for finding in findings if finding.get("confirmed")]
-        kev = [finding for finding in findings if finding.get("in_kev")]
+        # Confirmados y KEV se priorizan siempre por delante de la cola, y se
+        # deduplican por identidad antes de ordenar: un hallazgo puede ser
+        # confirmado Y estar en KEV a la vez, y una concatenación ingenua lo
+        # metía dos veces. Se ordenan por prioridad real (no por orden de
+        # repositorio) para que, al recortar, sobrevivan los más graves —
+        # y se recortan igual que la cola: antes solo _rest_ tenía tope, así
+        # que un scan con más de _MAX_HIGHLIGHTED_FINDINGS confirmados/KEV
+        # generaba un payload sin límite real pese a la constante (#118).
+        priority = list({id(finding): finding for finding in findings
+                          if finding.get("confirmed") or finding.get("in_kev")}.values())
+        priority.sort(key=self._sort_key)
 
-        # Confirmados y KEV van siempre; la cola se ordena por prioridad real
-        # (no por orden de repositorio) antes de recortarse, para que los
-        # hallazgos destacados sean los mismos que encabezan el informe.
-        priority_ids = {id(finding) for finding in confirmed} | {id(finding) for finding in kev}
+        priority_ids = {id(finding) for finding in priority}
         rest = sorted(
             (finding for finding in findings if id(finding) not in priority_ids),
             key=self._sort_key,
         )
-        highlighted = (confirmed + kev + rest)[:self._MAX_HIGHLIGHTED_FINDINGS]
+        highlighted = (priority + rest)[:self._MAX_HIGHLIGHTED_FINDINGS]
 
         findings_for_ai = [{
             "titulo": finding.get("title", "")[:160],
@@ -677,8 +703,8 @@ class LybraAIWriter:
                     .replace("{{started}}", str(started)) \
                     .replace("{{exposure}}", str(exposure)) \
                     .replace("{{total_findings}}", str(len(findings))) \
-                    .replace("{{confirmed_count}}", str(len(confirmed))) \
-                    .replace("{{kev_count}}", str(len(kev))) \
+                    .replace("{{confirmed_count}}", str(sum(1 for finding in findings if finding.get("confirmed")))) \
+                    .replace("{{kev_count}}", str(sum(1 for finding in findings if finding.get("in_kev")))) \
                     .replace("{{services_json}}", json.dumps(self._build_service_rollup(findings), indent=2, ensure_ascii=False)) \
                     .replace("{{findings_json}}", json.dumps(findings_for_ai, indent=2, ensure_ascii=False))
 

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -667,6 +667,7 @@ class LybraAIWriter:
             "estado": finding.get("state", "open"),
             "corregido_en": finding.get("fixed_version"),
             "descripcion": (finding.get("description") or "")[:self._MAX_DESCRIPTION_CHARS],
+            "requiere_so": finding.get("required_os"),
         } for finding in highlighted]
 
         prompts_config = CR.get_prompts_config()
@@ -725,6 +726,7 @@ class LybraAIWriter:
                 "service": row.service, "cpe": row.cpe, "cve_ids": row.cve_ids,
                 "cvss_score": row.cvss_score, "epss_score": row.epss_score, "in_kev": row.in_kev,
                 "confirmed": row.confirmed, "qod": row.qod, "state": row.state,
+                "required_os": row.required_os,
             } for row in rows]
 
         for finding in findings:

--- a/API/src/modules/features/themis/services/reports/base.py
+++ b/API/src/modules/features/themis/services/reports/base.py
@@ -20,6 +20,7 @@ from reportlab.platypus import PageBreak, Paragraph, Spacer, Table, TableStyle
 import src.modules.system.config_reading as CR
 
 from src.modules.shared._exceptions import IllegalStateError, ValidationError
+from src.modules.tools.scribe import AIPayloadTooLargeError
 from ...model import Scan, ScanType
 from src.modules.shared.report_theme import ColorType, ReportTheme, safe_markup
 
@@ -134,6 +135,16 @@ class PrintingStrategy(ABC):
                 raise IllegalStateError("Writer detectado como None")
 
             ai_analysis = self.writer.generate(self.scan, **writer_kwargs)
+        except AIPayloadTooLargeError as e:
+            logger.warning(f"[IA] Payload demasiado grande para scan {self.scan.id}: {e}")
+            elements.append(PageBreak())
+            elements.extend(theme.section_header("Análisis de Seguridad IA", "INTELIGENCIA ARTIFICIAL"))
+            elements.append(Paragraph(
+                "Este escaneo tiene demasiados hallazgos para generar un análisis de IA completo. "
+                "Consulta el detalle técnico del informe: contiene la misma información, sin resumir.",
+                theme.body,
+            ))
+            return
         except Exception as e:
             logger.error(f"[IA] Excepción: {e}", exc_info=True)
             ai_analysis = {}

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -118,6 +118,7 @@ class FindingsPrintingStrategy(PrintingStrategy):
             "cpe": row.cpe, "cve_ids": row.cve_ids or [], "cvss_score": row.cvss_score,
             "epss_score": row.epss_score, "in_kev": row.in_kev, "qod": row.qod, "confirmed": row.confirmed,
             "source": row.source, "state": row.state, "cpe_resolved": row.cpe_resolved,
+            "required_os": row.required_os,
         } for row in rows]
         for f in findings:
             f["priority"] = score_finding(f, exposure)
@@ -374,6 +375,8 @@ class FindingsPrintingStrategy(PrintingStrategy):
             details.append(["EPSS (30 días):", f"{finding['epss_score'] * 100:.1f}%"])
         if finding.get("in_kev"):
             details.append(["CISA KEV:", "Sí — explotada activamente"])
+        if finding.get("required_os") and not finding.get("confirmed"):
+            details.append(["Requiere SO:", f"{finding['required_os']} (no verificado en este escaneo)"])
         if finding.get("fixed_version"):
             details.append(["Corregido en:", f"{finding['fixed_version']} o superior"])
         if finding.get("state") and finding["state"] != "open":

--- a/API/src/modules/shared/__init__.py
+++ b/API/src/modules/shared/__init__.py
@@ -23,7 +23,19 @@ from ._ownership import assert_owned
 from ._time import utcnow_naive, isoformat_utc
 from ._task_states import CANCELLABLE_STATES
 from ._crypto import encrypt_at_rest, decrypt_at_rest
-from .schemas import ErrorSchema, SuccessMessageSchema, PaginationQuerySchema, UTCDateTime
+from ._white_label import (
+    WhiteLabel,
+    WhiteLabelColumns,
+    WhiteLabelLevel,
+    validate_logo_data_uri,
+)
+from .schemas import (
+    ErrorSchema,
+    SuccessMessageSchema,
+    PaginationQuerySchema,
+    UTCDateTime,
+    WhiteLabelSchemaMixin,
+)
 
 __all__ = [
     "Base",
@@ -42,5 +54,10 @@ __all__ = [
     "ErrorSchema",
     "SuccessMessageSchema",
     "PaginationQuerySchema",
-    "UTCDateTime"
+    "UTCDateTime",
+    "WhiteLabel",
+    "WhiteLabelColumns",
+    "WhiteLabelLevel",
+    "WhiteLabelSchemaMixin",
+    "validate_logo_data_uri",
 ]

--- a/API/src/modules/shared/__init__.py
+++ b/API/src/modules/shared/__init__.py
@@ -27,6 +27,7 @@ from ._white_label import (
     WhiteLabel,
     WhiteLabelColumns,
     WhiteLabelLevel,
+    validate_brand_color,
     validate_logo_data_uri,
 )
 from .schemas import (
@@ -59,5 +60,6 @@ __all__ = [
     "WhiteLabelColumns",
     "WhiteLabelLevel",
     "WhiteLabelSchemaMixin",
+    "validate_brand_color",
     "validate_logo_data_uri",
 ]

--- a/API/src/modules/shared/_white_label.py
+++ b/API/src/modules/shared/_white_label.py
@@ -14,7 +14,8 @@ Piezas:
     WhiteLabelLevel     — los tres niveles.
     WhiteLabel          — los ajustes ya resueltos, con el logo decodificable.
     WhiteLabelColumns   — mixin de columnas para persistirlos en cualquier modelo.
-    validate_logo_data_uri — validación del logo en el borde de confianza.
+    validate_logo_data_uri / validate_brand_color — validación en el borde de
+        confianza.
 """
 
 from __future__ import annotations
@@ -37,6 +38,11 @@ ALLOWED_LOGO_MIMETYPES: frozenset[str] = frozenset({"image/png", "image/jpeg", "
 #: tamaños de mensaje que aceptan los relays.
 MAX_LOGO_BYTES: int = 200 * 1024
 
+#: Color de énfasis: solo hexadecimal de 6 dígitos. Este valor acaba dentro de
+#: atributos ``style`` de la plantilla del correo, así que la validación es
+#: estricta a propósito — no se admite ningún valor CSS libre.
+_BRAND_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
 _DATA_URI_RE = re.compile(r"^data:(?P<mimetype>[\w.+-]+/[\w.+-]+);base64,(?P<payload>[A-Za-z0-9+/=\s]+)$")
 
 
@@ -44,13 +50,17 @@ class WhiteLabelLevel(str, Enum):
     """Cuánta marca propia sustituye a la del producto.
 
     NONE  — nada: el destinatario ve exactamente lo de siempre.
-    LOGO  — se añade el logo del cliente al contenido; la marca del producto
-            sigue en cabecera y pie.
+    COLOR — el color de énfasis pasa a ser el del cliente. Es el escalón
+            barato: un color lo tiene a mano cualquier marca, mientras que un
+            logo con fondo transparente y proporciones sanas no siempre.
+    LOGO  — además, se añade el logo del cliente al contenido; la marca del
+            producto sigue en cabecera y pie.
     FULL  — además, la marca del producto desaparece: cabecera, pie y página
             pública pasan a la del cliente.
     """
 
     NONE = "none"
+    COLOR = "color"
     LOGO = "logo"
     FULL = "full"
 
@@ -92,6 +102,7 @@ class WhiteLabelLevel(str, Enum):
 #: declara en ``PlanLimit`` para conceder ese nivel.
 _LEVEL_ORDER: tuple[WhiteLabelLevel, ...] = (
     WhiteLabelLevel.NONE,
+    WhiteLabelLevel.COLOR,
     WhiteLabelLevel.LOGO,
     WhiteLabelLevel.FULL,
 )
@@ -142,6 +153,25 @@ def validate_logo_data_uri(value: str) -> tuple[str, bytes]:
     return mimetype, data
 
 
+def validate_brand_color(value: str) -> str:
+    """
+    Valida un color de énfasis y lo normaliza a minúsculas.
+
+    Args:
+        value: Color hexadecimal de 6 dígitos ('#1a73e8').
+
+    Returns:
+        El mismo color en minúsculas.
+
+    Raises:
+        ValueError: Si no es un hexadecimal de 6 dígitos.
+    """
+    value = (value or "").strip()
+    if not _BRAND_COLOR_RE.match(value):
+        raise ValueError("El color debe ser hexadecimal de 6 dígitos ('#1a73e8').")
+    return value.lower()
+
+
 @dataclass(frozen=True)
 class WhiteLabel:
     """
@@ -150,13 +180,15 @@ class WhiteLabel:
     Attributes:
         level: Nivel aplicado.
         logo: Logo del cliente como data URI, o cadena vacía.
+        color: Color de énfasis del cliente ('#1a73e8'), o cadena vacía.
         brand_name: Nombre con el que sustituir la marca del producto en el
             nivel FULL. Sin él, el nivel FULL se queda sin nombre que poner y
-            degrada a LOGO (ver ``effective_level``).
+            degrada un escalón (ver ``effective_level``).
     """
 
     level: WhiteLabelLevel = WhiteLabelLevel.NONE
     logo: str = ""
+    color: str = ""
     brand_name: str = ""
 
     @classmethod
@@ -164,12 +196,14 @@ class WhiteLabel:
         cls,
         level: "WhiteLabelLevel | str | None",
         logo: str | None,
+        color: str | None,
         brand_name: str | None,
     ) -> "WhiteLabel":
         """Construye los ajustes a partir de lo persistido, tolerando NULLs."""
         return cls(
             level=WhiteLabelLevel.coerce(level),
             logo=(logo or "").strip(),
+            color=(color or "").strip(),
             brand_name=(brand_name or "").strip(),
         )
 
@@ -177,15 +211,20 @@ class WhiteLabel:
     def effective_level(self) -> WhiteLabelLevel:
         """El nivel que de verdad puede aplicarse con los datos que hay.
 
-        Pedir FULL sin nombre de marca dejaría el correo sin cabecera ni pie
-        legibles; pedir LOGO sin logo no cambia nada. En ambos casos se baja
-        un escalón en vez de entregar algo a medias.
+        Cada escalón necesita su dato: FULL un nombre con el que sustituir la
+        marca, LOGO un logo, COLOR un color. Si falta, se baja un escalón (y se
+        vuelve a comprobar) en vez de entregar algo a medias — un FULL sin
+        nombre dejaría el correo sin cabecera ni pie legibles.
         """
-        if self.level is WhiteLabelLevel.FULL and not self.brand_name:
-            return WhiteLabelLevel.LOGO if self.logo else WhiteLabelLevel.NONE
-        if self.level is WhiteLabelLevel.LOGO and not self.logo:
-            return WhiteLabelLevel.NONE
-        return self.level
+        requirements = {
+            WhiteLabelLevel.FULL:  self.brand_name,
+            WhiteLabelLevel.LOGO:  self.logo,
+            WhiteLabelLevel.COLOR: self.color,
+        }
+        level = self.level
+        while level is not WhiteLabelLevel.NONE and not requirements[level]:
+            level = _LEVEL_ORDER[level.rank - 1]
+        return level
 
     def capped_to(self, maximum: WhiteLabelLevel) -> "WhiteLabel":
         """Los mismos ajustes, sin pasar de ``maximum``.
@@ -197,7 +236,9 @@ class WhiteLabel:
         """
         if self.level.rank <= maximum.rank:
             return self
-        return WhiteLabel(level=maximum, logo=self.logo, brand_name=self.brand_name)
+        return WhiteLabel(
+            level=maximum, logo=self.logo, color=self.color, brand_name=self.brand_name,
+        )
 
     def decoded_logo(self) -> tuple[str, bytes] | None:
         """El logo como ``(mimetype, bytes)``, o None si no hay o no es válido.
@@ -229,3 +270,5 @@ class WhiteLabelColumns:
     #: Data URI del logo. Text, no bytes: se guarda como llega del navegador y
     #: se sirve igual al frontend para previsualizarlo, sin recodificar.
     brand_logo = Column(Text, nullable=True)
+    #: Color de énfasis en hexadecimal ('#1a73e8').
+    brand_color = Column(String(7), nullable=True)

--- a/API/src/modules/shared/_white_label.py
+++ b/API/src/modules/shared/_white_label.py
@@ -54,6 +54,24 @@ class WhiteLabelLevel(str, Enum):
     LOGO = "logo"
     FULL = "full"
 
+    @property
+    def rank(self) -> int:
+        """Posición en la escalera. Es también el valor que concede el plan."""
+        return _LEVEL_ORDER.index(self)
+
+    @classmethod
+    def from_allowance(cls, allowance: int | None) -> "WhiteLabelLevel":
+        """El nivel máximo que concede un tope de plan.
+
+        Traduce el ``value`` de una fila de ``PlanLimit`` (``None`` = sin
+        techo, ``0`` = no incluido, ``n`` = escalón n) al nivel. Un tope mayor
+        que el último escalón no es un error: concede el más alto, para que
+        añadir escalones más adelante no obligue a reescribir los planes.
+        """
+        if allowance is None:
+            return _LEVEL_ORDER[-1]
+        return _LEVEL_ORDER[max(0, min(allowance, len(_LEVEL_ORDER) - 1))]
+
     @classmethod
     def coerce(cls, value: "WhiteLabelLevel | str | None") -> "WhiteLabelLevel":
         """Convierte lo que haya en la BD (o None) en un nivel válido.
@@ -68,6 +86,15 @@ class WhiteLabelLevel(str, Enum):
             return cls(str(value or "").lower())
         except ValueError:
             return cls.NONE
+
+
+#: La escalera, de menos a más. El índice es el ``rank`` y el valor que un plan
+#: declara en ``PlanLimit`` para conceder ese nivel.
+_LEVEL_ORDER: tuple[WhiteLabelLevel, ...] = (
+    WhiteLabelLevel.NONE,
+    WhiteLabelLevel.LOGO,
+    WhiteLabelLevel.FULL,
+)
 
 
 def validate_logo_data_uri(value: str) -> tuple[str, bytes]:
@@ -159,6 +186,18 @@ class WhiteLabel:
         if self.level is WhiteLabelLevel.LOGO and not self.logo:
             return WhiteLabelLevel.NONE
         return self.level
+
+    def capped_to(self, maximum: WhiteLabelLevel) -> "WhiteLabel":
+        """Los mismos ajustes, sin pasar de ``maximum``.
+
+        El tope lo pone el plan, y se aplica **también al usar** los ajustes,
+        no solo al guardarlos: al bajar de plan, un nivel que era legal deja de
+        serlo, y nadie borra nada — igual que unas existencias que quedan por
+        encima del tope entran en solo lectura en vez de desaparecer.
+        """
+        if self.level.rank <= maximum.rank:
+            return self
+        return WhiteLabel(level=maximum, logo=self.logo, brand_name=self.brand_name)
 
     def decoded_logo(self) -> tuple[str, bytes] | None:
         """El logo como ``(mimetype, bytes)``, o None si no hay o no es válido.

--- a/API/src/modules/shared/_white_label.py
+++ b/API/src/modules/shared/_white_label.py
@@ -1,0 +1,192 @@
+"""
+shared._white_label
+───────────────────
+White-labeling: cuánto de la marca del producto ve el destinatario final de
+algo que la plataforma le entrega (un correo de campaña, la página pública de
+un test, …) y con qué marca se sustituye.
+
+Aquí vive el concepto en crudo — niveles, logo y validación — sin saber en qué
+canal se va a pintar. La proyección a un canal concreto vive en el canal:
+``tools.herald.branding`` lo traduce a la marca de un correo y a su imagen
+incrustada; un endpoint que sirva marca a la SPA lo traduce a JSON.
+
+Piezas:
+    WhiteLabelLevel     — los tres niveles.
+    WhiteLabel          — los ajustes ya resueltos, con el logo decodificable.
+    WhiteLabelColumns   — mixin de columnas para persistirlos en cualquier modelo.
+    validate_logo_data_uri — validación del logo en el borde de confianza.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from sqlalchemy import Column, String, Text
+
+
+#: Formatos admitidos para el logo. Sin SVG a propósito: prácticamente ningún
+#: cliente de correo lo renderiza, y es un vector de script embebido.
+ALLOWED_LOGO_MIMETYPES: frozenset[str] = frozenset({"image/png", "image/jpeg", "image/gif"})
+
+#: Tope del logo ya decodificado. Un correo entero debería quedar holgadamente
+#: por debajo de los límites de recorte de Gmail (~102 KB de HTML) y de los
+#: tamaños de mensaje que aceptan los relays.
+MAX_LOGO_BYTES: int = 200 * 1024
+
+_DATA_URI_RE = re.compile(r"^data:(?P<mimetype>[\w.+-]+/[\w.+-]+);base64,(?P<payload>[A-Za-z0-9+/=\s]+)$")
+
+
+class WhiteLabelLevel(str, Enum):
+    """Cuánta marca propia sustituye a la del producto.
+
+    NONE  — nada: el destinatario ve exactamente lo de siempre.
+    LOGO  — se añade el logo del cliente al contenido; la marca del producto
+            sigue en cabecera y pie.
+    FULL  — además, la marca del producto desaparece: cabecera, pie y página
+            pública pasan a la del cliente.
+    """
+
+    NONE = "none"
+    LOGO = "logo"
+    FULL = "full"
+
+    @classmethod
+    def coerce(cls, value: "WhiteLabelLevel | str | None") -> "WhiteLabelLevel":
+        """Convierte lo que haya en la BD (o None) en un nivel válido.
+
+        Un valor desconocido cae a NONE en vez de reventar: quedarse corto de
+        personalización es un defecto cosmético, romper el envío de una
+        campaña entera no.
+        """
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value or "").lower())
+        except ValueError:
+            return cls.NONE
+
+
+def validate_logo_data_uri(value: str) -> tuple[str, bytes]:
+    """
+    Valida un logo recibido como data URI y lo devuelve ya decodificado.
+
+    Es la validación del borde de confianza: el data URI llega del navegador,
+    así que ni el tipo declarado ni el tamaño son de fiar hasta pasar por aquí.
+
+    Args:
+        value: Data URI en base64 ('data:image/png;base64,iVBORw0…').
+
+    Returns:
+        ``(mimetype, bytes)``.
+
+    Raises:
+        ValueError: Si el formato, el tipo o el tamaño no son admisibles.
+    """
+    value = (value or "").strip()
+    # Corte antes de decodificar: base64 abulta ~4/3, así que cualquier cadena
+    # más larga que esto no puede caber en el tope una vez decodificada, y no
+    # tiene sentido gastar la decodificación (ni la memoria) en descubrirlo.
+    if len(value) > MAX_LOGO_BYTES * 2:
+        raise ValueError(f"El logo supera el máximo de {MAX_LOGO_BYTES // 1024} KB.")
+
+    match = _DATA_URI_RE.match(value)
+    if not match:
+        raise ValueError("El logo debe ser un data URI en base64 ('data:image/png;base64,…').")
+
+    mimetype = match.group("mimetype").lower()
+    if mimetype not in ALLOWED_LOGO_MIMETYPES:
+        allowed = ", ".join(sorted(ALLOWED_LOGO_MIMETYPES))
+        raise ValueError(f"Formato de logo no admitido: '{mimetype}'. Admitidos: {allowed}.")
+
+    try:
+        data = base64.b64decode(match.group("payload"), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("El logo no es base64 válido.") from exc
+
+    if not data:
+        raise ValueError("El logo está vacío.")
+    if len(data) > MAX_LOGO_BYTES:
+        raise ValueError(f"El logo supera el máximo de {MAX_LOGO_BYTES // 1024} KB.")
+
+    return mimetype, data
+
+
+@dataclass(frozen=True)
+class WhiteLabel:
+    """
+    Ajustes de white-labeling ya resueltos, listos para proyectar a un canal.
+
+    Attributes:
+        level: Nivel aplicado.
+        logo: Logo del cliente como data URI, o cadena vacía.
+        brand_name: Nombre con el que sustituir la marca del producto en el
+            nivel FULL. Sin él, el nivel FULL se queda sin nombre que poner y
+            degrada a LOGO (ver ``effective_level``).
+    """
+
+    level: WhiteLabelLevel = WhiteLabelLevel.NONE
+    logo: str = ""
+    brand_name: str = ""
+
+    @classmethod
+    def from_stored(
+        cls,
+        level: "WhiteLabelLevel | str | None",
+        logo: str | None,
+        brand_name: str | None,
+    ) -> "WhiteLabel":
+        """Construye los ajustes a partir de lo persistido, tolerando NULLs."""
+        return cls(
+            level=WhiteLabelLevel.coerce(level),
+            logo=(logo or "").strip(),
+            brand_name=(brand_name or "").strip(),
+        )
+
+    @property
+    def effective_level(self) -> WhiteLabelLevel:
+        """El nivel que de verdad puede aplicarse con los datos que hay.
+
+        Pedir FULL sin nombre de marca dejaría el correo sin cabecera ni pie
+        legibles; pedir LOGO sin logo no cambia nada. En ambos casos se baja
+        un escalón en vez de entregar algo a medias.
+        """
+        if self.level is WhiteLabelLevel.FULL and not self.brand_name:
+            return WhiteLabelLevel.LOGO if self.logo else WhiteLabelLevel.NONE
+        if self.level is WhiteLabelLevel.LOGO and not self.logo:
+            return WhiteLabelLevel.NONE
+        return self.level
+
+    def decoded_logo(self) -> tuple[str, bytes] | None:
+        """El logo como ``(mimetype, bytes)``, o None si no hay o no es válido.
+
+        No lanza: lo que está guardado ya pasó la validación de entrada, y un
+        logo corrupto no debe tumbar un envío en curso.
+        """
+        if not self.logo:
+            return None
+        try:
+            return validate_logo_data_uri(self.logo)
+        except ValueError:
+            return None
+
+
+class WhiteLabelColumns:
+    """
+    Mixin de columnas para persistir el white-labeling en cualquier modelo.
+
+    Un modelo que quiera ofrecerlo hereda de aquí y añade su migración; el
+    nombre de marca no se incluye a propósito, porque cada modelo ya suele
+    tener el suyo (``company``, ``name``, …) y duplicarlo lo dejaría
+    desincronizado.
+    """
+
+    white_label_level = Column(
+        String(16), nullable=False, default=WhiteLabelLevel.NONE.value, server_default=WhiteLabelLevel.NONE.value,
+    )
+    #: Data URI del logo. Text, no bytes: se guarda como llega del navegador y
+    #: se sirve igual al frontend para previsualizarlo, sin recodificar.
+    brand_logo = Column(Text, nullable=True)

--- a/API/src/modules/shared/_white_label.py
+++ b/API/src/modules/shared/_white_label.py
@@ -140,8 +140,13 @@ def validate_logo_data_uri(value: str) -> tuple[str, bytes]:
         allowed = ", ".join(sorted(ALLOWED_LOGO_MIMETYPES))
         raise ValueError(f"Formato de logo no admitido: '{mimetype}'. Admitidos: {allowed}.")
 
+    # Los espacios se quitan antes de decodificar, no después de rechazarlos:
+    # el regex los admite a propósito porque hay codificadores que parten el
+    # base64 en líneas de 76 caracteres (``base64.encodebytes``, RFC 2045), y
+    # ``validate=True`` los trata como alfabeto inválido.
+    payload = re.sub(r"\s+", "", match.group("payload"))
     try:
-        data = base64.b64decode(match.group("payload"), validate=True)
+        data = base64.b64decode(payload, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise ValueError("El logo no es base64 válido.") from exc
 

--- a/API/src/modules/shared/schemas.py
+++ b/API/src/modules/shared/schemas.py
@@ -1,6 +1,8 @@
 from datetime import timezone
 
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, ValidationError, fields, validate
+
+from ._white_label import WhiteLabelLevel, validate_logo_data_uri
 
 
 class UTCDateTime(fields.DateTime):
@@ -33,3 +35,30 @@ class SuccessMessageSchema(Schema):
 class PaginationQuerySchema(Schema):
     page = fields.Integer(load_default=1, validate=validate.Range(min=1))
     per_page = fields.Integer(load_default=10, validate=validate.Range(min=1, max=100))
+
+
+def _validate_brand_logo(value: str) -> None:
+    """Adapta la validación compartida del logo al contrato de marshmallow."""
+    if not value:
+        return
+    try:
+        validate_logo_data_uri(value)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+
+class WhiteLabelSchemaMixin:
+    """
+    Campos de white-labeling para el esquema de cualquier módulo que lo ofrezca.
+
+    Se hereda junto a ``Schema`` (``class MiSchema(WhiteLabelSchemaMixin, Schema)``)
+    y aporta la pareja de campos ya validada — el logo llega del navegador, así
+    que su tipo y su tamaño se comprueban aquí, en el borde de confianza, y no
+    en el manager ni en la plantilla.
+    """
+
+    whiteLabelLevel = fields.String(
+        load_default=WhiteLabelLevel.NONE.value,
+        validate=validate.OneOf([level.value for level in WhiteLabelLevel]),
+    )
+    brandLogo = fields.String(load_default="", allow_none=True, validate=_validate_brand_logo)

--- a/API/src/modules/shared/schemas.py
+++ b/API/src/modules/shared/schemas.py
@@ -2,7 +2,7 @@ from datetime import timezone
 
 from marshmallow import Schema, ValidationError, fields, validate
 
-from ._white_label import WhiteLabelLevel, validate_logo_data_uri
+from ._white_label import WhiteLabelLevel, validate_brand_color, validate_logo_data_uri
 
 
 class UTCDateTime(fields.DateTime):
@@ -47,14 +47,24 @@ def _validate_brand_logo(value: str) -> None:
         raise ValidationError(str(exc)) from exc
 
 
+def _validate_brand_color_field(value: str) -> None:
+    """Adapta la validación compartida del color al contrato de marshmallow."""
+    if not value:
+        return
+    try:
+        validate_brand_color(value)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+
 class WhiteLabelSchemaMixin:
     """
     Campos de white-labeling para el esquema de cualquier módulo que lo ofrezca.
 
     Se hereda junto a ``Schema`` (``class MiSchema(WhiteLabelSchemaMixin, Schema)``)
-    y aporta la pareja de campos ya validada — el logo llega del navegador, así
-    que su tipo y su tamaño se comprueban aquí, en el borde de confianza, y no
-    en el manager ni en la plantilla.
+    y aporta los campos ya validados — el logo y el color llegan del navegador,
+    así que su forma se comprueba aquí, en el borde de confianza, y no en el
+    manager ni en la plantilla (donde el color acaba dentro de un ``style``).
     """
 
     whiteLabelLevel = fields.String(
@@ -62,6 +72,7 @@ class WhiteLabelSchemaMixin:
         validate=validate.OneOf([level.value for level in WhiteLabelLevel]),
     )
     brandLogo = fields.String(load_default="", allow_none=True, validate=_validate_brand_logo)
+    brandColor = fields.String(load_default="", allow_none=True, validate=_validate_brand_color_field)
     #: Solo de salida: no es un ajuste sino el techo que concede el plan. El
     #: frontend lo usa para no ofrecer niveles que se van a rechazar. Sin
     #: ``dump_only`` el mismo esquema, que también valida la escritura, lo

--- a/API/src/modules/shared/schemas.py
+++ b/API/src/modules/shared/schemas.py
@@ -62,3 +62,8 @@ class WhiteLabelSchemaMixin:
         validate=validate.OneOf([level.value for level in WhiteLabelLevel]),
     )
     brandLogo = fields.String(load_default="", allow_none=True, validate=_validate_brand_logo)
+    #: Solo de salida: no es un ajuste sino el techo que concede el plan. El
+    #: frontend lo usa para no ofrecer niveles que se van a rechazar. Sin
+    #: ``dump_only`` el mismo esquema, que también valida la escritura, lo
+    #: descartaría al serializar.
+    maxWhiteLabelLevel = fields.String(dump_only=True)

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -586,7 +586,7 @@ class HeraldConfig(_StrategySelection):
     branding: dict = field(default_factory=dict)
     """Marca que pintan las plantillas: ``productName``, ``accentColor``,
     ``logoUrl``, ``supportEmail``, ``footerNote``. Lo que no se declare aquí
-    lo rellena ``herald.rendering._DEFAULT_BRAND``."""
+    lo rellena ``herald.branding.DEFAULT_BRAND``."""
 
     templates_dir: str = ""
     """Directorio externo con plantillas que pisan a las del paquete. Vacío

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -575,6 +575,20 @@ class ScribeConfig(_StrategySelection):
 
     default_strategy: str = "ollama"
 
+    max_input_tokens: int = 24000
+    """Tope de tokens estimados del prompt (system + examples + user) que
+    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia (Issue
+    #118).
+
+    Sin esto, un writer de dominio (p.ej. ``LybraAIWriter`` con un scan de
+    muchos hallazgos) podía generar un payload que OpenAI rechazaba con un
+    429 'Request too large' — tras haber quemado ``max_retries`` reintentos
+    con backoff, porque el mismo prompt sobredimensionado vuelve a fallar en
+    cada intento. 24000 deja margen bajo el límite TPM de 30000 observado en
+    el error original, incluso en la organización más ajustada; se aplica al
+    total estimado (no solo al último mensaje) e independientemente del
+    backend, ya que un contexto local también tiene un tope real."""
+
 
 @config_block("tools.herald")
 @dataclass(frozen=True)

--- a/API/src/modules/tools/herald/__init__.py
+++ b/API/src/modules/tools/herald/__init__.py
@@ -25,6 +25,7 @@ from .strategies import EmailStrategy, SmtpStrategy
 from .mailer import Mailer
 from .factory import build_mailer
 from .rendering import render_email
+from .branding import LOGO_CONTENT_ID, apply_white_label, default_brand
 from .exceptions import (
     EmailConnectionError,
     EmailSendError,
@@ -40,6 +41,9 @@ __all__ = [
     "Mailer",
     "build_mailer",
     "render_email",
+    "apply_white_label",
+    "default_brand",
+    "LOGO_CONTENT_ID",
     "EmailConnectionError",
     "EmailSendError",
     "EmailConfigurationError",

--- a/API/src/modules/tools/herald/__init__.py
+++ b/API/src/modules/tools/herald/__init__.py
@@ -20,7 +20,7 @@ Uso típico:
     ... ))
 """
 
-from .inputs import EmailMessage, SendResult
+from .inputs import EmailMessage, InlineImage, SendResult
 from .strategies import EmailStrategy, SmtpStrategy
 from .mailer import Mailer
 from .factory import build_mailer
@@ -33,6 +33,7 @@ from .exceptions import (
 
 __all__ = [
     "EmailMessage",
+    "InlineImage",
     "SendResult",
     "EmailStrategy",
     "SmtpStrategy",

--- a/API/src/modules/tools/herald/branding.py
+++ b/API/src/modules/tools/herald/branding.py
@@ -1,0 +1,98 @@
+"""
+herald.branding
+───────────────
+Proyección del white-labeling (``shared._white_label``) sobre un correo.
+
+El concepto — niveles, logo, validación — es del producto entero y vive en
+``shared``. Aquí solo se traduce al vocabulario de un correo: qué claves de
+``brand`` consumen las plantillas y cómo viaja el logo dentro del mensaje.
+
+Un módulo que ofrezca white-labeling guarda los ajustes donde le convenga y
+hace::
+
+    brand, images = apply_white_label(default_brand(), white_label)
+    html, text = render_email("campaign", brand=brand, …)
+    mailer.send(EmailMessage(…, inline_images=images))
+
+herald no sabe de qué módulo salen los ajustes, igual que no sabe de qué
+módulo sale el resto del contexto de la plantilla.
+"""
+
+from __future__ import annotations
+
+import src.modules.system.config_reading as CR
+from src.modules.shared import WhiteLabel, WhiteLabelLevel
+
+from .inputs import InlineImage
+
+
+#: Content-ID con el que las plantillas referencian el logo del cliente.
+LOGO_CONTENT_ID = "brand-logo"
+
+#: Marca por defecto del producto. La config solo declara lo que quiera cambiar.
+DEFAULT_BRAND: dict[str, str] = {
+    "productName": "Ellysia",
+    "accentColor": "#d4a04a",
+    "logoUrl": "",
+    "supportEmail": "",
+    "footerNote": "",
+    #: Logo del cliente que se pinta *además* de la marca del producto
+    #: (nivel LOGO). En el nivel FULL no se usa: ahí el logo del cliente ocupa
+    #: directamente el sitio de la marca, en ``logoUrl``.
+    "customerLogoUrl": "",
+    "whiteLabelLevel": WhiteLabelLevel.NONE.value,
+}
+
+
+def default_brand() -> dict[str, str]:
+    """La marca del producto para esta instancia: los defaults más la config."""
+    return {**DEFAULT_BRAND, **CR.herald_config().branding}
+
+
+def apply_white_label(
+    base_brand: dict[str, str],
+    white_label: WhiteLabel,
+) -> tuple[dict[str, str], tuple[InlineImage, ...]]:
+    """
+    Aplica los ajustes de white-labeling sobre la marca de un correo.
+
+    Args:
+        base_brand: Marca del producto (normalmente ``default_brand()``).
+        white_label: Ajustes del cliente.
+
+    Returns:
+        ``(brand, inline_images)`` — el contexto ``brand`` para
+        ``render_email`` y las imágenes a adjuntar al ``EmailMessage``. En el
+        nivel NONE devuelve la marca intacta y ninguna imagen, de modo que el
+        correo sale byte a byte como saldría sin white-labeling.
+    """
+    level = white_label.effective_level
+    brand = {**base_brand, "whiteLabelLevel": level.value}
+    if level is WhiteLabelLevel.NONE:
+        return brand, ()
+
+    decoded = white_label.decoded_logo()
+    images: tuple[InlineImage, ...] = ()
+    logo_url = ""
+    if decoded is not None:
+        mimetype, data = decoded
+        images = (InlineImage(content_id=LOGO_CONTENT_ID, data=data, mimetype=mimetype),)
+        logo_url = f"cid:{LOGO_CONTENT_ID}"
+
+    if level is WhiteLabelLevel.LOGO:
+        brand["customerLogoUrl"] = logo_url
+        return brand, images
+
+    # FULL: el logo del cliente ocupa el sitio de la marca del producto en vez
+    # de sumarse a ella — pintarlo en los dos sitios lo repetiría en la misma
+    # pantalla. El nombre sustituye también al del pie ("enviado desde …"), y
+    # el correo de soporte y la nota de pie de la instancia se vacían: son de
+    # la marca que aquí se está retirando.
+    brand.update(
+        productName=white_label.brand_name,
+        logoUrl=logo_url,
+        customerLogoUrl="",
+        supportEmail="",
+        footerNote="",
+    )
+    return brand, images

--- a/API/src/modules/tools/herald/branding.py
+++ b/API/src/modules/tools/herald/branding.py
@@ -71,6 +71,15 @@ def apply_white_label(
     if level is WhiteLabelLevel.NONE:
         return brand, ()
 
+    # El color entra desde el primer escalón y no se toca más arriba: las
+    # plantillas ya lo leen de brand.accentColor en el filete, el botón y los
+    # bordes, así que basta con sustituirlo aquí.
+    if white_label.color:
+        brand["accentColor"] = white_label.color
+
+    if level is WhiteLabelLevel.COLOR:
+        return brand, ()
+
     decoded = white_label.decoded_logo()
     images: tuple[InlineImage, ...] = ()
     logo_url = ""

--- a/API/src/modules/tools/herald/inputs.py
+++ b/API/src/modules/tools/herald/inputs.py
@@ -5,12 +5,52 @@ Dataclasses de tránsito del envío de correo.
 
     — EmailMessage: contrato de entrada que recibe ``Mailer.send``. Agnóstico
       al backend: cada estrategia lo traduce a su API nativa (SMTP, …).
+    — InlineImage: imagen incrustada en el cuerpo HTML y referenciada con
+      ``cid:``.
     — SendResult: contrato de salida de un envío individual.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InlineImage:
+    """
+    Imagen incrustada en el cuerpo del correo y referenciada desde el HTML
+    como ``<img src="cid:{content_id}">``.
+
+    Frente a un ``<img>`` a una URL externa, la imagen viaja dentro del
+    mensaje: no hace falta publicarla en un endpoint accesible sin
+    autenticación, y no se cae cuando el cliente bloquea contenido remoto.
+
+    Attributes:
+        content_id: Identificador con el que el HTML la referencia, *sin* los
+            ángulos del Content-ID (``logo``, no ``<logo>``).
+        data: Bytes de la imagen.
+        mimetype: Tipo MIME completo ('image/png').
+    """
+
+    content_id: str
+    data: bytes
+    mimetype: str
+
+    def __post_init__(self) -> None:
+        if not self.content_id or "<" in self.content_id or ">" in self.content_id:
+            raise ValueError(
+                f"'content_id' debe ser un identificador sin ángulos: {self.content_id!r}"
+            )
+        if not self.data:
+            raise ValueError("'data' no puede estar vacío")
+        if not self.mimetype.startswith("image/") or self.mimetype.count("/") != 1:
+            raise ValueError(f"'mimetype' debe ser un tipo de imagen: {self.mimetype!r}")
+
+    @property
+    def mime_parts(self) -> tuple[str, str]:
+        """El mimetype partido en ``(maintype, subtype)``."""
+        maintype, subtype = self.mimetype.split("/", 1)
+        return maintype, subtype
 
 
 @dataclass(frozen=True)
@@ -26,6 +66,8 @@ class EmailMessage:
         text_body: Cuerpo en texto plano (opcional). Si no se indica, la
             estrategia SMTP genera uno a partir del HTML.
         reply_to: Dirección de respuesta alternativa (opcional).
+        inline_images: Imágenes incrustadas que el HTML referencia con
+            ``cid:``. Tupla (no lista) porque el mensaje es inmutable.
     """
 
     to: str
@@ -34,6 +76,7 @@ class EmailMessage:
     to_name: str | None = None
     text_body: str | None = None
     reply_to: str | None = None
+    inline_images: tuple[InlineImage, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.to or "@" not in self.to:

--- a/API/src/modules/tools/herald/rendering.py
+++ b/API/src/modules/tools/herald/rendering.py
@@ -22,18 +22,11 @@ from jinja2 import ChoiceLoader, Environment, FileSystemLoader, TemplateNotFound
 
 import src.modules.system.config_reading as CR
 
+from .branding import default_brand
+
 logger = logging.getLogger(__name__)
 
 _PACKAGE_TEMPLATES = Path(__file__).parent / "templates"
-
-#: Marca por defecto. La config solo tiene que declarar lo que quiera cambiar.
-_DEFAULT_BRAND = {
-    "productName": "Ellysia",
-    "accentColor": "#d4a04a",
-    "logoUrl": "",
-    "supportEmail": "",
-    "footerNote": "",
-}
 
 #: (templatesDir configurado, entorno) — se reconstruye si la config cambia.
 _env_cache: tuple[str, Environment] | None = None
@@ -72,15 +65,17 @@ def render_email(template: str, **context) -> tuple[str, str | None]:
 
     Args:
         template: Nombre base de la plantilla, sin extensión ('campaign').
-        **context: Variables de la plantilla. ``brand`` se inyecta sola desde
-            ``tools.herald.branding`` si el llamante no la pasa.
+        **context: Variables de la plantilla. ``brand`` se inyecta sola con la
+            marca del producto (``branding.default_brand``) si el llamante no
+            la pasa — quien haga white-labeling pasa la suya ya resuelta con
+            ``branding.apply_white_label``.
 
     Returns:
         ``(html, text)``. ``text`` es None si la plantilla no tiene gemelo
         ``.txt.j2`` — en ese caso la estrategia SMTP deriva el texto del HTML.
     """
     env = _environment()
-    context.setdefault("brand", {**_DEFAULT_BRAND, **CR.herald_config().branding})
+    context.setdefault("brand", default_brand())
 
     html = env.get_template(f"{template}.html.j2").render(**context)
 

--- a/API/src/modules/tools/herald/strategies.py
+++ b/API/src/modules/tools/herald/strategies.py
@@ -149,6 +149,22 @@ class SmtpStrategy(EmailStrategy):
 
         mime.set_content(message.text_body or _html_to_text(message.html_body))
         mime.add_alternative(message.html_body, subtype="html")
+
+        # Las imágenes incrustadas cuelgan de la alternativa HTML, no del
+        # mensaje: ``add_related`` la convierte en un multipart/related con la
+        # imagen dentro, que es lo que hace que ``cid:`` resuelva. Colgarlas
+        # de la raíz las dejaría como adjuntos sueltos y el <img> saldría roto.
+        if message.inline_images:
+            html_part = mime.get_payload()[-1]
+            for image in message.inline_images:
+                maintype, subtype = image.mime_parts
+                html_part.add_related(
+                    image.data,
+                    maintype=maintype,
+                    subtype=subtype,
+                    cid=f"<{image.content_id}>",
+                )
+
         return mime
 
     def send(self, message: EmailMessage) -> SendResult:

--- a/API/src/modules/tools/herald/templates/_macros.html.j2
+++ b/API/src/modules/tools/herald/templates/_macros.html.j2
@@ -1,5 +1,5 @@
 {# Piezas reutilizables de los correos. Importar con:
-   {% from "_macros.html.j2" import button, data_row %} #}
+   {% from "_macros.html.j2" import button, data_row, brand_banner %} #}
 
 {#
   Botón "a prueba de balas": una tabla con el color de fondo y un <a> con
@@ -22,4 +22,25 @@
   <td style="padding:6px 12px 6px 0; font-family:Helvetica,Arial,sans-serif; font-size:14px; color:#8a857c; white-space:nowrap; vertical-align:top;">{{ label }}</td>
   <td style="padding:6px 0; font-family:Helvetica,Arial,sans-serif; font-size:14px; color:#2c2a26; font-weight:bold;">{{ value }}</td>
 </tr>
+{%- endmacro %}
+
+{#
+  Logo del cliente sobre el cuerpo del correo (white-labeling de nivel "logo").
+  No se pinta solo: se apoya en brand.customerLogoUrl, que herald.branding
+  rellena únicamente cuando ese nivel está activo — en el nivel "full" el logo
+  ya ocupa la cabecera y repetirlo aquí lo duplicaría en la misma pantalla.
+  `alt` es el nombre del cliente: brand.productName sigue siendo el del
+  producto mientras la marca no se haya retirado.
+#}
+{% macro brand_banner(brand, alt="") -%}
+{% if brand.customerLogoUrl %}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+  <tr>
+    <td>
+      <img src="{{ brand.customerLogoUrl }}" alt="{{ alt }}" width="160"
+           style="display:block; border:0; max-width:160px; height:auto;">
+    </td>
+  </tr>
+</table>
+{% endif %}
 {%- endmacro %}

--- a/API/src/modules/tools/herald/templates/campaign.html.j2
+++ b/API/src/modules/tools/herald/templates/campaign.html.j2
@@ -5,7 +5,7 @@
    (opcional). La píldora entera se entrega en el propio correo — el
    destinatario la lee aquí y termina en el CTA, que lleva directo al test. #}
 {% extends "base.html.j2" %}
-{% from "_macros.html.j2" import button %}
+{% from "_macros.html.j2" import button, brand_banner %}
 
 {% block title %}Formación de concienciación — {{ pill_title }}{% endblock %}
 
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block content %}
+{{ brand_banner(brand, company) }}
 <p style="margin:0 0 16px;">{% if recipient_name %}Hola, {{ recipient_name }}:{% else %}Hola:{% endif %}</p>
 
 <p style="margin:0 0 20px;">

--- a/API/src/modules/tools/scribe/__init__.py
+++ b/API/src/modules/tools/scribe/__init__.py
@@ -14,7 +14,7 @@ Uso típico:
     >>> data = result.parse_json()
 """
 
-from .inputs import AIInput, AIResult, Example
+from .inputs import AIInput, AIResult, Example, estimate_tokens
 from .strategies import ModelStrategy, OllamaStrategy, OpenAIStrategy, GoogleStrategy, ToolExecutor
 from .generator import AIGenerator
 from .factory import build_generator
@@ -23,6 +23,7 @@ from .exceptions import (
     AIConnectionError,
     AIResponseError,
     AIFallbackExhaustedError,
+    AIPayloadTooLargeError,
     CircuitBreakerOpenError,
     AIStrategyConfigurationError,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "AIInput",
     "AIResult",
     "Example",
+    "estimate_tokens",
     "ModelStrategy",
     "OllamaStrategy",
     "OpenAIStrategy",
@@ -43,6 +45,7 @@ __all__ = [
     "AIConnectionError",
     "AIResponseError",
     "AIFallbackExhaustedError",
+    "AIPayloadTooLargeError",
     "CircuitBreakerOpenError",
     "AIStrategyConfigurationError",
 ]

--- a/API/src/modules/tools/scribe/exceptions.py
+++ b/API/src/modules/tools/scribe/exceptions.py
@@ -45,6 +45,29 @@ class AIResponseError(EllysiaException):
         )
 
 
+class AIPayloadTooLargeError(EllysiaException):
+    """El prompt estimado supera el tope de tokens configurado (Issue #118).
+
+    Se lanza *antes* de invocar la estrategia — nunca es transitorio (el mismo
+    prompt sobredimensionado fallaría igual en cada reintento), así que
+    ``AIGenerator.digest`` no la reintenta como hace con el resto de errores.
+    """
+
+    default_code = ErrorCode.VALIDATION_ERROR
+    default_status_code = 422
+    default_severity = ErrorSeverity.MEDIUM
+
+    def __init__(self, estimated_tokens: int, max_tokens: int):
+        super().__init__(
+            message=(
+                f"Prompt de ~{estimated_tokens} tokens estimados supera el "
+                f"límite configurado de {max_tokens}."
+            ),
+            details={"estimated_tokens": estimated_tokens, "max_tokens": max_tokens},
+            user_message="El escaneo es demasiado grande para generar un análisis de IA completo.",
+        )
+
+
 class AIFallbackExhaustedError(EllysiaException):
     """Se agotaron todos los reintentos sin obtener una respuesta válida."""
 

--- a/API/src/modules/tools/scribe/generator.py
+++ b/API/src/modules/tools/scribe/generator.py
@@ -23,7 +23,7 @@ import threading
 import time
 from typing import Optional
 
-from .exceptions import AIFallbackExhaustedError, CircuitBreakerOpenError
+from .exceptions import AIFallbackExhaustedError, AIPayloadTooLargeError, CircuitBreakerOpenError
 from .inputs import AIInput, AIResult
 from .strategies import ModelStrategy, ToolExecutor
 from .tools import web_search
@@ -85,6 +85,29 @@ class AIGenerator:
             self._failures += 1
             self._last_failure_time = time.time()
 
+    # ── Guardarraíl de tamaño (Issue #118) ──────────────────────────────────
+
+    @staticmethod
+    def _check_payload_size(ai_input: AIInput) -> None:
+        """Rechaza un prompt sobredimensionado antes de llamar al backend.
+
+        Registra el tamaño estimado incluso cuando no excede el límite —
+        observabilidad para diagnosticar el próximo 429 sin depender de que
+        el backend lo reporte, que es exactamente lo que faltó para
+        diagnosticar el caso original de este issue.
+        """
+        import src.modules.system.config_reading as CR
+
+        estimated = ai_input.estimated_tokens()
+        limit = CR.scribe_config().max_input_tokens
+        logger.info("[scribe] prompt estimado: %d tokens (límite: %d)", estimated, limit)
+        if estimated > limit:
+            logger.warning(
+                "[scribe] prompt de ~%d tokens supera el límite de %d — rechazado sin llamar al backend",
+                estimated, limit,
+            )
+            raise AIPayloadTooLargeError(estimated, limit)
+
     # ── API pública ──────────────────────────────────────────────────────────
 
     def digest(
@@ -106,9 +129,15 @@ class AIGenerator:
 
         Raises:
             CircuitBreakerOpenError: Si el breaker del backend está abierto.
+            AIPayloadTooLargeError: Si el prompt estimado supera el tope
+                configurado — se comprueba antes de llamar a la estrategia y
+                no se reintenta (Issue #118): un prompt sobredimensionado
+                falla igual en cada intento, así que reintentarlo solo
+                desperdicia llamadas y tiempo.
             AIFallbackExhaustedError: Si se agotan los reintentos.
         """
         self._check_breaker()
+        self._check_payload_size(ai_input)
         executor = tool_executor or _default_tool_executor
 
         last_error: str = ""

--- a/API/src/modules/tools/scribe/inputs.py
+++ b/API/src/modules/tools/scribe/inputs.py
@@ -22,6 +22,29 @@ from .exceptions import AIResponseError
 
 logger = logging.getLogger(__name__)
 
+# Caracteres por token, aproximación heurística (sin dependencia nueva tipo
+# tiktoken, que además tokeniza distinto por modelo/backend). ~4 es la cifra
+# que la propia documentación de OpenAI da como regla general para texto en
+# inglés/español; de sobra para un guardarraín de "no mandes un payload
+# disparatado" — no hace falta precisión exacta para eso (Issue #118).
+_CHARS_PER_TOKEN = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimación heurística y barata del número de tokens de ``text``.
+
+    No es un tokenizador real: es la aproximación mínima necesaria para
+    detectar un prompt varias veces más grande que el límite configurado
+    antes de gastar una llamada de red en descubrirlo por el 429 del backend.
+
+    Args:
+        text: El texto a estimar.
+
+    Returns:
+        Una cota aproximada del número de tokens.
+    """
+    return (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN
+
 
 @dataclass(frozen=True)
 class Example:
@@ -70,6 +93,15 @@ class AIInput:
             messages.append({"role": "assistant", "content": ex.assistant})
         messages.append({"role": "user", "content": self.user_prompt})
         return messages
+
+    def estimated_tokens(self) -> int:
+        """Estimación heurística del tamaño del prompt completo (Issue #118).
+
+        Suma sobre todos los mensajes que ``to_messages`` enviaría — no solo
+        el último — porque es el total lo que un backend factura contra su
+        límite de tokens, no un mensaje aislado.
+        """
+        return sum(estimate_tokens(message["content"]) for message in self.to_messages())
 
 
 @dataclass

--- a/API/tests/integration/test_aegis_campaigns.py
+++ b/API/tests/integration/test_aegis_campaigns.py
@@ -637,3 +637,83 @@ def test_campaign_email_with_full_level_removes_the_product_brand(
     # ("Desde ACME, te hacemos llegar…"), que es la de la píldora.
     assert "ACME" in sent["html"]
     assert 'src="cid:brand-logo"' in sent["html"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Tope de nivel por plan (aegis.white_label)
+# ─────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def white_label_allowance(app):
+    """Fija el tope que concede el plan del usuario de test.
+
+    El plan por defecto de la suite lo da todo por ilimitado; aquí se baja a
+    un escalón concreto para ejercitar el corte.
+    """
+    def _set(value):
+        from src.modules.accounts.model import PlanLimit
+        from src.modules.infrastructure.unit_of_work import UnitOfWork
+
+        with app.app_context():
+            with UnitOfWork() as uow:
+                rows = uow.session.query(PlanLimit).filter(
+                    PlanLimit.limit_key == "aegis.white_label",
+                ).all()
+                for row in rows:
+                    row.value = value
+    return _set
+
+
+def test_profile_reports_the_level_its_plan_allows(client, admin_headers, white_label_allowance):
+    white_label_allowance(1)
+    profile = client.get("/aegis/org-profile", headers=admin_headers).get_json()
+    assert profile["maxWhiteLabelLevel"] == "logo"
+
+    white_label_allowance(0)
+    profile = client.get("/aegis/org-profile", headers=admin_headers).get_json()
+    assert profile["maxWhiteLabelLevel"] == "none"
+
+
+def test_saving_a_level_above_the_plan_is_rejected(client, admin_headers, white_label_allowance):
+    white_label_allowance(1)
+
+    rejected = _save_org_profile(
+        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI,
+    )
+    assert rejected.status_code == 402
+
+    allowed = _save_org_profile(
+        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+    )
+    assert allowed.status_code == 200
+
+
+def test_plan_without_white_label_cannot_even_add_a_logo(client, admin_headers, white_label_allowance):
+    white_label_allowance(0)
+    assert _save_org_profile(
+        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+    ).status_code == 402
+    # El nivel "none" es el de siempre y no depende del plan.
+    assert _save_org_profile(client, admin_headers, whiteLabelLevel="none").status_code == 200
+
+
+def test_campaign_send_caps_the_level_to_the_current_plan(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+    white_label_allowance,
+):
+    """Una bajada de plan surte efecto en el siguiente envío, sin tocar lo guardado."""
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+
+    white_label_allowance(1)
+    _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+
+    sent = local_email_config.messages[0]
+    # Degradado a "logo": el logo sigue, la marca del producto vuelve.
+    assert 'src="cid:brand-logo"' in sent["html"]
+    assert "Ellysia" in sent["html"]
+
+    # Y lo guardado no se ha tocado: al recuperar el plan vuelve a aplicarse.
+    assert client.get(
+        "/aegis/org-profile", headers=admin_headers
+    ).get_json()["whiteLabelLevel"] == "full"

--- a/API/tests/integration/test_aegis_campaigns.py
+++ b/API/tests/integration/test_aegis_campaigns.py
@@ -525,6 +525,7 @@ _LOGO_URI = (
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
     "CklEQVR4nGNgAAAAAgABf6ZX1AAAAABJRU5ErkJggg=="
 )
+_COLOR = "#1a73e8"
 
 
 def _save_org_profile(client, headers, **overrides):
@@ -564,15 +565,17 @@ def _run_campaign(client, app, headers, user_id, doc_id, email="empleado@empresa
 
 def test_org_profile_round_trips_white_label_settings(client, admin_headers):
     saved = _save_org_profile(
-        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI, brandColor=_COLOR,
     ).get_json()
 
     assert saved["whiteLabelLevel"] == "logo"
     assert saved["brandLogo"] == _LOGO_URI
+    assert saved["brandColor"] == _COLOR
 
     fetched = client.get("/aegis/org-profile", headers=admin_headers).get_json()
     assert fetched["whiteLabelLevel"] == "logo"
     assert fetched["brandLogo"] == _LOGO_URI
+    assert fetched["brandColor"] == _COLOR
 
 
 def test_org_profile_defaults_to_no_white_label(client, admin_headers):
@@ -580,6 +583,7 @@ def test_org_profile_defaults_to_no_white_label(client, admin_headers):
     profile = client.get("/aegis/org-profile", headers=admin_headers).get_json()
     assert profile["whiteLabelLevel"] == "none"
     assert profile["brandLogo"] == ""
+    assert profile["brandColor"] == ""
 
 
 @pytest.mark.parametrize(
@@ -588,6 +592,8 @@ def test_org_profile_defaults_to_no_white_label(client, admin_headers):
         {"brandLogo": "https://cdn.acme.test/logo.png"},
         {"brandLogo": "data:image/svg+xml;base64,PHN2Zy8+"},
         {"whiteLabelLevel": "parcial"},
+        {"brandColor": "rojo"},
+        {"brandColor": "#fff; background:url(http://x)"},
     ],
 )
 def test_org_profile_rejects_invalid_white_label_input(client, admin_headers, overrides):
@@ -607,11 +613,29 @@ def test_campaign_email_without_white_label_keeps_the_product_brand(
     assert "cid:" not in sent["html"]
 
 
+def test_campaign_email_with_color_level_only_repaints_the_accent(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(
+        client, admin_headers, whiteLabelLevel="color", brandLogo=_LOGO_URI, brandColor=_COLOR,
+    )
+
+    _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+
+    sent = local_email_config.messages[0]
+    assert _COLOR in sent["html"]
+    assert "cid:" not in sent["html"]
+    assert "Ellysia" in sent["html"]
+
+
 def test_campaign_email_with_logo_level_embeds_the_customer_logo(
     app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
 ):
     doc_id = make_aegis_doc_with_quiz(admin_user.id)
-    _save_org_profile(client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI)
+    _save_org_profile(
+        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI, brandColor=_COLOR,
+    )
 
     _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
 
@@ -627,7 +651,9 @@ def test_campaign_email_with_full_level_removes_the_product_brand(
     app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
 ):
     doc_id = make_aegis_doc_with_quiz(admin_user.id)
-    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+    _save_org_profile(
+        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI, brandColor=_COLOR,
+    )
 
     _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
 
@@ -665,7 +691,7 @@ def white_label_allowance(app):
 
 
 def test_profile_reports_the_level_its_plan_allows(client, admin_headers, white_label_allowance):
-    white_label_allowance(1)
+    white_label_allowance(2)
     profile = client.get("/aegis/org-profile", headers=admin_headers).get_json()
     assert profile["maxWhiteLabelLevel"] == "logo"
 
@@ -675,23 +701,23 @@ def test_profile_reports_the_level_its_plan_allows(client, admin_headers, white_
 
 
 def test_saving_a_level_above_the_plan_is_rejected(client, admin_headers, white_label_allowance):
-    white_label_allowance(1)
+    white_label_allowance(1)  # solo el color
 
     rejected = _save_org_profile(
-        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI,
+        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI, brandColor=_COLOR,
     )
     assert rejected.status_code == 402
 
     allowed = _save_org_profile(
-        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+        client, admin_headers, whiteLabelLevel="color", brandColor=_COLOR,
     )
     assert allowed.status_code == 200
 
 
-def test_plan_without_white_label_cannot_even_add_a_logo(client, admin_headers, white_label_allowance):
+def test_plan_without_white_label_cannot_even_change_the_color(client, admin_headers, white_label_allowance):
     white_label_allowance(0)
     assert _save_org_profile(
-        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+        client, admin_headers, whiteLabelLevel="color", brandColor=_COLOR,
     ).status_code == 402
     # El nivel "none" es el de siempre y no depende del plan.
     assert _save_org_profile(client, admin_headers, whiteLabelLevel="none").status_code == 200
@@ -703,14 +729,17 @@ def test_campaign_send_caps_the_level_to_the_current_plan(
 ):
     """Una bajada de plan surte efecto en el siguiente envío, sin tocar lo guardado."""
     doc_id = make_aegis_doc_with_quiz(admin_user.id)
-    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+    _save_org_profile(
+        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI, brandColor=_COLOR,
+    )
 
-    white_label_allowance(1)
+    white_label_allowance(2)  # baja de "sin marca" a "logo"
     _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
 
     sent = local_email_config.messages[0]
-    # Degradado a "logo": el logo sigue, la marca del producto vuelve.
+    # Degradado a "logo": el logo y el color siguen, la marca del producto vuelve.
     assert 'src="cid:brand-logo"' in sent["html"]
+    assert _COLOR in sent["html"]
     assert "Ellysia" in sent["html"]
 
     # Y lo guardado no se ha tocado: al recuperar el plan vuelve a aplicarse.
@@ -724,14 +753,16 @@ def test_public_quiz_serves_the_same_brand_as_the_email(
 ):
     """El test es la segunda mitad de la campaña: llega con la misma marca."""
     doc_id = make_aegis_doc_with_quiz(admin_user.id)
-    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+    _save_org_profile(
+        client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI, brandColor=_COLOR,
+    )
     campaign_id = _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
     token = _fetch_token_for_email(app, campaign_id, "empleado@empresa.test")
 
     quiz = client.get(f"/aegis/quiz?t={token}").get_json()
 
     assert quiz["whiteLabel"] == {
-        "level": "full", "brandName": "ACME", "brandLogo": _LOGO_URI,
+        "level": "full", "brandName": "ACME", "brandLogo": _LOGO_URI, "brandColor": _COLOR,
     }
 
 
@@ -745,4 +776,6 @@ def test_public_quiz_without_white_label_reports_nothing_to_replace(
 
     quiz = client.get(f"/aegis/quiz?t={token}").get_json()
 
-    assert quiz["whiteLabel"] == {"level": "none", "brandName": "", "brandLogo": ""}
+    assert quiz["whiteLabel"] == {
+        "level": "none", "brandName": "", "brandLogo": "", "brandColor": "",
+    }

--- a/API/tests/integration/test_aegis_campaigns.py
+++ b/API/tests/integration/test_aegis_campaigns.py
@@ -717,3 +717,32 @@ def test_campaign_send_caps_the_level_to_the_current_plan(
     assert client.get(
         "/aegis/org-profile", headers=admin_headers
     ).get_json()["whiteLabelLevel"] == "full"
+
+
+def test_public_quiz_serves_the_same_brand_as_the_email(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    """El test es la segunda mitad de la campaña: llega con la misma marca."""
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+    campaign_id = _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+    token = _fetch_token_for_email(app, campaign_id, "empleado@empresa.test")
+
+    quiz = client.get(f"/aegis/quiz?t={token}").get_json()
+
+    assert quiz["whiteLabel"] == {
+        "level": "full", "brandName": "ACME", "brandLogo": _LOGO_URI,
+    }
+
+
+def test_public_quiz_without_white_label_reports_nothing_to_replace(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers)
+    campaign_id = _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+    token = _fetch_token_for_email(app, campaign_id, "empleado@empresa.test")
+
+    quiz = client.get(f"/aegis/quiz?t={token}").get_json()
+
+    assert quiz["whiteLabel"] == {"level": "none", "brandName": "", "brandLogo": ""}

--- a/API/tests/integration/test_aegis_campaigns.py
+++ b/API/tests/integration/test_aegis_campaigns.py
@@ -514,3 +514,126 @@ def test_public_quiz_is_rate_limited(client, rate_limiting_enabled):
 
     resp = client.get("/aegis/quiz?t=this-token-does-not-exist")
     assert resp.status_code == 429
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# White-labeling
+# ─────────────────────────────────────────────────────────────────────────
+
+#: PNG de 1x1, el logo más pequeño que un cliente de correo acepta.
+_LOGO_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
+    "CklEQVR4nGNgAAAAAgABf6ZX1AAAAABJRU5ErkJggg=="
+)
+
+
+def _save_org_profile(client, headers, **overrides):
+    payload = {
+        "company": "ACME S.L.",
+        "mentionContact": "seguridad@acme.test",
+        "tone": "profesional",
+        "companySize": "",
+        "jurisdiction": "",
+        "language": "es",
+        "sector": "",
+        "workModel": "",
+        "employeeCount": None,
+        "trackedProducts": [],
+        "useHygeiaInventory": False,
+    }
+    payload.update(overrides)
+    return client.put("/aegis/org-profile", headers=headers, json=payload)
+
+
+def _run_campaign(client, app, headers, user_id, doc_id, email="empleado@empresa.test"):
+    list_id = client.post("/aegis/lists", headers=headers, json={"name": "Plantilla"}).get_json()["id"]
+    client.post(
+        f"/aegis/lists/{list_id}/recipients", headers=headers,
+        json={"recipients": [{"email": email, "name": "Empleado"}]},
+    )
+    campaign_id = client.post(
+        "/aegis/campaigns", headers=headers,
+        json={"documentId": doc_id, "listId": list_id, "name": "Campaña"},
+    ).get_json()["id"]
+    with mock.patch.object(TaskQueue, "get_instance", return_value=_FakeTaskQueue()):
+        client.post(f"/aegis/campaigns/{campaign_id}/launch", headers=headers)
+    with app.app_context():
+        CampaignManager.execute_campaign_send(campaign_id, user_id)
+    return campaign_id
+
+
+def test_org_profile_round_trips_white_label_settings(client, admin_headers):
+    saved = _save_org_profile(
+        client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI,
+    ).get_json()
+
+    assert saved["whiteLabelLevel"] == "logo"
+    assert saved["brandLogo"] == _LOGO_URI
+
+    fetched = client.get("/aegis/org-profile", headers=admin_headers).get_json()
+    assert fetched["whiteLabelLevel"] == "logo"
+    assert fetched["brandLogo"] == _LOGO_URI
+
+
+def test_org_profile_defaults_to_no_white_label(client, admin_headers):
+    """Un perfil que nunca tocó el ajuste manda el correo de siempre."""
+    profile = client.get("/aegis/org-profile", headers=admin_headers).get_json()
+    assert profile["whiteLabelLevel"] == "none"
+    assert profile["brandLogo"] == ""
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"brandLogo": "https://cdn.acme.test/logo.png"},
+        {"brandLogo": "data:image/svg+xml;base64,PHN2Zy8+"},
+        {"whiteLabelLevel": "parcial"},
+    ],
+)
+def test_org_profile_rejects_invalid_white_label_input(client, admin_headers, overrides):
+    assert _save_org_profile(client, admin_headers, **overrides).status_code == 422
+
+
+def test_campaign_email_without_white_label_keeps_the_product_brand(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers)
+
+    _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+
+    sent = local_email_config.messages[0]
+    assert "Ellysia" in sent["html"]
+    assert "cid:" not in sent["html"]
+
+
+def test_campaign_email_with_logo_level_embeds_the_customer_logo(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers, whiteLabelLevel="logo", brandLogo=_LOGO_URI)
+
+    _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+
+    sent = local_email_config.messages[0]
+    assert 'src="cid:brand-logo"' in sent["html"]
+    # La imagen viaja dentro del mensaje: nada que descargar de un servidor.
+    assert "image/png" in sent["content"]
+    # Este nivel solo añade: la marca del producto sigue en cabecera y pie.
+    assert "Ellysia" in sent["html"]
+
+
+def test_campaign_email_with_full_level_removes_the_product_brand(
+    app, client, admin_user, admin_headers, make_aegis_doc_with_quiz, local_email_config,
+):
+    doc_id = make_aegis_doc_with_quiz(admin_user.id)
+    _save_org_profile(client, admin_headers, whiteLabelLevel="full", brandLogo=_LOGO_URI)
+
+    _run_campaign(client, app, admin_headers, admin_user.id, doc_id)
+
+    sent = local_email_config.messages[0]
+    assert "Ellysia" not in sent["html"]
+    # La marca que sustituye es la misma que el destinatario lee en el cuerpo
+    # ("Desde ACME, te hacemos llegar…"), que es la de la píldora.
+    assert "ACME" in sent["html"]
+    assert 'src="cid:brand-logo"' in sent["html"]

--- a/API/tests/integration/test_hygeia_metrics_api.py
+++ b/API/tests/integration/test_hygeia_metrics_api.py
@@ -346,15 +346,25 @@ def test_series_bucketed_one_point_per_bucket_with_max(client, app, regular_user
 
 
 def test_series_bucketed_points_are_bucket_starts_and_ordered(client, app, regular_user, auth_headers):
-    """El instante del punto es el inicio del cubo, y la serie va en orden."""
+    """El instante del punto es el inicio del cubo, y la serie va en orden.
+
+    La alineación de los cubos depende del segundo exacto del reloj en el
+    momento de sembrar (ver test_series_bucketed_one_point_per_bucket_with_max),
+    así que el recuento esperado se calcula contra los propios ``received_at``
+    sembrados, no contra una constante.
+    """
     asset_id = _create_asset(app, regular_user.id)
-    stamps = _seed_snapshots(app, asset_id, 10)  # 10 × 15 s = 2,5 min → 3 cubos
+    stamps = _seed_snapshots(app, asset_id, 10)  # 10 × 15 s = 2,5 min
 
     snapshots = client.get(
         f"/hygeia/assets/{asset_id}/metrics?bucket=60", headers=auth_headers(regular_user)
     ).get_json()["snapshots"]
 
-    assert len(snapshots) == 3
+    def utc_epoch(t):
+        return t.replace(tzinfo=timezone.utc).timestamp()
+
+    expected = int(utc_epoch(stamps[-1]) // 60) - int(utc_epoch(stamps[0]) // 60) + 1
+    assert len(snapshots) == expected
     received = [datetime.fromisoformat(s["receivedAt"]).replace(tzinfo=None) for s in snapshots]
     collected = [datetime.fromisoformat(s["collectedAt"]).replace(tzinfo=None) for s in snapshots]
 

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -41,6 +41,50 @@ def test_cves_for_cpe_respects_version_range(app):
     assert wrong_product == []
 
 
+def test_cves_for_cpe_tags_result_with_required_os(app):
+    """#118: a match gated behind a platform (CpeMatch.required_os) must
+    surface on the returned CveEntry so the caller (LybraEngine) can avoid
+    treating an unverifiable OS precondition as a confirmed risk."""
+    match = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.59",
+             "version_start_including": None, "version_start_excluding": None,
+             "version_end_including": None, "version_end_excluding": None,
+             "required_os": "windows_10"}
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [match])
+
+        with UnitOfWork() as uow:
+            hit = KbRepository(uow).cves_for_cpe("apache", "http_server", "2.4.59")
+
+    assert [c.cve_id for c in hit] == ["CVE-2021-41773"]
+    assert hit[0].required_os == "windows_10"
+
+
+def test_cves_for_cpe_unconditional_rule_wins_over_os_gated_one(app):
+    """The same CVE can have several applicability rows for the same product
+    (different ranges from different NVD configuration nodes). If even one of
+    the rows matching this version is unconditional, the CVE genuinely
+    applies regardless of platform — the OS gate from the other row must not
+    leak into the result."""
+    windows_only = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.59",
+                     "version_start_including": None, "version_start_excluding": None,
+                     "version_end_including": None, "version_end_excluding": None,
+                     "required_os": "windows_10"}
+    unconditional = {"vendor": "apache", "product": "http_server",
+                      "version_start_including": "2.4.0", "version_end_excluding": "2.4.60",
+                      "version_start_excluding": None, "version_end_including": None,
+                      "exact_version": None, "required_os": None}
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [windows_only, unconditional])
+
+        with UnitOfWork() as uow:
+            hit = KbRepository(uow).cves_for_cpe("apache", "http_server", "2.4.59")
+
+    assert [c.cve_id for c in hit] == ["CVE-2021-41773"]
+    assert hit[0].required_os is None
+
+
 def test_upsert_cve_is_idempotent_and_replaces_matches(app):
     m1 = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.49",
           "version_start_including": None, "version_start_excluding": None,

--- a/API/tests/integration/test_plan_catalog_admin.py
+++ b/API/tests/integration/test_plan_catalog_admin.py
@@ -283,6 +283,11 @@ def test_the_limit_key_catalog_is_offered_to_the_panel(
     body = client.get("/plans/limit-keys", headers=auth_headers(root_user)).get_json()
     keys = {entry["key"]: entry["period"] for entry in body["keys"]}
 
-    assert len(keys) == 15
+    # Contra el enum y no contra un número: el catálogo crece, y una cuenta a
+    # mano solo obliga a editar este test cada vez que se añade una clave.
+    from src.modules.accounts.services.limits import LimitKey
+
+    assert set(keys) == {key.value for key in LimitKey}
     assert keys["iris.analyses"] == "month"
     assert keys["acheron.vaults"] == "stock"
+    assert keys["aegis.white_label"] == "tier"

--- a/API/tests/unit/test_accounts_limit_coverage.py
+++ b/API/tests/unit/test_accounts_limit_coverage.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.unit
 
 
 #: Claves que todavía no se exigen, y por qué. Vaciar esta lista es el objetivo,
-#: y desde la fase 5 está vacía: las quince pasan por caja.
+#: y desde la fase 5 está vacía: todas pasan por caja.
 DEFERRED: dict[LimitKey, str] = {}
 
 SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "modules"

--- a/API/tests/unit/test_accounts_seed.py
+++ b/API/tests/unit/test_accounts_seed.py
@@ -78,7 +78,7 @@ def test_seed_plan_codes_in_limits_exist():
 
 
 def test_seed_covers_every_holder_key_for_every_plan():
-    """Las 15 claves, en los 4 planes, explícitamente.
+    """Todas las claves, en los 4 planes, explícitamente.
 
     Omitir una no da error: se lee como 0 y desactiva la característica. Es el
     fallo cerrado que queremos cuando alguien añade una clave nueva y se olvida

--- a/API/tests/unit/test_herald_smtp.py
+++ b/API/tests/unit/test_herald_smtp.py
@@ -18,7 +18,7 @@ aiosmtpd_controller = pytest.importorskip("aiosmtpd.controller")
 Controller = aiosmtpd_controller.Controller
 
 from src.modules.tools.herald.exceptions import EmailConnectionError, EmailSendError
-from src.modules.tools.herald.inputs import EmailMessage
+from src.modules.tools.herald.inputs import EmailMessage, InlineImage
 from src.modules.tools.herald.strategies import SmtpStrategy
 
 pytestmark = pytest.mark.unit
@@ -171,3 +171,71 @@ def test_smtp_strategy_raises_send_error_when_recipient_rejected(rejecting_smtp_
 
     with pytest.raises(EmailSendError):
         strategy.send(message)
+
+
+# Un PNG de 1x1 real: basta para que el generador MIME lo trate como imagen.
+_PNG_1x1 = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6360000002000100ffff03000006000557bfabd400"
+    "00000049454e44ae426082"
+)
+
+
+def test_smtp_strategy_embeds_inline_images_as_related_parts(smtp_server):
+    """La imagen inline viaja dentro del mensaje y con su Content-ID.
+
+    Es lo que hace que ``<img src="cid:...">`` resuelva en el cliente: si la
+    imagen colgara de la raíz en vez de la alternativa HTML, llegaría como
+    adjunto suelto y el <img> saldría roto.
+    """
+    controller, handler = smtp_server
+    strategy = SmtpStrategy(
+        host=controller.hostname,
+        port=controller.port,
+        from_address="noreply@ellysia.test",
+        use_tls=False,
+    )
+    message = EmailMessage(
+        to="empleado@empresa.test",
+        subject="Con logo",
+        html_body='<p><img src="cid:brand-logo"></p>',
+        inline_images=(InlineImage(content_id="brand-logo", data=_PNG_1x1, mimetype="image/png"),),
+    )
+
+    result = strategy.send(message)
+
+    assert result.ok is True
+    received = handler.messages[0]
+    assert "cid:brand-logo" in received["html"]
+
+    images = [
+        part for part in received["headers"].walk()
+        if part.get_content_type() == "image/png"
+    ]
+    assert len(images) == 1
+    assert images[0]["Content-ID"] == "<brand-logo>"
+    assert images[0].get_payload(decode=True) == _PNG_1x1
+
+    # La imagen va emparentada con el HTML, no colgada de la raíz.
+    related = [
+        part for part in received["headers"].walk()
+        if part.get_content_type() == "multipart/related"
+    ]
+    assert len(related) == 1
+    assert {part.get_content_type() for part in related[0].iter_parts()} == {
+        "text/html", "image/png",
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"content_id": "", "data": _PNG_1x1, "mimetype": "image/png"},
+        {"content_id": "<logo>", "data": _PNG_1x1, "mimetype": "image/png"},
+        {"content_id": "logo", "data": b"", "mimetype": "image/png"},
+        {"content_id": "logo", "data": _PNG_1x1, "mimetype": "text/html"},
+    ],
+)
+def test_inline_image_rejects_invalid_input(kwargs):
+    with pytest.raises(ValueError):
+        InlineImage(**kwargs)

--- a/API/tests/unit/test_herald_templates.py
+++ b/API/tests/unit/test_herald_templates.py
@@ -302,13 +302,17 @@ class TestWhiteLabel:
         "CklEQVR4nGNgAAAAAgABf6ZX1AAAAABJRU5ErkJggg=="
     )
 
-    def _render(self, level, brand_name="ACME S.L.", logo=_LOGO_URI):
+    _COLOR = "#1a73e8"
+
+    def _render(self, level, brand_name="ACME S.L.", logo=_LOGO_URI, color=_COLOR):
         from src.modules.shared import WhiteLabel, WhiteLabelLevel
         from src.modules.tools.herald.branding import apply_white_label
 
         brand, images = apply_white_label(
             {**_BASE_BRAND},
-            WhiteLabel(level=WhiteLabelLevel(level), logo=logo, brand_name=brand_name),
+            WhiteLabel(
+                level=WhiteLabelLevel(level), logo=logo, color=color, brand_name=brand_name,
+            ),
         )
         html, text = render_email(
             "campaign",
@@ -326,10 +330,24 @@ class TestWhiteLabel:
         assert "cid:" not in html
         assert images == ()
         assert "Ellysia" in text
+        # Ni siquiera el acento cambia: el correo sale como saldría sin esto.
+        assert _BASE_BRAND["accentColor"] in html
+        assert self._COLOR not in html
+
+    def test_color_level_only_repaints_the_accent(self):
+        html, _, images = self._render("color")
+
+        assert self._COLOR in html
+        assert _BASE_BRAND["accentColor"] not in html
+        # Un logo guardado no se pinta todavía en este escalón.
+        assert "cid:" not in html
+        assert images == ()
+        assert "Ellysia" in html
 
     def test_logo_level_shows_the_customer_logo_above_the_intro(self):
         html, _, images = self._render("logo")
 
+        assert self._COLOR in html
         assert 'src="cid:brand-logo"' in html
         assert 'alt="ACME S.L."' in html
         # El logo va antes del saludo, no al final del cuerpo.

--- a/API/tests/unit/test_herald_templates.py
+++ b/API/tests/unit/test_herald_templates.py
@@ -13,6 +13,17 @@ from src.modules.tools.herald import render_email
 
 pytestmark = pytest.mark.unit
 
+#: Marca del producto tal y como la deja una instancia configurada.
+_BASE_BRAND = {
+    "productName": "Ellysia",
+    "accentColor": "#d4a04a",
+    "logoUrl": "",
+    "supportEmail": "soporte@ellysia.test",
+    "footerNote": "Ellysia S.L.",
+    "customerLogoUrl": "",
+    "whiteLabelLevel": "none",
+}
+
 
 class TestCampaignTemplate:
     def test_renders_shell_and_link(self):
@@ -276,3 +287,79 @@ def test_brand_defaults_are_injected():
     """Sin ``brand`` explícita, render_email la saca de la config + defaults."""
     html, _ = render_email("campaign", pill_title="X", link="https://e.es/q", recipient_name=None)
     assert "Ellysia" in html
+
+
+class TestWhiteLabel:
+    """Los tres niveles, vistos desde el correo ya renderizado.
+
+    Las plantillas no ramifican por nivel: leen las claves de ``brand`` que
+    ``apply_white_label`` deja puestas. Por eso el nivel FULL lo hereda
+    cualquier plantilla que use la envoltura, no solo la de campaña.
+    """
+
+    _LOGO_URI = (
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA"
+        "CklEQVR4nGNgAAAAAgABf6ZX1AAAAABJRU5ErkJggg=="
+    )
+
+    def _render(self, level, brand_name="ACME S.L.", logo=_LOGO_URI):
+        from src.modules.shared import WhiteLabel, WhiteLabelLevel
+        from src.modules.tools.herald.branding import apply_white_label
+
+        brand, images = apply_white_label(
+            {**_BASE_BRAND},
+            WhiteLabel(level=WhiteLabelLevel(level), logo=logo, brand_name=brand_name),
+        )
+        html, text = render_email(
+            "campaign",
+            brand=brand,
+            pill_title="Phishing por SMS",
+            link="https://ellysia.es/quiz?t=abc",
+            company="ACME S.L.",
+        )
+        return html, text, images
+
+    def test_none_keeps_the_product_brand_and_adds_no_image(self):
+        html, text, images = self._render("none")
+
+        assert "ELLYSIA" in html.upper()
+        assert "cid:" not in html
+        assert images == ()
+        assert "Ellysia" in text
+
+    def test_logo_level_shows_the_customer_logo_above_the_intro(self):
+        html, _, images = self._render("logo")
+
+        assert 'src="cid:brand-logo"' in html
+        assert 'alt="ACME S.L."' in html
+        # El logo va antes del saludo, no al final del cuerpo.
+        assert html.index("cid:brand-logo") < html.index("Hola:")
+        # La marca del producto sigue en su sitio: este nivel solo añade.
+        assert "Ellysia" in html
+        assert len(images) == 1
+
+    def test_full_level_removes_every_trace_of_the_product_brand(self):
+        html, text, images = self._render("full")
+
+        assert "Ellysia" not in html
+        assert "Ellysia" not in text
+        assert "ACME S.L." in text
+        # El logo ocupa la cabecera y no se repite sobre el cuerpo.
+        assert html.count("cid:brand-logo") == 1
+        assert len(images) == 1
+
+    def test_full_level_without_logo_falls_back_to_the_customer_name(self):
+        html, text, images = self._render("full", logo="")
+
+        assert "Ellysia" not in html
+        assert "Ellysia" not in text
+        assert "ACME S.L." in html
+        assert images == ()
+
+    def test_level_degrades_instead_of_rendering_half_a_brand(self):
+        """FULL sin nombre no puede retirar la marca: se queda en el logo."""
+        html, _, images = self._render("full", brand_name="")
+
+        assert "Ellysia" in html
+        assert 'src="cid:brand-logo"' in html
+        assert len(images) == 1

--- a/API/tests/unit/test_lybra_correlation.py
+++ b/API/tests/unit/test_lybra_correlation.py
@@ -144,6 +144,16 @@ def test_lifecycle_does_not_recarry_already_fixed():
     ({"cvss_score": 5.0, "epss_score": 0.6}, "public", "HIGH"),     # high EPSS escalates
     ({"cvss_score": 0.0, "confirmed": True}, "public", "MEDIUM"),   # confirmed w/o CVSS floors
     ({"cvss_score": 0.0}, "public", "INFO"),
+    # required_os (#118): an unconfirmed, platform-gated CVSS 9.8 match cannot
+    # be verified without OS-detection, so it is capped at MEDIUM instead of
+    # reading as CRITICAL.
+    ({"cvss_score": 9.8, "required_os": "windows_10"}, "public", "MEDIUM"),
+    ({"cvss_score": 9.8, "required_os": "windows_10", "in_kev": True}, "public", "MEDIUM"),  # cap wins over the KEV boost
+    # A confirmed finding (Hygeia inventory, host OS already known) is exempt
+    # from the cap — the platform precondition isn't a guess in that case.
+    ({"cvss_score": 9.8, "required_os": "windows_10", "confirmed": True}, "public", "CRITICAL"),
+    # required_os alongside a private-LAN target: both caps apply, smallest wins.
+    ({"cvss_score": 9.8, "required_os": "windows_10"}, "private", "MEDIUM"),
 ])
 def test_score_finding(finding, exposure, expected):
     assert score_finding(finding, exposure) == expected

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -127,9 +127,10 @@ def test_nmap_processor_keeps_cpe_in_ports_data():
 
 # ------------------------------------------------ version matcher (Fase 1)
 
-def _fake_cve(cve_id="CVE-2021-41773"):
+def _fake_cve(cve_id="CVE-2021-41773", required_os=None):
     return types.SimpleNamespace(
         cve_id=cve_id, cvss_score=7.5, cvss_vector="CVSS:3.1/AV:N", severity="HIGH",
+        required_os=required_os,
     )
 
 
@@ -176,6 +177,33 @@ def test_version_finding_from_nmap_cpe():
     assert vuln["epss_score"] == 0.97
     assert vuln["check_id"] == "lybra:version-match@1"
     assert vuln["cpe"] == "cpe:2.3:a:apache:http_server:2.4.49:*:*:*:*:*:*:*"
+
+
+def test_version_finding_carries_required_os_from_the_cve_lookup():
+    """#118: a cve_lookup result flagged with a platform gate (KbRepository's
+    transient CveEntry.required_os) must reach the finding dict, so
+    score_finding can avoid crowning an unverifiable platform hypothesis as
+    CRITICAL."""
+    engine = LybraEngine(cve_lookup=lambda *a: [_fake_cve(required_os="windows_10")])
+    service = Service(80, "tcp", "http", "Apache httpd", "2.4.59",
+                      "cpe:/a:apache:http_server:2.4.59")
+
+    findings = engine.analyze([service])
+
+    vuln = findings[1]
+    assert vuln["required_os"] == "windows_10"
+
+
+def test_version_finding_required_os_defaults_to_none():
+    """A cve_lookup result with no required_os attribute at all (a stub, or a
+    genuinely unconditional match) must not blow up — getattr defaults it."""
+    engine = LybraEngine(cve_lookup=_lookup_for(("apache", "http_server")))
+    service = Service(80, "tcp", "http", "Apache httpd", "2.4.49",
+                      "cpe:/a:apache:http_server:2.4.49")
+
+    findings = engine.analyze([service])
+
+    assert findings[1]["required_os"] is None
 
 
 def test_version_finding_via_override_when_no_cpe():

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -93,7 +93,24 @@ def test_normalize_cpe_23_passthrough():
 
 def test_parse_cpe23_extracts_fields():
     parsed = parse_cpe23("cpe:/a:apache:http_server:2.4.49")
-    assert parsed == {"part": "a", "vendor": "apache", "product": "http_server", "version": "2.4.49"}
+    assert parsed == {
+        "part": "a", "vendor": "apache", "product": "http_server", "version": "2.4.49",
+        "target_sw": None,
+    }
+
+
+def test_parse_cpe23_extracts_target_sw():
+    parsed = parse_cpe23("cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:windows:*:*")
+    assert parsed["target_sw"] == "windows"
+
+
+@pytest.mark.parametrize("cpe", [
+    "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*",   # wildcard
+    "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:-:*",   # not-applicable marker
+    "cpe:/a:apache:http_server:2.4.49",                     # 2.2 form has no target_sw field at all
+])
+def test_parse_cpe23_target_sw_none_when_unset(cpe):
+    assert parse_cpe23(cpe)["target_sw"] is None
 
 
 # ---------------------------------------------------------------- NVD ingest
@@ -158,6 +175,83 @@ def test_ingest_nvd_cve_range_beats_pinned_version():
 
 def test_ingest_nvd_cve_malformed_returns_none():
     assert ingest_nvd_cve({"cve": {}}) is None
+
+
+# ------------------------------------------------- platform-gated CVEs (#118)
+
+def _and_node_item(platform_cpe: str) -> dict:
+    """One CVE whose only applicability node ANDs an Apache match with a
+    platform-only CPE — the shape NVD uses for "product X, but only on
+    OS Y" CVEs."""
+    return {"cve": {
+        "id": "CVE-2024-00001",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{
+            "operator": "AND",
+            "cpeMatch": [
+                {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": platform_cpe},
+            ],
+        }]}],
+    }}
+
+
+def test_ingest_nvd_cve_and_node_tags_software_match_with_platform():
+    """NVD's 'product AND platform' node shape must gate the software row
+    with the platform's product token — the mechanism behind CVE-2024-38472-
+    style ("...on Windows") false positives reported against non-Windows
+    hosts (Issue #118)."""
+    item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
+    _cve, matches = ingest_nvd_cve(item)
+    assert len(matches) == 1  # the platform-only cpeMatch produces no row of its own
+    assert matches[0]["product"] == "http_server"
+    assert matches[0]["required_os"] == "windows_10"
+
+
+def test_ingest_nvd_cve_or_node_does_not_gate():
+    """An 'OR' node is not the 'product AND this one platform' shape — must
+    not guess a required_os from it."""
+    item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
+    item["cve"]["configurations"][0]["nodes"][0]["operator"] = "OR"
+    _cve, matches = ingest_nvd_cve(item)
+    # Both entries survive as independent rows once there is no AND to fold.
+    assert {m["product"] for m in matches} == {"http_server"}
+    assert matches[0]["required_os"] is None
+
+
+def test_ingest_nvd_cve_multiple_platforms_in_and_node_does_not_gate():
+    """Two distinct platform products under the same AND node is a shape this
+    module does not attempt to resolve (would need real node-tree/OR
+    semantics) — conservatively leaves required_os unset rather than
+    guessing either platform."""
+    item = {"cve": {
+        "id": "CVE-2024-00002",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{
+            "operator": "AND",
+            "cpeMatch": [
+                {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": "cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*"},
+                {"vulnerable": True, "criteria": "cpe:2.3:o:microsoft:windows_11:*:*:*:*:*:*:*:*"},
+            ],
+        }]}],
+    }}
+    _cve, matches = ingest_nvd_cve(item)
+    assert matches[0]["required_os"] is None
+
+
+def test_ingest_nvd_cve_target_sw_on_software_cpe_gates_directly():
+    """When NVD encodes the platform on the software's own CPE (target_sw)
+    rather than via a sibling AND node, that must gate the match too."""
+    item = {"cve": {
+        "id": "CVE-2024-00003",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "configurations": [{"nodes": [{"cpeMatch": [
+            {"vulnerable": True, "criteria": "cpe:2.3:a:apache:http_server:2.4.59:*:*:*:*:windows:*:*"},
+        ]}]}],
+    }}
+    _cve, matches = ingest_nvd_cve(item)
+    assert matches[0]["required_os"] == "windows"
 
 
 # --------------------------------------------------------------- KEV / EPSS

--- a/API/tests/unit/test_migration_column_coverage.py
+++ b/API/tests/unit/test_migration_column_coverage.py
@@ -1,0 +1,57 @@
+"""Que ninguna columna del modelo se quede sin migración.
+
+El esquema se construye de dos formas distintas y nadie las compara: los tests
+lo crean con ``Base.metadata.create_all`` (conftest.py) y el despliegue con
+``alembic upgrade head`` (run.py). Una columna declarada en el modelo y
+olvidada en la migración pasa la suite entera y revienta en producción con
+UndefinedColumn la primera vez que alguien lee esa tabla — que es justo lo que
+pasó con ``AegisOrgProfile.brand_color``.
+
+El test es textual a propósito: ejecutar la cadena de migraciones aquí exigiría
+un Postgres (hay JSONB, índices parciales y ARRAY por medio), y lo que se
+quiere cazar no es un fallo de SQL sino un descuido — el nombre de la columna
+no aparece en ninguna migración. Por eso solo busca el nombre, y por eso puede
+dar por buena una columna cuyo nombre coincida con el de otra tabla.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.modules.shared import Base
+
+# Los modelos tienen que estar importados para que estén en el metadata; el
+# paquete de cada módulo los arrastra.
+import src.modules.features.aegis.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.hygeia.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.iris.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.features.themis.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.accounts.model  # noqa: F401  pylint: disable=unused-import
+import src.modules.users.model  # noqa: F401  pylint: disable=unused-import
+
+pytestmark = pytest.mark.unit
+
+
+VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+
+def _migration_sources() -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in VERSIONS_DIR.glob("*.py")
+    )
+
+
+def test_every_model_column_appears_in_some_migration():
+    sources = _migration_sources()
+    missing = {
+        f"{table.name}.{column.name}"
+        for table in Base.metadata.sorted_tables
+        for column in table.columns
+        if f'"{column.name}"' not in sources and f"'{column.name}'" not in sources
+    }
+    assert not missing, (
+        "Estas columnas están en el modelo y no las crea ninguna migración, así "
+        "que la suite pasa (crea el esquema con create_all) y el despliegue "
+        f"revienta con UndefinedColumn: {sorted(missing)}."
+    )

--- a/API/tests/unit/test_nuclei_adapter.py
+++ b/API/tests/unit/test_nuclei_adapter.py
@@ -5,7 +5,7 @@ Pure functions over dicts (one decoded JSONL line) — no DB, no subprocess.
 
 import pytest
 
-from src.modules.features.themis.lybra.adapters import nuclei_result_to_finding, QOD_NUCLEI_MATCH
+from src.modules.features.themis.lybra.adapters import nuclei_result_to_finding, finding_to_json, QOD_NUCLEI_MATCH
 
 pytestmark = pytest.mark.unit
 
@@ -168,3 +168,22 @@ def test_cpe_and_cvss_vector_read_from_classification():
     }))
     assert f["cpe"] == "cpe:2.3:a:apache:http_server:2.4.49"
     assert f["cvss_vector"] == "CVSS:3.1/x"
+
+
+# ------------------------------------------------------- finding_to_json (#118)
+
+def test_finding_to_json_exposes_required_os_and_feeds_the_cap_into_priority():
+    """An unconfirmed, platform-gated CVSS 9.8 finding must serialize its
+    required_os and, via score_finding, read as MEDIUM rather than CRITICAL —
+    the same cap the PDF report and the AI writer apply."""
+    f = {"cvss_score": 9.8, "confirmed": False, "required_os": "windows_10"}
+    out = finding_to_json(f, exposure="public")
+    assert out["requiredOs"] == "windows_10"
+    assert out["priority"] == "MEDIUM"
+
+
+def test_finding_to_json_required_os_absent_is_none():
+    f = {"cvss_score": 9.8, "confirmed": False}
+    out = finding_to_json(f, exposure="public")
+    assert out["requiredOs"] is None
+    assert out["priority"] == "CRITICAL"

--- a/API/tests/unit/test_scribe_generator.py
+++ b/API/tests/unit/test_scribe_generator.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Scribe payload-size guardrail (Issue #118).
+
+Covers the heuristic token estimate (``estimate_tokens`` / ``AIInput.estimated_tokens``)
+and ``AIGenerator``'s pre-flight check: an oversized prompt must be rejected
+with ``AIPayloadTooLargeError`` *before* the strategy is ever called, and
+without burning a retry.
+"""
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.tools.scribe import AIInput, AIGenerator, AIPayloadTooLargeError, estimate_tokens
+from src.modules.tools.scribe.inputs import Example
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------- estimate_tokens
+
+def test_estimate_tokens_roughly_four_chars_per_token():
+    assert estimate_tokens("a" * 400) == 100
+
+
+def test_estimate_tokens_empty_string_is_zero():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_rounds_up_partial_token():
+    assert estimate_tokens("abc") == 1  # 3 chars, 1 token, not 0
+
+
+# ------------------------------------------------------- AIInput.estimated_tokens
+
+def test_ai_input_estimated_tokens_sums_all_messages():
+    ai_input = AIInput(system_prompt="s" * 40, user_prompt="u" * 40)
+    # system + user = 80 chars = 20 tokens
+    assert ai_input.estimated_tokens() == 20
+
+
+def test_ai_input_estimated_tokens_includes_examples():
+    ai_input = AIInput(
+        system_prompt="s" * 40,
+        user_prompt="u" * 40,
+        examples=[Example(user="e" * 40, assistant="a" * 40)],
+    )
+    # 40*4 chars = 160 chars = 40 tokens
+    assert ai_input.estimated_tokens() == 40
+
+
+# ------------------------------------------------------------------ AIGenerator
+
+class _FakeStrategy:
+    """A strategy stub that records whether it was ever called."""
+
+    name = "fake"
+
+    def __init__(self, response: str = "ok"):
+        self._response = response
+        self.calls = 0
+
+    def complete(self, ai_input, tool_executor=None):
+        self.calls += 1
+        return self._response
+
+
+def test_digest_rejects_oversized_prompt_without_calling_strategy(monkeypatch):
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=10))
+    strategy = _FakeStrategy()
+    generator = AIGenerator(strategy)
+    ai_input = AIInput(system_prompt="x" * 1000, user_prompt="y")  # far over 10 tokens
+
+    with pytest.raises(AIPayloadTooLargeError):
+        generator.digest(ai_input)
+
+    assert strategy.calls == 0  # never reached the backend — no wasted retry
+
+
+def test_digest_allows_prompt_within_limit(monkeypatch):
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=1000))
+    strategy = _FakeStrategy(response="respuesta")
+    generator = AIGenerator(strategy)
+    ai_input = AIInput(system_prompt="hola", user_prompt="mundo")
+
+    result = generator.digest(ai_input)
+
+    assert result.text == "respuesta"
+    assert strategy.calls == 1
+
+
+def test_ai_payload_too_large_error_is_not_retried(monkeypatch):
+    """Distinguishes the size guardrail from a normal transient failure: a
+    normal exception is retried up to max_retries times, but a payload that's
+    too large must fail on the very first check, every time, so retrying it
+    would be pure waste."""
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(max_input_tokens=1))
+    strategy = _FakeStrategy()
+    generator = AIGenerator(strategy, max_retries=3)
+    ai_input = AIInput(system_prompt="way too long for the limit", user_prompt="y")
+
+    with pytest.raises(AIPayloadTooLargeError):
+        generator.digest(ai_input)
+
+    assert strategy.calls == 0

--- a/API/tests/unit/test_themis_ai_analysis_error_message.py
+++ b/API/tests/unit/test_themis_ai_analysis_error_message.py
@@ -1,0 +1,91 @@
+"""Unit tests for how the PDF report reacts when the AI writer fails (#118).
+
+``PrintingStrategy._append_ai_analysis`` used to catch every exception the
+same way, rendering a generic "No se pudo generar análisis IA" paragraph
+regardless of cause. A scan too large for the configured token budget now
+gets its own, specific message instead of that generic fallback.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+from reportlab.lib.styles import getSampleStyleSheet
+
+import src.modules.system.config_reading as CR
+from src.modules.features.themis.services.reports.base import PrintingStrategy
+from src.modules.shared.report_theme import ColorType, ReportTheme
+from src.modules.tools.scribe import AIPayloadTooLargeError
+
+pytestmark = pytest.mark.unit
+
+_PALETTE = {
+    ColorType.BLACK: "#121212", ColorType.DARK: "#333333", ColorType.MAIN: "#014f86",
+    ColorType.SECONDARY: "#555b6e", ColorType.LIGHT: "#4a90e2", ColorType.WHITE: "#f5f5f5",
+}
+_FAKE_PROMPTS = {"nmap": {"system": "Eres un analista.", "userTemplate": "x"}}
+
+
+class _FakeWriter:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    def generate(self, scan, **kwargs):
+        raise self._exc
+
+
+class _MinimalPrintingStrategy(PrintingStrategy):
+    """The smallest concrete subclass that satisfies the ABC — only
+    ``_append_ai_analysis`` (inherited, not overridden) is under test."""
+
+    def append_body(self, theme, elements, ai_report=False):
+        raise NotImplementedError
+
+    def get_filename_suffix(self) -> str:
+        return "_Test.pdf"
+
+    def get_picture_name(self, dark: bool = True) -> str:
+        return "Test"
+
+    def get_report_title(self) -> str:
+        return "Test"
+
+
+def _strategy(exc: Exception) -> _MinimalPrintingStrategy:
+    scan = types.SimpleNamespace(id=1, scan_type="nmap")
+    strategy = _MinimalPrintingStrategy(scan=scan)
+    strategy.writer = _FakeWriter(exc)
+    return strategy
+
+
+def _theme() -> ReportTheme:
+    return ReportTheme(getSampleStyleSheet(), _PALETTE)
+
+
+def _rendered_text(elements: list) -> str:
+    return " ".join(el.getPlainText() for el in elements if hasattr(el, "getPlainText"))
+
+
+def test_payload_too_large_gets_a_specific_message(monkeypatch):
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_PROMPTS)
+    strategy = _strategy(AIPayloadTooLargeError(estimated_tokens=99999, max_tokens=24000))
+    elements: list = []
+
+    strategy._append_ai_analysis(elements, _theme())
+
+    text = _rendered_text(elements)
+    assert "demasiados hallazgos" in text
+    assert "No se pudo generar análisis IA" not in text
+
+
+def test_other_failures_keep_the_generic_message(monkeypatch):
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_PROMPTS)
+    strategy = _strategy(RuntimeError("boom"))
+    elements: list = []
+
+    strategy._append_ai_analysis(elements, _theme())
+
+    text = _rendered_text(elements)
+    assert "No se pudo generar análisis IA" in text
+    assert "demasiados hallazgos" not in text

--- a/API/tests/unit/test_themis_ai_writer.py
+++ b/API/tests/unit/test_themis_ai_writer.py
@@ -20,7 +20,7 @@ import json
 import pytest
 
 import src.modules.system.config_reading as CR
-from src.modules.features.themis.services.analyzers import LybraAIWriter
+from src.modules.features.themis.services.analyzers import LybraAIWriter, NmapAIWriter
 
 pytestmark = pytest.mark.unit
 
@@ -150,3 +150,127 @@ def test_la_cola_se_recorta_por_prioridad_y_nunca_descarta_confirmados(monkeypat
     assert hallazgos[0]["confirmado"] is True
     # El recuento total sigue siendo el real aunque el detalle esté recortado.
     assert sum(group["total_hallazgos"] for group in payload["servicios"]) == len(ruido) + 1
+
+
+def test_confirmados_y_kev_tambien_se_recortan_al_tope(monkeypatch):
+    """#118: antes solo la cola ('rest') tenía tope — un scan con más
+    confirmados/KEV que _MAX_HIGHLIGHTED_FINDINGS generaba un payload sin
+    límite real pese a la constante. Deben recortarse igual, priorizando por
+    severidad."""
+    muchos_confirmados = [
+        _finding(
+            title=f"CVE-2021-{40000 + i}", cve_ids=[f"CVE-2021-{40000 + i}"],
+            confirmed=True, cvss_score=5.0 + (i % 5), priority="MEDIUM",
+            port=1000 + i,
+        )
+        for i in range(LybraAIWriter._MAX_HIGHLIGHTED_FINDINGS + 15)
+    ]
+    # El más grave del lote, al final de la lista de entrada — debe
+    # sobrevivir al recorte pese a no ser el primero en orden de repositorio.
+    muchos_confirmados[-1] = _finding(
+        title="El más grave", cve_ids=["CVE-2021-99999"],
+        confirmed=True, cvss_score=9.8, priority="CRITICAL", port=9999,
+    )
+
+    hallazgos = _build(muchos_confirmados, monkeypatch)["hallazgos"]
+
+    assert len(hallazgos) == LybraAIWriter._MAX_HIGHLIGHTED_FINDINGS
+    assert all(h["confirmado"] for h in hallazgos)
+    assert hallazgos[0]["titulo"] == "El más grave"
+
+
+def test_hallazgo_confirmado_y_en_kev_no_se_duplica_en_el_payload(monkeypatch):
+    """Antes de deduplicar, un hallazgo confirmado Y en KEV a la vez entraba
+    dos veces en la lista destacada (concatenación ingenua confirmed + kev)."""
+    doble = _finding(confirmed=True, in_kev=True)
+
+    hallazgos = _build([doble], monkeypatch)["hallazgos"]
+
+    assert len(hallazgos) == 1
+
+
+def test_rollup_de_servicios_se_recorta_al_tope_priorizando_severidad(monkeypatch):
+    """#118: un objetivo con muchos productos/puertos distintos (un rango de
+    red, no un solo host) podía generar un 'services_json' sin límite."""
+    muchos_servicios = [
+        _finding(
+            title=f"Servicio {i}", cve_ids=[f"CVE-2020-{10000 + i}"],
+            port=2000 + i, service=f"svc{i}",
+            cpe=f"cpe:2.3:a:vendor{i}:product{i}:1.0:*:*:*:*:*:*:*",
+            cvss_score=float(i % 10), priority="LOW",
+        )
+        for i in range(LybraAIWriter._MAX_SERVICE_GROUPS + 20)
+    ]
+    mas_grave = _finding(
+        title="El más grave", cve_ids=["CVE-2020-99999"],
+        port=9999, service="svc-critico",
+        cpe="cpe:2.3:a:vendor-critico:product-critico:1.0:*:*:*:*:*:*:*",
+        cvss_score=9.8, priority="CRITICAL",
+    )
+
+    servicios = _build(muchos_servicios + [mas_grave], monkeypatch)["servicios"]
+
+    assert len(servicios) == LybraAIWriter._MAX_SERVICE_GROUPS
+    assert servicios[0]["producto"] == "product-critico 1.0"
+
+
+# ------------------------------------------------------- NmapAIWriter (#118)
+
+_FAKE_NMAP_PROMPTS = {
+    "nmap": {
+        "system": "Eres un analista senior.",
+        "userTemplate": (
+            "Objetivo {{target}} inicio {{started}} total {{total_ports}} "
+            "distribucion {{distribution}} perfil {{profile_type}}\n"
+            "PUERTOS:\n{{ports_json}}"
+        ),
+    }
+}
+
+
+def _open_port(port: int, service: str = "http") -> dict:
+    return {
+        "port": {"port": port, "protocol": "tcp"},
+        "given_use": service,
+        "product": "Apache",
+        "version": "2.4.7",
+        "reason": "syn-ack",
+    }
+
+
+def _build_nmap(open_ports: list, monkeypatch) -> dict:
+    monkeypatch.setattr(CR, "get_prompts_config", lambda: _FAKE_NMAP_PROMPTS)
+
+    writer = NmapAIWriter(generator=object())
+    network_ctx = {
+        "is_private": False, "network_type": "Red pública",
+        "max_risk_level": "CRÍTICO", "context_note": "CONTEXTO DE RED CONFIRMADO: público.",
+    }
+    prompt = writer._build_user_prompt(
+        {"target": "45.33.32.156", "started_at": "2026-08-11"}, open_ports, network_ctx,
+    )
+
+    header, _, ports_block = prompt.partition("PUERTOS:\n")
+    total_ports = int(header.split("total ")[1].split(" ")[0])
+    return {"total_ports": total_ports, "puertos": json.loads(ports_block)}
+
+
+def test_ports_se_recortan_al_tope_pero_total_ports_sigue_siendo_el_real(monkeypatch):
+    """#118: un host con muchos más puertos abiertos que el tope no debe
+    generar un 'ports_json' sin límite, pero '{{total_ports}}' debe seguir
+    reportando el recuento real — nunca menos puertos de los que hay."""
+    open_ports = [_open_port(1000 + i) for i in range(NmapAIWriter._MAX_PORTS + 25)]
+
+    payload = _build_nmap(open_ports, monkeypatch)
+
+    assert len(payload["puertos"]) == NmapAIWriter._MAX_PORTS
+    assert payload["total_ports"] == len(open_ports)
+
+
+def test_ports_bajo_el_tope_no_se_recortan(monkeypatch):
+    open_ports = [_open_port(80), _open_port(22, "ssh")]
+
+    payload = _build_nmap(open_ports, monkeypatch)
+
+    assert len(payload["puertos"]) == 2
+    assert payload["total_ports"] == 2

--- a/API/tests/unit/test_white_label.py
+++ b/API/tests/unit/test_white_label.py
@@ -1,0 +1,175 @@
+"""
+Tests del white-labeling transversal: el concepto (``shared._white_label``) y
+su proyección a un correo (``tools.herald.branding``).
+
+Ningún módulo de features aparece aquí a propósito: estas piezas no conocen a
+sus consumidores.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from marshmallow import Schema, ValidationError
+
+from src.modules.shared import (
+    WhiteLabel,
+    WhiteLabelLevel,
+    WhiteLabelSchemaMixin,
+    validate_logo_data_uri,
+)
+from src.modules.shared._white_label import MAX_LOGO_BYTES
+from src.modules.tools.herald.branding import (
+    LOGO_CONTENT_ID,
+    apply_white_label,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6360000002000100ffff03000006000557bfabd400"
+    "00000049454e44ae426082"
+)
+_PNG_URI = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode()
+
+_BASE_BRAND = {
+    "productName": "Ellysia",
+    "accentColor": "#d4a04a",
+    "logoUrl": "https://cdn.ellysia.test/logo.png",
+    "supportEmail": "soporte@ellysia.test",
+    "footerNote": "Ellysia S.L.",
+    "customerLogoUrl": "",
+    "whiteLabelLevel": "none",
+}
+
+
+class _ProfileSchema(WhiteLabelSchemaMixin, Schema):
+    """Esquema mínimo, como el que declararía cualquier módulo consumidor."""
+
+
+# ── Validación del logo ─────────────────────────────────────────────────────
+
+def test_validate_logo_data_uri_accepts_png():
+    mimetype, data = validate_logo_data_uri(_PNG_URI)
+    assert mimetype == "image/png"
+    assert data == _PNG_BYTES
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "https://cdn.empresa.test/logo.png",
+        "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode(),
+        "data:text/html;base64," + base64.b64encode(b"<h1>hi</h1>").decode(),
+        "data:image/png;base64,no-es-base64!!",
+    ],
+)
+def test_validate_logo_data_uri_rejects_invalid(value):
+    with pytest.raises(ValueError):
+        validate_logo_data_uri(value)
+
+
+def test_validate_logo_data_uri_rejects_oversized_logo():
+    oversized = "data:image/png;base64," + base64.b64encode(b"\x00" * (MAX_LOGO_BYTES + 1)).decode()
+    with pytest.raises(ValueError, match="máximo"):
+        validate_logo_data_uri(oversized)
+
+
+def test_schema_mixin_rejects_invalid_logo_and_level():
+    with pytest.raises(ValidationError):
+        _ProfileSchema().load({"brandLogo": "javascript:alert(1)"})
+    with pytest.raises(ValidationError):
+        _ProfileSchema().load({"whiteLabelLevel": "parcial"})
+
+
+def test_schema_mixin_defaults_to_no_white_label():
+    assert _ProfileSchema().load({}) == {"whiteLabelLevel": "none", "brandLogo": ""}
+
+
+# ── Degradación de nivel ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "level, logo, brand_name, expected",
+    [
+        (WhiteLabelLevel.NONE, _PNG_URI, "ACME", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.LOGO, _PNG_URI, "ACME", WhiteLabelLevel.LOGO),
+        # Sin logo, "añadir imagen corporativa" no añade nada.
+        (WhiteLabelLevel.LOGO, "", "ACME", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.FULL, _PNG_URI, "ACME", WhiteLabelLevel.FULL),
+        # Sin nombre no hay con qué sustituir la marca: baja un escalón.
+        (WhiteLabelLevel.FULL, _PNG_URI, "", WhiteLabelLevel.LOGO),
+        (WhiteLabelLevel.FULL, "", "", WhiteLabelLevel.NONE),
+    ],
+)
+def test_effective_level_degrades_when_data_is_missing(level, logo, brand_name, expected):
+    assert WhiteLabel(level=level, logo=logo, brand_name=brand_name).effective_level is expected
+
+
+def test_from_stored_tolerates_nulls_and_unknown_levels():
+    white_label = WhiteLabel.from_stored(None, None, None)
+    assert white_label.level is WhiteLabelLevel.NONE
+    assert WhiteLabel.from_stored("inventado", _PNG_URI, "ACME").level is WhiteLabelLevel.NONE
+
+
+def test_decoded_logo_returns_none_for_corrupt_stored_logo():
+    """Un logo corrupto en BD no debe tumbar un envío en curso."""
+    assert WhiteLabel(level=WhiteLabelLevel.LOGO, logo="data:image/png;base64,??").decoded_logo() is None
+
+
+# ── Proyección sobre el correo ──────────────────────────────────────────────
+
+def test_apply_white_label_none_leaves_brand_untouched():
+    brand, images = apply_white_label(_BASE_BRAND, WhiteLabel())
+
+    assert images == ()
+    assert brand["productName"] == "Ellysia"
+    assert brand["logoUrl"] == "https://cdn.ellysia.test/logo.png"
+    assert brand["customerLogoUrl"] == ""
+    assert brand["whiteLabelLevel"] == "none"
+
+
+def test_apply_white_label_logo_adds_customer_logo_and_keeps_product_brand():
+    brand, images = apply_white_label(
+        _BASE_BRAND,
+        WhiteLabel(level=WhiteLabelLevel.LOGO, logo=_PNG_URI, brand_name="ACME"),
+    )
+
+    assert brand["customerLogoUrl"] == f"cid:{LOGO_CONTENT_ID}"
+    assert brand["productName"] == "Ellysia"
+    assert brand["logoUrl"] == "https://cdn.ellysia.test/logo.png"
+    assert brand["supportEmail"] == "soporte@ellysia.test"
+    assert len(images) == 1
+    assert images[0].content_id == LOGO_CONTENT_ID
+    assert images[0].data == _PNG_BYTES
+
+
+def test_apply_white_label_full_replaces_product_brand():
+    brand, images = apply_white_label(
+        _BASE_BRAND,
+        WhiteLabel(level=WhiteLabelLevel.FULL, logo=_PNG_URI, brand_name="ACME"),
+    )
+
+    assert brand["productName"] == "ACME"
+    assert brand["logoUrl"] == f"cid:{LOGO_CONTENT_ID}"
+    # Sin duplicar: en FULL el logo ya está en la cabecera.
+    assert brand["customerLogoUrl"] == ""
+    assert brand["supportEmail"] == ""
+    assert brand["footerNote"] == ""
+    assert len(images) == 1
+    assert "Ellysia" not in " ".join(str(value) for value in brand.values())
+
+
+def test_apply_white_label_full_without_logo_drops_product_logo():
+    """Sin logo propio, la cabecera cae al nombre — nunca al logo del producto."""
+    brand, images = apply_white_label(
+        _BASE_BRAND,
+        WhiteLabel(level=WhiteLabelLevel.FULL, brand_name="ACME"),
+    )
+
+    assert brand["logoUrl"] == ""
+    assert brand["productName"] == "ACME"
+    assert images == ()

--- a/API/tests/unit/test_white_label.py
+++ b/API/tests/unit/test_white_label.py
@@ -75,6 +75,18 @@ def test_validate_logo_data_uri_rejects_invalid(value):
         validate_logo_data_uri(value)
 
 
+def test_validate_logo_data_uri_accepts_wrapped_base64():
+    """Base64 partido en líneas (RFC 2045) es válido y hay codificadores que lo
+    generan solos — ``base64.encodebytes``, sin ir más lejos. El regex ya lo
+    admitía; lo que fallaba era la decodificación con ``validate=True``."""
+    wrapped = "data:image/png;base64," + base64.encodebytes(_PNG_BYTES).decode()
+
+    mimetype, data = validate_logo_data_uri(wrapped)
+
+    assert mimetype == "image/png"
+    assert data == _PNG_BYTES
+
+
 def test_validate_logo_data_uri_rejects_oversized_logo():
     oversized = "data:image/png;base64," + base64.b64encode(b"\x00" * (MAX_LOGO_BYTES + 1)).decode()
     with pytest.raises(ValueError, match="máximo"):

--- a/API/tests/unit/test_white_label.py
+++ b/API/tests/unit/test_white_label.py
@@ -17,6 +17,7 @@ from src.modules.shared import (
     WhiteLabel,
     WhiteLabelLevel,
     WhiteLabelSchemaMixin,
+    validate_brand_color,
     validate_logo_data_uri,
 )
 from src.modules.shared._white_label import MAX_LOGO_BYTES
@@ -34,6 +35,7 @@ _PNG_BYTES = bytes.fromhex(
     "00000049454e44ae426082"
 )
 _PNG_URI = "data:image/png;base64," + base64.b64encode(_PNG_BYTES).decode()
+_COLOR = "#1a73e8"
 
 _BASE_BRAND = {
     "productName": "Ellysia",
@@ -87,32 +89,83 @@ def test_schema_mixin_rejects_invalid_logo_and_level():
 
 
 def test_schema_mixin_defaults_to_no_white_label():
-    assert _ProfileSchema().load({}) == {"whiteLabelLevel": "none", "brandLogo": ""}
+    assert _ProfileSchema().load({}) == {
+        "whiteLabelLevel": "none", "brandLogo": "", "brandColor": "",
+    }
+
+
+# ── Validación del color ────────────────────────────────────────────────────
+
+def test_validate_brand_color_normalizes_case():
+    assert validate_brand_color("#1A73E8") == "#1a73e8"
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "1a73e8", "#1a73e", "#1a73e88", "rojo", "red", "#12345g",
+     # El color acaba dentro de un atributo style: nada de CSS libre.
+     "#fff; background:url(http://x)"],
+)
+def test_validate_brand_color_rejects_anything_but_six_hex_digits(value):
+    with pytest.raises(ValueError):
+        validate_brand_color(value)
+
+
+def test_schema_mixin_rejects_an_invalid_color():
+    with pytest.raises(ValidationError):
+        _ProfileSchema().load({"brandColor": "red"})
 
 
 # ── Degradación de nivel ────────────────────────────────────────────────────
 
 @pytest.mark.parametrize(
-    "level, logo, brand_name, expected",
+    "level, logo, color, brand_name, expected",
     [
-        (WhiteLabelLevel.NONE, _PNG_URI, "ACME", WhiteLabelLevel.NONE),
-        (WhiteLabelLevel.LOGO, _PNG_URI, "ACME", WhiteLabelLevel.LOGO),
-        # Sin logo, "añadir imagen corporativa" no añade nada.
-        (WhiteLabelLevel.LOGO, "", "ACME", WhiteLabelLevel.NONE),
-        (WhiteLabelLevel.FULL, _PNG_URI, "ACME", WhiteLabelLevel.FULL),
+        (WhiteLabelLevel.NONE, _PNG_URI, _COLOR, "ACME", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.COLOR, "", _COLOR, "ACME", WhiteLabelLevel.COLOR),
+        # Sin color, "aplicar color corporativo" no aplica nada.
+        (WhiteLabelLevel.COLOR, _PNG_URI, "", "ACME", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.LOGO, _PNG_URI, _COLOR, "ACME", WhiteLabelLevel.LOGO),
+        # Sin logo baja al escalón de color, que sí puede aplicarse.
+        (WhiteLabelLevel.LOGO, "", _COLOR, "ACME", WhiteLabelLevel.COLOR),
+        (WhiteLabelLevel.LOGO, "", "", "ACME", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.FULL, _PNG_URI, _COLOR, "ACME", WhiteLabelLevel.FULL),
         # Sin nombre no hay con qué sustituir la marca: baja un escalón.
-        (WhiteLabelLevel.FULL, _PNG_URI, "", WhiteLabelLevel.LOGO),
-        (WhiteLabelLevel.FULL, "", "", WhiteLabelLevel.NONE),
+        (WhiteLabelLevel.FULL, _PNG_URI, _COLOR, "", WhiteLabelLevel.LOGO),
+        # Y sigue bajando hasta encontrar un escalón que se sostenga.
+        (WhiteLabelLevel.FULL, "", _COLOR, "", WhiteLabelLevel.COLOR),
+        (WhiteLabelLevel.FULL, "", "", "", WhiteLabelLevel.NONE),
     ],
 )
-def test_effective_level_degrades_when_data_is_missing(level, logo, brand_name, expected):
-    assert WhiteLabel(level=level, logo=logo, brand_name=brand_name).effective_level is expected
+def test_effective_level_degrades_when_data_is_missing(level, logo, color, brand_name, expected):
+    settings = WhiteLabel(level=level, logo=logo, color=color, brand_name=brand_name)
+    assert settings.effective_level is expected
 
 
 def test_from_stored_tolerates_nulls_and_unknown_levels():
-    white_label = WhiteLabel.from_stored(None, None, None)
+    white_label = WhiteLabel.from_stored(None, None, None, None)
     assert white_label.level is WhiteLabelLevel.NONE
-    assert WhiteLabel.from_stored("inventado", _PNG_URI, "ACME").level is WhiteLabelLevel.NONE
+    assert WhiteLabel.from_stored("inventado", _PNG_URI, _COLOR, "ACME").level is WhiteLabelLevel.NONE
+
+
+def test_capped_to_lowers_the_level_but_keeps_the_settings():
+    """Bajar de plan no borra lo guardado: solo deja de aplicarse."""
+    settings = WhiteLabel(
+        level=WhiteLabelLevel.FULL, logo=_PNG_URI, color=_COLOR, brand_name="ACME",
+    )
+    capped = settings.capped_to(WhiteLabelLevel.COLOR)
+
+    assert capped.level is WhiteLabelLevel.COLOR
+    assert capped.logo == _PNG_URI
+    assert capped.color == _COLOR
+
+
+@pytest.mark.parametrize(
+    "allowance, expected",
+    [(None, "full"), (0, "none"), (1, "color"), (2, "logo"), (3, "full"), (9, "full")],
+)
+def test_from_allowance_maps_the_plan_value_to_a_level(allowance, expected):
+    assert WhiteLabelLevel.from_allowance(allowance).value == expected
 
 
 def test_decoded_logo_returns_none_for_corrupt_stored_logo():
@@ -132,11 +185,26 @@ def test_apply_white_label_none_leaves_brand_untouched():
     assert brand["whiteLabelLevel"] == "none"
 
 
+def test_apply_white_label_color_only_swaps_the_accent():
+    brand, images = apply_white_label(
+        _BASE_BRAND,
+        WhiteLabel(level=WhiteLabelLevel.COLOR, logo=_PNG_URI, color=_COLOR, brand_name="ACME"),
+    )
+
+    assert brand["accentColor"] == _COLOR
+    assert brand["productName"] == "Ellysia"
+    # El logo puede estar guardado y este escalón todavía no lo usa.
+    assert brand["customerLogoUrl"] == ""
+    assert images == ()
+
+
 def test_apply_white_label_logo_adds_customer_logo_and_keeps_product_brand():
     brand, images = apply_white_label(
         _BASE_BRAND,
-        WhiteLabel(level=WhiteLabelLevel.LOGO, logo=_PNG_URI, brand_name="ACME"),
+        WhiteLabel(level=WhiteLabelLevel.LOGO, logo=_PNG_URI, color=_COLOR, brand_name="ACME"),
     )
+
+    assert brand["accentColor"] == _COLOR
 
     assert brand["customerLogoUrl"] == f"cid:{LOGO_CONTENT_ID}"
     assert brand["productName"] == "Ellysia"
@@ -150,7 +218,7 @@ def test_apply_white_label_logo_adds_customer_logo_and_keeps_product_brand():
 def test_apply_white_label_full_replaces_product_brand():
     brand, images = apply_white_label(
         _BASE_BRAND,
-        WhiteLabel(level=WhiteLabelLevel.FULL, logo=_PNG_URI, brand_name="ACME"),
+        WhiteLabel(level=WhiteLabelLevel.FULL, logo=_PNG_URI, color=_COLOR, brand_name="ACME"),
     )
 
     assert brand["productName"] == "ACME"
@@ -167,7 +235,7 @@ def test_apply_white_label_full_without_logo_drops_product_logo():
     """Sin logo propio, la cabecera cae al nombre — nunca al logo del producto."""
     brand, images = apply_white_label(
         _BASE_BRAND,
-        WhiteLabel(level=WhiteLabelLevel.FULL, brand_name="ACME"),
+        WhiteLabel(level=WhiteLabelLevel.FULL, color=_COLOR, brand_name="ACME"),
     )
 
     assert brand["logoUrl"] == ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,19 @@ A few things stay plain functions on purpose: env-only credentials (`get_*_envir
 - API version is config-driven: `create_app()` reads it via `CR.get_app_version()` from `appVersion` in `SecOpsConfig.json` (currently `4.2`) — it is not hardcoded.
 - `features.themis.areLocalIpsAllowed` is set to `true` in `SecOpsConfig.json` (intentional, for local dev against private IPs) — with it `true`, 3 SSRF tests don't trigger (`test_nikto_rejects_loopback_target`, `test_nikto_rejects_cloud_metadata_target`, `test_nmap_rejects_private_ip_target`; not a regression). **Must be reverted to `false` before any real deployment**, or the anti-SSRF defense stays disabled in production.
 - OpenVAS was removed from the product (roadmap `plans/feature/themis/lybra-engine-roadmap.md` §7/§6.3, Ronda 2). Its scheduled-flow SSRF fix (`run_scan()` self-validating via `ScanManager.reject_private_ip`) set the pattern the surviving scanners now all follow: each of Nmap, Nikto, Nuclei and Lybra self-validates inside its own `run_scan()` (`thirdparty_scans_managers.py`, `lybra_sources.py`), not just at the HTTP endpoint — so the scheduled flow (`scheduling.py` calling `run_scan()` directly) is covered. The one mode that is *not* validated by design is Lybra's `ExternalPayload` source (`lybra_sources.py`, `probes_target_network = False`): it analyses a services list the caller already resolved without touching the network, so there is no target to reject — deep corroborators from that mode require an explicit authorized-targets entry instead (`deep_requires_authorization = True`).
+
+## Tooling
+
+### Code exploration
+- Prefer **Serena** for semantic navigation, symbol lookup, references,
+  and structural refactoring when those capabilities provide a clear advantage.
+- Use native search/read/git tools when they are more appropriate, especially
+  for exact text, configuration, logs, non-code files, or repository history.
+- Avoid broadly reading files when a targeted lookup is sufficient.
+
+### External documentation
+- Use **Context7** when implementing or debugging against external libraries,
+  frameworks, or APIs.
+- Check the project's actual dependency version first.
+- Use Context7 selectively; do not query documentation when project code already
+  provides the required information.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Ollama](https://img.shields.io/badge/Ollama-llama3.2-ff7000?style=flat-square&logo=ollama)](https://ollama.com)
 [![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=flat-square&logo=docker&logoColor=white)](https://www.docker.com)
 
-[Overview](#overview) · [Features](#features) · [Architecture](#architecture) · [Modules](#modules) · [Quick start](#quick-start) · [Authentication](#authentication) · [API reference](#api-reference) · [TaskQueue](#taskqueue-rq--redis) · [Testing](#testing) · [Database migrations](#database-migrations) · [Docker](#docker) · [AI & email](#ai-and-email-configuration) · [Technology stack](#technology-stack) · [Configuration](#configuration)
+[Overview](#overview) · [Features](#features) · [Architecture](#architecture) · [Modules](#modules) · [Quick start](#quick-start) · [Authentication](#authentication) · [API reference](#api-reference) · [TaskQueue](#taskqueue-rq--redis) · [Testing](#testing) · [Continuous deployment (CI/CD)](#continuous-deployment-cicd) · [Database migrations](#database-migrations) · [Docker](#docker) · [AI & email](#ai-and-email-configuration) · [Technology stack](#technology-stack) · [Configuration](#configuration)
 
 ---
 
@@ -406,7 +406,7 @@ pytest -m integration     # boots create_app() + test HTTP client
 pytest -m oracle          # differential-oracle bench against real Docker containers (skipped in CI by default)
 ```
 
-CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed.
+CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
 
 ### Web SPA (node, no framework)
 
@@ -418,6 +418,60 @@ npm run test:polling      # usePolling composable tests
 npm run test:quiz         # aegis quiz-shuffle permutation tests
 npm run test:logs         # gzip log-payload decoding tests
 ```
+
+## Continuous deployment (CI/CD)
+
+Every merge to `main` is deployed automatically to the production machine, **after** the CI tests of the merged commit pass. The pipeline lives in `.github/workflows/deploy.yml` and chains to `.github/workflows/tests.yml` via the `workflow_run` trigger: when the "API Tests" workflow completes with `success` on a push to `main`, the deploy job connects by SSH to the target host and runs:
+
+```bash
+cd <checkout> && \
+git fetch origin && \
+git reset --hard origin/main && \
+docker compose --profile container up -d --build && \
+docker image prune -f
+```
+
+Then it polls the public health endpoint `https://<host>/system/say-hello` as a smoke test and fails the run if the API does not answer within a few minutes.
+
+> The deploy is strictly *after* the tests: the `workflow_run` trigger fires on the `main`-push run of "API Tests", and its `branches: [main]` filter excludes the PR-triggered runs (there `head_branch` is the source branch). If the tests fail, the deploy is skipped. To deploy without waiting for CI, change the trigger to `push: branches: [main]`; nothing else needs to change.
+
+### One-time setup
+
+Before the first automatic deploy works:
+
+1. **On the server** — a checkout of this repo in a fixed path (e.g. `~/ellysia`), a root `.env` with the real credentials (start from `.env.example`), and a SSH user that can run Docker without `sudo` (`usermod -aG docker <user>`). The API applies Alembic migrations automatically on startup, and the existing volumes (`ellysia_caddy_data` included) are reused, so a redeploy never re-issues certificates or drops data.
+2. **First boot is manual** — a fresh server needs `CREATE_DATABASE=True` in the server's `.env` for the *very first* `docker compose --profile container up -d --build` (it seeds the root user, its ABAC attributes and the awareness topics — it is **destructive**, set it back to `False` afterwards). From then on, deploys are fully automatic.
+3. **The checkout that deploy targets** — pin `DEPLOY_PATH` to the checkout the running containers came from:
+   ```bash
+   docker inspect Ellysia-Web --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}'
+   ```
+   The compose file already pins the project name (`name: ellysia`) and names the critical volumes explicitly, so running from a different directory cannot orphan volumes — but `git reset --hard` must run in the checkout you keep as canonical, and `DEPLOY_PATH` must be that one.
+4. **Server → GitHub access** — the repository is private, so `git fetch` on the server needs credentials. The least-privilege option is a read-only deploy key:
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/ellysia_deploy -N "" -C "server@ellysia"
+   # add ~/.ssh/ellysia_deploy.pub to Repo → Settings → Deploy keys (read-only)
+   cd ~/ellysia && git config core.sshCommand "ssh -i ~/.ssh/ellysia_deploy"
+   ```
+5. **CI → server SSH key** — a dedicated key for the deploy job; the public half goes in the deploy user's `authorized_keys`:
+   ```bash
+   ssh-keygen -t ed25519 -a 100 -f deploy_key -N "" -C "github-actions-deploy@ellysia"
+   ```
+6. **Repository secrets** — Settings → Secrets and variables → Actions → New repository secret:
+
+   | Secret | Value |
+   |---|---|
+   | `DEPLOY_HOST` | `www.ellysia.es` — el **dominio**, no la IP del VPS (Caddy no tiene catch-all por IP, el smoke test fallaría contra la IP; la DNS ya apunta el dominio a la IP) |
+   | `DEPLOY_USER` | the SSH user on the server |
+   | `DEPLOY_PATH` | absolute path to the server checkout (e.g. `/home/deploy/ellysia`) |
+   | `DEPLOY_KEY` | the full contents of the private `deploy_key` file |
+
+### Notes
+
+- **The domain is the identity, not the IP.** The workflow connects to `DEPLOY_HOST`, so changing VPS only means pointing the DNS (and `DEPLOY_HOST`) at the new IP. The first connection to the new host key is accepted automatically (`StrictHostKeyChecking=accept-new`); nothing else changes.
+- **`git reset --hard origin/main`** makes the tracked files of the checkout exactly match `main`; any local modification to tracked files is discarded. The `.env` is gitignored and never touched.
+- **Rollback:** push a revert to `main` (or restore a previous commit) and the next green push deploys it. Data lives in the volumes, only the images are rebuilt.
+- **Manual deploy:** the workflow also has a manual trigger (Actions → "Deploy to production" → Run workflow) that deploys `main` on demand without waiting for a push — useful for a rollback or to re-run after fixing the server.
+- **Renaming the "API Tests" workflow breaks the trigger:** `deploy.yml` references it by name (`workflows: ["API Tests"]`).
 
 ## Database Migrations
 
@@ -465,6 +519,9 @@ alembic downgrade -1
 
 > [!NOTE]
 > Ollama is deliberately **not** part of the `container` profile — the shipped config uses OpenAI by default, and a local LLM reserves 4–8 GB of RAM. Include it explicitly with `--profile local-ai`.
+
+> [!NOTE]
+> Production deploys on every merge to `main` are automated — see [Continuous deployment](#continuous-deployment-cicd) for the exact command the pipeline runs and the one-time setup.
 
 ```bash
 # Infrastructure only (develop locally)

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "test:acheron": "node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
     "test:hygeia": "node test/hygeia.format.test.mjs && node test/hygeia.chartMath.test.mjs",
     "test:polling": "node test/usePolling.test.mjs",
+    "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs"
   },

--- a/web/app/src/assets/css/shared.css
+++ b/web/app/src/assets/css/shared.css
@@ -562,12 +562,6 @@ select option { background: var(--surface); color: var(--text); }
   .card--interactive:hover { transform: none; }
 }
 
-.modal {
-  position: fixed; inset: 0; z-index: 1000;
-  display: none; align-items: center; justify-content: center;
-  padding: 1rem;
-}
-.modal.visible { display: flex; }
 .modal-backdrop {
   position: absolute; inset: 0;
   background: rgba(0,0,0,0.6);

--- a/web/app/src/assets/css/shared.css
+++ b/web/app/src/assets/css/shared.css
@@ -425,21 +425,14 @@ select option { background: var(--surface); color: var(--text); }
 .btn.loading .btn-spin  { display: inline-block; }
 .btn.loading .btn-label { display: none; }
 
-.toast {
-  position: fixed; bottom: 24px; left: 50%;
-  transform: translateX(-50%) translateY(16px);
-  background: var(--surface-3); border: 1px solid var(--border-med);
-  color: var(--text); font-family: var(--font-body); font-size-adjust: var(--fsa-body); font-size: var(--fs-md);
-  padding: 10px 18px; border-radius: var(--radius);
-  opacity: 0; pointer-events: none;
-  transition: opacity 0.22s ease, transform 0.22s ease;
-  z-index: 9999; white-space: nowrap;
-}
-.toast.visible         { opacity: 1; transform: translateX(-50%) translateY(0); }
-.toast--error    { border-color: var(--danger);  color: var(--danger);  }
-.toast--success  { border-color: var(--success); color: var(--success); }
-.toast--warn     { border-color: var(--warn);    color: var(--warn);    }
-.toast--info     { border-color: var(--accent);  color: var(--accent);  }
+/* Aquí vivían los estilos del `SeqToast` legacy (`.toast`, `.toast.visible`,
+   `.toast--*`). El toast lo renderiza AppToast.vue desde la migración a Vue
+   (cdf50d35) con sus propios estilos scoped, y nada volvió a poner la clase
+   `visible`, así que este bloque quedó muerto — pero no inerte: al ser global
+   seguía ganando en toda propiedad que el bloque scoped no declarase. Su
+   `opacity: 0` volvía el toast invisible en cuanto Vue retiraba
+   `.toast-enter-active` al acabar la animación de entrada (0.42 s), y su
+   `left: 50%` + `transform: translateX(-50%)` lo descolocaban. Ver #127. */
 
 .badge {
   display: inline-block; padding: 2px 7px; border-radius: 4px;

--- a/web/app/src/components/aegis/CampaignModal.vue
+++ b/web/app/src/components/aegis/CampaignModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
-    <div class="modal-overlay" data-module="aegis" @click.self="close" @keydown.esc="close">
-      <div class="modal--campaign" role="dialog" aria-modal="true" aria-labelledby="campaign-modal-title">
+    <div class="modal-overlay" data-module="aegis" @click.self="close">
+      <div ref="boxRef" class="modal--campaign" role="dialog" aria-modal="true" aria-labelledby="campaign-modal-title" tabindex="-1">
         <header class="campaign-header">
           <div class="campaign-header-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
@@ -164,6 +164,7 @@ bob@empresa.com"
 import { computed, ref } from 'vue'
 import { useAegisStore } from '@/stores/aegisStore'
 import { useUtils } from '@/composables/useUtils'
+import { useModalA11y } from '@/composables/useModalA11y'
 import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const props = defineProps({ doc: { type: Object, required: true } })
@@ -171,6 +172,8 @@ const emit = defineEmits(['close'])
 
 const store = useAegisStore()
 const { formatDate, parseEmails } = useUtils()
+
+const boxRef = ref(null)
 
 function defaultCampaignName() {
   const title = props.doc?.subtitle || props.doc?.title || 'Píldora'
@@ -226,6 +229,8 @@ async function handleLaunch() {
 
 function close() { emit('close') }
 
+useModalA11y(() => true, { boxRef, onClose: close })
+
 const deleteTarget = ref(null)
 async function confirmDelete() {
   const campaign = deleteTarget.value
@@ -266,7 +271,7 @@ const stats = computed(() => {
 
 <style scoped>
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 1rem; }
-.modal--campaign { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; }
+.modal--campaign { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; outline: none; }
 
 .campaign-header { display: flex; align-items: flex-start; gap: 0.75rem; padding: 1.1rem 1.25rem 0.9rem; border-bottom: 1px solid var(--border); flex-shrink: 0; }
 .campaign-header-icon { width: 34px; height: 34px; border-radius: 9px; background: var(--accent-dim); color: var(--accent-bright); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }

--- a/web/app/src/components/aegis/DistributionListsModal.vue
+++ b/web/app/src/components/aegis/DistributionListsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
-    <div class="modal-overlay" data-module="aegis" @click.self="close" @keydown.esc="close">
-      <div class="modal--lists" role="dialog" aria-modal="true" aria-labelledby="lists-modal-title">
+    <div class="modal-overlay" data-module="aegis" @click.self="close">
+      <div ref="boxRef" class="modal--lists" role="dialog" aria-modal="true" aria-labelledby="lists-modal-title" tabindex="-1">
         <header class="lists-header">
           <div class="lists-header-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
@@ -127,12 +127,15 @@
 import { computed, ref, watch } from 'vue'
 import { useAegisStore } from '@/stores/aegisStore'
 import { useUtils } from '@/composables/useUtils'
+import { useModalA11y } from '@/composables/useModalA11y'
 import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const emit = defineEmits(['close'])
 
 const store = useAegisStore()
 const { parseEmails } = useUtils()
+
+const boxRef = ref(null)
 
 /* Una sola caja de "añadir": solo hay una lista desplegada a la vez. */
 const addRaw = ref('')
@@ -162,11 +165,13 @@ async function confirmDelete() {
 }
 
 function close() { emit('close') }
+
+useModalA11y(() => true, { boxRef, onClose: close })
 </script>
 
 <style scoped>
 .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 1rem; }
-.modal--lists { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; }
+.modal--lists { background: var(--surface); border: 1px solid var(--border-solid); border-radius: var(--radius); max-width: 460px; width: 100%; max-height: 88vh; display: flex; flex-direction: column; overflow: hidden; outline: none; }
 
 .lists-header { display: flex; align-items: flex-start; gap: 0.75rem; padding: 1.1rem 1.25rem 0.9rem; border-bottom: 1px solid var(--border); flex-shrink: 0; }
 .lists-header-icon { width: 34px; height: 34px; border-radius: 9px; background: var(--accent-dim); color: var(--accent-bright); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }

--- a/web/app/src/components/aegis/OrgProfilePanel.vue
+++ b/web/app/src/components/aegis/OrgProfilePanel.vue
@@ -153,6 +153,11 @@
             </button>
           </div>
 
+          <WhiteLabelFields
+            v-model="store.whiteLabel"
+            :max-level="store.maxWhiteLabelLevel"
+          />
+
           <button
             type="button"
             class="btn-save-profile"
@@ -182,6 +187,7 @@
 <script setup>
 import { ref, computed, onMounted } from "vue";
 import { useAegisStore } from "@/stores/aegisStore";
+import WhiteLabelFields from "@/components/shared/WhiteLabelFields.vue";
 import TrackedProductsModal from "./TrackedProductsModal.vue";
 
 const store = useAegisStore();

--- a/web/app/src/components/aegis/OrgProfilePanel.vue
+++ b/web/app/src/components/aegis/OrgProfilePanel.vue
@@ -11,11 +11,8 @@
     </button>
 
     <p v-if="!expanded" class="op-summary">
-      {{ store.tweaks.company || "Sin configurar todavía" }}
-      <span v-if="usingInventory"> · productos de mis agentes</span>
-      <span v-else-if="store.trackedProducts.length">
-        · {{ store.trackedProducts.length }} producto(s)</span
-      >
+      {{ store.tweaks.company || "Sin configurar todavía" }} ·
+      {{ productsSummary }}
     </p>
 
     <div class="op-collapse" :class="{ expanded }">
@@ -140,71 +137,20 @@
             </div>
           </div>
 
-          <!-- Solo se ofrece si hay algún agente que haya reportado
-               inventario; si no, la preferencia queda latente. -->
-          <div class="form-group" v-if="store.hygeiaInventoryAvailable">
-            <label class="switch-row">
-              <input type="checkbox" v-model="store.useHygeiaInventory" />
-              <span>
-                Deducir los productos de mis agentes
-                <small
-                  >Usa el software que Hygeia inventaría en tus activos en
-                  lugar de la lista de abajo.</small
-                >
-              </span>
-            </label>
-          </div>
-
-          <div class="form-group" :class="{ 'form-group--muted': usingInventory }">
-            <label for="op-products">Productos vigilados</label>
-            <p class="field-hint" v-if="usingInventory">
-              Ahora mismo se usan los de tus agentes. Esta lista queda como
-              alternativa si desactivas la opción de arriba.
-            </p>
-
-            <div class="selected-brands" v-if="store.trackedProducts.length">
-              <span
-                v-for="p in store.trackedProducts"
-                :key="`${p.vendor}:${p.product}`"
-                class="brand-tag"
-              >
-                {{ p.vendor }}<template v-if="p.product"> · {{ p.product }}</template>
-                <button
-                  type="button"
-                  class="brand-remove"
-                  :aria-label="`Quitar ${p.vendor} ${p.product}`"
-                  @click="store.removeTrackedProduct(p)"
-                >
-                  &times;
-                </button>
-              </span>
-            </div>
-
-            <input
-              id="op-products"
-              v-model="productQuery"
-              type="search"
-              class="input"
-              placeholder="Busca un producto: windows, firefox, apache…"
-              autocomplete="off"
-              @input="onProductQuery"
-            />
-            <p class="field-hint" v-if="store.searchingProducts">Buscando…</p>
-            <p
-              class="field-hint"
-              v-else-if="productQuery.trim().length >= 2 && !store.productResults.length"
+          <!-- El buscador y el interruptor de inventario viven ahora en su
+               propio modal: en 400 px de panel no cabían. La lista de
+               seleccionados crecía sin tope y empujaba el buscador, y la de
+               resultados desplazaba al botón de guardar. -->
+          <div class="form-group">
+            <label>Productos vigilados</label>
+            <button
+              type="button"
+              class="products-btn"
+              @click="productsModalOpen = true"
             >
-              Sin coincidencias en el catálogo de vulnerabilidades.
-            </p>
-
-            <ul class="product-results" v-if="store.productResults.length">
-              <li v-for="p in store.productResults" :key="`${p.vendor}:${p.product}`">
-                <button type="button" @click="pickProduct(p)">
-                  <span class="product-name">{{ p.displayName }}</span>
-                  <span class="product-cpe">{{ p.vendor }}:{{ p.product }}</span>
-                </button>
-              </li>
-            </ul>
+              <span>Gestionar productos</span>
+              <span class="products-count">{{ productsSummary }}</span>
+            </button>
           </div>
 
           <button
@@ -225,12 +171,18 @@
         </div>
       </div>
     </div>
+
+    <TrackedProductsModal
+      :show="productsModalOpen"
+      @close="productsModalOpen = false"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useAegisStore } from "@/stores/aegisStore";
+import TrackedProductsModal from "./TrackedProductsModal.vue";
 
 const store = useAegisStore();
 
@@ -238,28 +190,24 @@ const store = useAegisStore();
 // mes); expandido si es la primera vez. Se ajusta tras cargar el perfil.
 const expanded = ref(true);
 
-const productQuery = ref("");
+const productsModalOpen = ref(false);
 
 /** Origen efectivo de los productos: los agentes mandan cuando están activos. */
 const usingInventory = computed(
   () => store.hygeiaInventoryAvailable && store.useHygeiaInventory,
 );
 
-// Debounce: cada pulsación consultaría el índice CPE, y el endpoint está
-// limitado a 120 peticiones/hora.
-let queryTimer = null;
-function onProductQuery() {
-  clearTimeout(queryTimer);
-  const term = productQuery.value;
-  queryTimer = setTimeout(() => store.searchProducts(term), 250);
-}
-
-function pickProduct(product) {
-  store.addTrackedProduct(product);
-  productQuery.value = "";
-}
-
-onUnmounted(() => clearTimeout(queryTimer));
+/**
+ * Qué se está vigilando, en una línea. Lo usan el resumen del acordeón
+ * colapsado y el botón que abre el modal: antes cada uno lo calculaba por su
+ * cuenta en el template.
+ */
+const productsSummary = computed(() => {
+  if (usingInventory.value) return "productos de mis agentes";
+  const count = store.trackedProducts.length;
+  if (!count) return "sin productos";
+  return count === 1 ? "1 producto" : `${count} productos`;
+});
 
 async function handleSave() {
   const ok = await store.saveOrgProfile();
@@ -377,103 +325,31 @@ onMounted(async () => {
 .input[type="number"] {
   -moz-appearance: textfield;
 }
-.selected-brands {
+/* ── Acceso al modal de productos vigilados ── */
+.products-btn {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  margin-bottom: 0.3rem;
-}
-.brand-tag {
-  display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.15rem 0.4rem;
-  font-size: var(--fs-md);
-  font-weight: 600;
-  background: var(--accent);
-  color: var(--on-accent);
-  border-radius: 4px;
-}
-.brand-remove {
-  background: none;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font-size: var(--fs-xl);
-  padding: 0;
-  line-height: 1;
-  opacity: 0.7;
-}
-.brand-remove:hover {
-  opacity: 1;
-}
-
-/* ── Buscador de productos (índice CPE) ── */
-.field-hint {
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-  margin: 0.2rem 0;
-}
-.form-group--muted .selected-brands,
-.form-group--muted .input {
-  opacity: 0.6;
-}
-.switch-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-.switch-row input {
-  margin-top: 0.25rem;
-  accent-color: var(--accent);
-  flex: 0 0 auto;
-}
-.switch-row small {
-  display: block;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-  font-weight: 400;
-}
-.product-results {
-  list-style: none;
-  margin: 0.3rem 0 0;
-  padding: 0;
-  max-height: 11rem;
-  overflow-y: auto;
-  border: 1px solid var(--border-med);
-  border-radius: var(--radius-sm);
-  background: var(--bg);
-}
-.product-results button {
-  display: flex;
   justify-content: space-between;
-  align-items: baseline;
   gap: 0.5rem;
   width: 100%;
-  padding: 0.4rem 0.55rem;
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  font-family: inherit;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-solid);
+  background: var(--bg);
   color: var(--text);
+  font-family: inherit;
+  font-size: var(--fs-input);
+  cursor: pointer;
+  transition: border-color 0.2s;
 }
-.product-results button:hover {
-  background: var(--accent-dim);
+.products-btn:hover {
+  border-color: var(--accent);
 }
-.product-results button:focus-visible {
-  outline: 2px solid var(--accent-bright);
-  outline-offset: -2px;
-}
-.product-name {
-  font-size: var(--fs-md);
-}
-.product-cpe {
-  font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  flex-shrink: 0;
+.products-count {
+  flex: 0 0 auto;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--accent-bright);
 }
 .btn-save-profile {
   margin-top: 0.2rem;

--- a/web/app/src/components/aegis/TrackedProductsModal.vue
+++ b/web/app/src/components/aegis/TrackedProductsModal.vue
@@ -138,8 +138,9 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useAegisStore } from "@/stores/aegisStore";
+import { useModalA11y } from "@/composables/useModalA11y";
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -183,8 +184,7 @@ function close() {
   emit("close");
 }
 
-// Al abrir se parte de cero; al cerrar se sueltan el bloqueo del scroll y el
-// listener global.
+// Al abrir se parte de cero; al cerrar se limpia el debounce pendiente.
 watch(
   () => props.show,
   (visible) => {
@@ -193,56 +193,13 @@ watch(
       // Con menos de 2 caracteres esto solo limpia resultados y error, sin
       // llegar a pedir nada. Evita tocar el estado del store a mano.
       store.searchProducts("");
-      document.body.style.overflow = "hidden";
-      nextTick(() => searchRef.value?.focus());
-      window.addEventListener("keydown", onGlobalKeydown);
     } else {
       clearTimeout(queryTimer);
-      document.body.style.overflow = "";
-      window.removeEventListener("keydown", onGlobalKeydown);
     }
   },
 );
 
-onBeforeUnmount(() => {
-  document.body.style.overflow = "";
-  window.removeEventListener("keydown", onGlobalKeydown);
-  clearTimeout(queryTimer);
-});
-
-/**
- * Escape cierra y Tab queda atrapado dentro del modal. El listener va en
- * `window` y no como `@keydown.esc` en el overlay: sobre un div solo dispara
- * si el foco está dentro, que es el fallo que arrastran CampaignModal y
- * DistributionListsModal.
- */
-function onGlobalKeydown(e) {
-  if (e.key === "Escape") {
-    close();
-    return;
-  }
-  if (e.key === "Tab") trapFocus(e);
-}
-
-function trapFocus(e) {
-  const root = boxRef.value;
-  if (!root) return;
-  const focusables = Array.from(
-    root.querySelectorAll(
-      'button:not(:disabled), input, [tabindex]:not([tabindex="-1"])',
-    ),
-  );
-  if (!focusables.length) return;
-  const first = focusables[0];
-  const last = focusables[focusables.length - 1];
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault();
-    last.focus();
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault();
-    first.focus();
-  }
-}
+useModalA11y(() => props.show, { boxRef, autofocusRef: searchRef, onClose: close });
 </script>
 
 <style scoped>

--- a/web/app/src/components/aegis/TrackedProductsModal.vue
+++ b/web/app/src/components/aegis/TrackedProductsModal.vue
@@ -1,0 +1,513 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <!-- `data-module` va en el overlay, no en la página: Teleport saca este
+           nodo de la raíz de la vista y sin esto el modal heredaría el acento
+           dorado por defecto en vez del de Aegis. -->
+      <div
+        v-if="show"
+        class="tp-overlay"
+        data-module="aegis"
+        @click.self="close"
+      >
+        <!-- Prefijo `tp-` en vez de `modal-`: shared.css define `.modal`,
+             `.modal-header` y compañía de forma global (restos del legacy), y
+             un bloque scoped solo gana en las propiedades que declara — el
+             global se cuela en todas las demás. IrisArchiveModal escapa igual
+             con `archive-`. -->
+        <div
+          ref="boxRef"
+          class="tp-box"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="tp-title"
+        >
+          <div class="tp-header">
+            <h3 id="tp-title">Productos vigilados</h3>
+            <button
+              type="button"
+              class="tp-close"
+              aria-label="Cerrar"
+              title="Cerrar (Esc)"
+              @click="close"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="tp-body">
+            <!-- Solo se ofrece si hay algún agente que haya reportado
+                 inventario; si no, la preferencia queda latente. -->
+            <label v-if="store.hygeiaInventoryAvailable" class="tp-switch">
+              <input type="checkbox" v-model="store.useHygeiaInventory" />
+              <span>
+                Deducir los productos de mis agentes
+                <small
+                  >Usa el software que Hygeia inventaría en tus activos en lugar
+                  de la lista de abajo.</small
+                >
+              </span>
+            </label>
+
+            <p v-if="usingInventory" class="tp-hint">
+              Ahora mismo se usan los de tus agentes. Esta lista queda como
+              alternativa si desactivas la opción de arriba.
+            </p>
+
+            <input
+              id="tp-search"
+              ref="searchRef"
+              v-model="productQuery"
+              type="search"
+              class="tp-search"
+              placeholder="Busca un producto: windows, firefox, apache…"
+              autocomplete="off"
+              @input="onProductQuery"
+            />
+
+            <!-- Un solo hueco para todos los estados, encadenados por
+                 prioridad: lo que esté pasando ahora manda sobre lo anterior. -->
+            <p class="tp-hint" aria-live="polite">
+              <template v-if="store.searchingProducts">Buscando…</template>
+              <template v-else-if="store.productSearchError">{{
+                store.productSearchError
+              }}</template>
+              <template v-else-if="trimmedQuery.length === 1"
+                >Escribe al menos 2 caracteres.</template
+              >
+              <template
+                v-else-if="trimmedQuery.length >= 2 && !store.productResults.length"
+                >Sin coincidencias en el catálogo de vulnerabilidades.</template
+              >
+            </p>
+
+            <ul v-if="store.productResults.length" class="tp-results">
+              <li
+                v-for="p in store.productResults"
+                :key="`${p.vendor}:${p.product}`"
+              >
+                <button type="button" @click="pickProduct(p)">
+                  <span class="tp-name">{{ p.displayName }}</span>
+                  <span class="tp-cpe">{{ p.vendor }}:{{ p.product }}</span>
+                </button>
+              </li>
+            </ul>
+
+            <!-- Los seleccionados van DEBAJO de los resultados, al revés que en
+                 AssetTagsModal: así el buscador y la lista no se desplazan
+                 hacia abajo cada vez que se añade uno, que es justo donde está
+                 mirando el usuario mientras escribe. -->
+            <div class="tp-chosen" :class="{ 'tp-chosen--muted': usingInventory }">
+              <p class="tp-chosen-title">
+                {{ countLabel }}
+              </p>
+              <div v-if="store.trackedProducts.length" class="tp-chips">
+                <span
+                  v-for="p in store.trackedProducts"
+                  :key="`${p.vendor}:${p.product}`"
+                  class="tp-chip"
+                >
+                  {{ p.vendor
+                  }}<template v-if="p.product"> · {{ p.product }}</template>
+                  <button
+                    type="button"
+                    class="tp-chip-remove"
+                    :aria-label="`Quitar ${p.vendor} ${p.product}`"
+                    @click="store.removeTrackedProduct(p)"
+                  >
+                    &times;
+                  </button>
+                </span>
+              </div>
+              <p v-else class="empty-state">Aún no vigilas ningún producto.</p>
+            </div>
+          </div>
+
+          <!-- El pie es hermano de `.tp-body`, no hijo: así queda fuera del
+               scroll y el botón no se mueve por muchos resultados que haya. -->
+          <div class="tp-footer">
+            <p class="tp-save-note">
+              Los cambios se guardan con «Guardar perfil».
+            </p>
+            <button type="button" class="tp-done" @click="close">Listo</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { useAegisStore } from "@/stores/aegisStore";
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+});
+const emit = defineEmits(["close"]);
+
+const store = useAegisStore();
+
+const productQuery = ref("");
+const searchRef = ref(null);
+const boxRef = ref(null);
+
+const trimmedQuery = computed(() => productQuery.value.trim());
+
+/** Origen efectivo de los productos: los agentes mandan cuando están activos. */
+const usingInventory = computed(
+  () => store.hygeiaInventoryAvailable && store.useHygeiaInventory,
+);
+
+const countLabel = computed(() => {
+  const count = store.trackedProducts.length;
+  if (!count) return "Seleccionados";
+  return count === 1 ? "1 producto vigilado" : `${count} productos vigilados`;
+});
+
+// Debounce: cada pulsación consultaría el índice CPE, y el endpoint está
+// limitado a 120 peticiones/hora.
+let queryTimer = null;
+function onProductQuery() {
+  clearTimeout(queryTimer);
+  const term = productQuery.value;
+  queryTimer = setTimeout(() => store.searchProducts(term), 250);
+}
+
+function pickProduct(product) {
+  store.addTrackedProduct(product);
+  productQuery.value = "";
+}
+
+function close() {
+  emit("close");
+}
+
+// Al abrir se parte de cero; al cerrar se sueltan el bloqueo del scroll y el
+// listener global.
+watch(
+  () => props.show,
+  (visible) => {
+    if (visible) {
+      productQuery.value = "";
+      // Con menos de 2 caracteres esto solo limpia resultados y error, sin
+      // llegar a pedir nada. Evita tocar el estado del store a mano.
+      store.searchProducts("");
+      document.body.style.overflow = "hidden";
+      nextTick(() => searchRef.value?.focus());
+      window.addEventListener("keydown", onGlobalKeydown);
+    } else {
+      clearTimeout(queryTimer);
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onGlobalKeydown);
+    }
+  },
+);
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = "";
+  window.removeEventListener("keydown", onGlobalKeydown);
+  clearTimeout(queryTimer);
+});
+
+/**
+ * Escape cierra y Tab queda atrapado dentro del modal. El listener va en
+ * `window` y no como `@keydown.esc` en el overlay: sobre un div solo dispara
+ * si el foco está dentro, que es el fallo que arrastran CampaignModal y
+ * DistributionListsModal.
+ */
+function onGlobalKeydown(e) {
+  if (e.key === "Escape") {
+    close();
+    return;
+  }
+  if (e.key === "Tab") trapFocus(e);
+}
+
+function trapFocus(e) {
+  const root = boxRef.value;
+  if (!root) return;
+  const focusables = Array.from(
+    root.querySelectorAll(
+      'button:not(:disabled), input, [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+<style scoped>
+.tp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+/* `min-height: 0` en toda la cadena flex: sin él un hijo no se encoge por
+   debajo de su contenido y ninguno de los `max-height` de abajo recorta nada
+   — que es exactamente lo que le pasaba al panel. */
+.tp-box {
+  display: flex;
+  flex-direction: column;
+  width: min(560px, 100%);
+  max-height: 85vh;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+.tp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+.tp-header h3 {
+  margin: 0;
+  font-size: var(--fs-xl);
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size-adjust: var(--fsa-display);
+}
+.tp-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--fs-xl);
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+.tp-close:hover {
+  color: var(--text);
+}
+
+.tp-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 0;
+  overflow: hidden;
+  padding: 1rem 1.1rem;
+}
+
+.tp-switch {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  color: var(--text-dim);
+  flex: 0 0 auto;
+}
+.tp-switch input {
+  margin-top: 0.25rem;
+  accent-color: var(--accent);
+  flex: 0 0 auto;
+}
+.tp-switch small {
+  display: block;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.tp-hint {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin: 0;
+  min-height: 1.2em;
+  flex: 0 0 auto;
+}
+
+.tp-search {
+  background: var(--bg);
+  border: 1px solid var(--border-solid);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: var(--text);
+  font-size: var(--fs-input);
+  font-family: inherit;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+  flex: 0 0 auto;
+}
+.tp-search:focus {
+  border-color: var(--accent);
+}
+
+/* Deja de ser in-flow sin tope real: aquí se queda con su alto y hace scroll,
+   en vez de empujar el botón de guardar fuera de la vista. */
+.tp-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: 20rem;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-med);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.tp-results button {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  width: 100%;
+  min-width: 0;
+  padding: 0.4rem 0.55rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--text);
+}
+.tp-results button:hover {
+  background: var(--accent-dim);
+}
+.tp-results button:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: -2px;
+}
+/* El `min-width: 0` es lo que permite que el ellipsis funcione dentro de flex:
+   sin él un hijo no baja de su ancho de contenido y el nombre desborda. */
+.tp-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-md);
+}
+.tp-cpe {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size-adjust: var(--fsa-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+.tp-chosen {
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: 7.5rem;
+  overflow-y: auto;
+  padding-top: 0.6rem;
+  border-top: 1px dashed var(--border-med);
+}
+.tp-chosen--muted {
+  opacity: 0.6;
+}
+.tp-chosen-title {
+  margin: 0 0 0.4rem;
+  font-size: var(--fs-caption);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+.tp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+.tp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.4rem;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--on-accent);
+  border-radius: 4px;
+}
+.tp-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: var(--fs-xl);
+  padding: 0;
+  line-height: 1;
+  opacity: 0.7;
+}
+.tp-chip-remove:hover {
+  opacity: 1;
+}
+
+.tp-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  padding: 0.75rem 1.1rem;
+  border-top: 1px solid var(--border);
+}
+.tp-save-note {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+.tp-done {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.9rem;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-family: inherit;
+  font-size: var(--fs-md);
+  font-weight: 600;
+  cursor: pointer;
+}
+.tp-done:hover {
+  background: var(--accent-bright);
+}
+
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 560px) {
+  .tp-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tp-done {
+    width: 100%;
+  }
+}
+</style>

--- a/web/app/src/components/iris/IrisArchiveModal.vue
+++ b/web/app/src/components/iris/IrisArchiveModal.vue
@@ -158,9 +158,10 @@
  * campo — antes inexistentes (el "orden" de la tira solo reordenaba lo ya
  * cargado en cliente).
  */
-import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+import { ref, watch, onBeforeUnmount } from 'vue'
 import AppPagination from '@/components/shared/AppPagination.vue'
 import { useIrisStore } from '@/stores/irisStore'
+import { useModalA11y } from '@/composables/useModalA11y'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -214,22 +215,16 @@ watch(() => props.show, (visible) => {
   if (visible) {
     searchInput.value = store.archive.filters.search
     focusedIndex.value = -1
-    document.body.style.overflow = 'hidden'
     store.fetchArchive()
-    nextTick(() => searchRef.value?.focus())
-    window.addEventListener('keydown', onGlobalKeydown)
-  } else {
-    document.body.style.overflow = ''
-    window.removeEventListener('keydown', onGlobalKeydown)
   }
 })
 
 onBeforeUnmount(() => {
-  document.body.style.overflow = ''
-  window.removeEventListener('keydown', onGlobalKeydown)
   clearTimeout(searchDebounce)
   clearTimeout(loadingTimer)
 })
+
+useModalA11y(() => props.show, { boxRef, autofocusRef: searchRef, onClose: close, onKeydown: onExtraKeydown })
 
 function close() {
   emit('close')
@@ -278,13 +273,11 @@ function formatDate(iso) {
   catch { return iso }
 }
 
-/** Escape cierra; "/" enfoca la búsqueda; ↑/↓ recorren filas; Enter abre la
- * fila enfocada; Tab queda atrapado dentro del modal mientras está abierto —
- * ConfirmModal no hace ninguna de las dos últimas cosas, pero a esta escala
- * (una tabla completa) se echan en falta. */
-function onGlobalKeydown(e) {
-  if (e.key === 'Escape') { close(); return }
-
+/** "/" enfoca la búsqueda; ↑/↓ recorren filas; Enter abre la fila enfocada —
+ * Escape y Tab ya los cubre useModalA11y. ConfirmModal no hace ninguna de
+ * las dos cosas de aquí, pero a esta escala (una tabla completa) se echan en
+ * falta. */
+function onExtraKeydown(e) {
   if (e.key === '/' && document.activeElement !== searchRef.value) {
     e.preventDefault()
     searchRef.value?.focus()
@@ -305,28 +298,9 @@ function onGlobalKeydown(e) {
   if (e.key === 'Enter' && focusedIndex.value >= 0) {
     const item = items[focusedIndex.value]
     if (item) choose(item.analysisId)
-    return
-  }
-  if (e.key === 'Tab') {
-    trapFocus(e)
   }
 }
 
-function trapFocus(e) {
-  const root = boxRef.value
-  if (!root) return
-  const focusables = Array.from(root.querySelectorAll('button:not(:disabled), input, [tabindex]:not([tabindex="-1"])'))
-  if (!focusables.length) return
-  const first = focusables[0]
-  const last = focusables[focusables.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
 </script>
 
 <style scoped>

--- a/web/app/src/components/iris/IrisDocumentsModal.vue
+++ b/web/app/src/components/iris/IrisDocumentsModal.vue
@@ -110,6 +110,22 @@ function verdictClass(v) {
 </script>
 
 <style scoped>
+/* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
+   (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
+   se borra (#131). */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.modal.visible {
+  display: flex;
+}
+
 .docs-modal-content {
   max-width: 560px;
 }

--- a/web/app/src/components/shared/AccountMenu.vue
+++ b/web/app/src/components/shared/AccountMenu.vue
@@ -198,6 +198,8 @@ onUnmounted(() => {
 .drop {
   position: absolute; top: calc(100% + 0.7rem); right: 0; z-index: 60;
   width: 300px;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
   background: var(--surface);
   border: 1px solid var(--border-solid);
   border-radius: 10px;

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -94,6 +94,13 @@ const toast = useToastStore()
   animation: toast-out 0.22s ease-in both;
 }
 
+/* Estado inicial de la entrada y final de la salida. En el caso normal los
+   `@keyframes` lo pisan, pero son lo único que queda cuando reduced-motion
+   anula la animación: sin estas dos reglas ahí no había nada que transicionar
+   y el fundido declarado más abajo era un corte seco. */
+.toast-enter-from,
+.toast-leave-to { opacity: 0; }
+
 @keyframes toast-in {
   0% { opacity: 0; transform: translate3d(0, 1.2rem, 0) scale(0.96); filter: blur(4px); }
   65% { opacity: 1; transform: translate3d(0, -0.15rem, 0) scale(1.005); filter: blur(0); }

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -46,7 +46,6 @@ const toast = useToastStore()
   position: fixed; bottom: 2rem; right: 2rem;
   z-index: 9999;
   pointer-events: none;
-  max-width: min(460px, calc(100vw - 2rem));
 }
 
 .toast {
@@ -56,7 +55,10 @@ const toast = useToastStore()
   font-size: var(--fs-body); font-weight: 500; line-height: 1.35;
   background: var(--surface-3); border: 1px solid var(--border);
   color: var(--text);
-  max-width: 100%; max-height: 7.5rem; overflow-y: auto;
+  /* El tope va aquí y no en la región: la región es `position: fixed` sin
+     ancho, o sea shrink-to-fit, y un `max-width: 100%` del hijo contra eso es
+     circular — el navegador lo ignora y el toast se estira más de la cuenta. */
+  max-width: min(460px, calc(100vw - 2rem)); max-height: 7.5rem; overflow-y: auto;
   overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap;
   backdrop-filter: blur(12px);
   box-shadow: 0 12px 32px rgba(0,0,0,0.34);
@@ -118,11 +120,8 @@ const toast = useToastStore()
 }
 
 @media (max-width: 560px) {
-  .toast-region {
-    right: 1rem; bottom: 1rem;
-    max-width: calc(100vw - 2rem);
-  }
-  .toast { align-items: flex-start; }
+  .toast-region { right: 1rem; bottom: 1rem; }
+  .toast { align-items: flex-start; max-width: calc(100vw - 2rem); }
   .toast__action { white-space: normal; }
 }
 

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -5,31 +5,53 @@ const toast = useToastStore()
 
 <template>
   <Teleport to="body">
-    <Transition name="toast">
-      <div v-if="toast.visible" :key="toast.id" class="toast"
-           :class="toast.type ? `toast--${toast.type}` : ''"
-           role="alert" aria-live="assertive">
-        <span class="toast__message">{{ toast.message }}</span>
-        <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
-                    @click="toast.dismiss">
-          {{ toast.action.label }}
-        </RouterLink>
-        <button type="button" class="toast__close" aria-label="Cerrar notificación"
-                @click="toast.dismiss">&times;</button>
-      </div>
-    </Transition>
+    <!--
+      La región live está siempre montada, aunque no haya toast. Un `aria-live`
+      solo se anuncia si ya existía en el DOM antes de que cambie su contenido;
+      cuando el `role="alert"` iba en el <div> del toast, que nace y muere con
+      el v-if, los lectores de pantalla no decían nada.
+
+      El toast tampoco lleva ya `:key`: con un único elemento bajo `v-if` la
+      clave es redundante (el <div> se crea de cero al pasar de oculto a
+      visible, y la animación de entrada corre igual), y cambiarla mientras la
+      salida seguía animando metía el entrante y el saliente a la vez en el DOM
+      — dos toasts `position: fixed` superpuestos en el mismo píxel.
+    -->
+    <div class="toast-region" role="alert" aria-live="assertive" aria-atomic="true">
+      <Transition name="toast">
+        <div v-if="toast.visible" class="toast"
+             :class="toast.type ? `toast--${toast.type}` : ''">
+          <span class="toast__message">{{ toast.message }}</span>
+          <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
+                      @click="toast.dismiss">
+            {{ toast.action.label }}
+          </RouterLink>
+          <button type="button" class="toast__close" aria-label="Cerrar notificación"
+                  @click="toast.dismiss">&times;</button>
+        </div>
+      </Transition>
+    </div>
   </Teleport>
 </template>
 
 <style scoped>
-.toast {
+/* El posicionamiento vive en la región, no en el toast: la región está montada
+   siempre, así que no debe interceptar clics cuando está vacía. */
+.toast-region {
   position: fixed; bottom: 2rem; right: 2rem;
+  z-index: 9999;
+  pointer-events: none;
+  max-width: min(460px, calc(100vw - 2rem));
+}
+
+.toast {
+  pointer-events: auto;
   display: flex; align-items: center; gap: 0.75rem;
   padding: 0.8rem 0.8rem 0.8rem 1.1rem; border-radius: 8px;
   font-size: var(--fs-body); font-weight: 500; line-height: 1.35;
   background: var(--surface-3); border: 1px solid var(--border);
-  color: var(--text); z-index: 9999;
-  max-width: min(460px, calc(100vw - 2rem)); max-height: 7.5rem; overflow-y: auto;
+  color: var(--text);
+  max-width: 100%; max-height: 7.5rem; overflow-y: auto;
   overflow-wrap: anywhere; word-break: break-word; white-space: pre-wrap;
   backdrop-filter: blur(12px);
   box-shadow: 0 12px 32px rgba(0,0,0,0.34);
@@ -84,11 +106,11 @@ const toast = useToastStore()
 }
 
 @media (max-width: 560px) {
-  .toast {
+  .toast-region {
     right: 1rem; bottom: 1rem;
-    align-items: flex-start;
     max-width: calc(100vw - 2rem);
   }
+  .toast { align-items: flex-start; }
   .toast__action { white-space: normal; }
 }
 

--- a/web/app/src/components/shared/AppToast.vue
+++ b/web/app/src/components/shared/AppToast.vue
@@ -19,8 +19,13 @@ const toast = useToastStore()
     -->
     <div class="toast-region" role="alert" aria-live="assertive" aria-atomic="true">
       <Transition name="toast">
+        <!-- La cuenta atrás se congela mientras el toast se lee o se recorre
+             con el teclado; `focusin`/`focusout` burbujean, así que cubren
+             también el enlace de acción y el botón de cerrar. -->
         <div v-if="toast.visible" class="toast"
-             :class="toast.type ? `toast--${toast.type}` : ''">
+             :class="toast.type ? `toast--${toast.type}` : ''"
+             @mouseenter="toast.pause" @mouseleave="toast.resume"
+             @focusin="toast.pause" @focusout="toast.resume">
           <span class="toast__message">{{ toast.message }}</span>
           <RouterLink v-if="toast.action?.to" class="toast__action" :to="toast.action.to"
                       @click="toast.dismiss">

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -149,7 +149,7 @@ function onFile(event) {
 .wl-legend {
   padding: 0; font-size: var(--fs-md); font-weight: 600; color: var(--text);
 }
-.wl-hint { margin: 0; font-size: var(--fs-xs); color: var(--text-muted); }
+.wl-hint { margin: 0; font-size: var(--fs-sm); color: var(--text-muted); }
 
 .wl-option {
   display: flex; align-items: flex-start; gap: 0.55rem;
@@ -163,7 +163,7 @@ function onFile(event) {
 .wl-option input { margin-top: 0.2rem; accent-color: var(--accent); }
 .wl-option-text { display: flex; flex-direction: column; gap: 0.15rem; }
 .wl-option-title { font-size: var(--fs-md); font-weight: 600; color: var(--text); }
-.wl-option-text small { font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.35; }
+.wl-option-text small { font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.35; }
 .wl-lock {
   margin-left: 0.4rem; padding: 0 0.35rem; border-radius: 4px;
   font-size: var(--fs-xs); font-weight: 600; text-transform: uppercase;
@@ -198,6 +198,6 @@ function onFile(event) {
 .wl-note {
   margin: 0.2rem 0 0; padding: 0.5rem 0.65rem; border-radius: 6px;
   background: var(--surface-2); border-left: 2px solid var(--border-med);
-  font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.4;
+  font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.4;
 }
 </style>

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -27,9 +27,29 @@
       </span>
     </label>
 
-    <!-- La imagen solo se pide cuando algún nivel la usa: pedirla en "none"
-         sería ofrecer un campo que no se pinta en ninguna parte. -->
-    <div v-if="modelValue.level !== 'none'" class="wl-logo">
+    <!-- Cada campo se pide desde el escalón que lo usa: ofrecerlo antes sería
+         un control que no se pinta en ninguna parte. -->
+    <div v-if="modelValue.level !== 'none'" class="wl-color">
+      <label class="wl-color-label" for="wl-color-input">Color de énfasis</label>
+      <input
+        id="wl-color-input"
+        type="color"
+        class="wl-swatch"
+        :value="modelValue.color || DEFAULT_COLOR"
+        @input="update({ color: $event.target.value })"
+      />
+      <code class="wl-color-value">{{ modelValue.color || DEFAULT_COLOR }}</code>
+      <button
+        v-if="modelValue.color"
+        type="button"
+        class="wl-remove"
+        @click="update({ color: '' })"
+      >
+        Restablecer
+      </button>
+    </div>
+
+    <div v-if="levelRank >= LEVELS.indexOf('logo')" class="wl-logo">
       <div v-if="modelValue.logo" class="wl-preview">
         <img :src="modelValue.logo" alt="Logo de la organización" />
         <button type="button" class="wl-remove" @click="clearLogo">Quitar</button>
@@ -79,7 +99,11 @@ const emit = defineEmits(['update:modelValue'])
 const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/gif']
 const MAX_KB = 200
 
-const LEVELS = ['none', 'logo', 'full']
+//: El acento del producto, que es lo que se sustituye. Sirve de punto de
+//: partida del selector cuando la organización todavía no ha elegido color.
+const DEFAULT_COLOR = '#d4a04a'
+
+const LEVELS = ['none', 'color', 'logo', 'full']
 
 const options = [
   {
@@ -88,9 +112,14 @@ const options = [
     description: 'Los envíos salen con la marca de Ellysia, como hasta ahora.',
   },
   {
+    value: 'color',
+    title: 'Aplicar color corporativo',
+    description: 'El color de énfasis (botones, filetes y bordes) pasa a ser el de la organización.',
+  },
+  {
     value: 'logo',
     title: 'Añadir imagen corporativa',
-    description: 'Se añade el logo de la organización al contenido, sobre el texto introductorio.',
+    description: 'Además del color, se añade el logo de la organización sobre el texto introductorio.',
   },
   {
     value: 'full',
@@ -101,6 +130,7 @@ const options = [
 
 const error = ref('')
 
+const levelRank = computed(() => Math.max(0, LEVELS.indexOf(props.modelValue.level)))
 const maxRank = computed(() => Math.max(0, LEVELS.indexOf(props.maxLevel)))
 function isLocked(level) {
   return LEVELS.indexOf(level) > maxRank.value
@@ -169,6 +199,19 @@ function onFile(event) {
   font-size: var(--fs-xs); font-weight: 600; text-transform: uppercase;
   letter-spacing: 0.04em; color: var(--text-dim); background: var(--surface-3);
 }
+
+.wl-color { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.2rem; }
+.wl-color-label { font-size: var(--fs-sm); color: var(--text-dim); }
+/* El selector nativo trae un marco y un relleno propios en cada navegador:
+   se recortan para que la muestra sea solo el color. */
+.wl-swatch {
+  width: 34px; height: 26px; padding: 0; cursor: pointer;
+  background: none; border: 1px solid var(--border-solid); border-radius: 5px;
+}
+.wl-swatch::-webkit-color-swatch-wrapper { padding: 2px; }
+.wl-swatch::-webkit-color-swatch { border: none; border-radius: 3px; }
+.wl-swatch:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
+.wl-color-value { font-size: var(--fs-xs); color: var(--text-muted); }
 
 .wl-logo { display: flex; flex-direction: column; gap: 0.45rem; margin-top: 0.2rem; }
 .wl-preview { display: flex; align-items: center; gap: 0.6rem; }

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -1,0 +1,203 @@
+<template>
+  <fieldset class="wl">
+    <legend class="wl-legend">White-labeling</legend>
+    <p class="wl-hint">
+      Cuánto de la marca de Ellysia ve quien recibe los envíos de este módulo.
+    </p>
+
+    <label
+      v-for="option in options"
+      :key="option.value"
+      class="wl-option"
+      :class="{ 'wl-option--active': modelValue.level === option.value, 'wl-option--locked': isLocked(option.value) }"
+    >
+      <input
+        type="radio"
+        :value="option.value"
+        :checked="modelValue.level === option.value"
+        :disabled="isLocked(option.value)"
+        @change="setLevel(option.value)"
+      />
+      <span class="wl-option-text">
+        <span class="wl-option-title">
+          {{ option.title }}
+          <span v-if="isLocked(option.value)" class="wl-lock">No incluido en tu plan</span>
+        </span>
+        <small>{{ option.description }}</small>
+      </span>
+    </label>
+
+    <!-- La imagen solo se pide cuando algún nivel la usa: pedirla en "none"
+         sería ofrecer un campo que no se pinta en ninguna parte. -->
+    <div v-if="modelValue.level !== 'none'" class="wl-logo">
+      <div v-if="modelValue.logo" class="wl-preview">
+        <img :src="modelValue.logo" alt="Logo de la organización" />
+        <button type="button" class="wl-remove" @click="clearLogo">Quitar</button>
+      </div>
+
+      <label class="wl-file">
+        <input type="file" :accept="ACCEPTED_TYPES.join(',')" @change="onFile" />
+        <span>{{ modelValue.logo ? 'Cambiar imagen' : 'Añadir imagen corporativa' }}</span>
+      </label>
+
+      <p v-if="error" class="wl-error">{{ error }}</p>
+      <p v-else class="wl-hint">PNG, JPG o GIF, hasta {{ MAX_KB }} KB.</p>
+    </div>
+
+    <p v-if="modelValue.level === 'full'" class="wl-note">
+      El remitente del correo sigue siendo el del servidor configurado en la
+      instancia: el white-labeling cambia lo que se ve dentro del mensaje, no
+      el dominio desde el que sale.
+    </p>
+  </fieldset>
+</template>
+
+<script setup>
+/**
+ * Ajustes de white-labeling de un módulo: nivel y logo de la organización.
+ *
+ * No sabe de qué módulo son los ajustes ni cómo se guardan — se ata con
+ * `v-model` a un objeto `{ level, logo }` y avisa de los cambios. El tope lo
+ * decide el plan y llega en `maxLevel`; el servidor lo vuelve a comprobar al
+ * guardar, así que aquí solo se evita ofrecer lo que se va a rechazar.
+ *
+ * El logo viaja como data URI, que es como lo guarda la API y como se
+ * previsualiza sin subir nada todavía.
+ */
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: Object, required: true },
+  /** Nivel máximo que concede el plan ('none' | 'logo' | 'full'). */
+  maxLevel: { type: String, default: 'none' },
+})
+const emit = defineEmits(['update:modelValue'])
+
+// Mismos límites que valida el servidor (shared/_white_label.py). Duplicados a
+// propósito: aquí solo evitan un viaje que iba a fallar; la comprobación de
+// verdad es la del borde de confianza, no esta.
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/gif']
+const MAX_KB = 200
+
+const LEVELS = ['none', 'logo', 'full']
+
+const options = [
+  {
+    value: 'none',
+    title: 'Nada de white-labeling',
+    description: 'Los envíos salen con la marca de Ellysia, como hasta ahora.',
+  },
+  {
+    value: 'logo',
+    title: 'Añadir imagen corporativa',
+    description: 'Se añade el logo de la organización al contenido, sobre el texto introductorio.',
+  },
+  {
+    value: 'full',
+    title: 'Eliminar todo lo relacionado con Ellysia',
+    description: 'La cabecera, el pie y la página del test pasan a la marca de la organización.',
+  },
+]
+
+const error = ref('')
+
+const maxRank = computed(() => Math.max(0, LEVELS.indexOf(props.maxLevel)))
+function isLocked(level) {
+  return LEVELS.indexOf(level) > maxRank.value
+}
+
+function update(patch) {
+  emit('update:modelValue', { ...props.modelValue, ...patch })
+}
+
+function setLevel(level) {
+  if (isLocked(level)) return
+  update({ level })
+}
+
+function clearLogo() {
+  error.value = ''
+  update({ logo: '' })
+}
+
+function onFile(event) {
+  const file = event.target.files?.[0]
+  // El input se vacía siempre: si no, elegir el mismo fichero dos veces
+  // seguidas (tras un error) no dispara un segundo 'change'.
+  event.target.value = ''
+  if (!file) return
+
+  error.value = ''
+  if (!ACCEPTED_TYPES.includes(file.type)) {
+    error.value = 'Formato no admitido. Usa PNG, JPG o GIF.'
+    return
+  }
+  if (file.size > MAX_KB * 1024) {
+    error.value = `La imagen ocupa ${Math.round(file.size / 1024)} KB y el máximo son ${MAX_KB} KB.`
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onerror = () => { error.value = 'No se ha podido leer la imagen.' }
+  reader.onload = () => update({ logo: String(reader.result || '') })
+  reader.readAsDataURL(file)
+}
+</script>
+
+<style scoped>
+.wl { border: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.wl-legend {
+  padding: 0; font-size: var(--fs-md); font-weight: 600; color: var(--text);
+}
+.wl-hint { margin: 0; font-size: var(--fs-xs); color: var(--text-muted); }
+
+.wl-option {
+  display: flex; align-items: flex-start; gap: 0.55rem;
+  padding: 0.55rem 0.7rem; border-radius: 7px; cursor: pointer;
+  background: var(--bg); border: 1px solid var(--border-solid);
+  transition: border-color 0.15s, background 0.15s;
+}
+.wl-option:hover:not(.wl-option--locked) { border-color: var(--accent); }
+.wl-option--active { border-color: var(--accent); background: var(--surface-2); }
+.wl-option--locked { opacity: 0.55; cursor: not-allowed; }
+.wl-option input { margin-top: 0.2rem; accent-color: var(--accent); }
+.wl-option-text { display: flex; flex-direction: column; gap: 0.15rem; }
+.wl-option-title { font-size: var(--fs-md); font-weight: 600; color: var(--text); }
+.wl-option-text small { font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.35; }
+.wl-lock {
+  margin-left: 0.4rem; padding: 0 0.35rem; border-radius: 4px;
+  font-size: var(--fs-xs); font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--text-dim); background: var(--surface-3);
+}
+
+.wl-logo { display: flex; flex-direction: column; gap: 0.45rem; margin-top: 0.2rem; }
+.wl-preview { display: flex; align-items: center; gap: 0.6rem; }
+.wl-preview img {
+  max-width: 140px; max-height: 56px; object-fit: contain;
+  background: var(--surface-2); border: 1px solid var(--border-med); border-radius: 6px; padding: 0.3rem;
+}
+.wl-remove {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-family: inherit; font-size: var(--fs-xs); color: var(--text-dim); text-decoration: underline;
+}
+.wl-remove:hover { color: var(--accent-bright); }
+
+/* El <input type="file"> nativo no se puede estilar: se oculta y el <label>
+   que lo envuelve hace de botón. */
+.wl-file input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.wl-file {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 0.4rem 0.75rem; border-radius: 7px; cursor: pointer;
+  background: var(--bg); border: 1px solid var(--border-solid);
+  color: var(--text-dim); font-size: var(--fs-md); font-weight: 600;
+}
+.wl-file:hover { border-color: var(--accent); color: var(--accent-bright); }
+.wl-file:focus-within { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
+
+.wl-error { margin: 0; font-size: var(--fs-xs); color: var(--danger, #c2621d); }
+.wl-note {
+  margin: 0.2rem 0 0; padding: 0.5rem 0.65rem; border-radius: 6px;
+  background: var(--surface-2); border-left: 2px solid var(--border-med);
+  font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.4;
+}
+</style>

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -39,11 +39,14 @@
         @input="update({ color: $event.target.value })"
       />
       <code class="wl-color-value">{{ modelValue.color || DEFAULT_COLOR }}</code>
+      <!-- "Restablecer" vuelve al acento del producto de forma explícita, no
+           vaciando el campo: un color vacío deja el nivel sin su dato y el
+           envío lo degradaría en silencio. -->
       <button
-        v-if="modelValue.color"
+        v-if="modelValue.color && modelValue.color !== DEFAULT_COLOR"
         type="button"
         class="wl-remove"
-        @click="update({ color: '' })"
+        @click="update({ color: DEFAULT_COLOR })"
       >
         Restablecer
       </button>
@@ -61,6 +64,10 @@
       </label>
 
       <p v-if="error" class="wl-error">{{ error }}</p>
+      <p v-else-if="!modelValue.logo" class="wl-warning">
+        Sin imagen este nivel no se aplica: los envíos saldrán con el escalón
+        anterior, «Aplicar color corporativo».
+      </p>
       <p v-else class="wl-hint">PNG, JPG o GIF, hasta {{ MAX_KB }} KB.</p>
     </div>
 
@@ -74,10 +81,11 @@
 
 <script setup>
 /**
- * Ajustes de white-labeling de un módulo: nivel y logo de la organización.
+ * Ajustes de white-labeling de un módulo: nivel, color y logo de la
+ * organización.
  *
  * No sabe de qué módulo son los ajustes ni cómo se guardan — se ata con
- * `v-model` a un objeto `{ level, logo }` y avisa de los cambios. El tope lo
+ * `v-model` a un objeto `{ level, color, logo }` y avisa de los cambios. El tope lo
  * decide el plan y llega en `maxLevel`; el servidor lo vuelve a comprobar al
  * guardar, así que aquí solo se evita ofrecer lo que se va a rechazar.
  *
@@ -88,7 +96,7 @@ import { computed, ref } from 'vue'
 
 const props = defineProps({
   modelValue: { type: Object, required: true },
-  /** Nivel máximo que concede el plan ('none' | 'logo' | 'full'). */
+  /** Nivel máximo que concede el plan ('none' | 'color' | 'logo' | 'full'). */
   maxLevel: { type: String, default: 'none' },
 })
 const emit = defineEmits(['update:modelValue'])
@@ -142,7 +150,13 @@ function update(patch) {
 
 function setLevel(level) {
   if (isLocked(level)) return
-  update({ level })
+  // El color del selector entra en el modelo en cuanto el nivel lo usa. Si no,
+  // se enseñaba DEFAULT_COLOR en la muestra y se guardaba una cadena vacía: el
+  // nivel quedaba sin su dato y el envío lo degradaba en silencio (el servidor
+  // acepta el guardado, así que no había ni error ni aviso).
+  const patch = { level }
+  if (level !== 'none' && !props.modelValue.color) patch.color = DEFAULT_COLOR
+  update(patch)
 }
 
 function clearLogo() {
@@ -238,6 +252,7 @@ function onFile(event) {
 .wl-file:focus-within { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 
 .wl-error { margin: 0; font-size: var(--fs-xs); color: var(--danger, #c2621d); }
+.wl-warning { margin: 0; font-size: var(--fs-sm); color: var(--warn, #a8842a); line-height: 1.35; }
 .wl-note {
   margin: 0.2rem 0 0; padding: 0.5rem 0.65rem; border-radius: 6px;
   background: var(--surface-2); border-left: 2px solid var(--border-med);

--- a/web/app/src/components/themis/ScanPreviewModal.vue
+++ b/web/app/src/components/themis/ScanPreviewModal.vue
@@ -127,6 +127,20 @@ function fmtDate(iso) { if (!iso) return ''; return new Date(iso).toLocaleDateSt
 </script>
 
 <style scoped>
+/* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
+   (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
+   se borra (#131). */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+.modal.visible { display: flex; }
+
 .preview-modal { max-width: 520px; animation: none; }
 
 .modal-enter-active, .modal-leave-active { transition: opacity 0.2s ease; }

--- a/web/app/src/composables/useModalA11y.js
+++ b/web/app/src/composables/useModalA11y.js
@@ -1,0 +1,75 @@
+import { nextTick, onBeforeUnmount, watch } from 'vue'
+
+/**
+ * Comportamiento de teclado y foco compartido por los modales: Escape cierra,
+ * Tab queda atrapado dentro de la caja, se bloquea el scroll del fondo
+ * mientras está abierto (con limpieza en onBeforeUnmount — si no, un
+ * desmontaje con el modal abierto deja el body bloqueado) y el foco vuelve al
+ * disparador al cerrar.
+ *
+ * El listener de Escape/Tab va en `window`, no como `@keydown.esc` sobre el
+ * div del overlay: sobre un div solo dispara si el foco ya está dentro, que
+ * es el fallo que arrastraban CampaignModal y DistributionListsModal.
+ *
+ * `isVisible` es un getter — reactivo para los modales que se quedan
+ * montados y alternan una prop `show` (p. ej. `() => props.show` en
+ * IrisArchiveModal), o `() => true` para los que el padre monta y desmonta
+ * con `v-if` (p. ej. CampaignModal) — ahí el `immediate: true` hace de
+ * "onMounted".
+ */
+export function useModalA11y(isVisible, { boxRef, autofocusRef, onClose, onKeydown } = {}) {
+  let previouslyFocused = null
+
+  function trapFocus(e) {
+    const root = boxRef?.value
+    if (!root) return
+    const focusables = Array.from(
+      root.querySelectorAll(
+        'button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), a[href], [tabindex]:not([tabindex="-1"])',
+      ),
+    )
+    if (!focusables.length) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Escape') {
+      onClose?.()
+      return
+    }
+    if (e.key === 'Tab') trapFocus(e)
+    onKeydown?.(e)
+  }
+
+  function cleanup() {
+    document.body.style.overflow = ''
+    window.removeEventListener('keydown', handleKeydown)
+    previouslyFocused?.focus?.()
+    previouslyFocused = null
+  }
+
+  watch(
+    isVisible,
+    (visible) => {
+      if (visible) {
+        previouslyFocused = document.activeElement
+        document.body.style.overflow = 'hidden'
+        window.addEventListener('keydown', handleKeydown)
+        nextTick(() => (autofocusRef?.value ?? boxRef?.value)?.focus())
+      } else {
+        cleanup()
+      }
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(cleanup)
+}

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -40,7 +40,7 @@ export const useAegisStore = defineStore('aegis', () => {
   /** Ajustes de white-labeling del perfil (v-model de WhiteLabelFields).
       `ref` y no `reactive`: el componente emite un objeto nuevo en cada
       cambio, y a un `reactive` del store no se le puede reasignar. */
-  const whiteLabel = ref({ level: 'none', logo: '' })
+  const whiteLabel = ref({ level: 'none', logo: '', color: '' })
   /** Nivel máximo que concede el plan contratado; lo dicta el servidor */
   const maxWhiteLabelLevel = ref('none')
   /** Resultados del buscador de productos */
@@ -225,7 +225,11 @@ export const useAegisStore = defineStore('aegis', () => {
       trackedProducts.value = [...(data.trackedProducts ?? [])]
       useHygeiaInventory.value = data.useHygeiaInventory ?? true
       hygeiaInventoryAvailable.value = data.hygeiaInventoryAvailable ?? false
-      whiteLabel.value = { level: data.whiteLabelLevel || 'none', logo: data.brandLogo ?? '' }
+      whiteLabel.value = {
+        level: data.whiteLabelLevel || 'none',
+        logo:  data.brandLogo ?? '',
+        color: data.brandColor ?? '',
+      }
       maxWhiteLabelLevel.value = data.maxWhiteLabelLevel || 'none'
     } finally { loadingOrgProfile.value = false }
   }
@@ -252,6 +256,7 @@ export const useAegisStore = defineStore('aegis', () => {
         useHygeiaInventory: useHygeiaInventory.value,
         whiteLabelLevel:  whiteLabel.value.level,
         brandLogo:        whiteLabel.value.logo,
+        brandColor:       whiteLabel.value.color,
       }
       const res = await apiFetch('/aegis/org-profile', { method: 'PUT', body: JSON.stringify(payload) })
       if (!res?.ok) {

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -37,6 +37,12 @@ export const useAegisStore = defineStore('aegis', () => {
   const useHygeiaInventory = ref(true)
   /** Si el usuario tiene algún agente con inventario (decide si se ofrece) */
   const hygeiaInventoryAvailable = ref(false)
+  /** Ajustes de white-labeling del perfil (v-model de WhiteLabelFields).
+      `ref` y no `reactive`: el componente emite un objeto nuevo en cada
+      cambio, y a un `reactive` del store no se le puede reasignar. */
+  const whiteLabel = ref({ level: 'none', logo: '' })
+  /** Nivel máximo que concede el plan contratado; lo dicta el servidor */
+  const maxWhiteLabelLevel = ref('none')
   /** Resultados del buscador de productos */
   const productResults = ref([])
   /** Búsqueda de productos en curso */
@@ -219,6 +225,8 @@ export const useAegisStore = defineStore('aegis', () => {
       trackedProducts.value = [...(data.trackedProducts ?? [])]
       useHygeiaInventory.value = data.useHygeiaInventory ?? true
       hygeiaInventoryAvailable.value = data.hygeiaInventoryAvailable ?? false
+      whiteLabel.value = { level: data.whiteLabelLevel || 'none', logo: data.brandLogo ?? '' }
+      maxWhiteLabelLevel.value = data.maxWhiteLabelLevel || 'none'
     } finally { loadingOrgProfile.value = false }
   }
 
@@ -242,6 +250,8 @@ export const useAegisStore = defineStore('aegis', () => {
         employeeCount:    tweaks.employeeCount || null,
         trackedProducts:  [...trackedProducts.value],
         useHygeiaInventory: useHygeiaInventory.value,
+        whiteLabelLevel:  whiteLabel.value.level,
+        brandLogo:        whiteLabel.value.logo,
       }
       const res = await apiFetch('/aegis/org-profile', { method: 'PUT', body: JSON.stringify(payload) })
       if (!res?.ok) {
@@ -721,6 +731,7 @@ export const useAegisStore = defineStore('aegis', () => {
   return {
     topics, documents, listError, selectedTopicId, currentDocId, sortMode,
     trackedProducts, useHygeiaInventory, hygeiaInventoryAvailable,
+    whiteLabel, maxWhiteLabelLevel,
     productResults, searchingProducts, productSearchError,
     generating, generateError, loading, editing, saving, tweaks, viewerDoc,
     loadingOrgProfile, savingOrgProfile, orgProfileConfigured,

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -702,6 +702,11 @@ export const useAegisStore = defineStore('aegis', () => {
     trackedProducts.value = []
     useHygeiaInventory.value = true
     hygeiaInventoryAvailable.value = false
+    // El logo y el color son del usuario que se va: dejarlos aquí los enseña
+    // al siguiente que entre en la misma pestaña, y si su GET del perfil falla
+    // (loadOrgProfile no sobrescribe nada entonces) se los acabaría guardando.
+    whiteLabel.value = { level: 'none', logo: '', color: '' }
+    maxWhiteLabelLevel.value = 'none'
     productResults.value = []
     searchingProducts.value = false
     productSearchError.value = ''

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -41,6 +41,11 @@ export const useAegisStore = defineStore('aegis', () => {
   const productResults = ref([])
   /** Búsqueda de productos en curso */
   const searchingProducts = ref(false)
+  /**
+   * Motivo por el que la última búsqueda no devolvió nada, cuando no fue
+   * porque el catálogo no tuviera coincidencias. Cadena vacía si fue bien.
+   */
+  const productSearchError = ref('')
   /** Generación en curso */
   const generating = ref(false)
   /** Último fallo de generación, para pintarlo donde ocurrió y no solo en un
@@ -141,14 +146,31 @@ export const useAegisStore = defineStore('aegis', () => {
    */
   async function searchProducts(term) {
     const query = (term || '').trim()
+    productSearchError.value = ''
     if (query.length < 2) { productResults.value = []; return }
     searchingProducts.value = true
     try {
       const res = await apiFetch(`/aegis/products?q=${encodeURIComponent(query)}`)
-      if (!res?.ok) { productResults.value = []; return }
+      if (!res?.ok) {
+        productResults.value = []
+        // Un fallo vaciaba `productResults` igual que una búsqueda sin
+        // coincidencias, así que la UI no podía distinguirlos y enseñaba "sin
+        // coincidencias en el catálogo" — al usuario le decía que su producto
+        // no existe cuando lo que pasa es que no hemos podido preguntarlo.
+        // El 429 además tiene su propio aviso porque el endpoint está limitado
+        // a 120 peticiones/hora; useApi ya lanza un toast, pero el toast se va
+        // a los pocos segundos y esto se queda junto a la lista vacía.
+        productSearchError.value = res?.status === 429
+          ? 'Has agotado las búsquedas por ahora. Inténtalo de nuevo en unos minutos.'
+          : 'No se pudo consultar el catálogo de vulnerabilidades.'
+        return
+      }
       const data = await res.json()
       productResults.value = data.products ?? []
-    } catch { productResults.value = [] }
+    } catch {
+      productResults.value = []
+      productSearchError.value = 'No se pudo conectar con el catálogo de vulnerabilidades.'
+    }
     finally { searchingProducts.value = false }
   }
 
@@ -664,6 +686,7 @@ export const useAegisStore = defineStore('aegis', () => {
     hygeiaInventoryAvailable.value = false
     productResults.value = []
     searchingProducts.value = false
+    productSearchError.value = ''
     generating.value = false
     loading.value = false
     editing.value = false
@@ -695,7 +718,7 @@ export const useAegisStore = defineStore('aegis', () => {
   return {
     topics, documents, listError, selectedTopicId, currentDocId, sortMode,
     trackedProducts, useHygeiaInventory, hygeiaInventoryAvailable,
-    productResults, searchingProducts,
+    productResults, searchingProducts, productSearchError,
     generating, generateError, loading, editing, saving, tweaks, viewerDoc,
     loadingOrgProfile, savingOrgProfile, orgProfileConfigured,
     searchProducts, addTrackedProduct, removeTrackedProduct,

--- a/web/app/src/stores/aegisStore.js
+++ b/web/app/src/stores/aegisStore.js
@@ -168,8 +168,11 @@ export const useAegisStore = defineStore('aegis', () => {
       const data = await res.json()
       productResults.value = data.products ?? []
     } catch {
+      // Aquí solo se llega si `res.json()` no puede parsear el cuerpo: los
+      // fallos de red los absorbe `apiFetch`, que devuelve `null` y entra por
+      // la rama de arriba. Mismo mensaje: para el usuario es el mismo problema.
       productResults.value = []
-      productSearchError.value = 'No se pudo conectar con el catálogo de vulnerabilidades.'
+      productSearchError.value = 'No se pudo consultar el catálogo de vulnerabilidades.'
     }
     finally { searchingProducts.value = false }
   }

--- a/web/app/src/stores/toastStore.js
+++ b/web/app/src/stores/toastStore.js
@@ -26,8 +26,6 @@ export const useToastStore = defineStore('toast', () => {
   const visible = ref(false)
   /** @type {import('vue').Ref<{label: string, to: string}|null>} Acción opcional */
   const action = ref(null)
-  /** Clave para reanudar la animación de entrada entre toasts distintos. */
-  const id = ref(0)
 
   /** @type {number|null} Referencia al timeout de auto-ocultación */
   let timer = null
@@ -46,11 +44,10 @@ export const useToastStore = defineStore('toast', () => {
     message.value = msg
     type.value = variant || ''
     action.value = nextAction
-    // Solo se anima la entrada cuando el toast no está visible. Si ya hay uno
-    // mostrándose, se actualiza en el sitio: cambiar `id` reemplazaría el
-    // elemento y `mode="out-in"` haría la animación de salida+entrada
-    // (doble amago de aparecer) aunque sea el mismo aviso.
-    if (!visible.value) id.value += 1
+    // Si ya hay un toast mostrándose se actualiza en el sitio, sin reanimar:
+    // `visible` no cambia, así que Vue no recrea el elemento. Cuando no lo
+    // hay, el `v-if` del componente crea el <div> de cero y la animación de
+    // entrada corre sola — no hace falta ninguna clave que la fuerce.
     visible.value = true
     timer = setTimeout(dismiss, duration)
   }
@@ -62,5 +59,5 @@ export const useToastStore = defineStore('toast', () => {
     visible.value = false
   }
 
-  return { message, type, visible, action, id, show, dismiss }
+  return { message, type, visible, action, show, dismiss }
 })

--- a/web/app/src/stores/toastStore.js
+++ b/web/app/src/stores/toastStore.js
@@ -1,5 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { readonly, ref } from 'vue'
+
+/** Milisegundos que dura un toast si no se pide otra cosa. */
+const DEFAULT_DURATION_MS = 7000
 
 /**
  * Store de notificaciones toast — mensajes temporales no bloqueantes.
@@ -13,6 +16,7 @@ import { ref } from 'vue'
  * const toast = useToastStore()
  * toast.show('Escaneo completado', 'success')
  * toast.show('Error de conexión', 'error', 5000)
+ * toast.show('Revisa esto antes de seguir', 'warn', 0)  // no se cierra solo
  */
 export const useToastStore = defineStore('toast', () => {
   /** @type {import('vue').Ref<string>} Texto del mensaje */
@@ -27,20 +31,42 @@ export const useToastStore = defineStore('toast', () => {
   /** @type {import('vue').Ref<{label: string, to: string}|null>} Acción opcional */
   const action = ref(null)
 
-  /** @type {number|null} Referencia al timeout de auto-ocultación */
+  /** @type {number|null} Timeout de auto-ocultación; `null` si no hay cuenta atrás. */
   let timer = null
+  /** Milisegundos que le quedaban al toast la última vez que se armó el timeout. */
+  let remainingMs = 0
+  /** `Date.now()` de ese último armado, para saber cuánto se ha consumido. */
+  let startedAt = 0
+
+  /**
+   * Arranca la cuenta atrás de cierre. Se mide contra el reloj de pared en vez
+   * de fiarse del timeout, porque `pause()` puede pararla a mitad y hay que
+   * saber exactamente cuánto quedaba.
+   *
+   * @param {number} durationMs - `<= 0` (o no numérico) deja el toast fijo.
+   */
+  function armTimer(durationMs) {
+    clearTimeout(timer)
+    timer = null
+    remainingMs = durationMs
+    // Un toast persistente es una petición legítima (un aviso que el usuario
+    // debe cerrar a mano). Antes `duration = 0` se traducía en
+    // `setTimeout(dismiss, 0)`, o sea desaparecía en el mismo frame.
+    if (!(durationMs > 0)) return
+    startedAt = Date.now()
+    timer = setTimeout(dismiss, durationMs)
+  }
 
   /**
    * Muestra un toast con el mensaje y tipo especificados.
    * Si ya hay otro toast visible, lo reemplaza (resetea el temporizador).
    *
    * @param {string} msg - Texto a mostrar
-   * @param {'success'|'error'|'warn'|'info'|''} [type='success'] - Variante visual
-   * @param {number} [duration=7000] - Milisegundos antes de ocultarse
+   * @param {'success'|'error'|'warn'|'info'|''} [variant='success'] - Variante visual
+   * @param {number} [duration=7000] - Milisegundos antes de ocultarse; `<= 0` lo deja fijo
    * @param {{label: string, to: string}|null} [nextAction=null] - Acción interna opcional
    */
-  function show(msg, variant = 'success', duration = 7000, nextAction = null) {
-    clearTimeout(timer)
+  function show(msg, variant = 'success', duration = DEFAULT_DURATION_MS, nextAction = null) {
     message.value = msg
     type.value = variant || ''
     action.value = nextAction
@@ -49,15 +75,55 @@ export const useToastStore = defineStore('toast', () => {
     // hay, el `v-if` del componente crea el <div> de cero y la animación de
     // entrada corre sola — no hace falta ninguna clave que la fuerce.
     visible.value = true
-    timer = setTimeout(dismiss, duration)
+    armTimer(duration)
+  }
+
+  /**
+   * Congela la cuenta atrás guardando lo que quedaba. Se llama al pasar el
+   * ratón o el foco por encima: el toast puede traer un error de validación
+   * largo (con scroll propio, ver `max-height` en AppToast.vue) y cerrarlo a
+   * los 7 s mientras se lee lo deja irrecuperable.
+   */
+  function pause() {
+    // Sin timeout no hay nada que congelar: o ya está pausado, o es persistente.
+    if (!timer) return
+    clearTimeout(timer)
+    timer = null
+    const pending = remainingMs - (Date.now() - startedAt)
+    // Si el navegador estranguló el timeout y el tiempo ya se había agotado, se
+    // cierra en vez de guardar un cero: `remainingMs === 0` significa "toast
+    // persistente", y confundir ambos casos dejaría el toast fijo para siempre.
+    if (pending <= 0) { dismiss(); return }
+    remainingMs = pending
+  }
+
+  /** Reanuda la cuenta atrás con el tiempo que quedaba al pausar. */
+  function resume() {
+    // Sin toast, con cuenta atrás ya corriendo, o persistente (`remainingMs`
+    // en 0): no hay nada que reanudar.
+    if (timer || !visible.value || remainingMs <= 0) return
+    armTimer(remainingMs)
   }
 
   /** Oculta el toast inmediatamente y cancela su cierre automático. */
   function dismiss() {
     clearTimeout(timer)
     timer = null
+    remainingMs = 0
     visible.value = false
   }
 
-  return { message, type, visible, action, show, dismiss }
+  // Solo lectura hacia fuera: el estado se cambia por `show`/`dismiss`, que son
+  // quienes mantienen el timeout en sincronía. Un `toast.visible = false` suelto
+  // dejaba un `setTimeout` huérfano que cerraba el toast siguiente antes de tiempo.
+  return {
+    message: readonly(message),
+    type: readonly(type),
+    visible: readonly(visible),
+    action: readonly(action),
+    show,
+    pause,
+    resume,
+    dismiss,
+  }
 })

--- a/web/app/src/views/AegisView.vue
+++ b/web/app/src/views/AegisView.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onBeforeUnmount } from 'vue'
 import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
 import { useAegisStore } from '@/stores/aegisStore'
@@ -109,11 +109,37 @@ const { collapsed: rightCollapsed, toggle: toggleRight } = usePanelCollapse('aeg
 const leftWidth = computed(() => (leftCollapsed.value ? '48px' : '400px'))
 const rightWidth = computed(() => (rightCollapsed.value ? '48px' : '320px'))
 
-onMounted(async () => { await store.loadTopics(); await store.loadHistory() })
+// El layout de escritorio es de una sola pantalla (.app-layout mide
+// calc(100vh - topbar) con overflow:hidden) y cada panel scrollea por su
+// cuenta en .panel-content. Pero `html` sí puede desplazarse (overflow-x
+// hidden fuerza overflow-y:auto, ver comentario en shared.css) y Chromium,
+// al devolver el foco al <input type="file"> oculto de WhiteLabelFields tras
+// cerrar el diálogo nativo, se salta `.app-layout` (overflow:hidden no cuenta
+// como contenedor de scroll) y desplaza `html` en su lugar — aunque el input
+// ya era visible. Como la página mide justo 100vh, ese scroll no revela más
+// contenido: revela hueco, con el fondo fijo de StarBackground asomando.
+// Bloquear el scroll de html en este rango de anchura (el mismo en el que
+// .app-layout es de una sola pantalla) impide que ese salto tenga adónde ir,
+// sin tocar el modo apilado por debajo de 1200px, donde sí debe desplazarse.
+onMounted(async () => {
+  document.documentElement.classList.add('aegis-scroll-lock')
+  await store.loadTopics()
+  await store.loadHistory()
+})
+onBeforeUnmount(() => {
+  document.documentElement.classList.remove('aegis-scroll-lock')
+})
 </script>
 
 <style scoped>
 .aegis-page { min-height: 100vh; background: var(--bg); padding-top: var(--topbar-h); position: relative; }
+
+/* Ver el porqué en el onMounted de <script setup>. Acotado al mismo ancho en
+   el que .app-layout es de una sola pantalla (media query de más abajo
+   apila los paneles y necesita que la página SÍ pueda desplazarse). */
+@media (min-width: 1201px) {
+  :global(html.aegis-scroll-lock) { overflow-y: hidden; }
+}
 
 /* Flex, no grid: el ancho de cada barra llega por :style inline (calculado
    en leftWidth/rightWidth) y se anima con "transition: width". */

--- a/web/app/src/views/LandingView.vue
+++ b/web/app/src/views/LandingView.vue
@@ -623,11 +623,15 @@ onUnmounted(() => {
 }
 
 /* ═══════════ HERO — la vista ═══════════ */
+/* Sin overflow:hidden aquí: `ElysianScene` ya se recorta a sí misma
+   (`.scene { overflow: hidden }`), así que este `overflow` no protegía nada
+   del fondo — solo recortaba, sin querer, cualquier desplegable de la
+   cabecera (AccountMenu, Herramientas, Documentación) que no cupiera en los
+   100vh del hero (issue #140). */
 .vista {
   position: relative;
   height: 100vh;
   min-height: 640px;
-  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/web/app/src/views/LogsView.vue
+++ b/web/app/src/views/LogsView.vue
@@ -221,7 +221,7 @@ onMounted(() => applyFilters())
 }
 .page-header h1 { margin: 0.35rem 0 0; color: var(--text); font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-3xl); font-weight: 800; }
 .subtitle { margin: 0.35rem 0 0; color: var(--text-dim); font-size: var(--fs-lg); }
-.filter-panel, .log-card { background: rgba(15, 19, 28, 0.72); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 18px 50px rgba(0,0,0,0.18); }
+.filter-panel, .log-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 18px 50px rgba(0,0,0,0.18); }
 .filter-panel { padding: 1.15rem; margin-bottom: 1.1rem; }
 .filter-heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; padding-bottom: 0.9rem; border-bottom: 1px solid var(--border); }
 .filter-heading h2, .log-card-head h2 { margin: 0.25rem 0 0; color: var(--text); font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-xl); }
@@ -242,8 +242,8 @@ onMounted(() => applyFilters())
 .log-card-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; padding: 1.1rem 1.15rem; border-bottom: 1px solid var(--border); }
 .log-stats { display: flex; gap: 0.85rem; color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); text-align: right; }
 .notice { padding: 0.6rem 1.15rem; background: var(--warn-dim); color: var(--warn); border-bottom: 1px solid var(--border); font-size: var(--fs-md); }
-.log-window { max-height: 62vh; overflow: auto; background: #090c12; }
-.log-window pre { min-width: max-content; margin: 0; padding: 1rem 1.15rem 1.25rem; color: #d9e2ed; font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); line-height: 1.65; tab-size: 4; }
+.log-window { max-height: 62vh; overflow: auto; background: var(--bg); }
+.log-window pre { min-width: max-content; margin: 0; padding: 1rem 1.15rem 1.25rem; color: var(--text); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); line-height: 1.65; tab-size: 4; }
 .log-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.85rem 1.15rem; border-top: 1px solid var(--border); }
 .line-range, .page-status { color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); }
 .pagination { display: flex; align-items: center; gap: 0.65rem; }

--- a/web/app/src/views/QuizView.vue
+++ b/web/app/src/views/QuizView.vue
@@ -4,7 +4,9 @@
 
     <main class="quiz-shell">
       <header class="quiz-brand">
-        <span class="brand-mark">Ellysia</span>
+        <img v-if="whiteLabel.brandLogo" class="brand-logo" :src="whiteLabel.brandLogo" :alt="whiteLabel.brandName" />
+        <span v-if="productBrandVisible" class="brand-mark">Ellysia</span>
+        <span v-else-if="!whiteLabel.brandLogo" class="brand-mark">{{ whiteLabel.brandName }}</span>
         <span class="brand-sub">Formación de concienciación</span>
       </header>
 
@@ -90,7 +92,7 @@
         </form>
       </template>
 
-      <footer class="quiz-foot">Ellysia · Concienciación en seguridad</footer>
+      <footer class="quiz-foot">{{ footerBrand }} · Concienciación en seguridad</footer>
     </main>
   </div>
 </template>
@@ -126,10 +128,21 @@ const answers = reactive({})
 // generarlo dentro del v-for lo recalcularía en cada render y las opciones
 // bailarían con cada clic.
 const optionOrder = reactive({})
+// Marca de la campaña: la sirve el propio endpoint del quiz, resuelta igual
+// que la del correo (ajustes de la organización, topados por su plan). Sin
+// white-labeling llega en nivel 'none' y la página queda como siempre.
+const whiteLabel = ref({ level: 'none', brandName: '', brandLogo: '' })
 const justSubmitted = ref(false)
 const submitError = ref('')
 const errorTitle = ref('')
 const errorDetail = ref('')
+
+/** En nivel 'full' la marca del producto desaparece de la página, igual que
+ *  desaparece del correo. En 'logo' solo se suma el logo del cliente. */
+const productBrandVisible = computed(() => whiteLabel.value.level !== 'full')
+const footerBrand = computed(
+  () => (productBrandVisible.value ? 'Ellysia' : whiteLabel.value.brandName),
+)
 
 const pendingCount = computed(
   () => quiz.value.questions.filter(q => answers[q.position] === undefined).length
@@ -184,6 +197,7 @@ async function load() {
   }
 
   const data = await response.json()
+  if (data.whiteLabel) whiteLabel.value = data.whiteLabel
   if (data.status === 'completed') {
     result.value = { score: data.score ?? 0, total: data.total ?? 0 }
     state.value = 'completed'
@@ -263,6 +277,7 @@ onMounted(load)
 
 /* ── Cabecera de marca (sin Topbar: el destinatario no tiene sesión) ── */
 .quiz-brand { text-align: center; margin-bottom: 1.25rem; }
+.brand-logo { display: block; margin: 0 auto 0.6rem; max-width: 180px; max-height: 64px; object-fit: contain; }
 .brand-mark {
   display: block; font-family: var(--font-epic); font-size-adjust: var(--fsa-epic); font-size: var(--fs-2xl);
   letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent);

--- a/web/app/src/views/QuizView.vue
+++ b/web/app/src/views/QuizView.vue
@@ -2,7 +2,7 @@
   <div class="quiz-page" data-module="aegis">
     <StarBackground />
 
-    <main class="quiz-shell">
+    <main class="quiz-shell" :style="brandStyle">
       <header class="quiz-brand">
         <img v-if="whiteLabel.brandLogo" class="brand-logo" :src="whiteLabel.brandLogo" :alt="whiteLabel.brandName" />
         <span v-if="productBrandVisible" class="brand-mark">Ellysia</span>
@@ -131,7 +131,7 @@ const optionOrder = reactive({})
 // Marca de la campaña: la sirve el propio endpoint del quiz, resuelta igual
 // que la del correo (ajustes de la organización, topados por su plan). Sin
 // white-labeling llega en nivel 'none' y la página queda como siempre.
-const whiteLabel = ref({ level: 'none', brandName: '', brandLogo: '' })
+const whiteLabel = ref({ level: 'none', brandName: '', brandLogo: '', brandColor: '' })
 const justSubmitted = ref(false)
 const submitError = ref('')
 const errorTitle = ref('')
@@ -140,6 +140,14 @@ const errorDetail = ref('')
 /** En nivel 'full' la marca del producto desaparece de la página, igual que
  *  desaparece del correo. En 'logo' solo se suma el logo del cliente. */
 const productBrandVisible = computed(() => whiteLabel.value.level !== 'full')
+/** El color del cliente se inyecta como variable local del contenedor: pisa
+ *  el acento del tema solo dentro de esta página, sin tocar el resto de la
+ *  app ni el resto de variables. */
+const brandStyle = computed(() =>
+  whiteLabel.value.brandColor
+    ? { '--accent': whiteLabel.value.brandColor, '--accent-bright': whiteLabel.value.brandColor }
+    : {},
+)
 const footerBrand = computed(
   () => (productBrandVisible.value ? 'Ellysia' : whiteLabel.value.brandName),
 )

--- a/web/app/test/toastStore.test.mjs
+++ b/web/app/test/toastStore.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Tests de `toastStore` — la cuenta atrás del toast (#127).
+ *
+ * Node puro, sin framework, misma convención que el resto de `test/`.
+ * Con timers reales y duraciones cortas, como en `usePolling.test.mjs`.
+ *
+ * Lo que se comprueba es justo lo que el store hacía mal:
+ *   - que `duration <= 0` sea un toast persistente y no uno que desaparece
+ *     en el mismo frame (`setTimeout(dismiss, 0)`);
+ *   - que `pause()`/`resume()` conserven el tiempo que quedaba en vez de
+ *     reiniciarlo o perderlo;
+ *   - que `dismiss()` no deje un timeout huérfano capaz de cerrar el toast
+ *     siguiente antes de tiempo.
+ */
+
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { useToastStore } = await import('../src/stores/toastStore.js')
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms))
+
+let failures = 0
+async function test(name, fn) {
+  setActivePinia(createPinia())   // store limpio por test
+  try { await fn(); console.log(`  ok   ${name}`) }
+  catch (err) { failures++; console.error(`  FAIL ${name}\n       ${err.message}`) }
+}
+
+console.log('toastStore')
+
+await test('duration <= 0 deja el toast fijo', async () => {
+  const toast = useToastStore()
+  toast.show('persistente', 'warn', 0)
+  assert.equal(toast.visible, true)
+  await sleep(80)
+  assert.equal(toast.visible, true, 'se cerro solo pese a pedir duracion 0')
+  toast.dismiss()
+  assert.equal(toast.visible, false, 'dismiss() no cierra el toast persistente')
+})
+
+await test('se cierra solo al agotar su duracion', async () => {
+  const toast = useToastStore()
+  toast.show('efimero', 'info', 60)
+  await sleep(30)
+  assert.equal(toast.visible, true, 'se cerro antes de tiempo')
+  await sleep(60)
+  assert.equal(toast.visible, false, 'no se cerro al agotarse')
+})
+
+await test('pause() congela la cuenta atras', async () => {
+  const toast = useToastStore()
+  toast.show('leyendome', 'error', 60)
+  await sleep(30)
+  toast.pause()
+  await sleep(120)              // el doble de su duracion, en pausa
+  assert.equal(toast.visible, true, 'se cerro estando pausado')
+})
+
+await test('resume() reanuda con lo que quedaba, no con la duracion entera', async () => {
+  const toast = useToastStore()
+  toast.show('leyendome', 'error', 100)
+  await sleep(70)              // consumidos ~70, quedan ~30
+  toast.pause()
+  await sleep(50)
+  toast.resume()
+  await sleep(10)
+  assert.equal(toast.visible, true, 'se cerro antes de agotar lo que quedaba')
+  await sleep(60)              // sobrado para esos ~30 restantes
+  assert.equal(toast.visible, false, 'reanudo con la duracion entera en vez de con el resto')
+})
+
+await test('resume() no revive un toast ya cerrado', async () => {
+  const toast = useToastStore()
+  toast.show('efimero', 'info', 30)
+  await sleep(60)
+  assert.equal(toast.visible, false)
+  toast.resume()
+  assert.equal(toast.visible, false, 'resume() reabrio un toast cerrado')
+})
+
+await test('dismiss() no deja un timeout que cierre el toast siguiente', async () => {
+  const toast = useToastStore()
+  toast.show('primero', 'success', 40)
+  await sleep(10)
+  toast.dismiss()              // quedaban ~30 ms del primero
+  toast.show('segundo', 'success', 120)
+  await sleep(60)              // el timeout huerfano ya habria disparado
+  assert.equal(toast.visible, true, 'el timeout del primer toast cerro al segundo')
+  assert.equal(toast.message, 'segundo')
+})
+
+await test('un show() sobre un toast visible reinicia la cuenta atras', async () => {
+  const toast = useToastStore()
+  toast.show('primero', 'success', 60)
+  await sleep(45)
+  toast.show('segundo', 'error', 60)
+  await sleep(40)              // el primero ya habria expirado
+  assert.equal(toast.visible, true, 'el reemplazo heredo la cuenta atras del anterior')
+  assert.equal(toast.message, 'segundo')
+  assert.equal(toast.type, 'error')
+})
+
+console.log(failures ? `\n${failures} test(s) fallaron` : '\nTodos los tests de toastStore pasaron')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
## Summary
Promoción de `develope` a `main`. Puntos destacados desde el último release:

- **CI/CD**: pipeline de auto-deploy a producción (`.github/workflows/deploy.yml`) — cada push a `main` con tests en verde despliega solo por SSH. A partir de este merge queda activo.
- **Aegis — white-labeling**: nivel de marca (ninguno / color corporativo) configurable en el perfil de organización, topado por plan, proyectado a la página pública del quiz y a las plantillas de correo (con imágenes `cid:` incrustadas).
- **Aegis — modal de productos vigilados**: sustituye el buscador inline del panel por un modal dedicado (`TrackedProductsModal.vue`).
- **Accesibilidad de teclado en modales** (#130): composable `useModalA11y` (Escape, focus trap, scroll-lock, retorno de foco) adoptado en Iris/TrackedProducts/Aegis; arregla el Escape roto de `CampaignModal`/`DistributionListsModal`.
- **Limpieza de CSS legacy** (#131): borra el bloque `.modal`/`.modal.visible` de `shared.css`.
- **Toast**: persistencia, pausa al leer, y limpieza de estilos legacy que lo volvían invisible.
- **Themis**: acota el payload de los AI writers para evitar peticiones sobredimensionadas a OpenAI, con mensaje específico cuando el escaneo es demasiado grande.
- Varios fixes de UI (recorte del hero de Aegis, tema de la vista de logs, tamaño de fuente en WhiteLabelFields) y de infraestructura (migraciones re-encadenadas, remitente SMTP).

## Validation
- CI (`tests.yml`) corre sobre este PR.
- Cada cambio se validó por separado en su propio PR antes de llegar a `develope` (ver los merges referenciados en el log).

## Notes
- El auto-deploy queda activo desde este merge: el siguiente push a `main` (este mismo, en cuanto se acepte) disparará el primer despliegue real a `www.ellysia.es`. La preparación del servidor (usuario `deploy`, claves SSH, secretos del repo) ya está hecha.