### PR TITLE
fix(web): anclar el input de imagen del white-labeling a su propia etiqueta

### DIFF
--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -59,13 +59,7 @@
       </div>
 
       <label class="wl-file">
-        <input
-          type="file"
-          :accept="ACCEPTED_TYPES.join(',')"
-          @click="captureScroll"
-          @focus="restoreScroll"
-          @change="onFile"
-        />
+        <input type="file" :accept="ACCEPTED_TYPES.join(',')" @change="onFile" />
         <span>{{ modelValue.logo ? 'Cambiar imagen' : 'Añadir imagen corporativa' }}</span>
       </label>
 
@@ -170,26 +164,6 @@ function clearLogo() {
   update({ logo: '' })
 }
 
-// Al cerrar el diálogo nativo de selección de fichero, el navegador devuelve
-// el foco a este input y desplaza la página para revelarlo — aunque ya fuera
-// visible, y aunque `.app-layout` bloquee su propio scroll con overflow:
-// hidden (ver aegis-scroll-lock en AegisView.vue). Ese bloqueo frena el
-// scroll por rueda/teclado y las llamadas a scrollTo(), pero no el
-// scroll-into-view que dispara la propia gestión de foco del navegador — va
-// por un camino interno distinto. Refs #135.
-let scrollBeforeDialog = null
-function captureScroll() {
-  scrollBeforeDialog = { x: window.scrollX, y: window.scrollY }
-}
-function restoreScroll() {
-  if (!scrollBeforeDialog) return
-  const { x, y } = scrollBeforeDialog
-  // rAF: el desplazamiento del navegador ocurre después del propio evento
-  // 'focus', así que corregir en el mismo tick no sirve — hay que esperar al
-  // siguiente frame, cuando ya ha tenido lugar.
-  requestAnimationFrame(() => window.scrollTo(x, y))
-}
-
 function onFile(event) {
   const file = event.target.files?.[0]
   // El input se vacía siempre: si no, elegir el mismo fichero dos veces
@@ -269,6 +243,13 @@ function onFile(event) {
    que lo envuelve hace de botón. */
 .wl-file input { position: absolute; width: 1px; height: 1px; opacity: 0; }
 .wl-file {
+  /* Ancla el containing block del input absoluto a esta misma etiqueta. Sin
+     esto, saltaba hasta .panel--left (el primer ancestro con position !=
+     static) — que no hace scroll — dejando el input clavado en un punto fijo
+     mientras .panel-content (el que sí scrollea, y queda por medio) se movía
+     por su cuenta. Al enfocarlo el navegador lo llevaba a su posición real
+     (desincronizada), desplazando toda la página. Refs #135. */
+  position: relative;
   display: inline-flex; align-items: center; justify-content: center;
   padding: 0.4rem 0.75rem; border-radius: 7px; cursor: pointer;
   background: var(--bg); border: 1px solid var(--border-solid);

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -59,7 +59,13 @@
       </div>
 
       <label class="wl-file">
-        <input type="file" :accept="ACCEPTED_TYPES.join(',')" @change="onFile" />
+        <input
+          type="file"
+          :accept="ACCEPTED_TYPES.join(',')"
+          @click="captureScroll"
+          @focus="restoreScroll"
+          @change="onFile"
+        />
         <span>{{ modelValue.logo ? 'Cambiar imagen' : 'Añadir imagen corporativa' }}</span>
       </label>
 
@@ -162,6 +168,26 @@ function setLevel(level) {
 function clearLogo() {
   error.value = ''
   update({ logo: '' })
+}
+
+// Al cerrar el diálogo nativo de selección de fichero, el navegador devuelve
+// el foco a este input y desplaza la página para revelarlo — aunque ya fuera
+// visible, y aunque `.app-layout` bloquee su propio scroll con overflow:
+// hidden (ver aegis-scroll-lock en AegisView.vue). Ese bloqueo frena el
+// scroll por rueda/teclado y las llamadas a scrollTo(), pero no el
+// scroll-into-view que dispara la propia gestión de foco del navegador — va
+// por un camino interno distinto. Refs #135.
+let scrollBeforeDialog = null
+function captureScroll() {
+  scrollBeforeDialog = { x: window.scrollX, y: window.scrollY }
+}
+function restoreScroll() {
+  if (!scrollBeforeDialog) return
+  const { x, y } = scrollBeforeDialog
+  // rAF: el desplazamiento del navegador ocurre después del propio evento
+  // 'focus', así que corregir en el mismo tick no sirve — hay que esperar al
+  // siguiente frame, cuando ya ha tenido lugar.
+  requestAnimationFrame(() => window.scrollTo(x, y))
 }
 
 function onFile(event) {


### PR DESCRIPTION
## Summary
El fix de #137 (bloquear el scroll de `html` con `overflow: hidden`) no era la causa real, y el primer intento de este PR (capturar/restaurar `window.scrollX/Y` al enfocar) tampoco — ambos corregían el síntoma por caminos que no cubrían el mecanismo real. Probado en vivo por el usuario en Brave: el salto ocurre **al pulsar el botón**, antes de que el diálogo nativo llegue a abrirse, e incluso pulsando "Cancelar" — descartando cualquier teoría centrada en "recuperar el foco al cerrar el diálogo".

**Causa real, verificada en vivo**: `.wl-file` (la etiqueta que envuelve el `<input type="file">` oculto) no tenía `position: relative`. El input es `position: absolute`, así que su containing block saltaba hasta `.panel--left` (el `<aside>`, primer ancestro con `position` distinto de `static`) — con `.panel-content` (el contenedor que de verdad hace scroll, `overflow-y: auto`) **entre medias**, sin formar parte de esa cadena de posicionamiento.

Comprobé haciendo scroll de `.panel-content` 200px: la etiqueta visible se movió esos 200px (normal, vive dentro del flujo que scrollea); el input invisible **no se movió nada** — se queda clavado en su posición absoluta relativa a `.panel--left`, que no scrollea. Como el botón está bastante abajo en un formulario largo, en el uso real casi siempre hay scroll de por medio, así que al enfocar un input que el navegador sabe que está en un sitio completamente distinto de donde parece, hace lo correcto: te lleva hasta ahí — desplazando la página.

## Related Issue
Fixes #135

## Implementation
- [WhiteLabelFields.vue](web/app/src/components/shared/WhiteLabelFields.vue): añade `position: relative` a `.wl-file`, ancla el containing block del input a su propia etiqueta (que sí forma parte del flujo que scrollea) en vez de a un ancestro más lejano.
- Quita el hack de captura/restauración de `window.scrollX/Y` del commit anterior: no atajaba la causa real y queda como complejidad muerta una vez aplicado este fix.

## Validation
- `npm run build` (Vite) sin errores.
- Verificación en vivo (forzando `maxWhiteLabelLevel = 'full'` vía Pinia para renderizar el input real, sin backend):
  - **Antes del fix**: scrollear `.panel-content` 200px movía la etiqueta 200px y el input 0px (desincronizados).
  - **Después del fix**: scrollear `.panel-content` 200px mueve ambos 200px exactamente igual.
  - **Antes y después de scrollear**, enfocar el input directamente (`input.focus()`) solo mueve el `scrollTop` de `.panel-content` (comportamiento normal y esperado) — `window.scrollY` y `document.documentElement.scrollTop` se quedan en 0 en todos los casos.

## Notes
- El primer commit de este PR (capturar/restaurar scroll en click/focus) quedó revertido por el segundo — el historial de la rama documenta el diagnóstico erróneo y la corrección, no hace falta squash.