### PR TITLE
hotfix: salto de scroll en white-labeling de Aegis (v0.5.9)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.8",
+  "appVersion": "0.5.9",
   "general": {
     "directories": {
       "logdir": "..",

--- a/README.md
+++ b/README.md
@@ -697,4 +697,4 @@ Config is read through frozen dataclasses bound to a branch of the tree (`@confi
 - `API/src/data/` and `docs/` are gitignored (scan outputs, generated PDFs).
 - PostgreSQL uses port **15432** locally (not standard 5432).
 - `themis/services/tasks.py` defines its own `TaskStatus` enum — distinct from `taskqueue.TaskStatus`. Don't conflate them.
-- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.6`, read by `CR.get_app_version()`).
+- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.9`, read by `CR.get_app_version()`).

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -59,13 +59,7 @@
       </div>
 
       <label class="wl-file">
-        <input
-          type="file"
-          :accept="ACCEPTED_TYPES.join(',')"
-          @click="captureScroll"
-          @focus="restoreScroll"
-          @change="onFile"
-        />
+        <input type="file" :accept="ACCEPTED_TYPES.join(',')" @change="onFile" />
         <span>{{ modelValue.logo ? 'Cambiar imagen' : 'Añadir imagen corporativa' }}</span>
       </label>
 
@@ -170,26 +164,6 @@ function clearLogo() {
   update({ logo: '' })
 }
 
-// Al cerrar el diálogo nativo de selección de fichero, el navegador devuelve
-// el foco a este input y desplaza la página para revelarlo — aunque ya fuera
-// visible, y aunque `.app-layout` bloquee su propio scroll con overflow:
-// hidden (ver aegis-scroll-lock en AegisView.vue). Ese bloqueo frena el
-// scroll por rueda/teclado y las llamadas a scrollTo(), pero no el
-// scroll-into-view que dispara la propia gestión de foco del navegador — va
-// por un camino interno distinto. Refs #135.
-let scrollBeforeDialog = null
-function captureScroll() {
-  scrollBeforeDialog = { x: window.scrollX, y: window.scrollY }
-}
-function restoreScroll() {
-  if (!scrollBeforeDialog) return
-  const { x, y } = scrollBeforeDialog
-  // rAF: el desplazamiento del navegador ocurre después del propio evento
-  // 'focus', así que corregir en el mismo tick no sirve — hay que esperar al
-  // siguiente frame, cuando ya ha tenido lugar.
-  requestAnimationFrame(() => window.scrollTo(x, y))
-}
-
 function onFile(event) {
   const file = event.target.files?.[0]
   // El input se vacía siempre: si no, elegir el mismo fichero dos veces
@@ -269,6 +243,13 @@ function onFile(event) {
    que lo envuelve hace de botón. */
 .wl-file input { position: absolute; width: 1px; height: 1px; opacity: 0; }
 .wl-file {
+  /* Ancla el containing block del input absoluto a esta misma etiqueta. Sin
+     esto, saltaba hasta .panel--left (el primer ancestro con position !=
+     static) — que no hace scroll — dejando el input clavado en un punto fijo
+     mientras .panel-content (el que sí scrollea, y queda por medio) se movía
+     por su cuenta. Al enfocarlo el navegador lo llevaba a su posición real
+     (desincronizada), desplazando toda la página. Refs #135. */
+  position: relative;
   display: inline-flex; align-items: center; justify-content: center;
   padding: 0.4rem 0.75rem; border-radius: 7px; cursor: pointer;
   background: var(--bg); border: 1px solid var(--border-solid);

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -59,7 +59,13 @@
       </div>
 
       <label class="wl-file">
-        <input type="file" :accept="ACCEPTED_TYPES.join(',')" @change="onFile" />
+        <input
+          type="file"
+          :accept="ACCEPTED_TYPES.join(',')"
+          @click="captureScroll"
+          @focus="restoreScroll"
+          @change="onFile"
+        />
         <span>{{ modelValue.logo ? 'Cambiar imagen' : 'Añadir imagen corporativa' }}</span>
       </label>
 
@@ -162,6 +168,26 @@ function setLevel(level) {
 function clearLogo() {
   error.value = ''
   update({ logo: '' })
+}
+
+// Al cerrar el diálogo nativo de selección de fichero, el navegador devuelve
+// el foco a este input y desplaza la página para revelarlo — aunque ya fuera
+// visible, y aunque `.app-layout` bloquee su propio scroll con overflow:
+// hidden (ver aegis-scroll-lock en AegisView.vue). Ese bloqueo frena el
+// scroll por rueda/teclado y las llamadas a scrollTo(), pero no el
+// scroll-into-view que dispara la propia gestión de foco del navegador — va
+// por un camino interno distinto. Refs #135.
+let scrollBeforeDialog = null
+function captureScroll() {
+  scrollBeforeDialog = { x: window.scrollX, y: window.scrollY }
+}
+function restoreScroll() {
+  if (!scrollBeforeDialog) return
+  const { x, y } = scrollBeforeDialog
+  // rAF: el desplazamiento del navegador ocurre después del propio evento
+  // 'focus', así que corregir en el mismo tick no sirve — hay que esperar al
+  // siguiente frame, cuando ya ha tenido lugar.
+  requestAnimationFrame(() => window.scrollTo(x, y))
 }
 
 function onFile(event) {


### PR DESCRIPTION
## Summary
Hotfix a producción — corrige la regresión reportada tras el último release: al pulsar "Añadir imagen corporativa" en el perfil de organización de Aegis, la página saltaba y dejaba un hueco con el fondo decorativo asomando.

- **[#149](https://github.com/ProjectEllysia/EllysiaServer/pull/149)**: causa real localizada y corregida — el `<input type="file">` oculto no tenía su containing block anclado a su propia etiqueta (`.wl-file` sin `position: relative`), así que quedaba desincronizado del contenedor que de verdad hace scroll (`.panel-content`). Verificado en vivo (geometría del DOM antes/después) y confirmado manualmente por el usuario en Brave tras el fix.
- Bump de versión a `0.5.9` en `API/SecOpsConfig.json` (+ README en sync).

## Related Issue
Fixes #135

## Implementation
Ver [#149](https://github.com/ProjectEllysia/EllysiaServer/pull/149) para el detalle completo del diagnóstico y la corrección (incluye el historial de un primer intento fallido, corregido en el mismo PR).

## Validation
- `npm run build` (Vite) sin errores.
- Verificación en vivo del fix (antes/después): scroll de `.panel-content` ahora mueve el input invisible exactamente igual que la etiqueta visible; enfocar el input solo mueve el scroll interno del panel, `window`/`html` no se mueven.
- Confirmado manualmente por el usuario en producción/Brave.

## Notes
- Hotfix: se salta la promoción habitual acumulada en `develope` porque solo contiene este fix y el bump de versión desde el último release a `main`.