### PR TITLE
feat(web): confirmación, generador de claves y alineación de los inputs en el alta pública

### DIFF
--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -743,12 +743,16 @@ onBeforeUnmount(() => {})
 }
 .field.focused .field-ico { color: var(--accent); }
 .field-box input {
-  width: 100%; padding: 0.82rem 2.7rem 0.82rem 2.5rem;
+  width: 100%; padding: 0.82rem 0.95rem;
   background: var(--surface-2);
   border: 1px solid var(--border-solid); border-radius: 10px;
   color: var(--text); font-size: var(--fs-input); font-family: var(--font-body); font-size-adjust: var(--fsa-body); outline: none;
   transition: border-color 0.3s, box-shadow 0.3s, background 0.3s;
 }
+/* El hueco lateral solo se reserva si hay algo que lo ocupe: los campos sin
+   icono ni botón arrancaban el texto desplazado 2.5rem hacia la derecha. */
+.field-box:has(.field-ico) input { padding-left: 2.5rem; }
+.field-box:has(.reveal) input { padding-right: 2.7rem; }
 .field-box input::placeholder { color: var(--text-muted); opacity: 0.6; }
 .field-box input:focus {
   border-color: var(--accent);

--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -140,7 +140,7 @@
         <!-- ───────── Alta pública ───────── -->
         <form v-else-if="!mfaStep && mode === 'register'" novalidate @submit.prevent="handleRegister">
           <div class="field" :class="{ focused: focus === 'reg-user' }">
-            <label for="reg-username">Identificador</label>
+            <label for="reg-username">Nombre de usuario</label>
             <div class="field-box">
               <input id="reg-username" v-model="reg.username" type="text" required
                      minlength="3" maxlength="64" autocomplete="username"
@@ -181,6 +181,16 @@
                      @focus="focus = 'reg-pass'" @blur="focus = ''" />
             </div>
             <span class="field-hint">Mínimo 8 caracteres.</span>
+          </div>
+
+          <div class="field" :class="{ focused: focus === 'reg-pass2' }">
+            <label for="reg-password-confirm">Repite la clave</label>
+            <div class="field-box">
+              <input id="reg-password-confirm" v-model="regConfirm" type="password" required
+                     autocomplete="new-password"
+                     :class="{ 'has-error': regConfirm && regConfirm !== reg.password }"
+                     @focus="focus = 'reg-pass2'" @blur="focus = ''" />
+            </div>
           </div>
 
           <button type="submit" class="submit" :class="{ loading }" :disabled="loading">
@@ -352,6 +362,9 @@ const mode = ref(
     : 'login',
 )
 const reg = ref({ username: '', email: '', first_name: '', last_name: '', password: '' })
+// Fuera de `reg` a propósito: ese objeto se manda tal cual a /users/register y
+// la confirmación es cosa del formulario, no del alta.
+const regConfirm = ref('')
 const recover = ref({ identifier: '' })
 
 /**
@@ -360,6 +373,12 @@ const recover = ref({ identifier: '' })
  * dejarán hasta que pulse el enlace.
  */
 async function handleRegister() {
+  // Lo único que el servidor no puede comprobar: nunca ve la confirmación.
+  if (reg.value.password !== regConfirm.value) {
+    showAlert('Las claves no coinciden. Repítela tal cual la escribiste.', 'error')
+    return
+  }
+
   loading.value = true
   try {
     const res = await fetch('/users/register', {
@@ -385,6 +404,7 @@ async function handleRegister() {
     )
     username.value = reg.value.username
     reg.value = { username: '', email: '', first_name: '', last_name: '', password: '' }
+    regConfirm.value = ''
     mode.value = 'login'
   } catch {
     showAlert('No se pudo conectar con el servidor.', 'error')

--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -176,9 +176,40 @@
           <div class="field" :class="{ focused: focus === 'reg-pass' }">
             <label for="reg-password">Clave de acceso</label>
             <div class="field-box">
-              <input id="reg-password" v-model="reg.password" type="password" required
+              <input id="reg-password" v-model="reg.password"
+                     :type="showRegPassword ? 'text' : 'password'" required
                      minlength="8" autocomplete="new-password"
                      @focus="focus = 'reg-pass'" @blur="focus = ''" />
+              <button
+                type="button"
+                class="reveal reveal-gen"
+                tabindex="-1"
+                aria-label="Generar una clave segura"
+                title="Generar una clave segura"
+                @click="generateRegPassword"
+              >
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="23 4 23 10 17 10" />
+                  <polyline points="1 20 1 14 7 14" />
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="reveal"
+                tabindex="-1"
+                :aria-label="showRegPassword ? 'Ocultar las claves' : 'Mostrar las claves'"
+                @click="showRegPassword = !showRegPassword"
+              >
+                <svg v-if="!showRegPassword" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              </button>
             </div>
             <span class="field-hint">Mínimo 8 caracteres.</span>
           </div>
@@ -186,10 +217,27 @@
           <div class="field" :class="{ focused: focus === 'reg-pass2' }">
             <label for="reg-password-confirm">Repite la clave</label>
             <div class="field-box">
-              <input id="reg-password-confirm" v-model="regConfirm" type="password" required
+              <input id="reg-password-confirm" v-model="regConfirm"
+                     :type="showRegPassword ? 'text' : 'password'" required
                      autocomplete="new-password"
                      :class="{ 'has-error': regConfirm && regConfirm !== reg.password }"
                      @focus="focus = 'reg-pass2'" @blur="focus = ''" />
+              <button
+                type="button"
+                class="reveal"
+                tabindex="-1"
+                :aria-label="showRegPassword ? 'Ocultar las claves' : 'Mostrar las claves'"
+                @click="showRegPassword = !showRegPassword"
+              >
+                <svg v-if="!showRegPassword" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              </button>
             </div>
           </div>
 
@@ -320,6 +368,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore } from '@/stores/themeStore'
 import { validationMessage } from '@/composables/useApi'
+import { generatePassword } from '@/acheron/passwordGenerator.js'
 import ElysianScene from '@/components/shared/ElysianScene.vue'
 import ellysiaIcon from '@/assets/images/ellysia/Ellysia-BgN.png'
 
@@ -365,7 +414,20 @@ const reg = ref({ username: '', email: '', first_name: '', last_name: '', passwo
 // Fuera de `reg` a propósito: ese objeto se manda tal cual a /users/register y
 // la confirmación es cosa del formulario, no del alta.
 const regConfirm = ref('')
+const showRegPassword = ref(false)
 const recover = ref({ identifier: '' })
+
+/**
+ * Aprovecha el generador de Acheron para el alta. Rellena también la
+ * confirmación —hacer teclear a mano una clave de 20 caracteres aleatorios solo
+ * sirve para equivocarse— y descubre ambos campos: una clave que no se puede
+ * leer no se puede guardar en ningún sitio.
+ */
+function generateRegPassword() {
+  reg.value.password = regConfirm.value = generatePassword()
+  showRegPassword.value = true
+}
+
 
 /**
  * Alta pública. Al terminar NO se inicia sesión sola: la cuenta nace sin el
@@ -405,6 +467,7 @@ async function handleRegister() {
     username.value = reg.value.username
     reg.value = { username: '', email: '', first_name: '', last_name: '', password: '' }
     regConfirm.value = ''
+    showRegPassword.value = false
     mode.value = 'login'
   } catch {
     showAlert('No se pudo conectar con el servidor.', 'error')
@@ -773,6 +836,7 @@ onBeforeUnmount(() => {})
    icono ni botón arrancaban el texto desplazado 2.5rem hacia la derecha. */
 .field-box:has(.field-ico) input { padding-left: 2.5rem; }
 .field-box:has(.reveal) input { padding-right: 2.7rem; }
+.field-box:has(.reveal-gen) input { padding-right: 4.6rem; }
 .field-box input::placeholder { color: var(--text-muted); opacity: 0.6; }
 .field-box input:focus {
   border-color: var(--accent);
@@ -794,6 +858,7 @@ onBeforeUnmount(() => {})
   background: none; border: none; color: var(--text-muted); cursor: pointer;
   border-radius: 7px; transition: color 0.2s, background 0.2s;
 }
+.reveal-gen { right: 40px; }
 .reveal:hover:not(:disabled) { color: var(--accent); background: var(--accent-dim); }
 .reveal:disabled { cursor: not-allowed; opacity: 0.4; }
 


### PR DESCRIPTION
## Resumen

Las cuatro cosas que pedía el Issue #142 sobre el panel de registro de `LoginView.vue`:

- `Identificador` pasa a **`Nombre de usuario`** en el alta.
- Nuevo campo **`Repite la clave`**, con marca en rojo en cuanto deja de coincidir y corte del envío antes de la petición.
- Botón **generar clave** que reutiliza el generador de Acheron, rellena los dos campos y los descubre.
- Corregida la alineación del texto dentro de los inputs.

## Issue relacionado

Closes #142

## Implementación

**1. `fix(web)`: el hueco lateral del input solo se reserva si hay icono o botón**

Causa raíz del punto 4: `.field-box input` aplicaba `padding: 0.82rem 2.7rem 0.82rem 2.5rem` a **todos** los campos de la vista. Esos huecos existen para `.field-ico` (izquierda) y `.reveal` (derecha), y los campos del alta no tienen ninguno de los dos, así que el texto y el cursor arrancaban desplazados ~2.5rem. No dependía del foco; solo se notaba al enfocar, que es cuando aparece el cursor.

El padding base pasa a ser simétrico y cada hueco se reserva con `:has()` únicamente cuando el elemento que lo ocupa está presente. Arreglado en la regla compartida, no campo a campo, así que vale para los cuatro formularios de la vista (entrada, alta, recuperación y MFA).

**2. `feat(web)`: confirmación de clave**

`regConfirm` vive en su propio `ref` y **no** dentro de `reg`: ese objeto se serializa tal cual hacia `/users/register`, y la confirmación es cosa del formulario. La comprobación corta antes del `fetch` — es lo único que el servidor no puede validar, porque nunca ve el segundo campo. El mínimo de 8 caracteres se deja donde ya estaba, en el servidor, que devuelve un 422 traducido por `validationMessage`.

**3. `feat(web)`: generador y revelado**

`generatePassword()` de `@/acheron/passwordGenerator.js`, con el mismo comportamiento que `ChangePasswordModal`: rellena clave y confirmación y descubre ambas. El revelado es un único interruptor para los dos campos —son la misma clave— y reutiliza el botón `.reveal` de la entrada.

## Validación

- `npm run build` ✅
- `npm run test:hygeia`, `test:polling`, `test:toast` ✅ (`test:acheron` falla por `tests/acheron-vectors.json`, que no está generado en local — falla igual en `develope`, no es una regresión)
- Comprobado en el navegador sobre el servidor de desarrollo: claves distintas → campo en rojo y alerta *"Las claves no coinciden…"* sin llegar a la petición; claves iguales → sigue adelante; el generador rellena los dos campos con el mismo valor y los muestra; el revelado alterna ambos.
- Verificado que la regla de padding no rompe los formularios vecinos: entrada (`40px` / `43.2px` con icono y ojo), recuperación (`40px` / base), alta (base / hueco de los dos botones).

## Notas

- No hay tooling de test para SFCs en el repo (los `test/` son scripts de node sobre módulos puros), así que la validación de esta vista es manual.
- Fuera de alcance a propósito: renombrar "Identificador" en los formularios de entrada y recuperación, y añadir `PasswordStrengthMeter` al alta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
