### PR TITLE
feat(users): baja de usuarios desde el panel de administración

### DIFF
--- a/API/src/modules/users/endpoints.py
+++ b/API/src/modules/users/endpoints.py
@@ -685,6 +685,47 @@ def remove_user_attribute(data: dict[str, Any], target_user_id: int):
     return {"message": "Attributes removed", "attributes": attrs_to_remove}
 
 
+@users_blp.delete("/<int:target_user_id>")
+@users_blp.response(200, SuccessMessageSchema, description="User deleted")
+@users_blp.alt_response(400, schema=ErrorSchema, description="Cannot delete your own account here")
+@users_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@users_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
+@require_oauth_token
+@require_role(Role.ADMIN)
+@handle_exceptions(default_exception=DatabaseError, logger=logger)
+def delete_user(target_user_id: int):
+    """Dar de baja a otro usuario desde el panel de administracion.
+
+    Borra lo mismo que la baja voluntaria —el barrido de
+    ``services/account_deletion.py``, con la disolucion de la organizacion que
+    el usuario tuviera— asi que la jerarquia se comprueba con
+    ``can_administer_user``: un admin no puede borrar a otro admin ni al root.
+
+    La propia cuenta no se borra por aqui aunque ``can_administer_user`` se lo
+    permita al root: para eso esta ``DELETE /users/me``, que re-verifica la
+    contrasenya. Sin este corte, un root se quedaria sin sistema de un clic.
+    """
+    current_user_id = get_current_user().id
+
+    if current_user_id == target_user_id:
+        raise EllysiaException(
+            "Usa DELETE /users/me para dar de baja tu propia cuenta",
+            status_code=400,
+        )
+
+    if not USER_MANAGER.can_administer_user(current_user_id, target_user_id):
+        logger.warning(f"Usuario {current_user_id} intento eliminar a {target_user_id} sin permiso")
+        raise EllysiaException(
+            "No tienes permiso para eliminar a este usuario",
+            status_code=403,
+        )
+
+    USER_MANAGER.delete_user(target_user_id)
+
+    logger.info(f"Usuario {target_user_id} eliminado por el administrador {current_user_id}")
+    return {"message": "Usuario eliminado."}
+
+
 # =========================================================================
 # MFA (TOTP) ENDPOINTS
 # =========================================================================

--- a/API/src/modules/users/endpoints.py
+++ b/API/src/modules/users/endpoints.py
@@ -685,6 +685,32 @@ def remove_user_attribute(data: dict[str, Any], target_user_id: int):
     return {"message": "Attributes removed", "attributes": attrs_to_remove}
 
 
+@users_blp.get("/<int:target_user_id>/deletion-preview")
+@users_blp.response(200, DeletionPreviewSchema, description="What deleting that user destroys")
+@users_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@users_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
+@require_oauth_token
+@require_role(Role.ADMIN)
+@handle_exceptions(default_exception=DatabaseError, logger=logger)
+def preview_user_deletion(target_user_id: int):
+    """Que se destruye si se da de baja a ese usuario. No borra nada.
+
+    El mismo aviso que ve quien se da de baja a si mismo, para quien lo hace en
+    su nombre: si el usuario es duenyo de una organizacion, esta DESAPARECE con
+    su cuenta y sus miembros se quedan sin ella. Lleva la autorizacion del
+    borrado —no de la lectura— porque solo tiene sentido antes de borrar.
+    """
+    current_user_id = get_current_user().id
+
+    if not USER_MANAGER.can_administer_user(current_user_id, target_user_id):
+        raise EllysiaException(
+            "No tienes permiso para eliminar a este usuario",
+            status_code=403,
+        )
+
+    return USER_MANAGER.preview_deletion(target_user_id)
+
+
 @users_blp.delete("/<int:target_user_id>")
 @users_blp.response(200, SuccessMessageSchema, description="User deleted")
 @users_blp.alt_response(400, schema=ErrorSchema, description="Cannot delete your own account here")

--- a/API/tests/integration/test_account_deletion.py
+++ b/API/tests/integration/test_account_deletion.py
@@ -156,6 +156,51 @@ def test_preview_does_not_delete_anything(client, owner, auth_headers):
     assert client.get("/users/me", headers=auth_headers(owner)).status_code == 200
 
 
+def test_admin_preview_warns_about_the_organization_that_dies_with_the_user(
+    client, app, admin_user, owner, make_user, auth_headers
+):
+    """El mismo aviso, pero para quien da de baja a otro.
+
+    Un administrador que borra al duenyo de una organizacion la disuelve sin
+    saberlo si nadie se lo dice.
+    """
+    from src.modules.accounts.model import OrganizationMember
+
+    organization = client.post("/organizations", headers=auth_headers(owner),
+                               json={"name": "Acme"}).get_json()
+    member = make_user()
+    with app.app_context():
+        with unit_of_work.UnitOfWork() as uow:
+            uow.session.add(OrganizationMember(
+                organization_id=organization["id"], user_id=member.id,
+                member_role="member",
+            ))
+            uow.session.flush()
+
+    body = client.get(f"/users/{owner.id}/deletion-preview",
+                      headers=auth_headers(admin_user)).get_json()
+
+    assert body["ownedOrganization"]["name"] == "Acme"
+    assert body["ownedOrganization"]["membersLosingAccess"] == 1
+
+
+def test_admin_preview_does_not_delete_anything(client, admin_user, regular_user, auth_headers):
+    client.get(f"/users/{regular_user.id}/deletion-preview", headers=auth_headers(admin_user))
+    assert client.get("/users/me", headers=auth_headers(regular_user)).status_code == 200
+
+
+def test_admin_preview_needs_the_same_permission_as_deleting(
+    client, admin_user, regular_user, make_user, auth_headers
+):
+    """El aviso solo lo ve quien puede ejecutar la baja."""
+    other_admin = make_user(role="role_admin")
+
+    assert client.get(f"/users/{regular_user.id}/deletion-preview",
+                      headers=auth_headers(regular_user)).status_code == 403
+    assert client.get(f"/users/{other_admin.id}/deletion-preview",
+                      headers=auth_headers(admin_user)).status_code == 403
+
+
 # ----------------------------------------------------------------- el borrado
 
 def test_deleting_requires_the_password(client, regular_user, auth_headers):

--- a/API/tests/integration/test_users.py
+++ b/API/tests/integration/test_users.py
@@ -154,3 +154,53 @@ def test_role_user_cannot_grant_attributes_to_itself(client, regular_user, auth_
                       headers=auth_headers(regular_user),
                       json={"attributes": ["themis_create"]})
     assert resp.status_code == 403
+
+
+def test_admin_deletes_a_user(client, admin_user, make_user, auth_headers):
+    """La baja administrativa borra de verdad: el usuario deja de estar en la lista."""
+    target = make_user(role="role_user")
+    headers = auth_headers(admin_user)
+
+    resp = client.delete(f"/users/{target.id}", headers=headers)
+    assert resp.status_code == 200
+
+    listed = client.get("/users", headers=headers)
+    assert target.username not in [u["username"] for u in listed.get_json()]
+
+
+def test_delete_user_requires_admin(client, regular_user, make_user, auth_headers):
+    target = make_user(role="role_user")
+    resp = client.delete(f"/users/{target.id}", headers=auth_headers(regular_user))
+    assert resp.status_code == 403
+
+
+def test_admin_cannot_delete_another_admin(client, admin_user, make_user, auth_headers):
+    """La jerarquia de `can_administer_user`: un admin solo llega a role_user.
+
+    Sin esta comprobacion, `require_role(Role.ADMIN)` dejaria que cualquier
+    administrador se quitase de encima a sus pares y al root.
+    """
+    other_admin = make_user(role="role_admin")
+    root = make_user(role="role_root")
+    headers = auth_headers(admin_user)
+
+    assert client.delete(f"/users/{other_admin.id}", headers=headers).status_code == 403
+    assert client.delete(f"/users/{root.id}", headers=headers).status_code == 403
+
+
+def test_root_cannot_delete_itself_from_the_admin_panel(client, root_user, auth_headers):
+    """Auto-borrado cortado a mano.
+
+    `can_administer_user` se lo permite al root a proposito (lo necesita para
+    sus propios atributos), asi que sin este corte el root se quedaria sin
+    sistema de un clic. Para darse de baja esta DELETE /users/me, que
+    re-verifica la contrasenya.
+    """
+    resp = client.delete(f"/users/{root_user.id}", headers=auth_headers(root_user))
+    assert resp.status_code == 400
+
+
+def test_root_deletes_an_admin(client, root_user, make_user, auth_headers):
+    target = make_user(role="role_admin")
+    resp = client.delete(f"/users/{target.id}", headers=auth_headers(root_user))
+    assert resp.status_code == 200

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `PUT` | `/users/change-password` | Password change (invalidates all tokens) |
 | `GET/POST/DELETE` | `/users/mfa`, `/users/mfa/totp/setup`, `/users/mfa/totp/confirm`, `/users/mfa/totp` | Check status / enroll / confirm / disable TOTP MFA |
 | `GET` | `/users` · `GET/PUT/DELETE /users/<id>/attributes` | (admin/root) User list and ABAC attribute management |
+| `GET` | `/users/<id>/deletion-preview` | (admin/root) Preview what deleting that user destroys — notably the organization they own |
 | `DELETE` | `/users/<id>` | (admin/root) Delete another user's account; same purge as self-deletion, hierarchy enforced (an admin cannot delete an admin or the root), own account excluded |
 | `GET` | `/system/say-hello` | **Public** health check, reports the API version |
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `PUT` | `/users/change-password` | Password change (invalidates all tokens) |
 | `GET/POST/DELETE` | `/users/mfa`, `/users/mfa/totp/setup`, `/users/mfa/totp/confirm`, `/users/mfa/totp` | Check status / enroll / confirm / disable TOTP MFA |
 | `GET` | `/users` · `GET/PUT/DELETE /users/<id>/attributes` | (admin/root) User list and ABAC attribute management |
+| `DELETE` | `/users/<id>` | (admin/root) Delete another user's account; same purge as self-deletion, hierarchy enforced (an admin cannot delete an admin or the root), own account excluded |
 | `GET` | `/system/say-hello` | **Public** health check, reports the API version |
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |
 | `GET` | `/system/logs` | (admin) Paginated central log viewer |

--- a/web/app/src/components/users/UserDetailsModal.vue
+++ b/web/app/src/components/users/UserDetailsModal.vue
@@ -47,9 +47,30 @@
               </div>
             </div>
           </div>
+          <div v-if="canDelete" class="detail-section danger-zone">
+            <h4>Dar de baja</h4>
+            <p class="danger-note">
+              Se borra la cuenta y todo lo que cuelga de ella: escaneos, campañas,
+              informes y su bóveda. No hay vuelta atrás.
+            </p>
+            <button class="btn btn--sm btn--danger" @click="showDeleteConfirm = true">
+              Eliminar usuario
+            </button>
+          </div>
         </template>
       </div>
     </div>
+
+    <ConfirmModal
+      :show="showDeleteConfirm"
+      title="Eliminar usuario"
+      emphasis="Esta acción no se puede deshacer."
+      :message="deleteMessage"
+      confirm-label="Eliminar"
+      danger
+      @confirm="handleDelete"
+      @cancel="showDeleteConfirm = false"
+    />
   </Teleport>
 </template>
 
@@ -58,6 +79,7 @@ import { ref, computed, watch } from 'vue'
 import { useUtils } from '@/composables/useUtils'
 import { useAuthStore } from '@/stores/authStore'
 import { useUsersStore } from '@/stores/usersStore'
+import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const { formatDate, getInitials } = useUtils()
 const auth = useAuthStore()
@@ -71,8 +93,21 @@ const attributes = ref([])
 const loadingUser = ref(false)
 const showAttrForm = ref(false)
 const selectedAttrs = ref([])
+const showDeleteConfirm = ref(false)
 
 const canManage = computed(() => auth.isAdmin)
+
+/** La jerarquía real la aplica el backend; aquí solo se evita ofrecer un 403.
+ *  Un admin llega a los usuarios normales, el root llega a todos, y nadie se
+ *  da de baja a sí mismo desde aquí: para eso está el perfil. */
+const canDelete = computed(() => {
+  if (!canManage.value || !user.value) return false
+  if (user.value.username === auth.username()) return false
+  return auth.isRoot || (user.value.role || 'role_user') === 'role_user'
+})
+const deleteMessage = computed(
+  () => `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`,
+)
 const ALL_ATTRIBUTES = [
   { module: 'Aegis', attrs: [{ name: 'aegis_read', desc: 'Lectura' }, { name: 'aegis_write', desc: 'Escritura' }, { name: 'aegis_create', desc: 'Creación' }, { name: 'aegis_delete', desc: 'Eliminación' }] },
   { module: 'Themis', attrs: [{ name: 'themis_read', desc: 'Lectura' }, { name: 'themis_write', desc: 'Escritura' }, { name: 'themis_create', desc: 'Creación' }, { name: 'themis_delete', desc: 'Eliminación' }] },
@@ -85,11 +120,16 @@ const roleLabel = computed(() => { const r = user.value?.role || 'role_user'; if
 
 watch(() => props.show, async (v) => {
   if (!v || !props.userId) return
-  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []
+  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false
   try { user.value = store.users.find(u => u.id == props.userId) || null; attributes.value = await store.loadUserAttributes(props.userId) } finally { loadingUser.value = false }
 })
 
 async function handleRemoveAttribute(attr) { const ok = await store.removeAttributes(props.userId, [attr]); if (ok) attributes.value = await store.loadUserAttributes(props.userId) }
+/** El store ya recarga la lista al terminar, así que aquí solo queda cerrar. */
+async function handleDelete() {
+  showDeleteConfirm.value = false
+  if (await store.deleteUser(props.userId)) emit('close')
+}
 async function handleAddAttributes() { if (selectedAttrs.value.length === 0) return; const ok = await store.addAttributes(props.userId, selectedAttrs.value); if (ok) { showAttrForm.value = false; selectedAttrs.value = []; attributes.value = await store.loadUserAttributes(props.userId) } }
 </script>
 
@@ -132,4 +172,7 @@ async function handleAddAttributes() { if (selectedAttrs.value.length === 0) ret
 .attr-check { display: flex; align-items: center; gap: 0.25rem; font-size: var(--fs-md); color: var(--text); cursor: pointer; }
 .attr-check input { accent-color: var(--accent); cursor: pointer; }
 .attr-form-actions { display: flex; gap: 0.4rem; justify-content: flex-end; margin-top: 0.65rem; }
+.danger-zone { border-top: 1px solid var(--border); padding-top: 1rem; }
+.danger-zone h4 { color: var(--danger); }
+.danger-note { font-size: var(--fs-md); color: var(--text-muted); margin: 0 0 0.65rem; }
 </style>

--- a/web/app/src/components/users/UserDetailsModal.vue
+++ b/web/app/src/components/users/UserDetailsModal.vue
@@ -53,7 +53,7 @@
               Se borra la cuenta y todo lo que cuelga de ella: escaneos, campañas,
               informes y su bóveda. No hay vuelta atrás.
             </p>
-            <button class="btn btn--sm btn--danger" @click="showDeleteConfirm = true">
+            <button class="btn btn--sm btn--danger" @click="askDelete">
               Eliminar usuario
             </button>
           </div>
@@ -94,6 +94,7 @@ const loadingUser = ref(false)
 const showAttrForm = ref(false)
 const selectedAttrs = ref([])
 const showDeleteConfirm = ref(false)
+const deletionPreview = ref(null)
 
 const canManage = computed(() => auth.isAdmin)
 
@@ -105,9 +106,18 @@ const canDelete = computed(() => {
   if (user.value.username === auth.username()) return false
   return auth.isRoot || (user.value.role || 'role_user') === 'role_user'
 })
-const deleteMessage = computed(
-  () => `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`,
-)
+const deleteMessage = computed(() => {
+  const base = `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`
+  const owned = deletionPreview.value?.ownedOrganization
+  if (!owned) return base
+  // La única consecuencia que sale de la cuenta borrada: su organización se
+  // disuelve con ella y los demás se enteran después si nadie lo dice antes.
+  const members = owned.membersLosingAccess
+  const tail = members
+    ? ` y ${members} ${members === 1 ? 'miembro se queda' : 'miembros se quedan'} sin ella`
+    : ''
+  return `${base} También desaparece su organización «${owned.name}»${tail}.`
+})
 const ALL_ATTRIBUTES = [
   { module: 'Aegis', attrs: [{ name: 'aegis_read', desc: 'Lectura' }, { name: 'aegis_write', desc: 'Escritura' }, { name: 'aegis_create', desc: 'Creación' }, { name: 'aegis_delete', desc: 'Eliminación' }] },
   { module: 'Themis', attrs: [{ name: 'themis_read', desc: 'Lectura' }, { name: 'themis_write', desc: 'Escritura' }, { name: 'themis_create', desc: 'Creación' }, { name: 'themis_delete', desc: 'Eliminación' }] },
@@ -120,11 +130,17 @@ const roleLabel = computed(() => { const r = user.value?.role || 'role_user'; if
 
 watch(() => props.show, async (v) => {
   if (!v || !props.userId) return
-  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false
+  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false; deletionPreview.value = null
   try { user.value = store.users.find(u => u.id == props.userId) || null; attributes.value = await store.loadUserAttributes(props.userId) } finally { loadingUser.value = false }
 })
 
 async function handleRemoveAttribute(attr) { const ok = await store.removeAttributes(props.userId, [attr]); if (ok) attributes.value = await store.loadUserAttributes(props.userId) }
+/** El aviso se pide al abrir la confirmación, no al abrir la ficha: así solo
+ *  se consulta cuando alguien va en serio. */
+async function askDelete() {
+  deletionPreview.value = await store.loadDeletionPreview(props.userId)
+  showDeleteConfirm.value = true
+}
 /** El store ya recarga la lista al terminar, así que aquí solo queda cerrar. */
 async function handleDelete() {
   showDeleteConfirm.value = false

--- a/web/app/src/stores/usersStore.js
+++ b/web/app/src/stores/usersStore.js
@@ -91,6 +91,21 @@ export const useUsersStore = defineStore('users', () => {
   }
 
   /**
+   * Consecuencias de dar de baja a un usuario (GET /users/{id}/deletion-preview).
+   *
+   * Es un aviso, no un requisito: si la llamada falla se confirma igual, con el
+   * mensaje genérico, en vez de bloquear la baja por no poder adornarla.
+   * @param {number|string} userId - ID del usuario
+   * @returns {Promise<object|null>} {ownedOrganization, leavesOrganizationId} o null
+   */
+  async function loadDeletionPreview(userId) {
+    try {
+      const res = await apiFetch(`/users/${userId}/deletion-preview`)
+      return res?.ok ? await res.json() : null
+    } catch { return null }
+  }
+
+  /**
    * Obtiene los atributos ABAC de un usuario.
    * @param {number|string} userId - ID del usuario
    * @returns {Promise<string[]>} Lista de nombres de atributos
@@ -150,5 +165,5 @@ export const useUsersStore = defineStore('users', () => {
     loading.value = false
   }
 
-  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
+  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadDeletionPreview, loadUserAttributes, addAttributes, removeAttributes, $reset }
 })

--- a/web/app/src/stores/usersStore.js
+++ b/web/app/src/stores/usersStore.js
@@ -71,6 +71,26 @@ export const useUsersStore = defineStore('users', () => {
   }
 
   /**
+   * Da de baja a un usuario vía DELETE /users/{id}.
+   *
+   * Borra la cuenta y todo lo que cuelga de ella; el backend es quien decide
+   * si el actor llega a ese usuario (un admin no llega a otro admin).
+   * @param {number|string} userId - ID del usuario
+   * @returns {Promise<boolean>} True si se eliminó correctamente
+   */
+  async function deleteUser(userId) {
+    const res = await apiFetch(`/users/${userId}`, { method: 'DELETE' })
+    if (!res?.ok) {
+      if (res?.status === 403) toast.show('No tienes permiso para eliminar a este usuario.', 'error')
+      else toast.show(await apiError(res, 'Error al eliminar el usuario.'), 'error')
+      return false
+    }
+    toast.show('Usuario eliminado.', 'success')
+    await loadUsers()
+    return true
+  }
+
+  /**
    * Obtiene los atributos ABAC de un usuario.
    * @param {number|string} userId - ID del usuario
    * @returns {Promise<string[]>} Lista de nombres de atributos
@@ -130,5 +150,5 @@ export const useUsersStore = defineStore('users', () => {
     loading.value = false
   }
 
-  return { users, loading, grouped, loadUsers, createUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
+  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
 })


### PR DESCRIPTION
## Resumen

El panel de administración ya puede dar de baja usuarios: endpoint nuevo, acción en la ficha del usuario y aviso previo de lo que se lleva por delante.

## Issue relacionado

Closes #124

## Implementación

**1. `feat(users)`: `DELETE /users/<id>`**

El trabajo sucio ya estaba hecho: `UserManager.delete_user()` hacía el barrido completo por módulo (`services/account_deletion.py`, con la disolución de la organización que el usuario poseyera) y **no la llamaba nadie** — era código muerto esperando esta puerta. Los tokens del borrado caen por cascada de la fila `User`, así que sus sesiones mueren con él.

Autorización en dos capas, la misma pareja que ya usan los endpoints de atributos:
- `require_role(Role.ADMIN)` — la restricción a `admin`/`root` que pedía el issue.
- `can_administer_user()` — la jerarquía: un admin no llega a otro admin ni al root.

Y un corte explícito de auto-borrado: `can_administer_user` se lo permite al root sobre sí mismo a propósito (lo necesita para sus propios atributos), lo que aplicado al borrado significaría quedarse sin sistema de un clic. Para eso está `DELETE /users/me`, que además re-verifica la contraseña.

**2. `feat(web)`: la acción en el panel**

`deleteUser` en `usersStore` + zona de baja en `UserDetailsModal` con `ConfirmModal` (`danger`), el mismo patrón destructivo de Hygeia, Iris y Aegis. El botón se oculta sobre uno mismo y sobre quien esté por encima en la jerarquía; es cortesía, no seguridad — si el backend responde 403 porque el rol cambió entre la carga de la lista y el clic, sale un aviso claro y el usuario sigue donde estaba.

**3. `feat(users)`: `GET /users/<id>/deletion-preview`**

Borrar a alguien puede disolver una organización entera y quien lo hace en nombre de otro no tiene forma de saberlo. `preview_deletion()` ya calculaba ese aviso para la baja voluntaria y acepta cualquier `user_id`, así que solo hacía falta exponerlo con la autorización del **borrado** (no la de la lectura). La confirmación lo pide al abrirse; si la llamada falla se confirma igual con el texto genérico — es un aviso, no un requisito.

## Validación

- Suite completa de la API: **1921 tests, todos en verde** (`python -m pytest -q`, exit 0).
- 8 tests nuevos: el borrado efectivo (desaparece de `GET /users`), 403 para `role_user`, 403 de admin contra admin y contra root, 400 del auto-borrado, root borrando a un admin, y tres del preview administrativo (incluido el aviso real de organización con miembros).
- `npm run build` ✅
- Flujo de la SPA probado extremo a extremo contra un backend simulado desechable (sin tocar la BD de desarrollo, que guarda el backfill de la KB de Lybra): el botón aparece sobre un `role_user` y no sobre el root ni sobre uno mismo; la confirmación muestra *"También desaparece su organización «Acme» y 3 miembros se quedan sin ella"*; al confirmar sale el toast, la ficha se cierra y el contador baja; y un 403 del servidor produce *"No tienes permiso para eliminar a este usuario."* dejando al usuario en la lista.
- Tabla de endpoints del README actualizada con las dos rutas nuevas.

## Notas

- Las animaciones de entrada/salida de las modales no se pudieron comprobar visualmente: el panel del navegador de pruebas reporta `document.hidden`, donde `requestAnimationFrame` no dispara y **cualquier** `<Transition>` de Vue se queda a medias. Es del entorno de automatización, no del cambio — el estado del componente sí se verificó correcto (`show === false` tras cancelar).
- `pylint src` no se ejecutó: el módulo no está instalado en este entorno.
- Fuera de alcance a propósito: re-verificar la contraseña del administrador (ningún otro endpoint de administración lo pide), `limiter` en el endpoint (idem) y borrado en lote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
