### PR TITLE
test: la suite deja de salir a la red real (6 min 15 s → 1 min 50 s)

### DIFF
--- a/API/src/modules/system/taskqueue/connection.py
+++ b/API/src/modules/system/taskqueue/connection.py
@@ -36,16 +36,13 @@ class RedisConnectionFactory:
 
     @staticmethod
     def _kwargs(blocking: bool = False) -> dict:
-        cfg = CR.redis_config()
-        kwargs = {
-            "host": cfg.host,
-            "port": cfg.port,
-            "db": cfg.db,
-            "password": cfg.password,
-            # Sin connect timeout, un Redis caído bloquearía indefinidamente al
-            # conectar, dejando el API colgado y "comiéndose" los CTRL+C.
-            "socket_connect_timeout": 5,
-        }
+        # connection_kwargs() ya trae host/port/db/password y el
+        # socket_connect_timeout de la configuración — sin ese timeout, un
+        # Redis caído bloquearía indefinidamente al conectar, dejando el API
+        # colgado y "comiéndose" los CTRL+C. Antes se hardcodeaba aquí un 5
+        # que ignoraba el valor del fichero (y dejaba muerto el que sí usa
+        # ping_redis, que llama a connection_kwargs directamente).
+        kwargs = CR.redis_config().connection_kwargs()
         if not blocking:
             # Timeout de lectura para que un Redis lento no cuelgue las
             # operaciones normales (estado de la cola, cancelación, apagado).

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -28,7 +28,9 @@ Decisiones de diseño (ver el plan de tests):
 
 from __future__ import annotations
 
+import ipaddress
 import os
+import socket
 import sys
 from pathlib import Path
 
@@ -212,6 +214,74 @@ def _redis_always_unavailable():
         raise redis_lib.ConnectionError("Redis deshabilitado en la suite de tests")
 
     with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection", _unavailable):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# 3-ter. Ningún socket sale de loopback
+# ---------------------------------------------------------------------------
+
+def _is_loopback(address) -> bool:
+    """¿Apunta ``address`` (el argumento de ``socket.connect``) a loopback?
+
+    Sockets Unix (dirección = ruta) y familias exóticas se dejan pasar: aquí
+    solo interesa el tráfico IP. Una dirección sin resolver (nombre en vez de
+    IP) se considera externa, que es el lado conservador.
+    """
+    if not isinstance(address, tuple) or not address:
+        return True
+    try:
+        return ipaddress.ip_address(address[0]).is_loopback
+    except ValueError:
+        return address[0] in ("localhost", "")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _no_outbound_sockets():
+    """Corta cualquier conexión que no sea a loopback, al instante.
+
+    Varios tests de Lybra ejecutan el motor completo contra ``10.0.0.5`` (una
+    IP privada que no enruta a ninguna parte). Cada check activo abría un
+    socket de verdad y esperaba su timeout completo — ``HttpProbe`` usa 8 s, y
+    un solo test se comía 10 checks × 8 s = 80 s. Los tests ya mockean las
+    sondas que recuerdan (``HttpProbe.fetch`` y compañía), pero basta con
+    olvidar una para que el escaneo salga a la red.
+
+    Se corta en ``socket.connect``, no sonda a sonda, porque es el único punto
+    por el que pasan todas: urllib (``HttpProbe``), TLS, las sesiones TCP
+    crudas de la Fase N y el descubrimiento de puertos. Un ``ConnectionRefused``
+    instantáneo es indistinguible de un host inalcanzable para el código bajo
+    test — que trata cualquier ``OSError`` como "no hay servicio" — solo que
+    sin la espera.
+
+    Loopback sí se permite: los tests de herald levantan un servidor SMTP real
+    (aiosmtpd) en 127.0.0.1 y tienen que poder hablar con él.
+    """
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+    real_gethostbyaddr = socket.gethostbyaddr
+
+    def guarded_connect(self, address):
+        if not _is_loopback(address):
+            raise ConnectionRefusedError(
+                f"La suite de tests no permite conexiones fuera de loopback: {address!r}"
+            )
+        return real_connect(self, address)
+
+    def guarded_connect_ex(self, address):
+        if not _is_loopback(address):
+            return 111  # ECONNREFUSED, la convención de connect_ex
+        return real_connect_ex(self, address)
+
+    def guarded_gethostbyaddr(ip):
+        # El DNS inverso es la otra forma de irse a la red sin abrir un socket
+        # propio: resolver 10.0.0.5 colgaba 16 s en un test de Lybra. El único
+        # caller (shared._endpoints) ya trata socket.herror como "no resuelve".
+        if not _is_loopback((ip,)):
+            raise socket.herror(f"DNS inverso bloqueado en tests: {ip!r}")
+        return real_gethostbyaddr(ip)
+
+    with mock.patch.object(socket.socket, "connect", guarded_connect),          mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),          mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr):
         yield
 
 

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -281,7 +281,11 @@ def _no_outbound_sockets():
             raise socket.herror(f"DNS inverso bloqueado en tests: {ip!r}")
         return real_gethostbyaddr(ip)
 
-    with mock.patch.object(socket.socket, "connect", guarded_connect),          mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),          mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr):
+    with (
+        mock.patch.object(socket.socket, "connect", guarded_connect),
+        mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),
+        mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr),
+    ):
         yield
 
 

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -20,7 +20,8 @@ Decisiones de diseño (ver el plan de tests):
     inexistentes en SQLite. Antes de crear el esquema se sustituyen *en memoria*
     por ``JSON`` genérico. No se toca ningún fichero de ``src/``.
 
-4.  **Servicios externos mockeados.** El ``ping`` a Redis de ``create_app`` se
+4.  **Servicios externos mockeados.** Redis se corta de raíz para toda la
+    sesión (``_redis_always_unavailable``); el ``ping`` de ``create_app`` se
     parchea; el scheduler se desactiva con ``start_scheduler=False``; el rate
     limiter se desactiva para no contaminar tests entre sí.
 """
@@ -66,17 +67,16 @@ os.environ.setdefault("SHUTDOWN_TIMEOUT", "30")
 # la app (que sigue mockeando Redis para create_app()).
 os.environ.setdefault("RATELIMIT_STORAGE_URI", "memory://")
 
-# T5: aislar Redis del de desarrollo. Solo se mockean `ping`/`close` (arriba)
-# para que create_app() arranque sin depender de un Redis real -- cualquier
-# otra operación (p. ej. un TaskQueue.submit() no mockeado en algún test) sí
-# llega a un Redis de verdad. Sin esto, esos tests encolaban jobs reales en la
-# MISMA base Redis que usa el servidor de desarrollo (REDIS_HOST/DB comparten
-# valor con .env), dejando jobs huérfanos que un worker real recogía más
-# tarde y fallaban con FK violation contra una fila que solo existió en el
-# SQLite efímero del test. Redis soporta 16 bases lógicas (0-15); moviendo los
-# tests a la 15 quedan en un espacio de claves separado del de dev (DB 0) sin
-# necesitar un Redis distinto. Asignación incondicional (no `setdefault`):
-# tiene que ganar aunque `.env` ya fije REDIS_DB.
+# T5: aislar Redis del de desarrollo. Segunda línea de defensa por debajo del
+# fixture `_redis_always_unavailable` (que ya corta cualquier conexión): si
+# alguien lo desactiva a propósito para depurar, los tests siguen escribiendo
+# en la base 15 y no en la del servidor de desarrollo. Sin ninguna de las dos,
+# un TaskQueue.submit() no mockeado encola jobs reales en la MISMA base Redis
+# que usa dev (REDIS_HOST/DB comparten valor con .env), dejando jobs huérfanos
+# que un worker real recoge más tarde y fallan con FK violation contra una
+# fila que solo existió en el SQLite efímero del test. Redis soporta 16 bases
+# lógicas (0-15). Asignación incondicional (no `setdefault`): tiene que ganar
+# aunque `.env` ya fije REDIS_DB.
 os.environ["REDIS_DB"] = "15"
 
 # Redis/Ollama: valores inertes; los servicios se mockean.
@@ -86,6 +86,7 @@ os.environ.setdefault("OLLAMA_HOST", "http://localhost:11434")
 from unittest import mock  # noqa: E402
 
 import pytest  # noqa: E402
+import redis as redis_lib  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
 from sqlalchemy.dialects.postgresql import JSONB  # noqa: E402
 
@@ -178,6 +179,40 @@ def _initialized_db(_sqlite_url):
     yield engine
     Base.metadata.drop_all(engine)
     session_factory.remove()
+
+
+# ---------------------------------------------------------------------------
+# 3-bis. Redis: siempre caído, siempre al instante
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def _redis_always_unavailable():
+    """Hace que cualquier operación contra Redis falle *al instante*.
+
+    La suite no necesita un Redis: los tests que ejercitan el encolado mockean
+    ``TaskQueue.get_instance`` con un doble. Pero basta con olvidarlo en un
+    test para que la operación salga a la red de verdad, y ahí el coste no es
+    un error rápido sino una espera larguísima: en Windows un ECONNREFUSED
+    contra ``localhost`` tarda ~4 s (resolución dual-stack, ~2 s por ``::1`` y
+    otros ~2 s por ``127.0.0.1``) y redis-py reintenta varias veces, así que un
+    único comando se comía ~48 s. Tres tests despistados sumaban 220 s de los
+    375 s de la suite entera. En el runner Linux de CI el rechazo es inmediato,
+    por eso el pipeline nunca lo delató.
+
+    Se parchea ``ConnectionPool.get_connection`` en vez de la fachada
+    ``Redis``: es el único punto por el que pasan tanto los comandos sueltos
+    como los pipelines, y deja intactos los objetos ``Redis`` reales, de modo
+    que el código bajo test sigue viendo un ``redis.ConnectionError`` (lo que
+    ya captura hoy) y no un doble con otra forma.
+
+    Efecto secundario buscado: el resultado deja de depender de si la máquina
+    tiene o no el Redis de desarrollo levantado.
+    """
+    def _unavailable(*_args, **_kwargs):
+        raise redis_lib.ConnectionError("Redis deshabilitado en la suite de tests")
+
+    with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection", _unavailable):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/API/tests/unit/test_config_reading.py
+++ b/API/tests/unit/test_config_reading.py
@@ -20,6 +20,26 @@ def test_redis_config_prefers_the_environment(monkeypatch):
     assert config.password is None
 
 
+def test_redis_connection_kwargs_honour_the_configured_connect_timeout(monkeypatch):
+    """El factory del taskqueue tiene que leer el timeout del fichero.
+
+    Hardcodeaba un 5 que ignoraba `infrastructure.redis.socket_connect_timeout`
+    y dejaba muerto el valor que sí usa ping_redis().
+    """
+    from src.modules.system.taskqueue.connection import RedisConnectionFactory
+
+    monkeypatch.setattr(
+        CR, "redis_config",
+        lambda: CR.RedisConfig(socket_connect_timeout=7),
+    )
+
+    kwargs = RedisConnectionFactory._kwargs()
+    assert kwargs["socket_connect_timeout"] == 7
+    # El de lectura no se aplica al worker: RQ saca jobs con BLPOP.
+    assert kwargs["socket_timeout"] == 5
+    assert "socket_timeout" not in RedisConnectionFactory._kwargs(blocking=True)
+
+
 def test_jwt_config_from_env():
     config = CR.jwt_config()
     assert config.secret == "test-secret-key-not-for-production"


### PR DESCRIPTION
## Resumen

La suite de la API tardaba **6 min 15 s**; ahora tarda **1 min 50 s** (−71 %), con los mismos 1838 tests en verde y la misma cobertura (80 %).

El problema no era el volumen de tests sino un puñado que hacía **E/S de red real**: se conectaban a un Redis que no está levantado y sondeaban por socket una IP no enrutable, pagando timeouts completos. Diez tests se llevaban el 75 % del tiempo total. Ahora ningún test pasa de 2,7 s.

| | antes | después |
|---|---|---|
| `pytest -q -m "not oracle" --no-cov` | 6 min 15,7 s | 1 min 51 s |
| `pytest -q -m "not oracle"` (con `--cov`, el de `addopts`) | 6 min 23,2 s | 1 min 50 s |
| test más lento | 94,6 s | 2,7 s |

## Issue relacionada

Closes #153

## Implementación

**1. `test(system)`: cortar Redis de raíz en la suite.** La suite no necesita Redis — los tests que ejercitan el encolado mockean `TaskQueue.get_instance` con un doble —, pero bastaba con olvidarlo en uno para que la operación saliera a la red. Y ahí el coste no era un error rápido: en Windows un ECONNREFUSED contra `localhost` tarda ~4 s (dual-stack) y redis-py reintenta, así que un solo comando se comía ~48 s. El caso claro es `test_generate_accepts_the_payload_the_frontend_sends`, que ya parcheaba `AegisManager.generate` con el comentario *"El encolado real necesita Redis"* sin efecto: quien toca Redis es el `__init__` del manager (`AegisPillsManager.__init__` → `TaskQueue.get_instance()` → `HistoryStore._migrate_legacy()`), no `generate`.

Se parchea `ConnectionPool.get_connection` para toda la sesión: es el único punto por el que pasan comandos sueltos y pipelines, y deja intactos los objetos `Redis` reales, así que el código bajo test sigue viendo el `redis.ConnectionError` que ya captura hoy.

**2. `test(themis)`: impedir que la suite salga a la red fuera de loopback.** Varios tests de Lybra corren el motor completo contra `10.0.0.5`. Cada check activo abría un socket de verdad y esperaba su timeout entero (`HttpProbe` usa 8 s → 10 checks × 8 s = 80 s en un único test), y otro se colgaba 16 s en un DNS inverso de esa misma IP (`shared._endpoints._gethostbyaddr_with_timeout`, que pese al nombre no lleva timeout).

El corte va en `socket.connect`/`connect_ex` y `socket.gethostbyaddr`, no sonda a sonda: es el punto por el que pasan urllib, TLS, las sesiones TCP crudas de la Fase N y el descubrimiento de puertos. Loopback se sigue permitiendo, porque los tests de herald levantan un aiosmtpd real en 127.0.0.1.

> **Desviación respecto al plan aprobado.** El plan decía inyectar el `connect` falso que `checks.py` ya admite en los tests de Lybra afectados. Al implementarlo se vio que no bastaba: `test_lybra_active_check_persists_confirmed_finding` *ya* stubbea `HttpProbe.fetch` y aun así tardaba 15 s por las sondas que no mockea, y los 16 s del DNS inverso no pasan por ningún `connect` inyectable. Cerrar el seam compartido resuelve los dos casos, deja un diff más pequeño (un fixture en `conftest.py` en vez de editar dos módulos de test) y establece el invariante que pedía la issue: ningún test abre un socket real.

**3. `fix(system)`: leer el `socket_connect_timeout` de Redis de la configuración.** `RedisConnectionFactory._kwargs()` hardcodeaba `socket_connect_timeout=5` y reconstruía a mano host/port/db/password, ignorando `infrastructure.redis.socket_connect_timeout` del `SecOpsConfig.json` (que vale 2). Ese valor solo lo veía `ping_redis()`. Ahora el factory parte del mismo `RedisConfig.connection_kwargs()`.

**4. `style(system)`**: partir en varias líneas el `with` de los parches de socket.

## Validación

- `pytest -q -m "not oracle"` (invocación de CI, con cobertura) — verde, 1 min 50 s, cobertura 80 % idéntica a la de `develope`.
- `pytest -q -m "not oracle" --no-cov` — verde, 1 min 51 s.
- Test nuevo `test_redis_connection_kwargs_honour_the_configured_connect_timeout` para el punto 3.
- Comprobación explícita de que los tests que sí necesitan red loopback siguen pasando (`test_herald_smtp.py` con aiosmtpd, `test_aegis_campaigns.py`).
- Diagnóstico hecho con `cProfile` sobre los tests lentos, no por inspección.

## Notas

- El cuello de botella era invisible en CI: en el runner Linux un ECONNREFUSED es inmediato y la IP privada falla rápido, así que el pipeline nunca se quejó. Es un problema de desarrollo local (y agudo en Windows).
- Efecto secundario buscado: el resultado deja de depender de si la máquina tiene levantado el Redis de desarrollo.
- **Fuera de alcance** (queda documentado en #153 para cuando compense): paralelizar con `pytest-xdist`; aligerar los fixtures autouse `_clean_db` (un `DELETE` por cada una de las 67 tablas después de cada test, sobre SQLite en fichero) y `_unlimited_default_plan`; que los tests marcados `unit` dejen de arrastrar app+BD pese a que el marcador se define como "sin base de datos ni aplicación Flask"; y bajar los parámetros de Argon2 en tests. Ese bloque es hoy ~50 ms/test, el grueso de lo que queda.
- El banco `tests/oracle` no se toca: hace red real por diseño y está excluido de CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
