### PR TITLE
release: 0.5.10 — baja administrativa de usuarios, UX del alta y suite de tests 3,4× más rápida

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.9",
+  "appVersion": "0.5.10",
   "general": {
     "directories": {
       "logdir": "..",

--- a/API/src/modules/system/taskqueue/connection.py
+++ b/API/src/modules/system/taskqueue/connection.py
@@ -36,16 +36,13 @@ class RedisConnectionFactory:
 
     @staticmethod
     def _kwargs(blocking: bool = False) -> dict:
-        cfg = CR.redis_config()
-        kwargs = {
-            "host": cfg.host,
-            "port": cfg.port,
-            "db": cfg.db,
-            "password": cfg.password,
-            # Sin connect timeout, un Redis caído bloquearía indefinidamente al
-            # conectar, dejando el API colgado y "comiéndose" los CTRL+C.
-            "socket_connect_timeout": 5,
-        }
+        # connection_kwargs() ya trae host/port/db/password y el
+        # socket_connect_timeout de la configuración — sin ese timeout, un
+        # Redis caído bloquearía indefinidamente al conectar, dejando el API
+        # colgado y "comiéndose" los CTRL+C. Antes se hardcodeaba aquí un 5
+        # que ignoraba el valor del fichero (y dejaba muerto el que sí usa
+        # ping_redis, que llama a connection_kwargs directamente).
+        kwargs = CR.redis_config().connection_kwargs()
         if not blocking:
             # Timeout de lectura para que un Redis lento no cuelgue las
             # operaciones normales (estado de la cola, cancelación, apagado).

--- a/API/src/modules/users/endpoints.py
+++ b/API/src/modules/users/endpoints.py
@@ -685,6 +685,47 @@ def remove_user_attribute(data: dict[str, Any], target_user_id: int):
     return {"message": "Attributes removed", "attributes": attrs_to_remove}
 
 
+@users_blp.delete("/<int:target_user_id>")
+@users_blp.response(200, SuccessMessageSchema, description="User deleted")
+@users_blp.alt_response(400, schema=ErrorSchema, description="Cannot delete your own account here")
+@users_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@users_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
+@require_oauth_token
+@require_role(Role.ADMIN)
+@handle_exceptions(default_exception=DatabaseError, logger=logger)
+def delete_user(target_user_id: int):
+    """Dar de baja a otro usuario desde el panel de administracion.
+
+    Borra lo mismo que la baja voluntaria —el barrido de
+    ``services/account_deletion.py``, con la disolucion de la organizacion que
+    el usuario tuviera— asi que la jerarquia se comprueba con
+    ``can_administer_user``: un admin no puede borrar a otro admin ni al root.
+
+    La propia cuenta no se borra por aqui aunque ``can_administer_user`` se lo
+    permita al root: para eso esta ``DELETE /users/me``, que re-verifica la
+    contrasenya. Sin este corte, un root se quedaria sin sistema de un clic.
+    """
+    current_user_id = get_current_user().id
+
+    if current_user_id == target_user_id:
+        raise EllysiaException(
+            "Usa DELETE /users/me para dar de baja tu propia cuenta",
+            status_code=400,
+        )
+
+    if not USER_MANAGER.can_administer_user(current_user_id, target_user_id):
+        logger.warning(f"Usuario {current_user_id} intento eliminar a {target_user_id} sin permiso")
+        raise EllysiaException(
+            "No tienes permiso para eliminar a este usuario",
+            status_code=403,
+        )
+
+    USER_MANAGER.delete_user(target_user_id)
+
+    logger.info(f"Usuario {target_user_id} eliminado por el administrador {current_user_id}")
+    return {"message": "Usuario eliminado."}
+
+
 # =========================================================================
 # MFA (TOTP) ENDPOINTS
 # =========================================================================

--- a/API/src/modules/users/endpoints.py
+++ b/API/src/modules/users/endpoints.py
@@ -685,6 +685,32 @@ def remove_user_attribute(data: dict[str, Any], target_user_id: int):
     return {"message": "Attributes removed", "attributes": attrs_to_remove}
 
 
+@users_blp.get("/<int:target_user_id>/deletion-preview")
+@users_blp.response(200, DeletionPreviewSchema, description="What deleting that user destroys")
+@users_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@users_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
+@require_oauth_token
+@require_role(Role.ADMIN)
+@handle_exceptions(default_exception=DatabaseError, logger=logger)
+def preview_user_deletion(target_user_id: int):
+    """Que se destruye si se da de baja a ese usuario. No borra nada.
+
+    El mismo aviso que ve quien se da de baja a si mismo, para quien lo hace en
+    su nombre: si el usuario es duenyo de una organizacion, esta DESAPARECE con
+    su cuenta y sus miembros se quedan sin ella. Lleva la autorizacion del
+    borrado —no de la lectura— porque solo tiene sentido antes de borrar.
+    """
+    current_user_id = get_current_user().id
+
+    if not USER_MANAGER.can_administer_user(current_user_id, target_user_id):
+        raise EllysiaException(
+            "No tienes permiso para eliminar a este usuario",
+            status_code=403,
+        )
+
+    return USER_MANAGER.preview_deletion(target_user_id)
+
+
 @users_blp.delete("/<int:target_user_id>")
 @users_blp.response(200, SuccessMessageSchema, description="User deleted")
 @users_blp.alt_response(400, schema=ErrorSchema, description="Cannot delete your own account here")

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -28,7 +28,9 @@ Decisiones de diseño (ver el plan de tests):
 
 from __future__ import annotations
 
+import ipaddress
 import os
+import socket
 import sys
 from pathlib import Path
 
@@ -212,6 +214,74 @@ def _redis_always_unavailable():
         raise redis_lib.ConnectionError("Redis deshabilitado en la suite de tests")
 
     with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection", _unavailable):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# 3-ter. Ningún socket sale de loopback
+# ---------------------------------------------------------------------------
+
+def _is_loopback(address) -> bool:
+    """¿Apunta ``address`` (el argumento de ``socket.connect``) a loopback?
+
+    Sockets Unix (dirección = ruta) y familias exóticas se dejan pasar: aquí
+    solo interesa el tráfico IP. Una dirección sin resolver (nombre en vez de
+    IP) se considera externa, que es el lado conservador.
+    """
+    if not isinstance(address, tuple) or not address:
+        return True
+    try:
+        return ipaddress.ip_address(address[0]).is_loopback
+    except ValueError:
+        return address[0] in ("localhost", "")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _no_outbound_sockets():
+    """Corta cualquier conexión que no sea a loopback, al instante.
+
+    Varios tests de Lybra ejecutan el motor completo contra ``10.0.0.5`` (una
+    IP privada que no enruta a ninguna parte). Cada check activo abría un
+    socket de verdad y esperaba su timeout completo — ``HttpProbe`` usa 8 s, y
+    un solo test se comía 10 checks × 8 s = 80 s. Los tests ya mockean las
+    sondas que recuerdan (``HttpProbe.fetch`` y compañía), pero basta con
+    olvidar una para que el escaneo salga a la red.
+
+    Se corta en ``socket.connect``, no sonda a sonda, porque es el único punto
+    por el que pasan todas: urllib (``HttpProbe``), TLS, las sesiones TCP
+    crudas de la Fase N y el descubrimiento de puertos. Un ``ConnectionRefused``
+    instantáneo es indistinguible de un host inalcanzable para el código bajo
+    test — que trata cualquier ``OSError`` como "no hay servicio" — solo que
+    sin la espera.
+
+    Loopback sí se permite: los tests de herald levantan un servidor SMTP real
+    (aiosmtpd) en 127.0.0.1 y tienen que poder hablar con él.
+    """
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+    real_gethostbyaddr = socket.gethostbyaddr
+
+    def guarded_connect(self, address):
+        if not _is_loopback(address):
+            raise ConnectionRefusedError(
+                f"La suite de tests no permite conexiones fuera de loopback: {address!r}"
+            )
+        return real_connect(self, address)
+
+    def guarded_connect_ex(self, address):
+        if not _is_loopback(address):
+            return 111  # ECONNREFUSED, la convención de connect_ex
+        return real_connect_ex(self, address)
+
+    def guarded_gethostbyaddr(ip):
+        # El DNS inverso es la otra forma de irse a la red sin abrir un socket
+        # propio: resolver 10.0.0.5 colgaba 16 s en un test de Lybra. El único
+        # caller (shared._endpoints) ya trata socket.herror como "no resuelve".
+        if not _is_loopback((ip,)):
+            raise socket.herror(f"DNS inverso bloqueado en tests: {ip!r}")
+        return real_gethostbyaddr(ip)
+
+    with mock.patch.object(socket.socket, "connect", guarded_connect),          mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),          mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr):
         yield
 
 

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -281,7 +281,11 @@ def _no_outbound_sockets():
             raise socket.herror(f"DNS inverso bloqueado en tests: {ip!r}")
         return real_gethostbyaddr(ip)
 
-    with mock.patch.object(socket.socket, "connect", guarded_connect),          mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),          mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr):
+    with (
+        mock.patch.object(socket.socket, "connect", guarded_connect),
+        mock.patch.object(socket.socket, "connect_ex", guarded_connect_ex),
+        mock.patch.object(socket, "gethostbyaddr", guarded_gethostbyaddr),
+    ):
         yield
 
 

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -20,7 +20,8 @@ Decisiones de diseño (ver el plan de tests):
     inexistentes en SQLite. Antes de crear el esquema se sustituyen *en memoria*
     por ``JSON`` genérico. No se toca ningún fichero de ``src/``.
 
-4.  **Servicios externos mockeados.** El ``ping`` a Redis de ``create_app`` se
+4.  **Servicios externos mockeados.** Redis se corta de raíz para toda la
+    sesión (``_redis_always_unavailable``); el ``ping`` de ``create_app`` se
     parchea; el scheduler se desactiva con ``start_scheduler=False``; el rate
     limiter se desactiva para no contaminar tests entre sí.
 """
@@ -66,17 +67,16 @@ os.environ.setdefault("SHUTDOWN_TIMEOUT", "30")
 # la app (que sigue mockeando Redis para create_app()).
 os.environ.setdefault("RATELIMIT_STORAGE_URI", "memory://")
 
-# T5: aislar Redis del de desarrollo. Solo se mockean `ping`/`close` (arriba)
-# para que create_app() arranque sin depender de un Redis real -- cualquier
-# otra operación (p. ej. un TaskQueue.submit() no mockeado en algún test) sí
-# llega a un Redis de verdad. Sin esto, esos tests encolaban jobs reales en la
-# MISMA base Redis que usa el servidor de desarrollo (REDIS_HOST/DB comparten
-# valor con .env), dejando jobs huérfanos que un worker real recogía más
-# tarde y fallaban con FK violation contra una fila que solo existió en el
-# SQLite efímero del test. Redis soporta 16 bases lógicas (0-15); moviendo los
-# tests a la 15 quedan en un espacio de claves separado del de dev (DB 0) sin
-# necesitar un Redis distinto. Asignación incondicional (no `setdefault`):
-# tiene que ganar aunque `.env` ya fije REDIS_DB.
+# T5: aislar Redis del de desarrollo. Segunda línea de defensa por debajo del
+# fixture `_redis_always_unavailable` (que ya corta cualquier conexión): si
+# alguien lo desactiva a propósito para depurar, los tests siguen escribiendo
+# en la base 15 y no en la del servidor de desarrollo. Sin ninguna de las dos,
+# un TaskQueue.submit() no mockeado encola jobs reales en la MISMA base Redis
+# que usa dev (REDIS_HOST/DB comparten valor con .env), dejando jobs huérfanos
+# que un worker real recoge más tarde y fallan con FK violation contra una
+# fila que solo existió en el SQLite efímero del test. Redis soporta 16 bases
+# lógicas (0-15). Asignación incondicional (no `setdefault`): tiene que ganar
+# aunque `.env` ya fije REDIS_DB.
 os.environ["REDIS_DB"] = "15"
 
 # Redis/Ollama: valores inertes; los servicios se mockean.
@@ -86,6 +86,7 @@ os.environ.setdefault("OLLAMA_HOST", "http://localhost:11434")
 from unittest import mock  # noqa: E402
 
 import pytest  # noqa: E402
+import redis as redis_lib  # noqa: E402
 import sqlalchemy as sa  # noqa: E402
 from sqlalchemy.dialects.postgresql import JSONB  # noqa: E402
 
@@ -178,6 +179,40 @@ def _initialized_db(_sqlite_url):
     yield engine
     Base.metadata.drop_all(engine)
     session_factory.remove()
+
+
+# ---------------------------------------------------------------------------
+# 3-bis. Redis: siempre caído, siempre al instante
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def _redis_always_unavailable():
+    """Hace que cualquier operación contra Redis falle *al instante*.
+
+    La suite no necesita un Redis: los tests que ejercitan el encolado mockean
+    ``TaskQueue.get_instance`` con un doble. Pero basta con olvidarlo en un
+    test para que la operación salga a la red de verdad, y ahí el coste no es
+    un error rápido sino una espera larguísima: en Windows un ECONNREFUSED
+    contra ``localhost`` tarda ~4 s (resolución dual-stack, ~2 s por ``::1`` y
+    otros ~2 s por ``127.0.0.1``) y redis-py reintenta varias veces, así que un
+    único comando se comía ~48 s. Tres tests despistados sumaban 220 s de los
+    375 s de la suite entera. En el runner Linux de CI el rechazo es inmediato,
+    por eso el pipeline nunca lo delató.
+
+    Se parchea ``ConnectionPool.get_connection`` en vez de la fachada
+    ``Redis``: es el único punto por el que pasan tanto los comandos sueltos
+    como los pipelines, y deja intactos los objetos ``Redis`` reales, de modo
+    que el código bajo test sigue viendo un ``redis.ConnectionError`` (lo que
+    ya captura hoy) y no un doble con otra forma.
+
+    Efecto secundario buscado: el resultado deja de depender de si la máquina
+    tiene o no el Redis de desarrollo levantado.
+    """
+    def _unavailable(*_args, **_kwargs):
+        raise redis_lib.ConnectionError("Redis deshabilitado en la suite de tests")
+
+    with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection", _unavailable):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/API/tests/integration/test_account_deletion.py
+++ b/API/tests/integration/test_account_deletion.py
@@ -156,6 +156,51 @@ def test_preview_does_not_delete_anything(client, owner, auth_headers):
     assert client.get("/users/me", headers=auth_headers(owner)).status_code == 200
 
 
+def test_admin_preview_warns_about_the_organization_that_dies_with_the_user(
+    client, app, admin_user, owner, make_user, auth_headers
+):
+    """El mismo aviso, pero para quien da de baja a otro.
+
+    Un administrador que borra al duenyo de una organizacion la disuelve sin
+    saberlo si nadie se lo dice.
+    """
+    from src.modules.accounts.model import OrganizationMember
+
+    organization = client.post("/organizations", headers=auth_headers(owner),
+                               json={"name": "Acme"}).get_json()
+    member = make_user()
+    with app.app_context():
+        with unit_of_work.UnitOfWork() as uow:
+            uow.session.add(OrganizationMember(
+                organization_id=organization["id"], user_id=member.id,
+                member_role="member",
+            ))
+            uow.session.flush()
+
+    body = client.get(f"/users/{owner.id}/deletion-preview",
+                      headers=auth_headers(admin_user)).get_json()
+
+    assert body["ownedOrganization"]["name"] == "Acme"
+    assert body["ownedOrganization"]["membersLosingAccess"] == 1
+
+
+def test_admin_preview_does_not_delete_anything(client, admin_user, regular_user, auth_headers):
+    client.get(f"/users/{regular_user.id}/deletion-preview", headers=auth_headers(admin_user))
+    assert client.get("/users/me", headers=auth_headers(regular_user)).status_code == 200
+
+
+def test_admin_preview_needs_the_same_permission_as_deleting(
+    client, admin_user, regular_user, make_user, auth_headers
+):
+    """El aviso solo lo ve quien puede ejecutar la baja."""
+    other_admin = make_user(role="role_admin")
+
+    assert client.get(f"/users/{regular_user.id}/deletion-preview",
+                      headers=auth_headers(regular_user)).status_code == 403
+    assert client.get(f"/users/{other_admin.id}/deletion-preview",
+                      headers=auth_headers(admin_user)).status_code == 403
+
+
 # ----------------------------------------------------------------- el borrado
 
 def test_deleting_requires_the_password(client, regular_user, auth_headers):

--- a/API/tests/integration/test_users.py
+++ b/API/tests/integration/test_users.py
@@ -154,3 +154,53 @@ def test_role_user_cannot_grant_attributes_to_itself(client, regular_user, auth_
                       headers=auth_headers(regular_user),
                       json={"attributes": ["themis_create"]})
     assert resp.status_code == 403
+
+
+def test_admin_deletes_a_user(client, admin_user, make_user, auth_headers):
+    """La baja administrativa borra de verdad: el usuario deja de estar en la lista."""
+    target = make_user(role="role_user")
+    headers = auth_headers(admin_user)
+
+    resp = client.delete(f"/users/{target.id}", headers=headers)
+    assert resp.status_code == 200
+
+    listed = client.get("/users", headers=headers)
+    assert target.username not in [u["username"] for u in listed.get_json()]
+
+
+def test_delete_user_requires_admin(client, regular_user, make_user, auth_headers):
+    target = make_user(role="role_user")
+    resp = client.delete(f"/users/{target.id}", headers=auth_headers(regular_user))
+    assert resp.status_code == 403
+
+
+def test_admin_cannot_delete_another_admin(client, admin_user, make_user, auth_headers):
+    """La jerarquia de `can_administer_user`: un admin solo llega a role_user.
+
+    Sin esta comprobacion, `require_role(Role.ADMIN)` dejaria que cualquier
+    administrador se quitase de encima a sus pares y al root.
+    """
+    other_admin = make_user(role="role_admin")
+    root = make_user(role="role_root")
+    headers = auth_headers(admin_user)
+
+    assert client.delete(f"/users/{other_admin.id}", headers=headers).status_code == 403
+    assert client.delete(f"/users/{root.id}", headers=headers).status_code == 403
+
+
+def test_root_cannot_delete_itself_from_the_admin_panel(client, root_user, auth_headers):
+    """Auto-borrado cortado a mano.
+
+    `can_administer_user` se lo permite al root a proposito (lo necesita para
+    sus propios atributos), asi que sin este corte el root se quedaria sin
+    sistema de un clic. Para darse de baja esta DELETE /users/me, que
+    re-verifica la contrasenya.
+    """
+    resp = client.delete(f"/users/{root_user.id}", headers=auth_headers(root_user))
+    assert resp.status_code == 400
+
+
+def test_root_deletes_an_admin(client, root_user, make_user, auth_headers):
+    target = make_user(role="role_admin")
+    resp = client.delete(f"/users/{target.id}", headers=auth_headers(root_user))
+    assert resp.status_code == 200

--- a/API/tests/unit/test_config_reading.py
+++ b/API/tests/unit/test_config_reading.py
@@ -20,6 +20,26 @@ def test_redis_config_prefers_the_environment(monkeypatch):
     assert config.password is None
 
 
+def test_redis_connection_kwargs_honour_the_configured_connect_timeout(monkeypatch):
+    """El factory del taskqueue tiene que leer el timeout del fichero.
+
+    Hardcodeaba un 5 que ignoraba `infrastructure.redis.socket_connect_timeout`
+    y dejaba muerto el valor que sí usa ping_redis().
+    """
+    from src.modules.system.taskqueue.connection import RedisConnectionFactory
+
+    monkeypatch.setattr(
+        CR, "redis_config",
+        lambda: CR.RedisConfig(socket_connect_timeout=7),
+    )
+
+    kwargs = RedisConnectionFactory._kwargs()
+    assert kwargs["socket_connect_timeout"] == 7
+    # El de lectura no se aplica al worker: RQ saca jobs con BLPOP.
+    assert kwargs["socket_timeout"] == 5
+    assert "socket_timeout" not in RedisConnectionFactory._kwargs(blocking=True)
+
+
 def test_jwt_config_from_env():
     config = CR.jwt_config()
     assert config.secret == "test-secret-key-not-for-production"

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `PUT` | `/users/change-password` | Password change (invalidates all tokens) |
 | `GET/POST/DELETE` | `/users/mfa`, `/users/mfa/totp/setup`, `/users/mfa/totp/confirm`, `/users/mfa/totp` | Check status / enroll / confirm / disable TOTP MFA |
 | `GET` | `/users` · `GET/PUT/DELETE /users/<id>/attributes` | (admin/root) User list and ABAC attribute management |
+| `GET` | `/users/<id>/deletion-preview` | (admin/root) Preview what deleting that user destroys — notably the organization they own |
 | `DELETE` | `/users/<id>` | (admin/root) Delete another user's account; same purge as self-deletion, hierarchy enforced (an admin cannot delete an admin or the root), own account excluded |
 | `GET` | `/system/say-hello` | **Public** health check, reports the API version |
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `PUT` | `/users/change-password` | Password change (invalidates all tokens) |
 | `GET/POST/DELETE` | `/users/mfa`, `/users/mfa/totp/setup`, `/users/mfa/totp/confirm`, `/users/mfa/totp` | Check status / enroll / confirm / disable TOTP MFA |
 | `GET` | `/users` · `GET/PUT/DELETE /users/<id>/attributes` | (admin/root) User list and ABAC attribute management |
+| `DELETE` | `/users/<id>` | (admin/root) Delete another user's account; same purge as self-deletion, hierarchy enforced (an admin cannot delete an admin or the root), own account excluded |
 | `GET` | `/system/say-hello` | **Public** health check, reports the API version |
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |
 | `GET` | `/system/logs` | (admin) Paginated central log viewer |

--- a/web/app/src/components/users/UserDetailsModal.vue
+++ b/web/app/src/components/users/UserDetailsModal.vue
@@ -47,9 +47,30 @@
               </div>
             </div>
           </div>
+          <div v-if="canDelete" class="detail-section danger-zone">
+            <h4>Dar de baja</h4>
+            <p class="danger-note">
+              Se borra la cuenta y todo lo que cuelga de ella: escaneos, campañas,
+              informes y su bóveda. No hay vuelta atrás.
+            </p>
+            <button class="btn btn--sm btn--danger" @click="showDeleteConfirm = true">
+              Eliminar usuario
+            </button>
+          </div>
         </template>
       </div>
     </div>
+
+    <ConfirmModal
+      :show="showDeleteConfirm"
+      title="Eliminar usuario"
+      emphasis="Esta acción no se puede deshacer."
+      :message="deleteMessage"
+      confirm-label="Eliminar"
+      danger
+      @confirm="handleDelete"
+      @cancel="showDeleteConfirm = false"
+    />
   </Teleport>
 </template>
 
@@ -58,6 +79,7 @@ import { ref, computed, watch } from 'vue'
 import { useUtils } from '@/composables/useUtils'
 import { useAuthStore } from '@/stores/authStore'
 import { useUsersStore } from '@/stores/usersStore'
+import ConfirmModal from '@/components/shared/ConfirmModal.vue'
 
 const { formatDate, getInitials } = useUtils()
 const auth = useAuthStore()
@@ -71,8 +93,21 @@ const attributes = ref([])
 const loadingUser = ref(false)
 const showAttrForm = ref(false)
 const selectedAttrs = ref([])
+const showDeleteConfirm = ref(false)
 
 const canManage = computed(() => auth.isAdmin)
+
+/** La jerarquía real la aplica el backend; aquí solo se evita ofrecer un 403.
+ *  Un admin llega a los usuarios normales, el root llega a todos, y nadie se
+ *  da de baja a sí mismo desde aquí: para eso está el perfil. */
+const canDelete = computed(() => {
+  if (!canManage.value || !user.value) return false
+  if (user.value.username === auth.username()) return false
+  return auth.isRoot || (user.value.role || 'role_user') === 'role_user'
+})
+const deleteMessage = computed(
+  () => `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`,
+)
 const ALL_ATTRIBUTES = [
   { module: 'Aegis', attrs: [{ name: 'aegis_read', desc: 'Lectura' }, { name: 'aegis_write', desc: 'Escritura' }, { name: 'aegis_create', desc: 'Creación' }, { name: 'aegis_delete', desc: 'Eliminación' }] },
   { module: 'Themis', attrs: [{ name: 'themis_read', desc: 'Lectura' }, { name: 'themis_write', desc: 'Escritura' }, { name: 'themis_create', desc: 'Creación' }, { name: 'themis_delete', desc: 'Eliminación' }] },
@@ -85,11 +120,16 @@ const roleLabel = computed(() => { const r = user.value?.role || 'role_user'; if
 
 watch(() => props.show, async (v) => {
   if (!v || !props.userId) return
-  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []
+  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false
   try { user.value = store.users.find(u => u.id == props.userId) || null; attributes.value = await store.loadUserAttributes(props.userId) } finally { loadingUser.value = false }
 })
 
 async function handleRemoveAttribute(attr) { const ok = await store.removeAttributes(props.userId, [attr]); if (ok) attributes.value = await store.loadUserAttributes(props.userId) }
+/** El store ya recarga la lista al terminar, así que aquí solo queda cerrar. */
+async function handleDelete() {
+  showDeleteConfirm.value = false
+  if (await store.deleteUser(props.userId)) emit('close')
+}
 async function handleAddAttributes() { if (selectedAttrs.value.length === 0) return; const ok = await store.addAttributes(props.userId, selectedAttrs.value); if (ok) { showAttrForm.value = false; selectedAttrs.value = []; attributes.value = await store.loadUserAttributes(props.userId) } }
 </script>
 
@@ -132,4 +172,7 @@ async function handleAddAttributes() { if (selectedAttrs.value.length === 0) ret
 .attr-check { display: flex; align-items: center; gap: 0.25rem; font-size: var(--fs-md); color: var(--text); cursor: pointer; }
 .attr-check input { accent-color: var(--accent); cursor: pointer; }
 .attr-form-actions { display: flex; gap: 0.4rem; justify-content: flex-end; margin-top: 0.65rem; }
+.danger-zone { border-top: 1px solid var(--border); padding-top: 1rem; }
+.danger-zone h4 { color: var(--danger); }
+.danger-note { font-size: var(--fs-md); color: var(--text-muted); margin: 0 0 0.65rem; }
 </style>

--- a/web/app/src/components/users/UserDetailsModal.vue
+++ b/web/app/src/components/users/UserDetailsModal.vue
@@ -53,7 +53,7 @@
               Se borra la cuenta y todo lo que cuelga de ella: escaneos, campañas,
               informes y su bóveda. No hay vuelta atrás.
             </p>
-            <button class="btn btn--sm btn--danger" @click="showDeleteConfirm = true">
+            <button class="btn btn--sm btn--danger" @click="askDelete">
               Eliminar usuario
             </button>
           </div>
@@ -94,6 +94,7 @@ const loadingUser = ref(false)
 const showAttrForm = ref(false)
 const selectedAttrs = ref([])
 const showDeleteConfirm = ref(false)
+const deletionPreview = ref(null)
 
 const canManage = computed(() => auth.isAdmin)
 
@@ -105,9 +106,18 @@ const canDelete = computed(() => {
   if (user.value.username === auth.username()) return false
   return auth.isRoot || (user.value.role || 'role_user') === 'role_user'
 })
-const deleteMessage = computed(
-  () => `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`,
-)
+const deleteMessage = computed(() => {
+  const base = `Vas a eliminar la cuenta de @${user.value?.username} y todos sus datos.`
+  const owned = deletionPreview.value?.ownedOrganization
+  if (!owned) return base
+  // La única consecuencia que sale de la cuenta borrada: su organización se
+  // disuelve con ella y los demás se enteran después si nadie lo dice antes.
+  const members = owned.membersLosingAccess
+  const tail = members
+    ? ` y ${members} ${members === 1 ? 'miembro se queda' : 'miembros se quedan'} sin ella`
+    : ''
+  return `${base} También desaparece su organización «${owned.name}»${tail}.`
+})
 const ALL_ATTRIBUTES = [
   { module: 'Aegis', attrs: [{ name: 'aegis_read', desc: 'Lectura' }, { name: 'aegis_write', desc: 'Escritura' }, { name: 'aegis_create', desc: 'Creación' }, { name: 'aegis_delete', desc: 'Eliminación' }] },
   { module: 'Themis', attrs: [{ name: 'themis_read', desc: 'Lectura' }, { name: 'themis_write', desc: 'Escritura' }, { name: 'themis_create', desc: 'Creación' }, { name: 'themis_delete', desc: 'Eliminación' }] },
@@ -120,11 +130,17 @@ const roleLabel = computed(() => { const r = user.value?.role || 'role_user'; if
 
 watch(() => props.show, async (v) => {
   if (!v || !props.userId) return
-  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false
+  loadingUser.value = true; showAttrForm.value = false; selectedAttrs.value = []; showDeleteConfirm.value = false; deletionPreview.value = null
   try { user.value = store.users.find(u => u.id == props.userId) || null; attributes.value = await store.loadUserAttributes(props.userId) } finally { loadingUser.value = false }
 })
 
 async function handleRemoveAttribute(attr) { const ok = await store.removeAttributes(props.userId, [attr]); if (ok) attributes.value = await store.loadUserAttributes(props.userId) }
+/** El aviso se pide al abrir la confirmación, no al abrir la ficha: así solo
+ *  se consulta cuando alguien va en serio. */
+async function askDelete() {
+  deletionPreview.value = await store.loadDeletionPreview(props.userId)
+  showDeleteConfirm.value = true
+}
 /** El store ya recarga la lista al terminar, así que aquí solo queda cerrar. */
 async function handleDelete() {
   showDeleteConfirm.value = false

--- a/web/app/src/stores/usersStore.js
+++ b/web/app/src/stores/usersStore.js
@@ -91,6 +91,21 @@ export const useUsersStore = defineStore('users', () => {
   }
 
   /**
+   * Consecuencias de dar de baja a un usuario (GET /users/{id}/deletion-preview).
+   *
+   * Es un aviso, no un requisito: si la llamada falla se confirma igual, con el
+   * mensaje genérico, en vez de bloquear la baja por no poder adornarla.
+   * @param {number|string} userId - ID del usuario
+   * @returns {Promise<object|null>} {ownedOrganization, leavesOrganizationId} o null
+   */
+  async function loadDeletionPreview(userId) {
+    try {
+      const res = await apiFetch(`/users/${userId}/deletion-preview`)
+      return res?.ok ? await res.json() : null
+    } catch { return null }
+  }
+
+  /**
    * Obtiene los atributos ABAC de un usuario.
    * @param {number|string} userId - ID del usuario
    * @returns {Promise<string[]>} Lista de nombres de atributos
@@ -150,5 +165,5 @@ export const useUsersStore = defineStore('users', () => {
     loading.value = false
   }
 
-  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
+  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadDeletionPreview, loadUserAttributes, addAttributes, removeAttributes, $reset }
 })

--- a/web/app/src/stores/usersStore.js
+++ b/web/app/src/stores/usersStore.js
@@ -71,6 +71,26 @@ export const useUsersStore = defineStore('users', () => {
   }
 
   /**
+   * Da de baja a un usuario vía DELETE /users/{id}.
+   *
+   * Borra la cuenta y todo lo que cuelga de ella; el backend es quien decide
+   * si el actor llega a ese usuario (un admin no llega a otro admin).
+   * @param {number|string} userId - ID del usuario
+   * @returns {Promise<boolean>} True si se eliminó correctamente
+   */
+  async function deleteUser(userId) {
+    const res = await apiFetch(`/users/${userId}`, { method: 'DELETE' })
+    if (!res?.ok) {
+      if (res?.status === 403) toast.show('No tienes permiso para eliminar a este usuario.', 'error')
+      else toast.show(await apiError(res, 'Error al eliminar el usuario.'), 'error')
+      return false
+    }
+    toast.show('Usuario eliminado.', 'success')
+    await loadUsers()
+    return true
+  }
+
+  /**
    * Obtiene los atributos ABAC de un usuario.
    * @param {number|string} userId - ID del usuario
    * @returns {Promise<string[]>} Lista de nombres de atributos
@@ -130,5 +150,5 @@ export const useUsersStore = defineStore('users', () => {
     loading.value = false
   }
 
-  return { users, loading, grouped, loadUsers, createUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
+  return { users, loading, grouped, loadUsers, createUser, deleteUser, loadUserAttributes, addAttributes, removeAttributes, $reset }
 })

--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -743,12 +743,16 @@ onBeforeUnmount(() => {})
 }
 .field.focused .field-ico { color: var(--accent); }
 .field-box input {
-  width: 100%; padding: 0.82rem 2.7rem 0.82rem 2.5rem;
+  width: 100%; padding: 0.82rem 0.95rem;
   background: var(--surface-2);
   border: 1px solid var(--border-solid); border-radius: 10px;
   color: var(--text); font-size: var(--fs-input); font-family: var(--font-body); font-size-adjust: var(--fsa-body); outline: none;
   transition: border-color 0.3s, box-shadow 0.3s, background 0.3s;
 }
+/* El hueco lateral solo se reserva si hay algo que lo ocupe: los campos sin
+   icono ni botón arrancaban el texto desplazado 2.5rem hacia la derecha. */
+.field-box:has(.field-ico) input { padding-left: 2.5rem; }
+.field-box:has(.reveal) input { padding-right: 2.7rem; }
 .field-box input::placeholder { color: var(--text-muted); opacity: 0.6; }
 .field-box input:focus {
   border-color: var(--accent);

--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -140,7 +140,7 @@
         <!-- ───────── Alta pública ───────── -->
         <form v-else-if="!mfaStep && mode === 'register'" novalidate @submit.prevent="handleRegister">
           <div class="field" :class="{ focused: focus === 'reg-user' }">
-            <label for="reg-username">Identificador</label>
+            <label for="reg-username">Nombre de usuario</label>
             <div class="field-box">
               <input id="reg-username" v-model="reg.username" type="text" required
                      minlength="3" maxlength="64" autocomplete="username"
@@ -181,6 +181,16 @@
                      @focus="focus = 'reg-pass'" @blur="focus = ''" />
             </div>
             <span class="field-hint">Mínimo 8 caracteres.</span>
+          </div>
+
+          <div class="field" :class="{ focused: focus === 'reg-pass2' }">
+            <label for="reg-password-confirm">Repite la clave</label>
+            <div class="field-box">
+              <input id="reg-password-confirm" v-model="regConfirm" type="password" required
+                     autocomplete="new-password"
+                     :class="{ 'has-error': regConfirm && regConfirm !== reg.password }"
+                     @focus="focus = 'reg-pass2'" @blur="focus = ''" />
+            </div>
           </div>
 
           <button type="submit" class="submit" :class="{ loading }" :disabled="loading">
@@ -352,6 +362,9 @@ const mode = ref(
     : 'login',
 )
 const reg = ref({ username: '', email: '', first_name: '', last_name: '', password: '' })
+// Fuera de `reg` a propósito: ese objeto se manda tal cual a /users/register y
+// la confirmación es cosa del formulario, no del alta.
+const regConfirm = ref('')
 const recover = ref({ identifier: '' })
 
 /**
@@ -360,6 +373,12 @@ const recover = ref({ identifier: '' })
  * dejarán hasta que pulse el enlace.
  */
 async function handleRegister() {
+  // Lo único que el servidor no puede comprobar: nunca ve la confirmación.
+  if (reg.value.password !== regConfirm.value) {
+    showAlert('Las claves no coinciden. Repítela tal cual la escribiste.', 'error')
+    return
+  }
+
   loading.value = true
   try {
     const res = await fetch('/users/register', {
@@ -385,6 +404,7 @@ async function handleRegister() {
     )
     username.value = reg.value.username
     reg.value = { username: '', email: '', first_name: '', last_name: '', password: '' }
+    regConfirm.value = ''
     mode.value = 'login'
   } catch {
     showAlert('No se pudo conectar con el servidor.', 'error')

--- a/web/app/src/views/LoginView.vue
+++ b/web/app/src/views/LoginView.vue
@@ -176,9 +176,40 @@
           <div class="field" :class="{ focused: focus === 'reg-pass' }">
             <label for="reg-password">Clave de acceso</label>
             <div class="field-box">
-              <input id="reg-password" v-model="reg.password" type="password" required
+              <input id="reg-password" v-model="reg.password"
+                     :type="showRegPassword ? 'text' : 'password'" required
                      minlength="8" autocomplete="new-password"
                      @focus="focus = 'reg-pass'" @blur="focus = ''" />
+              <button
+                type="button"
+                class="reveal reveal-gen"
+                tabindex="-1"
+                aria-label="Generar una clave segura"
+                title="Generar una clave segura"
+                @click="generateRegPassword"
+              >
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="23 4 23 10 17 10" />
+                  <polyline points="1 20 1 14 7 14" />
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="reveal"
+                tabindex="-1"
+                :aria-label="showRegPassword ? 'Ocultar las claves' : 'Mostrar las claves'"
+                @click="showRegPassword = !showRegPassword"
+              >
+                <svg v-if="!showRegPassword" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              </button>
             </div>
             <span class="field-hint">Mínimo 8 caracteres.</span>
           </div>
@@ -186,10 +217,27 @@
           <div class="field" :class="{ focused: focus === 'reg-pass2' }">
             <label for="reg-password-confirm">Repite la clave</label>
             <div class="field-box">
-              <input id="reg-password-confirm" v-model="regConfirm" type="password" required
+              <input id="reg-password-confirm" v-model="regConfirm"
+                     :type="showRegPassword ? 'text' : 'password'" required
                      autocomplete="new-password"
                      :class="{ 'has-error': regConfirm && regConfirm !== reg.password }"
                      @focus="focus = 'reg-pass2'" @blur="focus = ''" />
+              <button
+                type="button"
+                class="reveal"
+                tabindex="-1"
+                :aria-label="showRegPassword ? 'Ocultar las claves' : 'Mostrar las claves'"
+                @click="showRegPassword = !showRegPassword"
+              >
+                <svg v-if="!showRegPassword" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <svg v-else width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+              </button>
             </div>
           </div>
 
@@ -320,6 +368,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 import { useThemeStore } from '@/stores/themeStore'
 import { validationMessage } from '@/composables/useApi'
+import { generatePassword } from '@/acheron/passwordGenerator.js'
 import ElysianScene from '@/components/shared/ElysianScene.vue'
 import ellysiaIcon from '@/assets/images/ellysia/Ellysia-BgN.png'
 
@@ -365,7 +414,20 @@ const reg = ref({ username: '', email: '', first_name: '', last_name: '', passwo
 // Fuera de `reg` a propósito: ese objeto se manda tal cual a /users/register y
 // la confirmación es cosa del formulario, no del alta.
 const regConfirm = ref('')
+const showRegPassword = ref(false)
 const recover = ref({ identifier: '' })
+
+/**
+ * Aprovecha el generador de Acheron para el alta. Rellena también la
+ * confirmación —hacer teclear a mano una clave de 20 caracteres aleatorios solo
+ * sirve para equivocarse— y descubre ambos campos: una clave que no se puede
+ * leer no se puede guardar en ningún sitio.
+ */
+function generateRegPassword() {
+  reg.value.password = regConfirm.value = generatePassword()
+  showRegPassword.value = true
+}
+
 
 /**
  * Alta pública. Al terminar NO se inicia sesión sola: la cuenta nace sin el
@@ -405,6 +467,7 @@ async function handleRegister() {
     username.value = reg.value.username
     reg.value = { username: '', email: '', first_name: '', last_name: '', password: '' }
     regConfirm.value = ''
+    showRegPassword.value = false
     mode.value = 'login'
   } catch {
     showAlert('No se pudo conectar con el servidor.', 'error')
@@ -773,6 +836,7 @@ onBeforeUnmount(() => {})
    icono ni botón arrancaban el texto desplazado 2.5rem hacia la derecha. */
 .field-box:has(.field-ico) input { padding-left: 2.5rem; }
 .field-box:has(.reveal) input { padding-right: 2.7rem; }
+.field-box:has(.reveal-gen) input { padding-right: 4.6rem; }
 .field-box input::placeholder { color: var(--text-muted); opacity: 0.6; }
 .field-box input:focus {
   border-color: var(--accent);
@@ -794,6 +858,7 @@ onBeforeUnmount(() => {})
   background: none; border: none; color: var(--text-muted); cursor: pointer;
   border-radius: 7px; transition: color 0.2s, background 0.2s;
 }
+.reveal-gen { right: 40px; }
 .reveal:hover:not(:disabled) { color: var(--accent); background: var(--accent-dim); }
 .reveal:disabled { cursor: not-allowed; opacity: 0.4; }
 


### PR DESCRIPTION
## Resumen

Subida de `develope` a `main`. Corta la versión en **0.5.10** (`appVersion` en `API/SecOpsConfig.json`, que es de donde `create_app()` la lee vía `CR.get_app_version()`).

Entra el trabajo de tres PRs ya mergeadas en `develope`:

### Baja administrativa de usuarios (#152, closes #124)
- Endpoint de baja administrativa en `users/endpoints.py`, con aviso previo de lo que se lleva por delante la operación.
- Panel de administración: dar de baja usuarios desde `UserDetailsModal.vue` + `usersStore.js`.
- Tests: `test_account_deletion.py`, `test_users.py`.

### UX del alta pública (#151)
- Generador de claves y revelado en el formulario de alta (`LoginView.vue`).
- Confirmación de clave.
- Fix: reservar el hueco lateral del input solo cuando hay icono o botón.

### La suite de tests deja de salir a la red real (#154, ver #153)
- `pytest -q -m "not oracle"`: **6 min 15 s → 1 min 50 s** (−71 %), mismos 1838 tests en verde y misma cobertura (80 %). Ningún test pasa ya de 2,7 s, cuando el más lento tardaba 94,6 s.
- Redis se corta de raíz en la suite (parche de `ConnectionPool.get_connection`): un `TaskQueue` no mockeado se comía ~48 s por comando esperando timeouts de un Redis que no está levantado.
- Guarda en `socket.connect`/`connect_ex`/`gethostbyaddr` que bloquea todo lo que no sea loopback: los tests de Lybra corrían el motor completo contra `10.0.0.5` y pagaban 8 s por sonda.
- `RedisConnectionFactory._kwargs()` pasa a leer `socket_connect_timeout` de la configuración en vez de hardcodear un 5 que la ignoraba.

## Validación

- `pytest -q -m "not oracle"` (la invocación de CI, con cobertura) en verde en local: 1 min 50 s, cobertura 80 %.
- Este PR sí dispara `.github/workflows/tests.yml` — sólo corre en push/PR contra `main`, así que las PRs anteriores a `develope` no lo ejecutaron.

## Notas

- La issue #153 se cierra sola con este merge (el `Closes` de la PR #154 no disparó al ir contra `develope`).
- `features.themis.areLocalIpsAllowed` sigue en `true` en `SecOpsConfig.json`, como estaba: es lo que permite el desarrollo local contra IPs privadas, pero **debe volver a `false` antes de un despliegue real** o la defensa anti-SSRF queda desactivada. No lo toco aquí para no mezclarlo con el corte de versión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
