### PR TITLE
refactor(themis): renombrar el flag deep a is_deep_analysis

### DIFF
--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -372,7 +372,9 @@ def start_nuclei_scan(data):
 def start_lybra_scan(data):
     """Lanzar un escaneo Lybra: sobre un Nmap previo, o autodescubriendo."""
     timeout = data["timeout"]
-    deep = data.get("deep", False)
+    # La clave JSON sigue siendo "deep": es contrato de la API (la manda
+    # LybraLaunchPanel.vue) y no acompaña al renombrado del identificador.
+    is_deep_analysis = data.get("deep", False)
     source_scan_id = data.get("sourceScanId")
     user = get_current_user()
     manager = LybraEngineManager()
@@ -386,8 +388,8 @@ def start_lybra_scan(data):
                 message="El escaneo fuente debe ser un escaneo Nmap",
                 value=source_scan_id,
             )
-        scan_id = manager.run_scan(user_id=user.id, source_scan_id=source_scan_id, deep=deep, timeout=timeout)
-        logger.info(f"Lybra lanzado: ID={scan_id} fuente={source_scan_id} deep={deep} user={user.username}")
+        scan_id = manager.run_scan(user_id=user.id, source_scan_id=source_scan_id, is_deep_analysis=is_deep_analysis, timeout=timeout)
+        logger.info(f"Lybra lanzado: ID={scan_id} fuente={source_scan_id} deep={is_deep_analysis} user={user.username}")
     else:
         # Autodescubrimiento: valida el objetivo (rechaza IPs privadas, etc.)
         # igual que un escaneo Nmap, ya que el transporte propio toca el objetivo.
@@ -403,10 +405,10 @@ def start_lybra_scan(data):
             user_id=user.id, 
             target=target, 
             discover_ports=discover_ports,
-            deep=deep, 
+            is_deep_analysis=is_deep_analysis,
             timeout=timeout
         )
-        logger.info(f"Lybra lanzado: ID={scan_id} autodescubrimiento target={target} deep={deep} user={user.username}")
+        logger.info(f"Lybra lanzado: ID={scan_id} autodescubrimiento target={target} deep={is_deep_analysis} user={user.username}")
 
     return {
         "message": "Escaneo Lybra iniciado correctamente",

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -99,7 +99,10 @@ class LybraEngineManager(ScanManager):
         tiene un source_scan_id ni un payload de services que programar."""
         kwargs = super().scheduled_run_kwargs(arguments)
         kwargs["discover_ports"] = arguments.get("discover_ports")
-        kwargs["deep"] = bool(arguments.get("deep", False))
+        # La clave de lectura sigue siendo "deep": ``arguments`` es la columna
+        # JSON de ProgramedScan, es decir dato ya persistido. Renombrarla
+        # dejaría sin efecto el flag de los escaneos Lybra ya programados.
+        kwargs["is_deep_analysis"] = bool(arguments.get("deep", False))
         return kwargs
 
     def run_scan(self,
@@ -108,7 +111,7 @@ class LybraEngineManager(ScanManager):
         target: Optional[str] = None,
         services: Optional[List[Service]] = None,
         discover_ports: Optional[list] = None,
-        deep: bool = False,
+        is_deep_analysis: bool = False,
         timeout: int = 120,
         programed_scan_id: Optional[int] = None,
         asset_id: Optional[int] = None,
@@ -131,7 +134,7 @@ class LybraEngineManager(ScanManager):
           no Nmap needed. The caller validates the target (reject private, etc.).
 
         Args:
-            deep: Fase 6 "análisis profundo" — also launch Nmap/Nikto/Nuclei as
+            is_deep_analysis: Fase 6 "análisis profundo" — also launch Nmap/Nikto/Nuclei as
                 independent corroborator scans (fire-and-forget; their Finding
                 rows merge in at read time, see ``format_scan``). In the
                 external-payload mode, this additionally requires ``target`` to
@@ -172,14 +175,14 @@ class LybraEngineManager(ScanManager):
 
         self._task_queue.submit(
             func=LybraEngineManager.execute_lybra_scan, # type: ignore
-            args=(scan_id, source_scan_id, discover_ports, deep, services),
+            args=(scan_id, source_scan_id, discover_ports, is_deep_analysis, services),
             name=f"LybraScan-{scan_id}",
             category=self.TASK_CATEGORY, # type: ignore
             external_id=self.external_id_for(scan_id),
             timeout=timeout + self._scan_timeout_margin,
         )
 
-        mode = source.label + (" + análisis profundo" if deep else "")
+        mode = source.label + (" + análisis profundo" if is_deep_analysis else "")
         logger.info(f"Escaneo Lybra {scan_id} iniciado ({mode})")
         return scan_id  # type: ignore
 
@@ -188,7 +191,7 @@ class LybraEngineManager(ScanManager):
         scan_id: int,
         source_scan_id: Optional[int] = None,
         discover_ports: Optional[list] = None,
-        deep: bool = False,
+        is_deep_analysis: bool = False,
         services: Optional[List[Service]] = None
     ) -> None:
         """Entry point submitted to the TaskQueue. Runs the engine in the worker."""
@@ -198,7 +201,7 @@ class LybraEngineManager(ScanManager):
                 scan_id,
                 source_scan_id,
                 discover_ports,
-                deep,
+                is_deep_analysis,
                 services,
             )
 
@@ -207,7 +210,7 @@ class LybraEngineManager(ScanManager):
         scan_id: int,
         source_scan_id: Optional[int] = None,
         discover_ports: Optional[list] = None,
-        deep: bool = False,
+        is_deep_analysis: bool = False,
         services_payload: Optional[List[Service]] = None,
     ) -> None:
         """Resolve services (from Nmap, own discovery, or a payload), detect, persist.
@@ -281,7 +284,7 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(self._run_active_checks(source_target, services))
 
             deep_scan_ids: list = []
-            if deep and source_target:
+            if is_deep_analysis and source_target:
                 if source.deep_requires_authorization and not is_target_authorized:
                     logger.info(
                         f"Análisis profundo omitido para el escaneo Lybra {scan_id}: objetivo no autorizado"
@@ -828,6 +831,8 @@ class LybraEngineManager(ScanManager):
             "target": scan.target,
             "sourceScanId": scan.source_scan_id,
             "assetId": scan.asset_id,
+            # "deep"/"deepScanIds" son claves de respuesta: contrato de la API,
+            # no acompañan al renombrado de ``is_deep_analysis``.
             "deep": bool(deep_scan_ids),
             "deepScanIds": deep_scan_ids,
             "exposure": exposure,

--- a/API/src/modules/features/themis/schemas.py
+++ b/API/src/modules/features/themis/schemas.py
@@ -44,6 +44,12 @@ class LybraScanRequestSchema(Schema):
     ports = fields.String()
     # Fase 6 "análisis profundo": also launch Nmap/Nikto/Nuclei as independent
     # corroborator scans, fused with Lybra's own findings when read.
+    #
+    # C2: dentro de Python el flag se llama ``is_deep_analysis``, pero esta
+    # clave se queda como "deep" — es el nombre en el cable (lo manda
+    # LybraLaunchPanel.vue) y también el que quedó persistido en la columna
+    # JSON ``arguments`` de los ProgramedScan ya creados. Renombrarla sería un
+    # cambio de ruptura, no un renombrado.
     deep = fields.Boolean(load_default=False)
     timeout = fields.Integer(load_default=120, validate=validate.Range(min=1))
 

--- a/API/tests/integration/test_hygeia_lybra_analysis.py
+++ b/API/tests/integration/test_hygeia_lybra_analysis.py
@@ -80,7 +80,7 @@ def _run_pending_scan(app, scan_id, services):
     """Ejecuta el cuerpo del escaneo que la TaskQueue falsa no encoló."""
     with app.app_context():
         LybraEngineManager()._run_lybra(scan_id, source_scan_id=None, discover_ports=None,
-                                       deep=False, services_payload=services)
+                                       is_deep_analysis=False, services_payload=services)
 
 
 def _analyze(app, user, asset_id):

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -309,7 +309,7 @@ def test_lybra_payload_mode_produces_confirmed_inventory_findings(app, admin_use
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.9.9.9", user_id=admin_user.id)
         mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None,
-                       deep=False, services_payload=services)
+                       is_deep_analysis=False, services_payload=services)
 
         with UnitOfWork() as uow:
             repo = ScanRepository(uow)
@@ -344,7 +344,7 @@ def test_lybra_payload_mode_surface_tracking_distinguishes_portless_packages(app
         ]
         baseline = mgr._create_scan_record(target="10.9.9.20", user_id=admin_user.id)
         mgr._run_lybra(baseline.id, source_scan_id=None, discover_ports=None,
-                       deep=False, services_payload=baseline_services)
+                       is_deep_analysis=False, services_payload=baseline_services)
 
         with UnitOfWork() as uow:
             tracked = ScanRepository(uow).get_host_services(
@@ -360,7 +360,7 @@ def test_lybra_payload_mode_surface_tracking_distinguishes_portless_packages(app
         ]
         rescan = mgr._create_scan_record(target="10.9.9.20", user_id=admin_user.id)
         mgr._run_lybra(rescan.id, source_scan_id=None, discover_ports=None,
-                       deep=False, services_payload=rescan_services)
+                       is_deep_analysis=False, services_payload=rescan_services)
 
         with UnitOfWork() as uow:
             findings = ScanRepository(uow).get_findings_by_scan(rescan.id)
@@ -391,7 +391,7 @@ def test_lybra_payload_mode_deep_corroborators_require_authorization(app, admin_
         # Not authorized: skipped entirely, no corroborator ids recorded.
         escan = mgr._create_scan_record(target="10.9.9.10", user_id=admin_user.id)
         mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None,
-                       deep=True, services_payload=services)
+                       is_deep_analysis=True, services_payload=services)
         assert calls == []
         with UnitOfWork() as uow:
             escan = ScanRepository(uow).get_by_id(escan.id)
@@ -401,7 +401,7 @@ def test_lybra_payload_mode_deep_corroborators_require_authorization(app, admin_
         AuthorizedTargetManager().add(admin_user.id, "10.9.9.11")
         escan2 = mgr._create_scan_record(target="10.9.9.11", user_id=admin_user.id)
         mgr._run_lybra(escan2.id, source_scan_id=None, discover_ports=None,
-                       deep=True, services_payload=services)
+                       is_deep_analysis=True, services_payload=services)
         assert calls == ["10.9.9.11"]
 
 

--- a/API/tests/integration/test_lybra_deep_analysis.py
+++ b/API/tests/integration/test_lybra_deep_analysis.py
@@ -136,7 +136,7 @@ def test_deep_self_discovery_launches_three_with_http_service(app, admin_user, m
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id, source_scan_id=None)
-        mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None, deep=True)
+        mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None, is_deep_analysis=True)
 
         with UnitOfWork() as uow:
             escan = ScanRepository(uow).get_by_id(escan.id)
@@ -153,7 +153,7 @@ def test_deep_skips_nmap_when_source_scan_id_present(app, admin_user, monkeypatc
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id, source_scan_id=nmap_id)
-        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, deep=True)
+        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, is_deep_analysis=True)
 
     # A fresh Nmap corroborator would be redundant: Lybra already has Nmap ports.
     assert "nmap" not in calls
@@ -168,7 +168,7 @@ def test_deep_skips_nikto_and_nuclei_without_http_service(app, admin_user, monke
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id, source_scan_id=nmap_id)
-        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, deep=True)
+        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, is_deep_analysis=True)
 
     assert "nikto" not in calls
     assert "nuclei" not in calls       # same HTTP-only gate as Nikto
@@ -182,7 +182,7 @@ def test_deep_false_launches_nothing(app, admin_user, monkeypatch):
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id, source_scan_id=nmap_id)
-        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, deep=False)
+        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, is_deep_analysis=False)
 
         with UnitOfWork() as uow:
             escan = ScanRepository(uow).get_by_id(escan.id)
@@ -205,7 +205,7 @@ def test_deep_one_corroborator_failure_does_not_fail_the_scan(app, admin_user, m
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id, source_scan_id=None)
-        mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None, deep=True)
+        mgr._run_lybra(escan.id, source_scan_id=None, discover_ports=None, is_deep_analysis=True)
 
         with UnitOfWork() as uow:
             escan = ScanRepository(uow).get_by_id(escan.id)
@@ -231,7 +231,7 @@ def test_format_scan_merges_corroborator_finding_without_double_counting(app, ad
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id, source_scan_id=nmap_id)
-        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, deep=False)
+        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, is_deep_analysis=False)
 
         # Simulate what _launch_deep_corroborators would have recorded.
         with UnitOfWork() as uow:
@@ -261,7 +261,7 @@ def test_format_scan_without_deep_scan_ids_is_unaffected(app, admin_user):
     with app.app_context():
         mgr = LybraEngineManager()
         escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id, source_scan_id=nmap_id)
-        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, deep=False)
+        mgr._run_lybra(escan.id, source_scan_id=nmap_id, discover_ports=None, is_deep_analysis=False)
         result = mgr.format_scan(escan.id)
 
     assert result["deep"] is False
@@ -284,7 +284,12 @@ def test_lybra_endpoint_accepts_deep_flag(client, app, admin_user, auth_headers,
                        json={"sourceScanId": nmap_id, "deep": True})
 
     assert resp.status_code == 201
-    assert captured.get("deep") is True
+    # C2: la clave del cable sigue siendo "deep" y el kwarg de Python es
+    # ``is_deep_analysis``. Esta aserción es justo la costura entre ambos: si
+    # alguien renombra el campo del schema, el endpoint deja de recibir nada y
+    # esto cae.
+    assert captured.get("is_deep_analysis") is True
+    assert "deep" not in captured
 
 
 def test_lybra_endpoint_deep_defaults_to_false(client, app, admin_user, auth_headers, monkeypatch):
@@ -300,4 +305,4 @@ def test_lybra_endpoint_deep_defaults_to_false(client, app, admin_user, auth_hea
                        json={"sourceScanId": nmap_id})
 
     assert resp.status_code == 201
-    assert captured.get("deep") is False
+    assert captured.get("is_deep_analysis") is False


### PR DESCRIPTION
## Resumen

Cierra la parte que quedaba viva de **C2**: el flag `deep` de Lybra pasa a llamarse `is_deep_analysis` como identificador Python.

## Issue relacionado

Closes #171

## Hallazgo que cambió el alcance

El issue proponía renombrar `deep` citando `themis/schemas.py:47`. Ese `deep` **no es una variable, es la clave del contrato**. Aplicarlo al pie de la letra habría sido un cambio de ruptura disfrazado de renombrado. Tres sitios son dato y se quedan intactos:

| Frontera | Sitio | Riesgo evitado |
|---|---|---|
| Petición HTTP | `themis/schemas.py` | Es la clave JSON; la manda `LybraLaunchPanel.vue:188`. Renombrar el atributo del schema la habría convertido en `isDeepAnalysis` y **roto el SPA**. |
| Respuesta HTTP | `managers/lybra/engine.py::format_scan` | `"deep"` / `"deepScanIds"` son claves de salida ya consumidas. |
| Dato persistido | `managers/lybra/engine.py::scheduled_run_kwargs` | `arguments` es la columna JSON de `ProgramedScan`. Renombrar la clave habría dejado **sin efecto el flag de los escaneos Lybra ya programados en la BD**. |

## Implementación

- Renombrado del parámetro en `run_scan`, `execute_lybra_scan` y `_run_lybra`, y de los locales de `start_lybra_scan`.
- Los `args` de la TaskQueue son posicionales, así que los jobs en vuelo durante un despliegue no se ven afectados.
- Las tres fronteras llevan ahora un comentario que explica por qué la cadena no acompaña al identificador.
- `test_lybra_endpoint_accepts_deep_flag` pasa a afirmar la traducción en ambos sentidos: entra `"deep"` por el cable, sale `is_deep_analysis` como kwarg, y `"deep" not in captured`. Si alguien renombra el campo del schema, ese test cae.

## Validación

- `pytest tests/integration/test_lybra.py test_lybra_deep_analysis.py test_hygeia_lybra_analysis.py test_scheduling.py` — 67 tests, verde.
- Suite completa: **1850 tests, exit 0**, sin fallos.

## Notas

- La parte (b) de C2 y el resto de la (a) (`was_cancelled`, `did_succeed`, `is_finished`, `was_written`, `is_verified`, `active_scans`, `matched_phrases`…) ya estaban hechas en `develope`; este PR solo cierra el flag que faltaba.
- C1 (#178) va en un PR aparte a propósito: su diff es un barrido mecánico amplio y aquí enterraría las decisiones de frontera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
