### PR TITLE
fix(themis): que el criterio de fin de respuesta lo declare el protocolo (#265)

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -54,9 +54,13 @@ logger = logging.getLogger(__name__)
 # ``type: "network"`` check; checks-3: "redis-unauthenticated-access", the
 # second ``network`` protocol; checks-4: "smb-signing-not-required", the first
 # ``type: "script"`` check; checks-5: "snmp-default-community", the first
-# check over UDP) — never for a fix to an existing check, which bumps that
-# check's own ``version`` instead (see ``Check.check_id``).
-CHECKS_FEED_VERSION = "lybra-checks-5"
+# check over UDP; checks-6: el vocabulario ``read``/``expectBanner``, que es
+# capacidad nueva del esquema y no el arreglo de un check suelto) — nunca por
+# arreglar un check ya existente, que sube su propio ``version`` (ver
+# ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
+# en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
+# decir cuál de las dos formas lo produjo.
+CHECKS_FEED_VERSION = "lybra-checks-6"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -193,12 +197,18 @@ class Request:
         send: For ``type: "network"``, the raw payload to write before
             reading a reply (e.g. ``"USER anonymous\\r\\n"``). ``None`` reads
             without writing anything first. Unused by ``type: "http"``.
+        read: For ``type: "network"``, how the reply *ends* — see
+            :data:`NETWORK_READ_MODES`. The transport cannot know this on its
+            own: where a reply stops is a fact about the protocol, so the feed
+            declares it. Defaults to ``"line"``, the original behaviour.
+            Unused by ``type: "http"``.
     """
     method: str = "GET"
     path: str = "/"
     matchers: tuple = ()
     condition: str = "and"
     send: Optional[str] = None
+    read: str = "line"
 
     def evaluate(self, response: Response) -> bool:
         """Return whether this request's matchers are satisfied by a response.
@@ -247,6 +257,14 @@ class Check:
             to fall back to :data:`CHECKS_FEED_VERSION`. A single global
             constant stopped being truthful once checks could come from two
             feeds with independent version lines.
+        expect_banner: For ``type: "network"``, whether the server volunteers a
+            greeting the moment the connection opens (FTP, SMTP, POP3 and IMAP
+            all do; Redis and MySQL do not). When set, the runtime reads and
+            **discards** that greeting before writing the check's first
+            payload. Without it the greeting is still sitting in the socket
+            buffer and every subsequent read comes back one reply out of step
+            — the whole check then matches against the wrong text and silently
+            never fires.
         tags: Free-form labels (Nuclei's ``info.tags``, plus vendor/product
             metadata). Not used by the runtime, which runs whatever it is
             given: they exist so a *selector* can decide which of thousands of
@@ -266,6 +284,7 @@ class Check:
     script: Optional[str] = None
     namespace: str = "lybra"
     feed_version: Optional[str] = None
+    expect_banner: bool = False
     tags: tuple = ()
 
     @property
@@ -326,6 +345,7 @@ def _parse_check(c: dict) -> Check:
             path=request.get("path", "/"),
             condition=request.get("matchers-condition", "and"),
             send=request.get("send"),
+            read=_parse_read_mode(request.get("read"), c.get("id")),
             matchers=tuple(
                 Matcher(
                     type=matcher["type"],
@@ -350,7 +370,38 @@ def _parse_check(c: dict) -> Check:
         finding=c.get("finding", {}),
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
+        expect_banner=bool(c.get("expectBanner", False)),
     )
+
+
+def _parse_read_mode(declared: Optional[str], check_id: Optional[str]) -> str:
+    """Validate a request's declared ``read`` mode, defaulting to ``"line"``.
+
+    A mode nobody implements is a feed bug, not a runtime case: left to fall
+    back silently it would read one line where the protocol needs a block and
+    the check would simply never fire — the same class of silent false
+    negative this whole change exists to remove. So it raises at load time,
+    where a human is looking.
+
+    Args:
+        declared: The feed's ``read`` value, or ``None`` when absent.
+        check_id: The check being parsed, for the error message.
+
+    Returns:
+        The validated mode name.
+
+    Raises:
+        ValueError: If ``declared`` names a mode that does not exist.
+    """
+    if declared is None:
+        return "line"
+    mode = str(declared).strip().lower()
+    if mode not in NETWORK_READ_MODES:
+        raise ValueError(
+            f"Check {check_id!r}: modo de lectura {declared!r} desconocido "
+            f"(disponibles: {', '.join(sorted(NETWORK_READ_MODES))})"
+        )
+    return mode
 
 
 # =========================================================================
@@ -727,6 +778,12 @@ class CheckRuntime:
         over it in order (combined with AND, same as ``_run_check``) — the
         session, not a fresh connection per request, is what lets a login
         sequence like FTP's ``USER``/``PASS`` see its own prior state.
+
+        When the check declares ``expectBanner``, the server's unprompted
+        greeting is read and thrown away first. It has to be: the greeting is
+        already in the socket buffer at connect time, so leaving it there would
+        put every later read one reply out of step — the check would evaluate
+        ``USER``'s matchers against the greeting and never fire.
         """
         if self._rl is not None:
             self._rl.acquire(host)
@@ -734,8 +791,12 @@ class CheckRuntime:
         if session is None:
             return None
         try:
+            if check.expect_banner:
+                # Read as a block: a greeting may span several continuation
+                # lines, and a single-line one ends the block immediately.
+                session.exchange(None, read="block")
             for request in check.requests:
-                response = session.exchange(request.send)
+                response = session.exchange(request.send, read=request.read)
                 if response is None or not request.evaluate(response):
                     return None
             return self._finding(check, service)
@@ -930,45 +991,81 @@ class HttpProbe:
 # NETWORK PROBE (the network edge for ``type: "network"`` checks — Fase N)
 # =========================================================================
 
+# How a reply ends, declared per request by the feed (``read:``). The transport
+# cannot infer this: "one line" is a property of some protocols and of no
+# others, and guessing it wrong does not raise — it just reads the wrong bytes
+# and the check never fires.
+#
+#   line       One line, terminated by LF. The original behaviour and the
+#              default: right for a protocol whose every reply is one line.
+#   block      A multi-line status block, the shape FTP/SMTP/POP3 use: lines
+#              whose status code is followed by "-" are continuations, and the
+#              first line *without* that dash closes the block. Degrades to a
+#              single line when the server does not use continuations, which is
+#              what makes it safe as the banner reader for any protocol.
+#   resp-bulk  Redis' RESP bulk string: a "$<n>" header line followed by
+#              exactly n bytes of payload. Any other first line (an error like
+#              "-NOAUTH ...", a simple "+OK") is returned as-is, because that
+#              *is* the whole reply.
+NETWORK_READ_MODES = ("line", "block", "resp-bulk")
+
+# A status line whose code is followed by "-" instead of a space: the reply
+# continues on the next line (RFC 959 §4.2 for FTP, RFC 5321 §4.2 for SMTP).
+_STATUS_CONTINUATION_RE = re.compile(rb"^\d{3}-")
+
+
 class NetworkSession:
     """One TCP connection, shared across every request of a single check run.
 
-    Deliberately protocol-agnostic: it knows nothing about FTP, SMB or any
-    other protocol a future check targets — it only writes a payload (if any)
-    and reads back one line, decoded as text so the existing word/regex
-    matchers can evaluate it exactly like an HTTP response (``status=0`` and
-    empty ``headers``, since neither concept exists here).
+    Deliberately protocol-agnostic: it knows nothing about FTP, Redis or any
+    other protocol a check targets. What it does know is that *where a reply
+    ends* is a protocol decision, so the feed declares it per request (see
+    :data:`NETWORK_READ_MODES`) and this class only implements the mechanics.
+    The reply comes back decoded as text, so the existing word/regex matchers
+    evaluate it exactly like an HTTP response (``status=0`` and empty
+    ``headers``, since neither concept exists here).
+
+    Reads are buffered: whatever a read mode does not consume stays for the
+    next one, which is what lets a bulk-string read hand back the leftovers
+    instead of losing them. It also stops the previous byte-at-a-time
+    ``recv(1)`` loop, one system call per byte received.
 
     Args:
         sock: The connected socket this session wraps.
-        max_bytes: The maximum number of bytes to read per line.
+        max_bytes: The maximum number of bytes to read for a single reply. A
+            hostile or broken server must not be able to make us read forever.
     """
 
-    def __init__(self, sock, max_bytes: int = 4096) -> None:
+    _CHUNK = 4096
+
+    def __init__(self, sock, max_bytes: int = 65536) -> None:
         self._sock = sock
         self._max_bytes = max_bytes
+        self._buffer = b""
 
-    def exchange(self, send: Optional[str]) -> Optional[Response]:
-        """Write ``send`` (if any), then read and return one line of reply.
+    def exchange(self, send: Optional[str], read: str = "line") -> Optional[Response]:
+        """Write ``send`` (if any), then read one reply under the given mode.
 
         Args:
             send: The raw payload to write first, or ``None`` to only read —
-                the shape a banner-only check needs, since some protocols
-                (FTP) volunteer a line unprompted right after connecting.
+                the shape a banner-only read needs, since some protocols (FTP)
+                volunteer a greeting unprompted right after connecting.
+            read: How the reply ends — one of :data:`NETWORK_READ_MODES`.
 
         Returns:
-            A :class:`Response` wrapping the decoded line (``status=0``,
-            empty ``headers``), or ``None`` on any transport failure.
+            A :class:`Response` wrapping the decoded reply (``status=0``,
+            empty ``headers``), or ``None`` on a transport failure or an empty
+            reply.
         """
         try:
             if send is not None:
                 self._sock.sendall(send.encode("utf-8"))
-            data = b""
-            while not data.endswith(b"\n") and len(data) < self._max_bytes:
-                chunk = self._sock.recv(1)
-                if not chunk:
-                    break
-                data += chunk
+            if read == "block":
+                data = self._read_block()
+            elif read == "resp-bulk":
+                data = self._read_resp_bulk()
+            else:
+                data = self._read_line()
         except OSError as err:
             logger.debug("Network check exchange failed: %s", err)
             return None
@@ -983,6 +1080,74 @@ class NetworkSession:
             self._sock.close()
         except OSError:
             pass
+
+    def _fill(self) -> bool:
+        """Pull one more chunk off the socket into the buffer.
+
+        Returns:
+            ``False`` when the peer closed the connection (nothing more will
+            ever arrive), ``True`` otherwise.
+        """
+        chunk = self._sock.recv(self._CHUNK)
+        if not chunk:
+            return False
+        self._buffer += chunk
+        return True
+
+    def _read_line(self) -> bytes:
+        """Read up to and including the next LF, or whatever arrived before EOF."""
+        while b"\n" not in self._buffer and len(self._buffer) < self._max_bytes:
+            if not self._fill():
+                break
+        line, separator, rest = self._buffer.partition(b"\n")
+        self._buffer = rest
+        return line + separator
+
+    def _read_block(self) -> bytes:
+        """Read a status block: continuation lines plus the line that closes it."""
+        block = b""
+        while len(block) < self._max_bytes:
+            line = self._read_line()
+            if not line:
+                break
+            block += line
+            if not _STATUS_CONTINUATION_RE.match(line):
+                break
+        return block
+
+    def _read_resp_bulk(self) -> bytes:
+        """Read a RESP bulk string, or hand back a non-bulk reply untouched.
+
+        A bulk string announces its own length (``$3116``), so unlike every
+        other reply here its end is a byte count and not a delimiter. A reply
+        that is not a bulk string — an error, a simple string — is complete as
+        the single line it already is.
+        """
+        header = self._read_line()
+        if not header.startswith(b"$"):
+            return header
+        try:
+            length = int(header[1:].strip())
+        except ValueError:
+            return header
+        if length < 0:                      # "$-1" is RESP's null bulk string
+            return header
+        length = min(length, self._max_bytes)
+        while len(self._buffer) < length:
+            if not self._fill():
+                break
+        payload, self._buffer = self._buffer[:length], self._buffer[length:]
+        # RESP cierra el bulk con un CRLF que no cuenta en la longitud
+        # anunciada. Se descarta si ya está en el buffer, para que no se cuele
+        # como una línea vacía en la lectura siguiente. Deliberadamente no se
+        # pide más al socket para conseguirlo: el servidor manda ese CRLF
+        # pegado al contenido, y un recv extra sólo podría bloquear hasta el
+        # timeout — perdiendo una respuesta que ya teníamos entera.
+        if self._buffer.startswith(b"\r\n"):
+            self._buffer = self._buffer[2:]
+        elif self._buffer.startswith(b"\n"):
+            self._buffer = self._buffer[1:]
+        return payload
 
 
 class NetworkProbe:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-5
+feedVersion: lybra-checks-6
 checks:
   - id: git-config-exposure
     version: 1
@@ -290,15 +290,24 @@ checks:
       title: Protocolo TLS obsoleto negociado (SSLv3/TLSv1.0/TLSv1.1)
       qod: 99
       confirmed: true
+  # expectBanner: un servidor FTP saluda (220 ...) en cuanto se abre la
+  # conexion, sin que el cliente pida nada. Ese saludo hay que consumirlo antes
+  # de escribir USER; si se deja en el buffer, la respuesta que se lee tras
+  # USER es el saludo y no el 331, y el check no dispara jamas.
+  # read: block — el saludo y las respuestas de FTP pueden venir en varias
+  # lineas (220-... / 220 ...), asi que el fin de la respuesta es "la primera
+  # linea cuyo codigo NO lleva guion", no "el primer salto de linea".
   - id: ftp-anonymous-login
-    version: 1
+    version: 2
     type: network
     category: default_credentials
     severity: HIGH
     service: ftp
     mode: safe
+    expectBanner: true
     requests:
       - send: "USER anonymous\r\n"
+        read: block
         matchers-condition: and
         matchers:
           - type: word
@@ -306,6 +315,7 @@ checks:
             words:
               - '331'
       - send: "PASS anonymous@lybra.local\r\n"
+        read: block
         matchers-condition: and
         matchers:
           - type: word
@@ -316,8 +326,14 @@ checks:
       title: 'FTP: login anónimo permitido'
       qod: 99
       confirmed: true
+  # Redis no saluda: no lleva expectBanner. Lo que si tiene es una respuesta
+  # que no termina en el primer salto de linea — INFO devuelve un "bulk string"
+  # RESP, es decir una linea con la longitud ($3116) seguida de esos bytes. Con
+  # read: line se leia "$3116" y se buscaba redis_version ahi dentro, que
+  # nunca esta. Una respuesta que no sea bulk (el error -NOAUTH, por ejemplo)
+  # vuelve tal cual, que es justo lo que el matcher negativo necesita ver.
   - id: redis-unauthenticated-access
-    version: 1
+    version: 2
     type: network
     category: default_credentials
     severity: CRITICAL
@@ -325,6 +341,7 @@ checks:
     mode: safe
     requests:
       - send: "INFO\r\n"
+        read: resp-bulk
         matchers-condition: and
         matchers:
           - type: word

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -601,24 +601,42 @@ def test_lybra_active_check_persists_confirmed_finding(app, admin_user, monkeypa
 
 def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, admin_user, monkeypatch):
     """Fase N: the runtime's first ``type: "network"`` check, wired end to
-    end through the real manager (not a bare ``CheckRuntime``) — a scripted
-    fake session stands in for the raw TCP connection."""
+    end through the real manager (not a bare ``CheckRuntime``).
+
+    Lo que se sustituye es el **socket**, no la sesión: el ``NetworkSession``
+    real hace su trabajo, saludo incluido. Un doble por encima de la sesión
+    entrega respuestas que el transporte real no produce, y eso fue justo lo
+    que ocultó el bug de #265 (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.lybra import checks as checks_mod
 
     monkeypatch.setattr(CR, "lybra_config", lambda: CR.LybraConfig(active_checks=True))
 
-    class _FakeSession:
-        def __init__(self):
-            self._replies = iter(["331 Please specify the password.", "230 Login successful."])
+    class _FakeFtpSocket:
+        """Un vsftpd de mentira: saluda al conectar y contesta a cada comando."""
 
-        def exchange(self, send):
-            return checks_mod.Response(status=0, body=next(self._replies), headers={})
+        def __init__(self):
+            self._buffer = b"220 (vsFTPd 2.3.4)\r\n"
+            self._replies = [
+                b"331 Please specify the password.\r\n",
+                b"230 Login successful.\r\n",
+            ]
+
+        def recv(self, size):
+            chunk, self._buffer = self._buffer[:size], self._buffer[size:]
+            return chunk
+
+        def sendall(self, data):
+            if self._replies:
+                self._buffer += self._replies.pop(0)
 
         def close(self):
             pass
 
-    monkeypatch.setattr(checks_mod.NetworkProbe, "open", lambda self, host, port: _FakeSession())
+    monkeypatch.setattr(
+        checks_mod.NetworkProbe, "open",
+        lambda self, host, port: checks_mod.NetworkSession(_FakeFtpSocket()),
+    )
 
     ftp_ports = [
         {"protocol": "21/tcp", "reason": "syn-ack", "product": "vsftpd",
@@ -636,7 +654,7 @@ def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, 
         with UnitOfWork() as uow:
             findings = ScanRepository(uow).get_findings_by_scan(escan.id)
 
-    active = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@1"]
+    active = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@2"]
     assert len(active) == 1
     assert active[0].qod == 99
     assert active[0].confirmed is True

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -83,6 +83,50 @@ def _free_tls_port() -> int:
     return _TLS_PORT
 
 
+# Los checks ``network`` se seleccionan por nombre de servicio o por puerto
+# (``is_ftp_service`` / ``is_redis_service`` en checks.py), y el
+# autodescubrimiento sólo aporta el puerto. Así que estos contenedores tienen
+# que publicarse en el puerto canónico de su protocolo o el check ni se
+# consideraría. Son puertos fijos, no elegibles: si algo del host ya los ocupa
+# —un Redis de desarrollo en el 6379, por ejemplo— el caso se salta con un
+# motivo legible en vez de fallar por una colisión que no es del motor.
+_FTP_PORT = 21
+_REDIS_PORT = 6379
+
+
+def _require_free_port(port: int, label: str) -> None:
+    if not port_is_free("127.0.0.1", port):
+        pytest.skip(f"El puerto {port} ({label}) está ocupado en el host")
+
+
+def _vsftpd_container_cmd(anonymous: bool) -> str:
+    """Comando que instala y configura un vsftpd dentro del contenedor.
+
+    Se genera la configuración al arrancar, sin bind mount, por la misma razón
+    que el resto de fixtures de este módulo: evitar la traducción de rutas
+    WSL↔Docker Desktop.
+
+    ``no_anon_password=NO`` es deliberado y no un detalle: con ``YES`` el
+    servidor concede el acceso ya en el ``USER`` (responde 230 directamente) y
+    la secuencia USER→331→PASS→230 que el check espera no llega a existir. El
+    caso negativo mantiene ``local_enable=YES`` para que vsftpd tenga algún
+    modo de acceso habilitado y arranque, aunque no haya ninguna cuenta usable.
+    """
+    anonymous_enable = "YES" if anonymous else "NO"
+    local_enable = "NO" if anonymous else "YES"
+    settings = " ".join([
+        "'listen=YES'", "'listen_ipv6=NO'",
+        f"'anonymous_enable={anonymous_enable}'", f"'local_enable={local_enable}'",
+        "'no_anon_password=NO'", "'seccomp_sandbox=NO'", "'anon_root=/var/lib/ftp'",
+    ])
+    return (
+        "apk add --no-cache vsftpd >/dev/null 2>&1 && "
+        "mkdir -p /var/lib/ftp && chmod 555 /var/lib/ftp && "
+        f"printf '%s\\n' {settings} > /etc/vsftpd/vsftpd.conf && "
+        "vsftpd /etc/vsftpd/vsftpd.conf"
+    )
+
+
 def _tls_container_cmd(days: int, expired: bool) -> str:
     """Shell command that generates a self-signed cert *inside* the container
     at startup (no bind mount, same philosophy as ``git_exposed_port``) and
@@ -186,6 +230,65 @@ def tls_expired_port():
         docker_rm(_DOCKER, name)
 
 
+@pytest.fixture
+def ftp_anonymous_port():
+    """Un vsftpd real con el acceso anónimo **abierto**: el caso positivo."""
+    _require_free_port(_FTP_PORT, "FTP")
+    name = f"lybra-oracle-ftp-anon-{_FTP_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
+            "sh", "-c", _vsftpd_container_cmd(anonymous=True))
+    try:
+        _wait_for_port("127.0.0.1", _FTP_PORT)
+        yield _FTP_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def ftp_no_anonymous_port():
+    """El mismo vsftpd con el acceso anónimo **cerrado**: el control negativo.
+
+    Sin él, el caso positivo no demuestra gran cosa — un check que disparase
+    siempre también pasaría el positivo.
+    """
+    _require_free_port(_FTP_PORT, "FTP")
+    name = f"lybra-oracle-ftp-noanon-{_FTP_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
+            "sh", "-c", _vsftpd_container_cmd(anonymous=False))
+    try:
+        _wait_for_port("127.0.0.1", _FTP_PORT)
+        yield _FTP_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def redis_open_port():
+    """Un ``redis:7`` sin contraseña: cualquiera puede pedirle un INFO."""
+    _require_free_port(_REDIS_PORT, "Redis")
+    name = f"lybra-oracle-redis-open-{_REDIS_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7")
+    try:
+        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        yield _REDIS_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def redis_password_port():
+    """El mismo ``redis:7`` con ``requirepass``: contesta ``-NOAUTH`` al INFO."""
+    _require_free_port(_REDIS_PORT, "Redis")
+    name = f"lybra-oracle-redis-auth-{_REDIS_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7",
+            "redis-server", "--requirepass", "lybra-oracle")
+    try:
+        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        yield _REDIS_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
 def _run_self_discovery(app, admin_user, target: str, port: int, monkeypatch):
     """Lanza un escaneo Lybra de autodescubrimiento real contra ``target:port``.
 
@@ -280,6 +383,57 @@ def test_tls_expired_cert_detected_against_real_container(app, admin_user, tls_e
     tls_findings = {f.check_id for f in findings if f.category == "tls"}
     assert tls_findings == {"lybra:tls-self-signed-cert@1", "lybra:tls-expired-cert@1"}
     assert all(f.confirmed and f.qod == 99 for f in findings if f.category == "tls")
+
+
+# ------------------------------------------- familia network contra servidores reales
+#
+# Los cuatro casos que cierran #265. Hasta aquí, los dos únicos checks no-web
+# del motor sólo se habían ejercitado contra dobles, y por eso nadie vio que el
+# transporte leía una forma de respuesta que ni FTP ni Redis producen: el
+# escaneo terminaba en verde y el FTP anónimo seguía ahí. Un positivo y un
+# negativo por protocolo, contra el servidor de verdad.
+
+def test_ftp_anonymous_login_detected_against_real_vsftpd(app, admin_user, ftp_anonymous_port, monkeypatch):
+    """Con el acceso anónimo abierto, el check tiene que confirmarlo.
+
+    Es la prueba de que el saludo (``220 ...``) se consume antes de escribir
+    ``USER`` y de que la respuesta se lee como bloque de estado: sin las dos
+    cosas, el check evalúa el saludo contra el matcher del ``331`` y calla.
+    """
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", ftp_anonymous_port, monkeypatch)
+
+    ftp = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@2"]
+    assert len(ftp) == 1, f"hallazgos: {[(f.category, f.title) for f in findings]}"
+    assert ftp[0].confirmed is True and ftp[0].qod == 99
+    assert ftp[0].category == "default_credentials"
+    assert ftp[0].port == 21
+
+
+def test_ftp_anonymous_login_absent_against_a_locked_down_vsftpd(app, admin_user, ftp_no_anonymous_port, monkeypatch):
+    """Con el acceso anónimo cerrado, el mismo check no debe producir nada."""
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", ftp_no_anonymous_port, monkeypatch)
+    assert not any(f.check_id.startswith("lybra:ftp-anonymous-login") for f in findings)
+
+
+def test_redis_unauthenticated_access_detected_against_real_redis(app, admin_user, redis_open_port, monkeypatch):
+    """Un Redis sin contraseña contesta al INFO, y eso es el hallazgo.
+
+    Prueba de que la respuesta se lee como *bulk string*: el contenido va
+    detrás de una línea que sólo trae su longitud, así que leyendo una línea
+    suelta nunca se llegaba a ver ``redis_version``.
+    """
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", redis_open_port, monkeypatch)
+
+    redis_findings = [f for f in findings if f.check_id == "lybra:redis-unauthenticated-access@2"]
+    assert len(redis_findings) == 1, f"hallazgos: {[(f.category, f.title) for f in findings]}"
+    assert redis_findings[0].confirmed is True and redis_findings[0].qod == 99
+    assert redis_findings[0].category == "default_credentials"
+
+
+def test_redis_unauthenticated_access_absent_when_requirepass_is_set(app, admin_user, redis_password_port, monkeypatch):
+    """Con ``requirepass``, el INFO recibe ``-NOAUTH`` y no hay hallazgo."""
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", redis_password_port, monkeypatch)
+    assert not any(f.check_id.startswith("lybra:redis-unauthenticated-access") for f in findings)
 
 
 @pytest.mark.skipif(_NMAP is None, reason="nmap no disponible")

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -22,7 +22,9 @@ usuario, no como una puerta de cada commit.
 from __future__ import annotations
 
 import shutil
+import socket
 import subprocess
+import time
 
 import pytest
 
@@ -97,6 +99,49 @@ _REDIS_PORT = 6379
 def _require_free_port(port: int, label: str) -> None:
     if not port_is_free("127.0.0.1", port):
         pytest.skip(f"El puerto {port} ({label}) está ocupado en el host")
+
+
+def _wait_until_answering(port: int, expect: bytes, send: bytes = None, timeout: float = 120.0) -> None:
+    """Espera a que el servicio conteste lo que se espera de él, no sólo a que el puerto acepte.
+
+    ``wait_for_port`` no vale para estos dos contenedores. Docker publica el
+    puerto en el host en cuanto arranca el contenedor, así que el TCP acepta a
+    los 0,0 s — medido — mientras dentro todavía se está instalando el
+    servidor. Un escaneo lanzado en ese hueco encuentra una conexión que se
+    cierra sin decir nada, el check se abandona, y el test falla por una
+    carrera de arranque que no tiene nada que ver con el motor. Es exactamente
+    lo que pasó la primera vez que se ejecutaron estas pruebas.
+
+    Exigir además el saludo correcto (``220`` en FTP, ``+PONG`` o ``-NOAUTH``
+    en Redis) hace de paso de comprobación de que el contenedor quedó
+    configurado como el caso pide: un control negativo mal montado falla aquí,
+    en voz alta, en vez de pasar el test sin demostrar nada.
+
+    Args:
+        port: El puerto publicado en 127.0.0.1.
+        expect: El prefijo con el que debe empezar la respuesta.
+        send: Lo que hay que escribir para provocarla, o ``None`` si el
+            protocolo saluda solo.
+        timeout: Cuánto esperar antes de rendirse — generoso, porque la
+            primera ejecución instala paquetes dentro del contenedor.
+    """
+    deadline = time.monotonic() + timeout
+    seen = b""
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=2.0) as sock:
+                sock.settimeout(2.0)
+                if send is not None:
+                    sock.sendall(send)
+                seen = sock.recv(128)
+                if seen.startswith(expect):
+                    return
+        except OSError:
+            pass
+        time.sleep(0.3)
+    raise TimeoutError(
+        f"127.0.0.1:{port} no contestó {expect!r} en {timeout}s (última respuesta: {seen!r})"
+    )
 
 
 def _vsftpd_container_cmd(anonymous: bool) -> str:
@@ -238,7 +283,7 @@ def ftp_anonymous_port():
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=True))
     try:
-        _wait_for_port("127.0.0.1", _FTP_PORT)
+        _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -256,7 +301,7 @@ def ftp_no_anonymous_port():
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=False))
     try:
-        _wait_for_port("127.0.0.1", _FTP_PORT)
+        _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -269,7 +314,7 @@ def redis_open_port():
     name = f"lybra-oracle-redis-open-{_REDIS_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7")
     try:
-        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        _wait_until_answering(_REDIS_PORT, expect=b"+PONG", send=b"PING\r\n")
         yield _REDIS_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -283,7 +328,7 @@ def redis_password_port():
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7",
             "redis-server", "--requirepass", "lybra-oracle")
     try:
-        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        _wait_until_answering(_REDIS_PORT, expect=b"-NOAUTH", send=b"PING\r\n")
         yield _REDIS_PORT
     finally:
         docker_rm(_DOCKER, name)

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -185,8 +185,10 @@ class _FakeNetSocket:
         self._chunk = chunk_size
         self.sent = b""
         self.closed = False
+        self.recv_calls = 0
 
     def recv(self, size: int) -> bytes:
+        self.recv_calls += 1
         take = min(size, self._chunk)
         chunk, self._buffer = self._buffer[:take], self._buffer[take:]
         return chunk
@@ -219,7 +221,7 @@ class _FakeNetworkSession:
         self.sent: list = []
         self.closed = False
 
-    def exchange(self, send):
+    def exchange(self, send, read="line"):
         self.sent.append(send)
         if not self._replies:
             return None
@@ -248,18 +250,13 @@ def _findings_for(check_id, sock, service):
 
 # ------------------------------------------ ftp-anonymous-login (comportamiento)
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: exchange lee una línea suelta, y tras USER la línea pendiente "
-           "en el buffer sigue siendo el saludo 220, no el 331",
-)
 def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     sock = _FakeNetSocket(
         greeting=_FTP_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
     )
 
-    ftp = _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)
+    ftp = _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP)
 
     assert len(ftp) == 1
     assert ftp[0]["qod"] == 99 and ftp[0]["confirmed"] is True
@@ -269,16 +266,12 @@ def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     assert sock.sent == b"USER anonymous\r\nPASS anonymous@lybra.local\r\n"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: un saludo multilínea desplaza la ventana de lectura una línea más",
-)
 def test_ftp_anonymous_login_confirmed_with_a_multiline_banner():
     sock = _FakeNetSocket(
         greeting=_FTP_MULTILINE_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
     )
-    assert len(_findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)) == 1
+    assert len(_findings_for("lybra:ftp-anonymous-login@2", sock, _FTP)) == 1
 
 
 def test_ftp_anonymous_login_absent_when_credentials_rejected():
@@ -286,32 +279,27 @@ def test_ftp_anonymous_login_absent_when_credentials_rejected():
         greeting=_FTP_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"530 Login incorrect.\r\n"],
     )
-    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
+    assert _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP) == []
 
 
 def test_ftp_anonymous_login_abandoned_when_the_server_says_nothing():
     sock = _FakeNetSocket(greeting=b"", replies=[])
-    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
+    assert _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP) == []
 
 
 def test_ftp_anonymous_login_abandoned_on_connect_failure():
     findings = CheckRuntime(
         load_checks(), lambda *a: None, network_open=lambda host, port: None
     ).run("h", [_FTP])
-    assert not any(f["check_id"] == "lybra:ftp-anonymous-login@1" for f in findings)
+    assert not any(f["check_id"] == "lybra:ftp-anonymous-login@2" for f in findings)
 
 
 # ------------------------------- redis-unauthenticated-access (comportamiento)
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: la respuesta a INFO es un bulk string RESP y exchange corta en "
-           "su primera línea, que es la longitud ($3116), no el contenido",
-)
 def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
     sock = _FakeNetSocket(replies=[_REDIS_INFO])
 
-    redis_findings = _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS)
+    redis_findings = _findings_for("lybra:redis-unauthenticated-access@2", sock, _REDIS)
 
     assert len(redis_findings) == 1
     assert redis_findings[0]["qod"] == 99 and redis_findings[0]["confirmed"] is True
@@ -321,7 +309,7 @@ def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
 
 def test_redis_unauthenticated_access_absent_when_auth_required():
     sock = _FakeNetSocket(replies=[b"-NOAUTH Authentication required.\r\n"])
-    assert _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS) == []
+    assert _findings_for("lybra:redis-unauthenticated-access@2", sock, _REDIS) == []
 
 
 # ------------------------------------------------- selección y orquestación
@@ -399,6 +387,129 @@ def test_network_session_exchange_returns_none_on_empty_read():
     sock = _FakeNetSocket(greeting=b"")
     session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
     assert session.exchange(None) is None
+
+
+def test_network_session_no_longer_reads_one_byte_per_syscall():
+    # El lector anterior pedía los bytes de uno en uno: una llamada al sistema
+    # por byte recibido. Una línea corta debe costar un puñado de recv, no uno
+    # por carácter.
+    sock = _FakeNetSocket(greeting=_FTP_BANNER)
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
+
+    session.exchange(None)
+
+    assert sock.recv_calls < len(_FTP_BANNER)
+
+
+# ------------------------------------------- modos de lectura (``read:``)
+#
+# Dónde termina una respuesta es un hecho del protocolo, no del transporte. Un
+# modo mal elegido no da error: lee los bytes equivocados y el check deja de
+# disparar en silencio, que es el fallo que este bloque existe para impedir.
+
+def _session_over(greeting=b"", replies=()):
+    sock = _FakeNetSocket(greeting=greeting, replies=replies)
+    return NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
+
+
+def test_read_line_stops_at_the_first_newline():
+    session = _session_over(greeting=b"331 Primera\r\n230 Segunda\r\n")
+    assert session.exchange(None, read="line").body == "331 Primera"
+
+
+def test_read_block_joins_the_continuation_lines_of_a_status_reply():
+    # Un código seguido de "-" anuncia que la respuesta sigue; el mismo código
+    # seguido de espacio la cierra.
+    session = _session_over(greeting=b"220-Primera\r\n220-Segunda\r\n220 Ultima\r\n")
+
+    body = session.exchange(None, read="block").body
+
+    assert "Primera" in body and "Segunda" in body and "Ultima" in body
+
+
+def test_read_block_stops_at_a_line_that_is_not_a_continuation():
+    # Con una respuesta de una sola línea, "block" se comporta como "line": no
+    # se queda esperando más datos que no van a llegar.
+    session = _session_over(greeting=b"220 Unica\r\n331 De la siguiente respuesta\r\n")
+    assert session.exchange(None, read="block").body == "220 Unica"
+
+
+def test_read_block_does_not_over_read_a_banner_without_status_codes():
+    # Un saludo que no usa códigos de estado (SSH, por ejemplo) tampoco es una
+    # continuación, así que cierra el bloque en la primera línea. Sin esta
+    # regla, "block" se quedaría leyendo hasta agotar el tiempo de espera.
+    session = _session_over(greeting=b"SSH-2.0-OpenSSH_8.9\r\nmas cosas\r\n")
+    assert session.exchange(None, read="block").body == "SSH-2.0-OpenSSH_8.9"
+
+
+def test_read_resp_bulk_returns_the_announced_payload_and_not_its_header():
+    session = _session_over(replies=[_REDIS_INFO])
+
+    body = session.exchange("INFO\r\n", read="resp-bulk").body
+
+    assert body.startswith("# Server")
+    assert "redis_version:7.0.11" in body
+    assert "$" not in body                 # la línea de longitud no forma parte del contenido
+
+
+def test_read_resp_bulk_returns_a_non_bulk_reply_untouched():
+    # Un error de Redis es una línea suelta que empieza por "-": ya es la
+    # respuesta entera, y es justo la que el matcher negativo tiene que ver.
+    session = _session_over(replies=[b"-NOAUTH Authentication required.\r\n"])
+    assert session.exchange("INFO\r\n", read="resp-bulk").body == "-NOAUTH Authentication required."
+
+
+def test_read_resp_bulk_leaves_the_trailing_bytes_for_the_next_read():
+    # RESP cierra el bulk con un CRLF que no cuenta en la longitud anunciada.
+    # Ese sobrante se queda en el buffer y no puede comerse la respuesta
+    # siguiente.
+    session = _session_over(replies=[b"$2\r\nOK\r\n+PONG\r\n"])
+
+    assert session.exchange("INFO\r\n", read="resp-bulk").body == "OK"
+    assert session.exchange("PING\r\n", read="line").body == "+PONG"
+
+
+def test_a_truncated_bulk_reply_returns_what_arrived_instead_of_hanging():
+    # El servidor anuncia 3116 bytes y cierra la conexión tras unos pocos.
+    session = _session_over(replies=[b"$3116\r\nredis_version:7.0.11\r\n"])
+    assert "redis_version:7.0.11" in session.exchange("INFO\r\n", read="resp-bulk").body
+
+
+# ------------------------------------ el feed declara cómo termina cada respuesta
+
+def test_the_bundled_network_checks_declare_their_read_semantics():
+    checks = {check.id: check for check in load_checks()}
+
+    ftp = checks["ftp-anonymous-login"]
+    assert ftp.expect_banner is True       # FTP saluda al conectar
+    assert [request.read for request in ftp.requests] == ["block", "block"]
+
+    redis_check = checks["redis-unauthenticated-access"]
+    assert redis_check.expect_banner is False   # Redis no saluda
+    assert [request.read for request in redis_check.requests] == ["resp-bulk"]
+
+
+def test_a_request_without_a_declared_read_mode_keeps_the_original_behaviour():
+    git = next(check for check in load_checks() if check.id == "git-config-exposure")
+    assert git.requests[0].read == "line"
+    assert git.expect_banner is False
+
+
+def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
+    # Un modo que nadie implementa es un bug del feed. Si se ignorase en
+    # silencio, el check leería una línea donde el protocolo necesita un
+    # bloque y no dispararía nunca: exactamente el falso negativo silencioso
+    # que este cambio elimina.
+    feed = tmp_path / "feed.json"
+    feed.write_text(json.dumps({"checks": [{
+        "id": "modo-inventado", "version": 1, "type": "network",
+        "category": "network_config", "severity": "HIGH", "service": "ftp",
+        "requests": [{"send": "PING\r\n", "read": "telepatia", "matchers": []}],
+        "finding": {"title": "x"},
+    }]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="telepatia"):
+        load_checks(str(feed))
 
 
 # --------------------------------------------------- ``type: "script"`` (Fase R)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,29 @@ despliega.
 > `appVersion` de `SecOpsConfig.json` puede ir por detrás del nombre de la rama. Ninguna de las
 > dos cosas es un error, pero conviene mirarlas antes de afirmar «esto ya está en producción».
 
+## Cómo se escriben los PR, los issues y sus comentarios
+
+Se escriben para **alguien que no conoce el módulo que se está tocando**. Quien abre un PR de
+Themis puede no saber qué es Lybra, qué hace el runtime de checks o qué significa `feed_version`, y
+una descripción comprimida sólo la entiende quien ya sabía la respuesta: no informa a nadie, es un
+recordatorio para el autor disfrazado de documentación.
+
+Tres reglas concretas:
+
+- **Primero el problema en lenguaje llano, después el símbolo.** Antes de nombrar
+  `xfail(strict=True)`, `NetworkSession.exchange` o «bulk string RESP», di qué es y por qué importa
+  aquí. «Un *bulk string* de Redis es una respuesta que empieza por una línea con la longitud del
+  contenido, así que la primera línea no trae datos» cuesta una frase y ahorra el viaje al código.
+- **Nada de taquigrafía ni de explicaciones planas.** Una tabla o una lista siguen valiendo, pero
+  cada fila necesita su frase de contexto; una fila que sólo repite el nombre del test no explica
+  por qué falla.
+- **Vale alargarse; no vale dar por supuesto.** El coste de leer un párrafo de más es mucho menor
+  que el de reconstruir el contexto entrando al código.
+
+Esto aplica a los cuerpos de PR, a los issues que se abran y a los comentarios de seguimiento. No
+aplica al **código**: ahí manda la concisión de siempre (nombres completos, comentarios que
+explican el *por qué*, no el *qué*).
+
 ## Deuda técnica
 
 `plans/deuda-tecnica-y-calidad.md` es la auditoría de origen (fechada 2026-08-03) y `plans/` en


### PR DESCRIPTION
## El problema, en lenguaje llano

Lybra tiene dos comprobaciones que no miran páginas web sino servicios de red: una detecta si un servidor **FTP acepta el acceso anónimo** (entrar sin cuenta, con el usuario `anonymous`) y otra si un **Redis contesta sin pedir contraseña**. Son las dos únicas de su clase en el motor.

Ninguna de las dos podía producir un hallazgo contra un servidor real. No es que fallaran de vez en cuando: la pieza que las ejecuta leía del socket una forma de respuesta que ninguno de los dos protocolos produce.

Eso es el peor fallo que puede tener un escáner de seguridad, porque **no se nota**: el escaneo termina en verde, el informe dice que no hay hallazgos de red, y el FTP anónimo sigue abierto. En la jerga, un *falso negativo silencioso*.

### Por qué fallaba cada uno

**FTP.** Un servidor FTP saluda solo. En cuanto se abre la conexión manda una línea del tipo `220 (vsFTPd 3.0.3)`, sin que el cliente pida nada. Ese saludo se queda esperando en el buffer del socket. Cuando la comprobación escribía `USER anonymous` y leía "la siguiente línea", lo que leía era **el saludo**, no la respuesta `331 Please specify the password.` que estaba buscando. Comparaba `331` contra `220 (vsFTPd 3.0.3)`, no casaba, y abandonaba. Además, muchos servidores parten el saludo en varias líneas (`220-...` seguido de `220 ...`), lo que corría la ventana de lectura una línea más todavía.

**Redis.** La respuesta al comando `INFO` es lo que Redis llama un *bulk string*: una primera línea que sólo trae **la longitud** del contenido (`$3116`) y, detrás, esos 3116 bytes con la información de verdad. La comprobación leía una línea, se quedaba con `$3116`, buscaba ahí la palabra `redis_version` y no la encontraba nunca.

## Issue relacionado

Closes #265. Depende de #329 (ya mergeado), que es lo que dejó los tres tests en rojo demostrando el fallo.

## La corrección

La idea de fondo: **dónde termina una respuesta es un hecho del protocolo, no del transporte**. `NetworkSession` seguía leyendo "una línea" a fuego porque es lo que hace FTP la mayor parte del tiempo, pero eso es una propiedad de algunos protocolos y de ningún otro. Así que ahora lo declara el feed, y `NetworkSession` sigue sin saber nada de FTP ni de Redis — sólo implementa los mecanismos.

Tres modos de lectura, declarables por petición con `read:`:

| Modo | Cómo decide que la respuesta terminó | Para qué |
|---|---|---|
| `line` | En el primer salto de línea. Es el valor por defecto y el comportamiento de siempre, así que ningún check existente cambia. | Protocolos cuyas respuestas son de una línea |
| `block` | Las líneas cuyo código de estado va seguido de un guion (`220-`) anuncian que la respuesta continúa; la primera línea sin ese guion la cierra. | Las respuestas multilínea de FTP, SMTP o POP3 |
| `resp-bulk` | Lee la cabecera `$<n>` y luego exactamente n bytes. Si la primera línea no es una cabecera de ésas (un error como `-NOAUTH ...`), la devuelve tal cual, porque **ésa es** la respuesta entera. | Redis |

Y una marca a nivel de check, `expectBanner: true`, para los protocolos que saludan al conectar: el saludo se lee y se descarta antes de escribir el primer comando. FTP la lleva; Redis no, porque no saluda.

Un detalle de diseño que merece explicarse: `block` cierra el bloque en **cualquier** línea que no sea una continuación, no sólo en una que tenga código de estado. Eso es lo que lo hace seguro como lector de saludos para cualquier protocolo: un servidor SSH, que saluda con `SSH-2.0-OpenSSH_8.9` y ningún código, cierra en la primera línea en vez de dejar al lector esperando datos que no van a llegar.

Tres cosas más, pequeñas:

- **Un modo de lectura desconocido revienta al cargar el feed.** Si se ignorase, el check leería una línea donde el protocolo necesita un bloque y no dispararía nunca — otra vez el mismo falso negativo callado, que es justo lo que este PR viene a eliminar.
- **La lectura ya no cuesta una llamada al sistema por byte.** Antes era `recv(1)` en un bucle; ahora es un lector con buffer de 4 KiB, y lo que una lectura no consume queda disponible para la siguiente (que es lo que permite que el modo bulk devuelva los sobrantes en vez de perderlos).
- **Versionado.** `feedVersion` sube a `lybra-checks-6` porque el esquema gana vocabulario nuevo, y los dos checks de red suben a `version: 2` porque su comportamiento cambia: un hallazgo ya guardado tiene que poder decir cuál de las dos formas lo produjo. Su identificador pasa de `lybra:ftp-anonymous-login@1` a `@2`.

## Implementación, commit a commit

1. `docs(agents)` — la convención de escritura de PR/issues que faltaba en `CLAUDE.md`. No es del issue; va aparte y no toca código.
2. `fix(themis)` — el runtime y el feed: modos de lectura, `expectBanner`, lector con buffer, validación al cargar.
3. `test(themis)` — se quitan los tres `xfail` de #269 (pasaron a verde solos: era el transporte, no el test) y se cubren los modos de lectura uno a uno. El test de integración de FTP, que usaba el mismo tipo de doble que #269 desterró, baja también al socket.
4. `test(themis)` — el banco oracle: contenedores reales de vsftpd y redis, un positivo y un negativo por protocolo.
5. `test(themis)` — la espera de arranque de esos contenedores (ver "Lo que salió mal por el camino").

## Validación

**Suite normal** (`pytest tests/unit tests/integration`): en verde. Los 52 tests de `test_lybra_checks.py` pasan, incluidos los tres que #269 dejó en rojo.

**Contra servidores de verdad**, que es el criterio de cierre del issue:

| Caso | Resultado |
|---|---|
| vsftpd con acceso anónimo abierto | Dispara `lybra:ftp-anonymous-login@2` ✔ |
| vsftpd con acceso anónimo cerrado | No dispara ✔ |
| redis:7 sin contraseña | Dispara `lybra:redis-unauthenticated-access@2` ✔ |
| redis:7 con `requirepass` | No dispara ✔ |

Los dos casos de FTP se ejecutaron con las fixtures nuevas del banco oracle. Los dos de Redis **se saltan en esta máquina** porque el puerto 6379 lo ocupa el Redis de desarrollo del `docker-compose` del repositorio, así que se verificaron aparte, con dos contenedores `redis:7` reales en puertos libres (16379 y 16380) y el runtime de checks apuntado a ellos. El resultado es el de la tabla. En una máquina con el 6379 libre, las fixtures corren solas.

## Lo que salió mal por el camino

La primera ejecución real del banco oracle **falló**, y el motivo no tenía nada que ver con el motor: Docker publica el puerto en el host en cuanto arranca el contenedor, así que el TCP acepta conexiones **a los 0,0 s** —medido— mientras dentro todavía se está instalando vsftpd. El escaneo caía en ese hueco, encontraba una conexión que se cerraba sin decir nada y abandonaba el check.

`wait_for_port`, el ayudante que ya existía, no puede distinguir ese caso porque quien acepta la conexión es el proxy de Docker y no el servidor. Se añade `_wait_until_answering`, que exige la respuesta que el protocolo debe dar (`220` en FTP, `+PONG` o `-NOAUTH` en Redis) antes de dejar correr el test. Exigir el saludo *correcto* y no unos bytes cualesquiera tiene un segundo efecto que interesa: un control negativo mal configurado falla en la espera, en voz alta, en vez de pasar el test sin haber demostrado nada.

## Notas y trabajo que queda fuera

- **Las fixtures TLS del mismo banco tienen la misma carrera latente**: también instalan paquetes (`openssl`) dentro del contenedor antes de arrancar nginx. Hoy pasan, seguramente porque esa instalación es más rápida, pero es el mismo fallo esperando. No se toca aquí porque no es de este issue; queda anotado.
- **Ningún otro protocolo gana `read:` en este PR.** El vocabulario existe y está probado, pero darle uso —checks de SMTP, MongoDB y compañía— es #297, y antes hace falta #272, que es lo que permite que un check declare un `service:` que no sea `ftp` o `redis` sin que se ignore en silencio.
- `pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
