### PR TITLE
refactor(themis): derivar del módulo a qué protocolo aplica un check network (#272)

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -358,7 +358,7 @@ def _parse_check(c: dict) -> Check:
         )
         for request in c.get("requests", [])
     )
-    return Check(
+    check = Check(
         id=c["id"],
         version=c.get("version", 1),
         type=c.get("type", "http"),
@@ -371,6 +371,36 @@ def _parse_check(c: dict) -> Check:
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
+    )
+    _assert_service_is_reachable(check)
+    return check
+
+
+def _assert_service_is_reachable(check: Check) -> None:
+    """Fail loudly when a ``network`` check names a protocol nobody can match.
+
+    A check whose ``service`` has no predicate can never apply to anything: it
+    is a bug in the feed, not a runtime case. Left to fall through it looks
+    exactly like "this check simply did not fire against this host", which is
+    normal and unremarkable — so nobody ever finds out. Raising here puts the
+    error where a human is looking, at load time.
+
+    Only ``network`` checks are validated: the other families do not dispatch
+    on this field (``http`` and ``tls`` decide by service shape, ``script``
+    delegates to its plugin), so an odd ``service`` there is a label and not a
+    routing decision.
+
+    Args:
+        check: The freshly parsed check.
+
+    Raises:
+        ValueError: If a ``network`` check names an unknown protocol.
+    """
+    if check.type != "network" or check.service in _NETWORK_SERVICE_MATCHERS:
+        return
+    raise ValueError(
+        f"Check {check.id!r}: el servicio {check.service!r} no tiene predicado "
+        f"(disponibles: {', '.join(sorted(_NETWORK_SERVICE_MATCHERS))})"
     )
 
 
@@ -496,14 +526,34 @@ def is_snmp_service(service: Service) -> bool:
     return (service.name or "").lower() in _SNMP_SERVICE_NAMES or service.port in _SNMP_PORTS
 
 
-# Maps a ``type: "network"`` check's declared ``service`` (the feed's plain
-# string, e.g. ``"ftp"``) to the predicate that decides whether a discovered
-# Service is that protocol. One entry per protocol Fase N adds — the runtime
-# itself (``CheckRuntime._applies_network``) stays protocol-agnostic.
-_NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = {
-    "ftp": is_ftp_service,
-    "redis": is_redis_service,
-}
+def _network_service_matchers() -> Dict[str, Callable[[Service], bool]]:
+    """Derive the ``service`` → predicate map from this module's own predicates.
+
+    A ``type: "network"`` check declares which protocol it targets as a plain
+    string (``service: ftp``), and the runtime needs the predicate that decides
+    whether a discovered service *is* that protocol. That map used to be
+    written out by hand and had **two** entries while the module already
+    defined eleven predicates: a check for SMTP, MySQL or VNC loaded fine,
+    validated fine, and was then dropped without a word.
+
+    Deriving it removes the second edit entirely — defining
+    ``is_mongodb_service`` is all it takes for ``service: mongodb`` to work.
+
+    Introspection rather than the ``@register_dissector`` decorator the
+    fingerprinting package uses, and for a reason: a decorator would have to
+    restate the protocol name (``@service_predicate("ftp")``) that the
+    function name already carries, which is one more place for the two to
+    disagree. Here the naming convention *is* the registration.
+    """
+    suffix = "_service"
+    return {
+        name[len("is_"):-len(suffix)]: predicate
+        for name, predicate in globals().items()
+        if name.startswith("is_") and name.endswith(suffix) and callable(predicate)
+    }
+
+
+_NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = _network_service_matchers()
 
 
 # Protocol versions considered deprecated/weak for a service exposed today.
@@ -717,11 +767,25 @@ class CheckRuntime:
         :data:`_NETWORK_SERVICE_MATCHERS`, so the runtime itself never needs to
         know about a specific protocol — only each protocol's applicability
         predicate does.
+
+        A check the feed loader already rejected cannot reach this point, so an
+        unknown protocol here means a check that never went through it — one
+        translated from a Nuclei template, whose ``service`` is whatever the
+        upstream document said. It is still a check that can never fire, so it
+        is logged rather than silently skipped: the two cases (unknown protocol
+        / protocol that does not apply to this service) are not the same thing
+        and must not look the same.
         """
         if check.type != "network":
             return False
         matches = _NETWORK_SERVICE_MATCHERS.get(check.service)
-        if matches is None or not matches(service):
+        if matches is None:
+            logger.warning(
+                "Check %s declara el servicio %r, que no tiene predicado: no se ejecutará",
+                check.check_id, check.service,
+            )
+            return False
+        if not matches(service):
             return False
         return self._applies_mode(check)
 

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -16,6 +16,7 @@ import yaml
 
 import pytest
 
+from src.modules.features.themis.lybra import checks as checks_mod
 from src.modules.features.themis.lybra import (
     load_checks,
     CheckRuntime,
@@ -510,6 +511,95 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
 
     with pytest.raises(ValueError, match="telepatia"):
         load_checks(str(feed))
+
+
+# --------------------------- a qué protocolo aplica un check ``network``
+#
+# Un check `network` dice a qué protocolo va dirigido con una cadena
+# (`service: ftp`), y el runtime necesita el predicado que decide si un
+# servicio descubierto es de ese protocolo. Ese mapa se mantenía a mano y tenía
+# dos entradas cuando el módulo ya definía once predicados: un check de SMTP o
+# de MySQL se cargaba, se validaba, y se descartaba sin decir nada.
+
+_MYSQL = Service(3306, "tcp", "mysql", "", "", None)
+
+_MYSQL_NETWORK_FEED = {
+    "checks": [{
+        "id": "mysql-saluda", "version": 1, "type": "network",
+        "category": "network_config", "severity": "INFO", "service": "mysql",
+        "mode": "safe",
+        "requests": [{"matchers": [{"type": "word", "part": "body", "words": ["mysql_native_password"]}]}],
+        "finding": {"title": "MySQL contesta"},
+    }]
+}
+
+
+def _feed_file(tmp_path, document):
+    feed = tmp_path / "feed.json"
+    feed.write_text(json.dumps(document), encoding="utf-8")
+    return str(feed)
+
+
+def test_every_service_predicate_is_available_to_a_network_check():
+    # Invariante al estilo de test_config_shape: definir un predicado nuevo
+    # basta para poder escribir checks de ese protocolo. Sin esto, cada
+    # protocolo costaba dos ediciones y olvidar la segunda no daba error.
+    predicates = {
+        name for name in dir(checks_mod)
+        if name.startswith("is_") and name.endswith("_service")
+    }
+    esperados = {name[len("is_"):-len("_service")] for name in predicates}
+
+    assert esperados == set(checks_mod._NETWORK_SERVICE_MATCHERS)
+    assert len(esperados) > 2, "el mapa derivado debe cubrir más que ftp y redis"
+
+
+def test_a_network_check_for_a_protocol_that_nobody_wired_by_hand_runs(tmp_path):
+    # MySQL nunca estuvo en la tabla escrita a mano, y su predicado sí existía.
+    checks = load_checks(_feed_file(tmp_path, _MYSQL_NETWORK_FEED))
+    sock = _FakeNetSocket(greeting=b"5.7.42-log\x00mysql_native_password\n")
+
+    findings = CheckRuntime(
+        checks, lambda *a: None, network_open=_network_open_over(sock)
+    ).run("h", [_MYSQL])
+
+    assert [f["check_id"] for f in findings] == ["lybra:mysql-saluda@1"]
+
+
+def test_an_unknown_service_fails_at_load_time(tmp_path):
+    # Un check que no puede aplicar a nada es un bug del feed. Si se ignora,
+    # se confunde con "no ha disparado contra este host", que es normal — y
+    # así nadie se entera nunca.
+    document = {"checks": [dict(_MYSQL_NETWORK_FEED["checks"][0], id="protocolo-inventado",
+                                service="noexiste")]}
+
+    with pytest.raises(ValueError, match="noexiste"):
+        load_checks(_feed_file(tmp_path, document))
+
+
+def test_every_network_service_in_the_bundled_feed_has_a_predicate():
+    network_services = {check.service for check in load_checks() if check.type == "network"}
+    assert network_services <= set(checks_mod._NETWORK_SERVICE_MATCHERS)
+
+
+def test_a_check_that_skipped_the_loader_with_an_unknown_service_is_logged(caplog):
+    # Los checks traducidos de plantillas de Nuclei se construyen directamente,
+    # sin pasar por el cargador, así que su `service` es lo que dijera el
+    # documento de origen. Ahí el aviso lo tiene que dar el runtime.
+    translated = checks_mod.Check(
+        id="traducido", version=1, type="network", category="network_config",
+        severity="INFO", service="protocolo-de-otro-mundo", mode="safe",
+        requests=(), finding={}, namespace="nuclei",
+    )
+    sock = _FakeNetSocket(greeting=b"lo que sea\r\n")
+
+    with caplog.at_level("WARNING"):
+        findings = CheckRuntime(
+            [translated], lambda *a: None, network_open=_network_open_over(sock)
+        ).run("h", [_FTP])
+
+    assert findings == []
+    assert "protocolo-de-otro-mundo" in caplog.text
 
 
 # --------------------------------------------------- ``type: "script"`` (Fase R)


### PR DESCRIPTION
## El problema, en lenguaje llano

Lybra tiene una familia de comprobaciones llamada `network`: las que hablan directamente con un servicio de red en vez de pedir páginas web. Cada una declara a qué protocolo va dirigida con una cadena de texto en el feed — `service: ftp`, `service: redis`.

Para saber si un servicio descubierto en el objetivo es de ese protocolo, el runtime consulta un mapa que traduce esa cadena a la función que lo decide (`is_ftp_service` y compañía). **Ese mapa estaba escrito a mano y tenía dos entradas**, mientras que el módulo ya definía **once** de esas funciones: HTTP, TLS, FTP, SMTP, IMAP, POP3, SMB, MySQL, Redis, VNC y SNMP.

La consecuencia: si alguien escribía una comprobación para SMTP o para MySQL, el feed la cargaba, la validación la daba por buena, y después el runtime la descartaba **sin decir absolutamente nada**. Lo mismo con una errata: `service: ftp ` con un espacio de más, o `service: FTP` en mayúsculas, apagaban la comprobación en silencio.

Y hay un agravante que es el que convierte esto en un problema de verdad y no en una incomodidad: el código no distinguía entre *"este protocolo no existe en el mapa"* (un error de configuración, algo que hay que arreglar) y *"este servicio no es de ese protocolo"* (funcionamiento normal, que pasa constantemente). Las dos cosas devolvían lo mismo, así que la primera era invisible detrás de la segunda.

Es el mismo patrón que el motor ya corrigió dos veces antes: la selección de dissector era una cadena de `if`/`elif` y se sustituyó por un registro, y el bucle de `CheckRuntime.run` estaba triplicado por tipo de check y se unificó. Éste era el tercer sitio con la misma forma.

## Issue relacionado

Closes #272.

## La corrección

**El mapa se deriva del propio módulo.** En vez de mantenerlo a mano, se construye por introspección a partir de las funciones que ya existen: toda función llamada `is_<protocolo>_service` queda automáticamente disponible como `service: <protocolo>`. Escribir `is_mongodb_service` es todo lo que hace falta para que `service: mongodb` funcione — se acabaron las dos ediciones en dos sitios, que es donde se olvidaba la segunda.

Pasa de 2 protocolos disponibles a 11.

**Por qué introspección y no un decorador.** El paquete de fingerprinting usa `@register_dissector`, y el issue contemplaba seguir ese patrón. Aquí no encaja igual de bien: un decorador tendría que repetir el nombre del protocolo (`@service_predicate("ftp")`) que el nombre de la función ya lleva, y eso es un sitio más donde los dos pueden acabar discrepando. En el caso de los dissectors el decorador aporta algo real —registra clases que viven en módulos distintos, sin que nadie tenga que importarlas—, pero estos predicados están todos en el mismo fichero y su nombre ya es su identificador. La convención de nombres *es* el registro.

**Un `service` desconocido deja de ser silencioso**, por dos caminos distintos porque hay dos formas de que un check llegue al runtime:

- **Al cargar el feed, revienta.** Es donde nacen los checks de primera parte, y donde hay un humano mirando. Un check que no puede aplicar a nada es un bug del feed, no un caso de ejecución.
- **En el runtime, avisa por log.** Ahí llegan los checks traducidos de plantillas de Nuclei, que se construyen directamente sin pasar por el cargador y cuyo `service` es lo que dijera el documento de origen. No se puede hacer fallar la carga de algo que no se carga, pero sí dejar rastro.

Sólo se validan los checks `network`. Las otras familias no despachan por ese campo —`http` y `tls` deciden por la forma del servicio, `script` delega en su plugin—, así que ahí un `service` raro es una etiqueta descriptiva y no una decisión de encaminamiento.

## Implementación

Dos commits:

1. `refactor(themis)` — el mapa derivado, la validación al cargar y el aviso en el runtime.
2. `test(themis)` — los tests.

## Validación

- **Invariante nuevo, al estilo de `test_config_shape.py`**: el conjunto de predicados `is_*_service` del módulo y el de protocolos que un check `network` puede declarar tienen que coincidir exactamente. Es lo que impide que la tabla vuelva a quedarse atrás sin que nadie lo note.
- Un check de **MySQL** —protocolo que nunca estuvo en la tabla escrita a mano, y cuyo predicado sí existía desde hace tiempo— dispara contra un servicio MySQL sin que haya hecho falta tocar ningún mapa.
- Un `service` inventado **falla al cargar el feed**.
- Todo `service` del feed empotrado tiene predicado.
- Un check que se saltó el cargador con un protocolo desconocido **deja rastro en el log** y no produce hallazgos.

`pytest tests/unit tests/integration`: en verde, incluidos los tests de la ingesta de plantillas de Nuclei, que son los que podrían haber sufrido la validación nueva.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **Esto no añade ninguna comprobación nueva**, sólo quita el obstáculo. Escribir los checks de configuración de red que faltan es #297, y este PR es su precondición: sin esto, un check de SMTP o de MongoDB se habría escrito, cargado y descartado en silencio.
- El aviso por log del runtime se emite una vez por check y servicio evaluado. Con el feed propio eso son cero mensajes (todos sus protocolos existen); con la ingesta de Nuclei activada podría repetirse, pero esa ingesta está desactivada por defecto y filtra por relevancia antes de llegar aquí. Si algún día molesta, el sitio de arreglarlo es #275 (validación del feed en CI), que es donde el error debería detectarse mucho antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
