### PR TITLE
fix(themis): tener en cuenta CVSS v4.0 al elegir la puntuación de un CVE (#266)

### DIFF
--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -413,8 +413,21 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
     """Choose the best available CVSS metric from an NVD ``metrics`` block.
 
     A CVE may carry several CVSS versions at once; we prefer the newest
-    (v3.1 over v3.0 over v2), since that is the most accurate scoring the entry
-    offers.
+    (v4.0 over v3.1 over v3.0 over v2), since that is the most accurate scoring
+    the entry offers.
+
+    **v4.0 goes first, and that is the whole point of the order.** It is the
+    most recent and most precise metric an entry can carry, which is the same
+    rule the rest of the chain already followed — but until it was listed here
+    a CVE whose *only* published metric was v4 came back empty, and empty is
+    not a cosmetic gap downstream: ``_cvss_band`` reads a missing score as
+    ``0.0``, which is INFO. A critical vulnerability published only with v4
+    was landing in reports as informational, and the AI summary described it
+    as such.
+
+    The v4 ``cvssData`` block exposes ``baseScore``, ``vectorString`` and
+    ``baseSeverity`` under the very same names as v3.x, so nothing below this
+    line has to know which version it is reading.
 
     Args:
         metrics: The ``metrics`` object of an NVD CVE record.
@@ -423,7 +436,7 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
         A ``(base_score, vector_string, severity)`` tuple. Each element is
         ``None`` if no CVSS metric of any version is present.
     """
-    for key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+    for key in ("cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
         entries = metrics.get(key) or []
         if not entries:
             continue

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -177,6 +177,93 @@ def test_ingest_nvd_cve_malformed_returns_none():
     assert ingest_nvd_cve({"cve": {}}) is None
 
 
+# ------------------------------------------------------- elección de métrica CVSS
+#
+# Un CVE puede publicar varias versiones de CVSS a la vez, y se coge la más
+# reciente porque es la más precisa. La v4.0 no estaba en esa cadena, así que un
+# CVE que sólo publicara v4 entraba sin puntuación — y aguas abajo "sin
+# puntuación" no es un hueco cosmético: se lee como 0.0, que es INFO. Una
+# vulnerabilidad crítica aparecía en el informe como informativa.
+
+def _nvd_item_with(metrics: dict) -> dict:
+    return {"cve": {
+        "id": "CVE-2026-0001",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "metrics": metrics,
+        "configurations": [{"nodes": [{"cpeMatch": [{
+            "vulnerable": True,
+            "criteria": "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
+        }]}]}],
+    }}
+
+
+_CVSS_V40 = {"cvssMetricV40": [{"cvssData": {
+    "baseScore": 9.3,
+    "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+    "baseSeverity": "CRITICAL",
+}}]}
+
+_CVSS_V31 = {"cvssMetricV31": [{"cvssData": {
+    "baseScore": 7.5, "vectorString": "CVSS:3.1/AV:N", "baseSeverity": "HIGH",
+}}]}
+
+
+def test_a_cve_published_only_with_cvss_v4_is_scored():
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with(_CVSS_V40))
+
+    assert cve_row["cvss_score"] == 9.3
+    assert cve_row["severity"] == "CRITICAL"
+    assert cve_row["cvss_vector"].startswith("CVSS:4.0/")
+
+
+def test_v4_wins_over_v31_when_a_cve_publishes_both():
+    # La regla de la cadena es "la métrica más reciente que ofrezca la entrada",
+    # y v4 es más precisa que v3.1 sobre el mismo CVE.
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with({**_CVSS_V31, **_CVSS_V40}))
+
+    assert cve_row["cvss_score"] == 9.3
+    assert cve_row["severity"] == "CRITICAL"
+
+
+def test_v31_still_wins_when_there_is_no_v4():
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with(_CVSS_V31))
+    assert cve_row["cvss_score"] == 7.5
+    assert cve_row["severity"] == "HIGH"
+
+
+def test_a_cve_with_no_metric_at_all_stays_unscored():
+    # Regresión: no tener métrica sigue siendo distinto de tener una de cero.
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with({}))
+    assert (cve_row["cvss_score"], cve_row["cvss_vector"], cve_row["severity"]) == (None, None, None)
+
+
+def test_the_longest_possible_v4_vector_fits_in_the_column():
+    """Un vector v4 es bastante más largo que uno de v3.1, y se guarda entero.
+
+    El peor caso de la especificación —base completa, más amenaza, más entorno,
+    más suplementarias, cogiendo en cada métrica el valor más largo— se
+    construye aquí en vez de fiarse de un ejemplo suelto: un ejemplo corto que
+    quepa no demuestra nada sobre el que no quepa. Son 188 caracteres, así que
+    ``String(255)`` vale y no hace falta migración; si alguien acorta la
+    columna, este test lo dice.
+    """
+    from src.modules.features.themis.model import CveEntry
+
+    metricas = [
+        ("AV", "N"), ("AC", "L"), ("AT", "P"), ("PR", "N"), ("UI", "A"),
+        ("VC", "H"), ("VI", "H"), ("VA", "H"), ("SC", "H"), ("SI", "H"), ("SA", "H"),
+        ("E", "U"),
+        ("CR", "H"), ("IR", "H"), ("AR", "H"),
+        ("MAV", "N"), ("MAC", "L"), ("MAT", "P"), ("MPR", "N"), ("MUI", "A"),
+        ("MVC", "H"), ("MVI", "H"), ("MVA", "H"),
+        ("MSC", "H"), ("MSI", "Safety"), ("MSA", "Safety"),
+        ("S", "P"), ("AU", "Y"), ("R", "I"), ("V", "C"), ("RE", "M"), ("U", "Clear"),
+    ]
+    peor_caso = "/".join(["CVSS:4.0"] + [f"{metrica}:{valor}" for metrica, valor in metricas])
+
+    assert len(peor_caso) <= CveEntry.__table__.c.cvss_vector.type.length
+
+
 # ------------------------------------------------- platform-gated CVEs (#118)
 
 def _and_node_item(platform_cpe: str) -> dict:


### PR DESCRIPTION
## El problema, en lenguaje llano

CVSS es la puntuación estándar de gravedad de una vulnerabilidad: el número del 0 al 10 que decide si algo es crítico o anecdótico. Un mismo CVE puede traer publicadas **varias versiones** de esa puntuación a la vez (v2, v3.0, v3.1, v4.0), y Lybra coge la más reciente porque es la más precisa que ofrece la entrada.

Esa cadena de preferencia se paraba en la v3.1. La v4.0, que NVD ya publica, **no estaba en la lista**. Así que un CVE cuya única métrica publicada fuera v4 entraba en la base de conocimiento sin puntuación, sin vector y sin severidad.

Y aquí viene la parte que lo convierte en un problema serio en vez de un hueco cosmético: **la ausencia de puntuación no se trata como "no se sabe", se trata como cero**. La función que reparte los hallazgos en bandas de prioridad lee un score ausente como `0.0`, y `0.0` cae en la banda INFO. El resultado es que una vulnerabilidad crítica publicada sólo con v4 aparecía en el informe como **informativa**, y el resumen ejecutivo generado por IA la describía como tal.

Es la clase de fallo que hace que un escáner deje de ser creíble: no se rompe, no avisa, simplemente miente en voz baja.

## Issue relacionado

Closes #266.

## Cuánto pasa esto de verdad

En vez de dejarlo en "esto podría pasar", lo he medido contra la base de conocimiento local, que tiene el catálogo histórico completo (371.104 CVEs).

**23.971 CVEs (6,5 %) están guardados sin puntuación.** Ése es el techo del problema, no su tamaño: ahí dentro hay también CVEs que NVD todavía no ha analizado y que no tienen ninguna métrica. La distribución por año de publicación sí es sugerente:

| Año | Sin puntuación | Total | % |
|---|---|---|---|
| 2023 | 2.133 | 30.948 | 6,9 % |
| 2024 | 1.070 | 40.701 | 2,6 % |
| 2025 | 5.025 | 49.972 | 10,1 % |
| 2026 | 4.048 | 45.832 | 8,8 % |

El salto de 2024 a 2025 coincide con la adopción de v4 por parte de NVD, pero correlación no es prueba. Así que cogí una muestra de seis de esos CVEs sin puntuación —los más recientes— y consulté qué métricas tienen hoy en NVD:

| CVE | Métricas que publica NVD | Lectura |
|---|---|---|
| CVE-2026-14354 | **sólo `cvssMetricV40`** | El caso exacto de este bug |
| CVE-2026-65883 | `cvssMetricV31` + `cvssMetricV40` | Tiene puntuación en NVD; nuestra copia se guardó antes de que la tuviera |
| CVE-2026-56390 | `cvssMetricV31` + `cvssMetricV40` | Igual que el anterior |
| CVE-2026-65944 | sólo `cvssMetricV31` | Se ingirió antes de que NVD lo analizara |
| CVE-2026-65943 | sólo `cvssMetricV31` | Igual |
| CVE-2026-65891 | sólo `cvssMetricV31` | Igual |

Uno de cada seis en la muestra es literalmente el caso que este PR arregla. Los demás enseñan otra cosa que conviene tener presente, y que va más abajo en las notas.

## La corrección

Anteponer `cvssMetricV40` a la tupla de preferencia. El bloque `cvssData` de v4 expone `baseScore`, `vectorString` y `baseSeverity` con los mismos nombres que v3.x, así que nada por debajo de esa línea tiene que saber qué versión está leyendo.

Va **primero** y no último por la misma regla que ya gobernaba el orden: la métrica más reciente es la más precisa que ofrece la entrada. Eso queda escrito en el docstring, junto al motivo de que su ausencia doliera tanto — que es la parte que no era evidente.

**Sobre la longitud de la columna.** El issue pedía revisar si un vector v4 cabe en `CveEntry.cvss_vector`, que es `String(255)`, porque son bastante más largos que los de v3.1. Cabe: el vector v4 más largo que permite la especificación —base completa, más amenaza, más entorno, más suplementarias, cogiendo en cada métrica el valor más largo posible— mide **188 caracteres**. **No hace falta migración.**

## Validación

- Un CVE que sólo publica v4 se ingiere con puntuación, vector y severidad.
- Un CVE que publica v4 **y** v3.1 se queda con la v4.
- Sin v4, sigue ganando la v3.1 (nada de lo que ya funcionaba cambia).
- **Regresión que importa**: un CVE sin ninguna métrica sigue entrando sin puntuación. No tener métrica tiene que seguir siendo distinto de tener una de cero.
- El test del largo del vector **construye el peor caso de la especificación** en vez de fiarse de un ejemplo suelto: un ejemplo corto que quepa no demuestra nada sobre el que no quepa. Si alguien acorta la columna, ese test lo dice.

`pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **Los CVEs ya guardados no se arreglan solos con este PR.** La corrección actúa en el momento de ingerir, así que las 23.971 filas sin puntuación siguen igual hasta que ese CVE se vuelva a ingerir. La buena noticia es que `upsert_cve` sobrescribe todos los campos al re-ingerir, y la sincronización incremental de NVD vuelve a tocar un CVE cuando cambia su `lastModified` — así que el atraso se cura solo, poco a poco. Si se quiere de golpe, hace falta una re-ingesta completa, que es una decisión operativa y no de este PR.
- **La muestra enseñó un segundo desajuste que no es de este issue**: dos de los seis CVEs tienen puntuación en NVD desde hace tiempo y en nuestra copia siguen sin ella. Eso no es el bug de v4, es frescura de la base de conocimiento — el territorio de #302, que es justamente el issue que propone registrar y vigilar cuándo se sincronizó cada fuente.
- **`cvssMetricV2` sigue en la cadena, el último.** No se toca: un CVE viejo que sólo tenga v2 es preferible con puntuación de v2 que sin ninguna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
