### PR TITLE
fix(themis): separar epoch y revisión antes de comparar una versión (#267)

### DIFF
--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -56,6 +56,7 @@ from .engine import (
 )
 from .kb import (
     version_compare,
+    split_distro_version,
     version_in_range,
     normalize_cpe_to_23,
     normalize_product_name,
@@ -192,6 +193,7 @@ __all__ = [
     "QOD_OPEN_PORT",
     "QOD_INVENTORY_MATCH",
     "version_compare",
+    "split_distro_version",
     "version_in_range",
     "normalize_cpe_to_23",
     "normalize_product_name",

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -24,7 +24,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Iterable, List, Optional, Tuple
 
-from .kb import load_product_aliases, normalize_cpe_to_23, normalize_product_name, parse_cpe23
+from .kb import (
+    load_product_aliases,
+    normalize_cpe_to_23,
+    normalize_product_name,
+    parse_cpe23,
+    split_distro_version,
+)
 
 
 # Quality of Detection for a bare "the port is open" observation. It is low
@@ -193,11 +199,18 @@ class LybraEngine:
         banner guess, so it earns a higher ``qod`` and is born ``confirmed`` —
         there is no back-port ambiguity to hedge against when the version came
         straight from the package manager.
+
+        When the discovered version is a distro package version, the title says
+        which upstream release it was matched as. Otherwise the finding is
+        unexplainable on its face: nothing in it would account for why a host
+        running ``2.4.49-1ubuntu1`` is reported against a CVE whose range ends
+        at ``2.4.49``, and "the matcher normalized it" is not something a
+        reader can be expected to know.
         """
         cve_id = cve.cve_id
         is_verified = service.origin == "inventory"
         return {
-            "title":        f"{service.label} — {cve_id}",
+            "title":        f"{self._version_label(service)} — {cve_id}",
             "category":     "outdated_software",
             "port":         service.port,
             "service":      service.name or service.product or None,
@@ -217,6 +230,27 @@ class LybraEngine:
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
             "state":        "open",
         }
+
+    @staticmethod
+    def _version_label(service: Service) -> str:
+        """The service's label, naming the upstream release when they differ.
+
+        ``apache2 1:2.4.49-1ubuntu1`` becomes
+        ``apache2 1:2.4.49-1ubuntu1 (upstream 2.4.49)``. A vendor banner, an
+        NVD-shaped version or anything else that carries no epoch or revision
+        is left exactly as it was — the note only appears where there is
+        actually something to explain.
+
+        Args:
+            service: The service the finding is about.
+
+        Returns:
+            The label to put in the finding's title.
+        """
+        _epoch, upstream, _revision = split_distro_version(service.version or "")
+        if not upstream or upstream == (service.version or "").strip():
+            return service.label
+        return f"{service.label} (upstream {upstream})"
 
     def _informational_finding(self, service: Service, resolved) -> dict:
         """Build the baseline informational finding for one service.

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -54,6 +54,68 @@ logger = logging.getLogger(__name__)
 # VERSION LOGIC
 # =========================================================================
 
+# Una revisión de distribución empieza por dígito ("1ubuntu1", "2",
+# "1+deb11u1") o es la forma de Alpine ("r0"). Lo que va tras un guion y no
+# encaja aquí —"rc1", "beta", "pre"— es una preversión del fabricante, que
+# significa lo contrario: no acompaña a una versión, la precede. Distinguirlas
+# importa porque se tratan al revés (la revisión no cuenta frente a NVD; la
+# preversión ordena por debajo de su versión final).
+_DISTRO_REVISION_RE = re.compile(r"^(?:\d|r\d+$)")
+
+
+def split_distro_version(version: str) -> Tuple[Optional[int], str, Optional[str]]:
+    """Split a distribution package version into ``(epoch, upstream, revision)``.
+
+    A distro package version is not the vendor's version: Debian and its
+    derivatives write ``1:2.4.49-1ubuntu1``, where ``1:`` is the *epoch* (a
+    counter the distribution bumps when it has to renumber downwards) and
+    ``-1ubuntu1`` is the *revision* (which packaging of that same upstream
+    release this is). Alpine writes ``2.4.49-r0``. Only the middle part —
+    ``2.4.49`` — is the version the vendor released, and the only one NVD ever
+    talks about.
+
+    Both extras break comparison in *opposite* directions, which is why they
+    have to come off before comparing rather than be tolerated:
+
+    * The epoch is read as a leading component, so ``1:2.4.49`` compares as
+      ``[1, 2, 4, 49]`` and lands *below* ``2.4.49``.
+    * The revision is read as a trailing component, so ``2.4.49-1ubuntu1``
+      compares *above* ``2.4.49`` and falls outside a range that ends there.
+
+    Anything after a ``+`` is packaging or build metadata (``2.4.49+dfsg``,
+    ``1.0.0+20130313144700``) and is dropped from the upstream part, following
+    the same rule semver §10 states for build metadata: it never affects
+    precedence.
+
+    Args:
+        version: A raw version string, distro-flavoured or not.
+
+    Returns:
+        ``(epoch, upstream, revision)``. ``epoch`` and ``revision`` are
+        ``None`` when the string does not carry them — which is the normal
+        case for a vendor banner or an NVD bound, and is exactly what tells
+        the comparator it is not looking at a distro version.
+    """
+    remainder = version.strip()
+
+    epoch: Optional[int] = None
+    head, colon, tail = remainder.partition(":")
+    if colon and head.isdigit():
+        epoch = int(head)
+        remainder = tail
+
+    revision: Optional[str] = None
+    if "-" in remainder:
+        # El último guion es el que separa: una versión upstream puede llevar
+        # guiones propios, la revisión de distribución nunca.
+        upstream, _, candidate = remainder.rpartition("-")
+        if _DISTRO_REVISION_RE.match(candidate):
+            revision = candidate
+            remainder = upstream
+
+    return epoch, remainder.split("+", 1)[0], revision
+
+
 def _version_key(version: str) -> List[tuple]:
     """Break a version string into components that sort correctly.
 
@@ -78,6 +140,18 @@ def _version_key(version: str) -> List[tuple]:
     return key
 
 
+def _compare_keys(key_a: List[tuple], key_b: List[tuple]) -> int:
+    """Compare two component lists, padding the shorter one with zeros."""
+    for index in range(max(len(key_a), len(key_b))):
+        token_a = key_a[index] if index < len(key_a) else (1, 0, "")
+        token_b = key_b[index] if index < len(key_b) else (1, 0, "")
+        if token_a < token_b:
+            return -1
+        if token_a > token_b:
+            return 1
+    return 0
+
+
 def version_compare(a: str, b: str) -> int:
     """Compare two version strings component by component.
 
@@ -87,6 +161,27 @@ def version_compare(a: str, b: str) -> int:
     are treated as equal. This is good enough for the dotted vendor versions the
     matcher sees; it is not a full PEP 440 / semver implementation.
 
+    **Distro package versions are normalized first** (see
+    :func:`split_distro_version`), because the matcher's two inputs are not the
+    same kind of string: one side is a package version from an agent inventory
+    (``1:2.4.49-1ubuntu1``), the other is a bound NVD published, and NVD only
+    ever speaks upstream. Comparing the extras against something that cannot
+    have them is a category error, and it broke in both directions at once —
+    an epoch produced false positives by dragging the version down, a revision
+    produced false negatives by pushing it past the top of a range.
+
+    Two deliberate asymmetries, both following from that:
+
+    * **Epochs count only when both sides have one.** Between two distro
+      versions the epoch is the most significant component and is honoured.
+      Against an NVD bound, which never carries one, it is dropped from both
+      sides rather than compared against an implicit zero.
+    * **Revisions count only as a tiebreaker, and only when both sides have
+      one.** ``2.4.49-1`` is older than ``2.4.49-2``, which matters when
+      ordering packages among themselves; but ``2.4.49-1ubuntu1`` against the
+      plain ``2.4.49`` compares *equal*, which is what makes a package land
+      inside the range its upstream release belongs to.
+
     Args:
         a: The first version string.
         b: The second version string.
@@ -95,14 +190,18 @@ def version_compare(a: str, b: str) -> int:
         ``-1`` if ``a`` is older than ``b``, ``0`` if they are equal, ``1`` if
         ``a`` is newer.
     """
-    ka, kb = _version_key(a), _version_key(b)
-    for i in range(max(len(ka), len(kb))):
-        token_a = ka[i] if i < len(ka) else (1, 0, "")
-        token_b = kb[i] if i < len(kb) else (1, 0, "")
-        if token_a < token_b:
-            return -1
-        if token_a > token_b:
-            return 1
+    epoch_a, upstream_a, revision_a = split_distro_version(a)
+    epoch_b, upstream_b, revision_b = split_distro_version(b)
+
+    if epoch_a is not None and epoch_b is not None and epoch_a != epoch_b:
+        return -1 if epoch_a < epoch_b else 1
+
+    upstream_order = _compare_keys(_version_key(upstream_a), _version_key(upstream_b))
+    if upstream_order != 0:
+        return upstream_order
+
+    if revision_a is not None and revision_b is not None:
+        return _compare_keys(_version_key(revision_a), _version_key(revision_b))
     return 0
 
 

--- a/API/tests/unit/test_hygeia_inventory_adapter.py
+++ b/API/tests/unit/test_hygeia_inventory_adapter.py
@@ -121,24 +121,32 @@ def test_other_sources_are_left_alone():
         assert services[0].version == expected, f"{item} -> {services[0].version}"
 
 
-def test_the_stripped_version_matches_an_nvd_range_that_the_raw_one_missed():
+def test_the_stripped_version_matches_an_nvd_range():
     """El motivo de todo esto, comprobado contra el comparador de verdad.
 
     Un rango ``version_start_including="2.39"`` debe casar con la libc de un
-    Ubuntu que reporta "2.39-0ubuntu8.3". Con la versión sin recortar no casa:
-    ``version_compare`` parte la cadena en tramos de dígitos y letras, las
-    letras ordenan por debajo de los números, y el sufijo de empaquetado deja
-    la versión instalada por debajo del inicio del rango.
+    Ubuntu que reporta "2.39-0ubuntu8.3".
+
+    Este test afirmaba también lo contrario para la versión **sin** recortar
+    (``version_compare(raw, "2.39") < 0``), porque entonces era cierto: el
+    comparador partía la cadena en tramos de dígitos y de letras, y el sufijo
+    de empaquetado dejaba la instalada por debajo del inicio del rango. Desde
+    #267 ya no lo es — el comparador reconoce y separa la revisión de
+    distribución él mismo, así que las dos formas comparan igual. Afirmar aquí
+    el fallo antiguo sería congelarlo.
+
+    Que el recorte del adaptador siga existiendo no sobra: es lo que hace que
+    ``Service.version`` sea la versión de origen para el resto del motor. Pero
+    ya no es la única defensa, ni la que decide si la CVE se reporta.
     """
     from src.modules.features.themis.lybra import version_compare
 
     raw = "2.39-0ubuntu8.3"
-    # El fallo que se está corrigiendo: sin recortar, la instalada parece
-    # anterior al inicio del rango y la CVE no se reportaría.
-    assert version_compare(raw, "2.39") < 0
-
     services = services_from_inventory([_deb("libc6", raw)])
+
     assert version_compare(services[0].version, "2.39") == 0
+    # Y la cruda compara igual, sin depender del recorte de aguas arriba.
+    assert version_compare(raw, "2.39") == 0
 
 
 def test_stripping_never_leaves_the_version_empty():

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -16,6 +16,7 @@ from src.modules.features.themis.lybra import (
     services_from_payload,
     QOD_OPEN_PORT,
     QOD_INVENTORY_MATCH,
+    version_in_range,
 )
 from src.modules.features.themis.services.processors import NmapResultProcessor
 
@@ -318,6 +319,58 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["category"] == "outdated_software"
     assert vuln["qod"] == QOD_INVENTORY_MATCH == 95
     assert vuln["confirmed"] is True
+
+
+def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
+    """El criterio de cierre de #267, extremo a extremo dentro del motor.
+
+    El inventario de un agente entrega versiones de paquete de distribución
+    (`1:7.4-1ubuntu1`), y NVD sólo publica rangos sobre versiones de
+    fabricante (`7.4`). Si el paquete no cae en los mismos rangos que su
+    versión upstream, la Fase I entera —el sustituto del escaneo autenticado—
+    mide otra cosa.
+
+    La búsqueda que se inyecta aquí usa `version_in_range` de verdad, no una
+    tabla de respuestas: lo que se comprueba es el camino completo, no que el
+    doble diga que sí.
+    """
+    afectado = {"version_start_including": "7.0", "version_end_including": "7.4"}
+
+    def lookup(vendor, product, version):
+        return [_fake_cve()] if version_in_range(version, afectado) else []
+
+    engine = LybraEngine(cve_lookup=lookup)
+    upstream = Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)
+    paquete = Service(port=None, protocol="", name="", product="OpenSSH",
+                      version="1:7.4-1ubuntu1", cpe=None, origin="inventory")
+
+    del_banner = [f for f in engine.analyze([upstream]) if f["category"] == "outdated_software"]
+    del_paquete = [f for f in engine.analyze([paquete]) if f["category"] == "outdated_software"]
+
+    assert len(del_banner) == 1
+    assert [f["cve_ids"] for f in del_paquete] == [f["cve_ids"] for f in del_banner]
+
+
+def test_a_normalized_version_says_so_in_the_finding():
+    # Sin esto, el hallazgo es inexplicable de puertas afuera: nada en él da
+    # cuenta de por qué un host con 1:7.4-1ubuntu1 sale contra un CVE cuyo
+    # rango termina en 7.4.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    paquete = Service(port=None, protocol="", name="", product="OpenSSH",
+                      version="1:7.4-1ubuntu1", cpe=None, origin="inventory")
+
+    vuln = [f for f in engine.analyze([paquete]) if f["category"] == "outdated_software"][0]
+
+    assert "1:7.4-1ubuntu1" in vuln["title"]      # lo que se descubrió, tal cual
+    assert "(upstream 7.4)" in vuln["title"]      # y contra qué se comparó
+
+
+def test_a_plain_vendor_version_gets_no_normalization_note():
+    # La nota sólo aparece donde hay algo que explicar.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert "upstream" not in findings[1]["title"]
 
 
 def test_version_finding_from_network_origin_stays_a_hypothesis():

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -10,6 +10,7 @@ import pytest
 from src.modules.features.themis.lybra import (
     version_compare,
     version_in_range,
+    split_distro_version,
     normalize_cpe_to_23,
     normalize_product_name,
     extract_trailing_version,
@@ -37,6 +38,70 @@ pytestmark = pytest.mark.unit
 ])
 def test_version_compare(a, b, expected):
     assert version_compare(a, b) == expected
+
+
+# ------------------------------------------- versiones de paquete de distribución
+#
+# La versión de un paquete de distribución no es la del fabricante. Debian y sus
+# derivadas escriben `1:2.4.49-1ubuntu1`: el `1:` es el *epoch* (un contador que
+# la distribución sube cuando tiene que renumerar hacia abajo) y el `-1ubuntu1`
+# es la *revisión* (qué empaquetado de esa misma versión es). Alpine escribe
+# `2.4.49-r0`. Sólo el trozo del medio es lo que publicó el fabricante, y es lo
+# único de lo que habla NVD.
+#
+# Los dos extras rompían la comparación en direcciones opuestas: el epoch
+# arrastraba la versión hacia abajo (falsos positivos) y la revisión la
+# empujaba por encima del final del rango (CVEs perdidos).
+
+@pytest.mark.parametrize("raw,expected", [
+    ("1:2.4.49-1ubuntu1", (1, "2.4.49", "1ubuntu1")),   # Debian/Ubuntu completo
+    ("2.4.49-1ubuntu1", (None, "2.4.49", "1ubuntu1")),  # sin epoch
+    ("2.4.49-r0", (None, "2.4.49", "r0")),              # Alpine
+    ("2.4.49+dfsg-1", (None, "2.4.49", "1")),           # Debian con metadato de empaquetado
+    ("7.0.11", (None, "7.0.11", None)),                 # versión de fabricante, intacta
+    ("1.0.0-rc1", (None, "1.0.0-rc1", None)),           # preversión, NO es una revisión
+])
+def test_split_distro_version(raw, expected):
+    assert split_distro_version(raw) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", [
+    # El caso que perdía CVEs: la revisión empujaba el paquete por encima del
+    # final del rango, así que un versionEndIncluding: 2.4.49 no casaba.
+    ("2.4.49-1ubuntu1", "2.4.49", 0),
+    ("1:2.4.49-1ubuntu1", "2.4.49", 0),
+    ("2.4.49-r0", "2.4.49", 0),
+    ("2.4.49+dfsg-1", "2.4.49", 0),
+    # El caso que producía falsos positivos: el epoch se leía como primer
+    # componente, así que 1:1.2.3 se ordenaba por debajo de 1.0.0.
+    ("1:1.2.3", "1.0.0", 1),
+    # Entre dos versiones de distribución sí mandan epoch y revisión.
+    ("1:1.0", "2:0.9", -1),
+    ("2.4.49-1", "2.4.49-2", -1),
+    ("2.4.49-2", "2.4.49-1", 1),
+    # Regresión: una preversión sigue ordenando por debajo de su versión final.
+    ("1.0.0-rc1", "1.0.0", -1),
+])
+def test_version_compare_with_distro_versions(a, b, expected):
+    assert version_compare(a, b) == expected
+
+
+def test_a_distro_package_lands_in_the_range_of_its_upstream_release():
+    """El criterio de cierre: un paquete de distribución tiene que casar los
+    mismos rangos que su versión upstream, ni más ni menos."""
+    rango = {"version_start_including": "2.4.0", "version_end_including": "2.4.49"}
+
+    assert version_in_range("2.4.49", rango) is True            # referencia
+    assert version_in_range("1:2.4.49-1ubuntu1", rango) is True  # el mismo paquete, empaquetado
+    assert version_in_range("2.4.49-r0", rango) is True          # y en Alpine
+
+    # Y sigue quedándose fuera lo que tiene que quedarse fuera.
+    assert version_in_range("2.4.50-1ubuntu1", rango) is False
+    assert version_in_range("2.3.9-1ubuntu1", rango) is False
+
+
+def test_an_exact_pinned_version_also_matches_the_packaged_form():
+    assert version_in_range("1:2.4.49-1ubuntu1", {"exact_version": "2.4.49"}) is True
 
 
 # --------------------------------------------------------------- version range


### PR DESCRIPTION
## El problema, en lenguaje llano

Cuando Lybra quiere saber si un software instalado es vulnerable, compara su versión con los rangos que NVD publica para cada CVE ("afecta de la 2.4.0 a la 2.4.49"). Esa comparación funcionaba bien para versiones de fabricante (`2.4.49`) y fallaba para las de paquete de distribución, que son justo las que llegan por el inventario de los agentes de Hygeia — el sustituto declarado del escaneo autenticado.

**La versión de un paquete no es la del fabricante.** Debian y sus derivadas escriben `1:2.4.49-1ubuntu1`, donde:

- el `1:` inicial es el **epoch**: un contador que la distribución sube cuando necesita renumerar hacia abajo (por ejemplo, cuando el fabricante cambia de esquema de numeración y la nueva versión "parece" más antigua que la anterior);
- el `-1ubuntu1` final es la **revisión**: qué empaquetado de esa misma versión de origen es éste, después de aplicar los parches de la distribución.

Alpine escribe lo mismo como `2.4.49-r0`. Sólo el trozo del medio —`2.4.49`— es lo que publicó el fabricante, y es lo único de lo que NVD habla jamás.

El comparador trataba esos dos extras como componentes más de la versión, y eso rompía **en las dos direcciones a la vez**:

- **El epoch arrastraba la versión hacia abajo.** `1:2.4.49` se troceaba como `[1, 2, 4, 49]`, cuyo primer componente es 1, así que quedaba por debajo de `2.4.49` (`[2, 4, 49]`). Un rango que empieza en 2.0 dejaba de aplicar. → **Falsos positivos.**
- **La revisión la empujaba hacia arriba.** `2.4.49-1ubuntu1` se troceaba como `[2, 4, 49, 1, "ubuntu", 1]`, que es *mayor* que `[2, 4, 49]`, así que se salía por arriba de un rango que termina en 2.4.49. → **CVEs perdidos**, que es el fallo caro.

Ninguna de las dos avisa de nada.

## Issue relacionado

Closes #267.

## Cuánto pasa esto de verdad

Medido sobre datos reales: las **2.005 reglas de aplicabilidad** de `apache/http_server` que hay en la base de conocimiento local. La referencia es lo que resuelve la versión de fabricante `2.4.49`: **69 CVEs**. Con el comparador anterior:

| Versión instalada | CVEs que resolvía | CVEs perdidos | CVEs inventados |
|---|---|---|---|
| `2.4.49` (referencia) | 69 | — | — |
| `1:2.4.49-1ubuntu1` | 51 | **43** | **25** |
| `2.4.49-1ubuntu1` | 66 | 3 | 0 |
| `2.4.49-r0` (Alpine) | 69 | 3 | 3 |
| `2.4.49+dfsg-1` (Debian) | 69 | 3 | 3 |

Un mismo Apache, según cómo lo nombrara su distribución, producía desde 51 hasta 69 CVEs.

Las dos últimas filas merecen una mirada: **el total cuadraba y el contenido no**. Tres CVEs reales fuera y tres ajenos dentro, con el recuento intacto. Ninguna comprobación basada en "salen los mismos números" habría visto eso.

Con el arreglo, las cinco formas resuelven exactamente los mismos 69 CVEs.

## La corrección

Una función nueva, `split_distro_version`, separa la cadena en `(epoch, versión_de_origen, revisión)`, y el comparador usa cada parte con reglas distintas. Dos asimetrías deliberadas, ambas por el mismo motivo de fondo: **los dos lados de la comparación no son la misma clase de cadena**. Uno viene del inventario de un agente; el otro es una cota que publicó NVD, que sólo habla el idioma del fabricante. Compararlos como si fueran lo mismo es un error de categoría.

- **El epoch cuenta sólo si lo traen los dos lados.** Entre dos versiones de paquete es el componente más significativo y manda (`1:1.0` es anterior a `2:0.9`). Contra una cota de NVD, que nunca lleva epoch, se descarta de los dos lados en vez de compararlo contra un cero implícito.
- **La revisión cuenta sólo como desempate, y sólo si la traen los dos.** Así `2.4.49-1` sigue siendo anterior a `2.4.49-2` —que importa al ordenar paquetes entre sí—, pero `2.4.49-1ubuntu1` compara **igual** que `2.4.49`, que es lo que mete al paquete en el rango al que pertenece su versión de origen.

**El detalle que más cuidado necesitaba: no todo lo que va tras un guion es una revisión.** `1.0.0-rc1` es una *preversión* del fabricante, y significa lo contrario que una revisión: no acompaña a una versión, la precede, así que tiene que seguir ordenando **por debajo** de `1.0.0`. Tratarla como revisión la habría hecho comparar igual, y eso habría convertido un arreglo en un bug nuevo. Se distinguen por su forma: una revisión empieza por dígito (`1ubuntu1`, `2`, `1+deb11u1`) o es la forma de Alpine (`r0`); lo demás se queda donde estaba.

Lo que va tras un `+` (`2.4.49+dfsg`) se descarta como metadato de empaquetado, siguiendo la misma regla que semver §10 aplica a los metadatos de construcción: nunca afectan a la precedencia.

## El hallazgo explica la normalización

El issue pedía, y con razón, que «un `Finding` cuya versión se normalizó debe poder explicarlo». Sin eso el hallazgo es inexplicable de puertas afuera: nada en él da cuenta de por qué un host con `1:2.4.49-1ubuntu1` sale contra un CVE cuyo rango termina en `2.4.49`, y "el comparador lo normaliza" no es algo que quien lee un informe tenga por qué saber.

El título pasa a decir las dos cosas — `apache2 1:2.4.49-1ubuntu1 (upstream 2.4.49)` —, y **sólo** cuando hay algo que explicar: un banner de fabricante o una versión con forma de NVD se quedan exactamente como estaban.

Se hace en el título y no en una columna nueva a propósito: una columna significaría migración, y el dato ya tiene dónde vivir en un sitio que el usuario lee.

## Implementación

Cuatro commits: el comparador, la nota en el hallazgo, sus tests, y el test de Hygeia del que hablo abajo.

## Validación

- Tabla de casos sobre la separación y sobre el comparador: Debian completo, sin epoch, Alpine, `+dfsg`, versión de fabricante intacta, y la preversión `1.0.0-rc1`.
- **El criterio de cierre se comprueba en el motor y con el rango de verdad**, no con una tabla de respuestas: un paquete de inventario `1:7.4-1ubuntu1` resuelve exactamente los mismos CVEs que un banner que dijera `7.4`.
- El hallazgo nombra las dos versiones cuando se normalizó, y ninguna cuando no.
- La medición sobre las 2.005 reglas reales de la tabla de arriba.
- `pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Un test que había que cambiar, y por qué

La suite falló en `tests/unit/test_hygeia_inventory_adapter.py`, y el fallo resultó ser informativo.

Existe ya una mitigación previa de este mismo problema, aguas arriba: `_debian_upstream_version`, en el adaptador de inventario de Hygeia, recorta el sufijo **antes** de que el motor compare. Su test afirmaba, como premisa, que la versión sin recortar comparaba por debajo del inicio del rango (`version_compare("2.39-0ubuntu8.3", "2.39") < 0`). Era cierto cuando se escribió y ha dejado de serlo.

Se ha actualizado explicando el cambio, porque mantener esa afirmación habría **congelado el fallo**: un test que exige que el comparador siga equivocándose. Lo que el test venía a demostrar —que el recorte produce una versión que casa el rango— se queda igual, y se añade que la cruda también casa sin depender de ese recorte.

## Notas y trabajo que queda fuera

- **La normalización del adaptador de Hygeia queda como redundancia, y conviene revisarla en su momento.** Sólo actúa sobre `dpkg` (RPM no lo necesita y snap se excluye a propósito), y es *con pérdida*: el motor ve `2.39` y ya no sabe que lo instalado era `2.39-0ubuntu8.3`. Ahora que el comparador lo maneja, esa pérdida sólo resta — con la versión completa, el hallazgo podría decir qué empaquetado exacto está instalado, que es justo lo que dice si un parche de la distribución está aplicado. Cambiarlo es tocar Hygeia y modifica lo que se guarda en `Service.version`, así que no entra aquí.
- **Los otros dos comparadores del repositorio no se tocan, y he comprobado por qué no hace falta.** `analyzers.py::_version_key` y `reports/findings.py::_find_fixed_version` sólo ven cotas publicadas por NVD, que son versiones de fabricante por definición: nunca llega ahí una cadena con epoch o revisión.
- **Esto no resuelve el problema de los parches retroportados**, que es harina de otro costal: una distribución puede haber corregido la vulnerabilidad en `2.4.49-1ubuntu1` sin cambiar la versión de origen, y saberlo exige leer los avisos de la propia distribución (DSA, USN, OVAL). Este PR sólo garantiza que el paquete case los mismos rangos que su versión de origen — ni más, ni menos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
