### PR TITLE
fix(themis): decidir la firma SMB sobre el bit, no sobre un texto en castellano (#271)

### DIFF
--- a/API/src/modules/features/themis/lybra/fingerprinting/smb.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/smb.py
@@ -55,7 +55,14 @@ _DIALECT_LABELS = {
 }
 
 # SMB2_NEGOTIATE_SIGNING_REQUIRED (MS-SMB2 §2.2.4, SecurityMode bit 0x0002).
-_SIGNING_REQUIRED_BIT = 0x0002
+#
+# Público a propósito: es el hecho de seguridad que el servidor declara sobre
+# sí mismo, y quien tenga que decidir sobre él —el fingerprint de aquí abajo,
+# el plugin `smb-signing-not-required` de ``script_checks``— debe leer este
+# bit y no la etiqueta legible que se deriva de él. Una etiqueta es prosa para
+# humanos; convertirla en el protocolo entre dos piezas de código hace que
+# retocar el texto apague un check en silencio.
+SIGNING_REQUIRED_BIT = 0x0002
 
 _SMB2_HEADER_LEN = 64
 _PROTOCOL_ID = b"\xfeSMB"
@@ -157,7 +164,7 @@ def fingerprint_smb(dialect_revision: int, security_mode: int) -> SmbFingerprint
     version = _DIALECT_LABELS.get(dialect_revision)
     if version is None:
         return SmbFingerprint(product=None, version=None, confidence=0.0)
-    signing_required = bool(security_mode & _SIGNING_REQUIRED_BIT)
+    signing_required = bool(security_mode & SIGNING_REQUIRED_BIT)
     product = "SMB2" if signing_required else "SMB2 (firma no requerida)"
     return SmbFingerprint(product=product, version=version, confidence=0.9)
 

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -37,7 +37,7 @@ from typing import Dict, Optional
 
 from .checks import ScriptContext, ScriptPlugin, is_smb_service, is_snmp_service
 from .engine import Service
-from .fingerprinting.smb import SmbProbe, fingerprint_smb
+from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
 from .fingerprinting.snmp import SnmpProbe
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,15 @@ class SmbSigningNotRequiredPlugin(ScriptPlugin):
     manipular el tráfico SMB (la familia de ataques de relay). El dato no se
     infiere: sale del ``SecurityMode`` que el propio servidor devuelve en su
     respuesta NEGOTIATE, así que el hallazgo nace ``confirmed``.
+
+    **La decisión se toma sobre el bit, no sobre la etiqueta.** Este plugin
+    llegó a resolverse buscando la subcadena ``"firma no requerida"`` dentro
+    del texto legible que produce ``fingerprint_smb``. Eso ataba una decisión
+    de seguridad a una cadena de interfaz: traducir esa etiqueta, corregirle
+    una tilde o cambiarle el fraseo apagaba el check **en silencio** —seguía
+    ejecutándose, seguía devolviendo ``False``, y nadie se enteraba de que
+    había dejado de detectar nada—. El dato crudo estaba dos líneas más
+    arriba, en la misma tupla.
 
     Args:
         probe: Sonda inyectable, para que un test use un socket falso — mismo
@@ -71,12 +80,14 @@ class SmbSigningNotRequiredPlugin(ScriptPlugin):
             # Sin negociación no hay evidencia, y sin evidencia no hay hallazgo.
             return False
         dialect_revision, security_mode = result
-        fingerprint = fingerprint_smb(dialect_revision, security_mode)
-        if fingerprint.product is None:
+        if fingerprint_smb(dialect_revision, security_mode).version is None:
             # Respuesta no reconocible: se ignora en vez de asumir lo peor. Un
             # dialecto desconocido no es prueba de que la firma no se exija.
+            # Se consulta ``version`` —un campo con tipo— y no el texto del
+            # producto: lo que hace falta saber aquí es si la respuesta se
+            # entendió, y eso es justo lo que ese campo significa.
             return False
-        return "firma no requerida" in fingerprint.product
+        return not security_mode & SIGNING_REQUIRED_BIT
 
 
 class SnmpDefaultCommunityPlugin(ScriptPlugin):

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -669,6 +669,41 @@ def test_smb_script_check_silent_on_unrecognised_dialect():
     assert findings == []
 
 
+def test_the_smb_verdict_survives_renaming_the_fingerprint_label(monkeypatch):
+    """Invariante: la etiqueta legible no es el protocolo entre dos piezas.
+
+    El plugin decidía buscando la subcadena ``"firma no requerida"`` dentro del
+    texto que produce ``fingerprint_smb``. Con eso, traducir esa etiqueta al
+    inglés —o corregirle una tilde— apagaba el check sin que fallara nada: se
+    ejecutaba, devolvía ``False``, y el SMB sin firma dejaba de aparecer.
+
+    Aquí se renombra la etiqueta a propósito, dejando intacto el dato que sí
+    importa (el ``SecurityMode``), y el veredicto tiene que ser el mismo en los
+    dos sentidos.
+    """
+    from src.modules.features.themis.lybra import script_checks as script_module
+
+    original = script_module.fingerprint_smb
+
+    def renamed(dialect_revision, security_mode):
+        fingerprint = original(dialect_revision, security_mode)
+        etiqueta = None if fingerprint.product is None else "SMB2 (unsigned!)"
+        return type(fingerprint)(
+            product=etiqueta, version=fingerprint.version, confidence=fingerprint.confidence,
+        )
+
+    monkeypatch.setattr(script_module, "fingerprint_smb", renamed)
+
+    sin_firma = _FakeSmbProbe((_DIALECT_302, _SIGNING_ENABLED_ONLY))
+    con_firma = _FakeSmbProbe((_DIALECT_302, _SIGNING_REQUIRED))
+
+    dispara = _script_runtime(sin_firma).run("10.0.0.5", [_SMB])
+    calla = _script_runtime(con_firma).run("10.0.0.5", [_SMB])
+
+    assert [f["check_id"] for f in dispara] == ["lybra:smb-signing-not-required@1"]
+    assert calla == []
+
+
 def test_script_checks_never_run_without_plugins_injected():
     """The default wiring of a caller that knows nothing about scripts."""
     findings = CheckRuntime(load_checks(), _fetcher({})).run("10.0.0.5", [_SMB])


### PR DESCRIPTION
## El problema, en lenguaje llano

SMB es el protocolo de comparticiones de archivos de Windows. Puede firmar sus mensajes para que nadie los manipule por el camino, y esa firma puede estar *ofrecida* o *exigida*. Si sólo está ofrecida, alguien situado en medio de la comunicación puede alterar el tráfico: es la familia de ataques conocida como *relay*. Que un servidor no exija firma es, por tanto, un hallazgo de seguridad legítimo.

El servidor declara esa configuración él mismo, en un campo llamado `SecurityMode` que devuelve al negociar la conexión. Lybra ya lo recibe: la sonda SMB devuelve una tupla con el dialecto negociado y ese `SecurityMode`.

**Y el plugin que decide el hallazgo no lo miraba.** En vez de eso, construía a partir de esa tupla la etiqueta legible que se enseña a las personas —`"SMB2 (firma no requerida)"`— y buscaba dentro la subcadena `"firma no requerida"`.

Es decir: una decisión de seguridad colgando de una cadena de interfaz de usuario. Traducir esa etiqueta al inglés, corregirle una tilde o cambiarle el fraseo **apagaba el check en silencio**. No fallaba nada: el check seguía ejecutándose, seguía devolviendo "no", y el SMB sin firma dejaba de aparecer en los informes sin que nadie tuviera motivo para sospecharlo.

El dato bueno estaba dos líneas más arriba, en la misma tupla que ya se había desempaquetado.

## Issue relacionado

Closes #271.

## La corrección

La decisión se toma ahora sobre el bit: `security_mode & SIGNING_REQUIRED_BIT`. La constante (`0x0002`, definida en MS-SMB2 §2.2.4) **ya existía** en `fingerprinting/smb.py`, sólo que era privada; pasa a ser pública, con el porqué escrito al lado — es el hecho que el servidor declara sobre sí mismo, y quien deba decidir sobre él tiene que leerlo de ahí y no de la prosa derivada.

`fingerprint_smb` existe para producir una etiqueta para humanos. Este PR no se la quita: se la deja para lo que sí es suyo.

**Un matiz que merece explicación, porque no es evidente.** El plugin todavía llama a `fingerprint_smb`, pero para otra cosa: para saber si la respuesta del servidor se entendió. Si el dialecto negociado no es ninguno de los conocidos, el plugin se calla — un dialecto desconocido no es prueba de que la firma no se exija, y asumir lo peor ahí sería inventarse un hallazgo. Para esa pregunta se consulta `version`, que es un campo con tipo y cuyo significado es exactamente "¿reconocí esto?", en lugar del texto del producto. La diferencia entre las dos consultas no es cosmética: una lee un dato estructurado, la otra leía prosa.

## Validación

- Los tests que ya existían (dispara con la firma sólo ofrecida, calla con la firma exigida, se abandona si la negociación falla, se calla ante un dialecto desconocido) siguen pasando **sin tocarlos**. La corrección no cambia el comportamiento observable: cambia de qué depende.
- **Test de invariante nuevo**, que es el que faltaba: renombra a propósito la etiqueta legible —dejando intacto el `SecurityMode`, que es el dato que decide— y comprueba que el veredicto sigue siendo el mismo en los dos sentidos. Con la implementación anterior este test habría fallado, que es precisamente lo que *no* pasaba en producción cuando alguien tocaba el texto.
- Ningún test del plugin menciona ya una cadena en castellano. La única afirmación que queda sobre ese texto está en el test de `fingerprint_smb`, que es quien lo produce; ahí una cadena literal es lo correcto y no se toca.
- `pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **El precedente importa más que el arreglo.** Hoy hay dos plugins `script`; cuando haya cinco o diez, este antipatrón —decidir sobre un texto derivado en vez de sobre el dato observado— es el que hay que vigilar. El test de invariante queda como el modelo a copiar en cada plugin nuevo que tenga una etiqueta legible cerca.
- **El plugin sigue sin verificarse contra un servidor SMB real.** Es una limitación anterior a este PR y está anotada en el propio módulo (`fingerprinting/smb.py` lo dice en su docstring: el parser sólo se ejercita contra una secuencia de bytes construida a mano). Cerrarlo es #284, que pide precisamente eso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
