### PR TITLE
fix(themis): que el limitador duerma fuera del lock y reserve el turno antes (#273)

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -920,17 +920,40 @@ class HostRateLimiter:
     """Enforces a minimum interval between requests to the same host.
 
     Thread-safe, so it can be shared across concurrent probes without letting any
-    single host be hit faster than the configured rate.
+    single host be hit faster than the configured rate — and **without holding
+    anyone else up while it waits**. The waiting happens outside the lock: the
+    turn is reserved under it (a few microseconds of bookkeeping), and the
+    sleeping is done after releasing it.
+
+    That distinction is the whole point of this class's shape. With the sleep
+    inside the lock, a probe waiting its turn for host A also blocked every
+    probe heading for host B — a limiter meant to protect *one* host at a time
+    was throttling all of them at once, and the wait bought nobody any
+    protection.
+
+    Reserving the turn before sleeping (writing the *future* timestamp, not the
+    current one) is what makes concurrent callers for the same host stagger
+    instead of all waking up at the same instant and firing together.
 
     Args:
         min_interval: The minimum time, in seconds, between two requests to the
             same host.
+        clock: An injectable monotonic clock, so a test can assert the schedule
+            instead of waiting for it.
+        sleeper: An injectable sleep, same reason.
     """
 
-    def __init__(self, min_interval: float = 0.2) -> None:
+    def __init__(
+        self,
+        min_interval: float = 0.2,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._min = min_interval
         self._last: Dict[str, float] = {}
         self._lock = threading.Lock()
+        self._clock = clock
+        self._sleeper = sleeper
 
     def acquire(self, host: str) -> None:
         """Block, if necessary, until it is safe to hit ``host`` again.
@@ -939,10 +962,21 @@ class HostRateLimiter:
             host: The host about to be requested.
         """
         with self._lock:
-            wait = self._min - (time.monotonic() - self._last.get(host, 0.0))
-            if wait > 0:
-                time.sleep(wait)
-            self._last[host] = time.monotonic()
+            now = self._clock()
+            # El turno se reserva escribiendo la marca *futura*, no la actual:
+            # así dos hilos que piden el mismo host se escalonan en vez de
+            # despertarse a la vez y disparar juntos.
+            #
+            # Un host que no se ha visto nunca se distingue con None y no con
+            # un 0.0 por defecto: contra un reloj real da igual (0.0 queda
+            # infinitamente atrás), pero contra uno inyectado que empiece en
+            # cero, ese 0.0 haría esperar a la primera petición de cada host.
+            last_turn = self._last.get(host)
+            earliest = now if last_turn is None else max(now, last_turn + self._min)
+            self._last[host] = earliest
+        wait = earliest - now
+        if wait > 0:
+            self._sleeper(wait)
 
 
 class HttpProbe:

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,110 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# ------------------------------------------------ limitador de peticiones
+#
+# El limitador existe para no golpear a UN host más rápido de la cuenta. Con el
+# `sleep` dentro del lock limitaba a todos a la vez: mientras una sonda esperaba
+# su turno para el host A, cualquier sonda hacia el host B también estaba
+# bloqueada — una espera que no protegía a nadie.
+#
+# El reloj y el `sleep` se inyectan para poder afirmar el horario en vez de
+# esperarlo: un test que midiera tiempo real sería lento y frágil.
+
+class _RelojFalso:
+    """Un reloj monótono que sólo avanza cuando se le dice, y su `sleep`."""
+
+    def __init__(self, ahora: float = 1000.0):
+        self.ahora = ahora
+        self.esperas: list = []
+
+    def __call__(self) -> float:
+        return self.ahora
+
+    def sleep(self, segundos: float) -> None:
+        self.esperas.append(segundos)
+        self.ahora += segundos
+
+
+def _limiter(reloj, min_interval=0.2):
+    from src.modules.features.themis.lybra import HostRateLimiter
+    return HostRateLimiter(min_interval=min_interval, clock=reloj, sleeper=reloj.sleep)
+
+
+def test_the_first_request_to_a_host_never_waits():
+    reloj = _RelojFalso()
+    _limiter(reloj).acquire("10.0.0.5")
+    assert reloj.esperas == []
+
+
+def test_two_different_hosts_do_not_wait_for_each_other():
+    # El bug: la espera del host A bloqueaba también al host B.
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj)
+
+    limiter.acquire("10.0.0.5")
+    limiter.acquire("10.0.0.6")
+    limiter.acquire("10.0.0.7")
+
+    assert reloj.esperas == []
+
+
+def test_two_requests_to_the_same_host_are_spaced_by_the_interval():
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj, min_interval=0.2)
+
+    limiter.acquire("10.0.0.5")
+    limiter.acquire("10.0.0.5")
+
+    assert reloj.esperas == [pytest.approx(0.2)]
+
+
+def test_a_host_that_had_time_to_cool_down_does_not_wait():
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj, min_interval=0.2)
+
+    limiter.acquire("10.0.0.5")
+    reloj.ahora += 5.0            # la sonda tardó lo suyo; el intervalo ya pasó
+    limiter.acquire("10.0.0.5")
+
+    assert reloj.esperas == []
+
+
+def test_concurrent_requests_to_one_host_get_distinct_increasing_turns():
+    """N hilos sobre el mismo host se reparten N turnos, sin solaparse.
+
+    Es lo que consigue reservar el turno *antes* de dormir: si cada hilo
+    escribiera la marca al despertarse, todos leerían el mismo "último turno",
+    dormirían lo mismo y despertarían juntos — que es exactamente el golpe que
+    el limitador existe para evitar.
+    """
+    import threading
+
+    from src.modules.features.themis.lybra import HostRateLimiter
+
+    esperas: list = []
+    apuntador = threading.Lock()
+
+    def anotar_espera(segundos):
+        with apuntador:
+            esperas.append(segundos)
+
+    # El reloj se queda quieto para que el reparto sea determinista: lo que se
+    # mide es cuánto le toca esperar a cada hilo, no cuánto tarda la máquina.
+    limiter = HostRateLimiter(min_interval=0.2, clock=lambda: 1000.0, sleeper=anotar_espera)
+
+    hilos = [threading.Thread(target=limiter.acquire, args=("10.0.0.5",)) for _ in range(5)]
+    for hilo in hilos:
+        hilo.start()
+    for hilo in hilos:
+        hilo.join()
+
+    # Uno entra sin esperar y los otros cuatro se escalonan de 0,2 en 0,2. Con
+    # el turno reservado al despertar, los cinco habrían esperado lo mismo.
+    assert sorted(esperas) == [pytest.approx(0.2), pytest.approx(0.4),
+                               pytest.approx(0.6), pytest.approx(0.8)]
+
+
 # --------------------------- a qué protocolo aplica un check ``network``
 #
 # Un check `network` dice a qué protocolo va dirigido con una cadena


### PR DESCRIPTION
## El problema, en lenguaje llano

Cuando Lybra sondea un objetivo, no quiere bombardearlo: espacia sus peticiones para no golpear al mismo servidor más rápido de lo configurado (0,2 segundos por defecto). De eso se encarga `HostRateLimiter`, que lleva la cuenta de cuándo fue la última petición **a cada host** y hace esperar si hace falta.

La idea es correcta. La implementación limitaba a todos los hosts a la vez.

El motivo cabe en una línea: la espera (`time.sleep`) ocurría **dentro** del candado que protege esa contabilidad. Un candado sirve para que dos hilos no toquen los mismos datos a la vez, y para eso hacen falta unos microsegundos; pero si además se duerme dentro, el hilo que espera su turno para el host A retiene el candado durante toda la espera, y cualquier otro hilo que quiera preguntar por el host B se queda parado detrás. Esperando por una limitación que no le corresponde y que no protege a nadie.

## Issue relacionado

Closes #273.

## Medido, no supuesto

Con un hilo pidiendo repetidamente al host A (que sí debe esperar), medí cuánto tarda en pasar **la primera petición al host B**, que no debería esperar absolutamente nada:

| | Latencia de una petición a un host que no está limitado |
|---|---|
| Antes | **150,1 ms** |
| Ahora | **0,0 ms** |

También el efecto agregado, con varios hosts en paralelo y varias peticiones cada uno:

| Hosts × peticiones | Antes | Ahora | Mínimo teórico |
|---|---|---|---|
| 2 × 3 | 0,60 s | 0,40 s | 0,40 s |
| 10 × 3 | 0,60 s | 0,40 s | 0,40 s |
| 10 × 5 | 1,00 s | 0,80 s | 0,80 s |

La versión nueva toca el mínimo teórico: lo único que se espera es lo que cada host exige por sí mismo. Conviene ser honesto con la segunda tabla: el sobrecoste agregado es de un intervalo por ronda, no proporcional al número de hosts, porque mientras un hilo duerme el reloj corre también para los demás y sus esperas pendientes se acortan. El daño real es el de la primera tabla — la latencia que se le mete a quien no tenía por qué esperar.

## La corrección

Es el patrón habitual de un *token bucket* por clave: calcular y **reservar** el turno dentro del candado (unos microsegundos de contabilidad) y dormir fuera.

Reservar el turno significa escribir en la tabla la marca de tiempo **futura**, no la actual. Eso es lo que hace que dos hilos que piden el mismo host se escalonen: si cada uno apuntara su marca al despertarse, los dos leerían el mismo "último turno", dormirían lo mismo y despertarían a la vez — que es exactamente el golpe simultáneo que el limitador existe para evitar.

**Un detalle que sólo aparece al hacer los tests.** Un host que no se ha visto nunca se distingue ahora con `None` y no con un `0.0` por defecto. Contra un reloj real da igual, porque `0.0` queda infinitamente atrás en la escala del reloj monótono; pero contra un reloj inyectado que empiece cerca de cero, ese valor por defecto haría esperar a la primera petición de cada host. Es la clase de detalle que no se ve hasta que el reloj deja de ser el del sistema.

El reloj y el `sleep` pasan a ser inyectables, para poder afirmar el horario en un test en vez de esperarlo.

## Validación

Tests con reloj y `sleep` falsos, que afirman el reparto en vez de medir tiempo real (un test que durmiera de verdad sería lento y frágil):

- La primera petición a un host no espera.
- **Dos hosts distintos no se esperan entre sí** — el bug.
- Dos peticiones al mismo host se escalonan exactamente `min_interval`.
- Un host que tuvo tiempo de enfriarse no espera.
- **Concurrencia**: cinco hilos sobre el mismo host reciben esperas de 0,2 / 0,4 / 0,6 / 0,8 — cinco turnos escalonados. Con el turno reservado al despertar en vez de al pedirlo, los cinco habrían esperado lo mismo.

El test de concurrencia afirma **las esperas que el limitador reparte**, no su estado interno: lo que importa es el comportamiento observable, y un test que lea atributos privados se rompe con cualquier reorganización que no cambie nada. Ejecutado varias veces seguidas para descartar que dependa del orden de los hilos.

`pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **Hoy este bug está latente, no activo.** El pipeline de fingerprinting es secuencial (`_fingerprint_services` itera servicio a servicio), así que rara vez hay dos hilos compitiendo. Su importancia es la contraria a la que sugiere el síntoma actual: es lo que impide que **dejar** de ser secuencial sirva de algo. Es precondición de #294 (fingerprinting concurrente) y de #313 (varios objetivos), y con cualquiera de los dos este candado sería el techo duro de todo.
- **`min_interval` sigue a fuego**, en 0,2 s. El issue sugería aprovechar para sacarlo a configuración, pero eso es #307 y trae consigo su clave nueva, su bloque en `SecOpsConfig.json` y su entrada en `test_config_shape.py`. Mezclarlo aquí convertiría un arreglo de cinco líneas en un cambio de configuración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
