### PR TITLE
perf(themis): compartir cada sonda entre los checks que leen lo mismo (#274)

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -701,6 +701,10 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
+        # Sondas compartidas dentro de una ejecución; :meth:`run` las vacía al
+        # empezar. Aquí sólo para que el objeto esté completo desde que nace.
+        self._responses: Dict[tuple, Optional[Response]] = {}
+        self._handshakes: Dict[tuple, object] = {}
         self._families: Tuple[_CheckFamily, ...] = (
             _CheckFamily(
                 applies_to_service=is_http_service,
@@ -727,6 +731,11 @@ class CheckRuntime:
     def run(self, host: str, services: Iterable[Service]) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
+        Probes are shared within one call: several checks reading the same
+        evidence make one request between them, not one each. See
+        :meth:`_probe_response` for why that is a property of this loop and not
+        a caching layer.
+
         Args:
             host: The target host.
             services: The host's discovered services (non-applicable ones are
@@ -735,6 +744,12 @@ class CheckRuntime:
         Returns:
             A finding dict for each check that fired.
         """
+        # La caché nace y muere con la ejecución: dos escaneos del mismo
+        # objetivo tienen que volver a mirar, porque entre uno y otro el
+        # objetivo ha podido cambiar — que es justo lo que un escáner mide.
+        self._responses: Dict[tuple, Optional[Response]] = {}
+        self._handshakes: Dict[tuple, object] = {}
+
         findings: List[dict] = []
         for service in services:
             for family in self._families:
@@ -815,12 +830,53 @@ class CheckRuntime:
         nothing.
         """
         for request in check.requests:
-            if self._rl is not None:
-                self._rl.acquire(host)
-            response = self._fetch(host, service.port, request.method, request.path)
+            response = self._probe_response(host, service, request.method, request.path)
             if response is None or not request.evaluate(response):
                 return None
         return self._finding(check, service)
+
+    def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
+        """Return the response for one request, asking the target only once.
+
+        Every check runs independently, which is what keeps them simple, but
+        the feed has three ``security_header`` checks and all three inspect the
+        headers of the same ``GET /``. Run literally, that is three identical
+        requests, three rate-limiter waits, and three entries in the target's
+        access log for one bit of information.
+
+        Noise on the target is not a side issue for a security scanner: it
+        shows up in the SIEM of whoever hired us. So a response is fetched once
+        per ``(method, path)`` and shared by every check that asks for it,
+        within one :meth:`run`.
+
+        A transport failure is remembered too. Not caching it would mean three
+        attempts against a service that is down — the case where retrying costs
+        the most and informs the least.
+        """
+        key = (host, service.port, method, path)
+        if key in self._responses:
+            return self._responses[key]
+        if self._rl is not None:
+            self._rl.acquire(host)
+        response = self._fetch(host, service.port, method, path)
+        self._responses[key] = response
+        return response
+
+    def _probe_handshake(self, host: str, service: Service):
+        """Return the TLS handshake facts for one service, negotiating once.
+
+        Same reasoning as :meth:`_probe_response`: the three ``tls`` checks in
+        the feed evaluate three different rules over the **same** ``TlsInfo``,
+        so there is no reason to shake hands three times with the same port.
+        """
+        key = (host, service.port)
+        if key in self._handshakes:
+            return self._handshakes[key]
+        if self._rl is not None:
+            self._rl.acquire(host)
+        info = self._tls_fetch(host, service.port)
+        self._handshakes[key] = info
+        return info
 
     def _run_tls_check(self, check: Check, host: str, service: Service) -> Optional[dict]:
         """Run one TLS hygiene check against one service's handshake.
@@ -828,9 +884,7 @@ class CheckRuntime:
         A transport failure (unreachable, handshake error) abandons the check —
         no evidence means no finding, the same rule ``_run_check`` follows.
         """
-        if self._rl is not None:
-            self._rl.acquire(host)
-        info = self._tls_fetch(host, service.port)
+        info = self._probe_handshake(host, service)
         if info is None or not _TLS_RULES[check.tls_rule](info):
             return None
         return self._finding(check, service)

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,118 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# --------------------------------- sondas compartidas dentro de una ejecución
+#
+# Cada check corre por su cuenta, que es lo que los mantiene simples, pero el
+# feed tiene tres checks de cabeceras que miran la misma respuesta a `GET /` y
+# tres de TLS que evalúan reglas distintas sobre el mismo handshake. Ejecutado
+# al pie de la letra, eso son cuatro sondas de más por servicio: tiempo de
+# escaneo, esperas del limitador, y ruido en el registro del objetivo — que en
+# un escáner de seguridad no es un detalle, porque aparece en el SIEM de quien
+# nos contrata.
+
+_TLS_SERVICE = Service(443, "tcp", "https", "", "", None)
+
+
+class _TlsInfoFalso:
+    """Lo mínimo que las reglas TLS del feed consultan de un handshake."""
+
+    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3"):
+        self.self_signed = self_signed
+        self.expired = expired
+        self.protocol = protocol
+        self.days_until_expiry = 200
+
+
+def _contador_de_handshakes(info=None):
+    llamadas = []
+
+    def tls_fetch(host, port):
+        llamadas.append((host, port))
+        return info
+
+    tls_fetch.llamadas = llamadas
+    return tls_fetch
+
+
+def test_the_three_header_checks_make_one_request_between_them():
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+
+    findings = CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
+
+    # Los tres checks de cabeceras disparan (el nginx de mentira no manda
+    # ninguna) y aun así "/" se pidió una sola vez.
+    cabeceras = [f for f in findings if f["category"] == "security_header"]
+    assert len(cabeceras) == 3
+    assert [ruta for _h, _p, _m, ruta in fetch.calls].count("/") == 1
+
+
+def test_each_distinct_path_is_still_requested():
+    # Compartir no es dejar de mirar: rutas distintas siguen siendo sondas
+    # distintas, una por ruta.
+    fetch = _fetcher({})
+    CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
+
+    rutas = [ruta for _h, _p, _m, ruta in fetch.calls]
+    assert len(rutas) == len(set(rutas))
+    assert "/.git/config" in rutas and "/" in rutas
+
+
+def test_the_three_tls_checks_share_one_handshake():
+    tls_fetch = _contador_de_handshakes(_TlsInfoFalso(self_signed=True))
+
+    findings = CheckRuntime(
+        load_checks(), _fetcher({}), tls_fetch=tls_fetch
+    ).run("10.0.0.5", [_TLS_SERVICE])
+
+    assert any(f["check_id"] == "lybra:tls-self-signed-cert@1" for f in findings)
+    assert len(tls_fetch.llamadas) == 1
+
+
+def test_a_transport_failure_is_shared_too():
+    # El caso donde reintentar cuesta más y informa menos: un servicio caído.
+    # Sin compartir el fallo, los tres checks de TLS intentarían el handshake
+    # por separado contra algo que ya se sabe que no contesta.
+    tls_fetch = _contador_de_handshakes(None)
+
+    findings = CheckRuntime(
+        load_checks(), _fetcher({}), tls_fetch=tls_fetch
+    ).run("10.0.0.5", [_TLS_SERVICE])
+
+    assert findings == []
+    assert len(tls_fetch.llamadas) == 1
+
+
+def test_two_services_of_the_same_host_are_probed_separately():
+    # La sonda se comparte por (host, puerto, método, ruta): dos servicios
+    # distintos del mismo host son dos objetivos distintos.
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+    otro_http = Service(8080, "tcp", "http", "", "", None)
+
+    CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP, otro_http])
+
+    puertos = {puerto for _h, puerto, _m, ruta in fetch.calls if ruta == "/"}
+    assert puertos == {80, 8080}
+
+
+def test_a_second_run_probes_again():
+    """La caché nace y muere con la ejecución, y eso es deliberado.
+
+    Dos escaneos del mismo objetivo tienen que volver a mirar: entre uno y otro
+    el objetivo ha podido cambiar, que es exactamente lo que un escáner mide.
+    Una caché que sobreviviera al escaneo convertiría el segundo informe en una
+    copia del primero.
+    """
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+    runtime = CheckRuntime(load_checks(), fetch)
+
+    runtime.run("10.0.0.5", [_HTTP])
+    peticiones_tras_la_primera = len(fetch.calls)
+    runtime.run("10.0.0.5", [_HTTP])
+
+    assert len(fetch.calls) == peticiones_tras_la_primera * 2
+
+
 # ------------------------------------------------ limitador de peticiones
 #
 # El limitador existe para no golpear a UN host más rápido de la cuenta. Con el


### PR DESCRIPTION
## El problema, en lenguaje llano

El runtime de checks ejecuta cada comprobación de forma independiente. Eso es bueno: es lo que las mantiene simples y lo que permite que el feed crezca sin que nadie tenga que pensar en el conjunto.

El coste es que varios checks distintos leen **exactamente la misma evidencia**, y cada uno se la pedía al objetivo por su cuenta. Sobre un solo servicio HTTPS:

- **Tres handshakes TLS** contra el mismo puerto, uno por cada check de la familia `tls` (autofirmado, caducado, protocolo obsoleto), cuando los tres evalúan reglas distintas sobre el **mismo** resultado de la negociación.
- **Tres peticiones a `/`**, una por cada check de cabeceras de seguridad (HSTS, X-Frame-Options, X-Content-Type-Options), cuando las tres inspeccionan las cabeceras de la **misma** respuesta.

Cuatro sondas que no aportan ni un bit de información nueva. Y no sólo cuestan tiempo: cada una es una entrada más en el registro del objetivo. Para un escáner de seguridad eso no es un detalle secundario — ese ruido aparece en el SIEM de quien nos contrata, y minimizarlo es parte del trabajo.

## Issue relacionado

Closes #274.

## Medido

Feed completo, un servicio HTTPS:

| | Antes | Ahora |
|---|---|---|
| Peticiones HTTP | 10 | 8 |
| Handshakes TLS | 3 | 1 |
| **Sondas totales** | **13** | **9** (30 % menos) |

Con el limitador a 0,2 s eso son **0,8 segundos menos por servicio**, además de cuatro entradas menos en el registro del objetivo. La cifra crece con el feed: cada check web nuevo sobre `/` (y #296 quiere añadir bastantes) habría sido antes una sonda más, y ahora no es ninguna.

## La corrección

Una respuesta se pide una vez por `(host, puerto, método, ruta)` y un handshake una vez por `(host, puerto)`, dentro de una misma llamada a `run`.

Nada de TTL, ni invalidación, ni configuración: es un diccionario que **nace y muere con el escaneo**. Y eso es una decisión, no una simplificación por pereza — una caché que sobreviviera al escaneo convertiría el segundo informe del mismo objetivo en una copia del primero, cuando lo que un escáner mide es precisamente lo que ha cambiado entre uno y otro. Hay un test que lo fija.

Dos detalles que merecen explicación:

- **Un fallo de transporte se comparte igual que un éxito.** Es el caso donde reintentar cuesta más y informa menos: sin esto, tres checks de TLS intentarían el handshake por separado contra un servicio que ya se sabe que no contesta, y cada intento se come su tiempo de espera completo.
- **Compartir la sonda ahorra también la espera del limitador.** La petición y el turno del limitador van juntos, así que no se pide turno para algo que no se va a pedir. Ése es el origen real de los 0,8 s: no es que las peticiones sean caras, es que la espera entre ellas lo era.

## Validación

- Los tres checks de cabeceras hacen **una** petición a `/` entre los tres, y los tres siguen disparando.
- Los tres checks de TLS comparten **un** handshake.
- Un servicio caído recibe **un** intento, no tres.

Y los controles de que compartir no es dejar de mirar, que es el riesgo real de un cambio así:

- Cada ruta distinta sigue teniendo su propia sonda (`/.git/config` no se resuelve con la respuesta de `/`).
- Dos servicios del mismo host se sondean por separado — el reparto es por `(host, puerto, …)`, y dos puertos son dos objetivos.
- Una segunda ejecución vuelve a preguntar.

`pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **La familia `network` no comparte nada, y es correcto.** Cada check de esa familia abre su propia conexión TCP y escribe una secuencia de comandos por ella; compartirla no sería compartir una sonda, sería mezclar dos conversaciones distintas en la misma sesión. Un `USER`/`PASS` de FTP y un `INFO` de Redis no tienen respuesta reutilizable.
- **La familia `script` tampoco.** Sus plugins gestionan sus propias sondas y su propio limitador, precisamente porque sólo ellos saben cuántos intercambios necesitan. Meterlos aquí exigiría que el runtime supiera de qué protocolos hablan, que es justo lo que no hace.
- **Esto va antes de #296** (ampliar el feed web) a propósito: sin compartir sondas, cada check nuevo sobre `/` multiplicaba el ruido en el objetivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
