### PR TITLE
fix(themis): observar el esquema en vez de deducirlo del puerto (#268)

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -72,11 +72,30 @@ QOD_CONFIRMED = 99
 # detection rules is the difference between being able to explain why a check
 # exists and not.
 _BUNDLED_FEED = Path(__file__).parent / "feeds" / "checks_feed.yaml"
-# Service names and ports that indicate an HTTP-speaking service worth probing.
+# Un mismo conjunto de puertos respondía antes a dos preguntas que no son la
+# misma —"¿esto habla TLS?" y "¿esto merece checks de higiene TLS?"— y las
+# respondía mal a las dos: tenía dos elementos, 443 y 8443. Un panel de
+# administración HTTPS en 9443 se sondeaba en claro y no recibía ningún check
+# de certificado.
+#
+# Ahora cada pregunta se responde por su lado. El **esquema** (http o https) ya
+# no se deduce del puerto: se observa, intentando el handshake (ver
+# :func:`negotiates_tls`). Lo que queda aquí es sólo la **candidatura**: a qué
+# servicios merece la pena acercarse siquiera.
 _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
-_HTTP_PORTS = {80, 443, 8080, 8443, 8000, 8888, 8008}
-# Ports we should reach over TLS.
-_TLS_PORTS = {443, 8443}
+
+# Puertos donde es habitual encontrar TLS. Deciden qué servicios reciben los
+# checks de higiene de certificado, no cómo se habla con ellos. La lista es una
+# red de seguridad barata, no una verdad: un TLS en un puerto que no esté aquí
+# se sondea igual de bien (el esquema se observa), pero no recibe los checks de
+# certificado. Ampliarla es gratis; hacerla innecesaria es #283, que ataca la
+# misma enfermedad —decidir por número de puerto— desde el otro lado.
+_TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986}
+
+# Puertos que se consideran servicio HTTP. Incluye los de TLS: un HTTPS en 9443
+# tampoco entraba por esta puerta, así que ampliar sólo la lista de TLS no
+# habría servido de nada.
+_HTTP_PORTS = {80, 8080, 8000, 8888, 8008} | _TLS_HYGIENE_PORTS
 # Service names and ports for FTP — Fase N's first ``type: "network"`` family.
 _FTP_SERVICE_NAMES = {"ftp"}
 _FTP_PORTS = {21}
@@ -451,15 +470,22 @@ def is_http_service(service: Service) -> bool:
 
 
 def is_tls_service(service: Service) -> bool:
-    """Return whether a service should be probed by TLS hygiene checks.
+    """Return whether a service is a candidate for the TLS hygiene checks.
+
+    Candidacy, not identification: this says "merece la pena intentar el
+    handshake aquí", and the checks themselves abandon quietly if there is no
+    TLS on the other side. It is deliberately *not* the function that decides
+    whether to speak HTTPS to a service — that is observed, not guessed (see
+    :func:`negotiates_tls`).
 
     Args:
         service: The service to test.
 
     Returns:
-        ``True`` if the service's port is one we reach over TLS.
+        ``True`` if the service's port is one where TLS is common enough to be
+        worth a handshake.
     """
-    return service.port in _TLS_PORTS
+    return service.port in _TLS_HYGIENE_PORTS
 
 
 def is_ftp_service(service: Service) -> bool:
@@ -1033,6 +1059,45 @@ class HostRateLimiter:
             self._sleeper(wait)
 
 
+def negotiates_tls(host: str, port: int, timeout: float = 5.0, connect: Optional[Callable] = None) -> bool:
+    """Return whether ``host:port`` completes a TLS handshake.
+
+    The question "is this HTTPS?" used to be answered by looking the port up in
+    a set of two. This asks the service instead, which is the only way to be
+    right about a panel someone chose to publish on 9443, or about a plain HTTP
+    server sitting on 8443 — the inverse mistake, and just as real.
+
+    Deliberately implemented here with ``ssl`` rather than by reusing
+    ``fingerprinting.tls.TlsProbe``, which does exactly this handshake plus
+    certificate parsing: this module must not import the fingerprinting
+    package, because the dissectors in it import their applicability predicates
+    from here and the two imports would close a cycle (the same reason
+    ``_TLS_RULES`` is duck-typed). What is shared is the reasoning, not the
+    code — and what this needs is a yes/no, not a certificate.
+
+    Args:
+        host: The target host.
+        port: The target port.
+        timeout: The connection timeout, in seconds.
+        connect: An injectable ``(address, timeout) -> socket`` callable, the
+            same pattern the probes use.
+
+    Returns:
+        ``True`` if the handshake completed, ``False`` on any failure —
+        including a plaintext server, which answers a TLS ``ClientHello`` with
+        something that is not a ``ServerHello`` and fails the handshake.
+    """
+    connect = connect or socket.create_connection
+    context = ssl._create_unverified_context()
+    try:
+        with connect((host, port), timeout) as sock:
+            with context.wrap_socket(sock, server_hostname=host):
+                return True
+    except Exception as err:  # noqa: BLE001 - cualquier fallo significa "no es TLS"
+        logger.debug("Scheme detection: %s:%s does not speak TLS (%s)", host, port, err)
+        return False
+
+
 class HttpProbe:
     """Performs the runtime's actual HTTP requests — safe, read-only GETs.
 
@@ -1045,11 +1110,24 @@ class HttpProbe:
     Args:
         timeout: The per-request timeout, in seconds.
         max_bytes: The maximum number of response body bytes to read.
+        detect_scheme: An injectable ``(host, port) -> bool`` telling whether
+            the service speaks TLS. Defaults to :func:`negotiates_tls`; a test
+            passes a stub instead of opening a socket.
     """
 
-    def __init__(self, timeout: int = 8, max_bytes: int = 131072) -> None:
+    def __init__(
+        self,
+        timeout: int = 8,
+        max_bytes: int = 131072,
+        detect_scheme: Optional[Callable[[str, Optional[int]], bool]] = None,
+    ) -> None:
         self._timeout = timeout
         self._max_bytes = max_bytes
+        self._detect_scheme = detect_scheme or (lambda host, port: negotiates_tls(host, port, timeout))
+        # El esquema se observa una vez por servicio y se recuerda: la pregunta
+        # es sobre el servicio, no sobre la petición, y no cambia entre una y
+        # otra dentro del mismo escaneo.
+        self._schemes: Dict[tuple, str] = {}
         # E7: este probe se queda deliberadamente en ``urllib`` mientras el
         # resto del tráfico HTTP ordinario del proyecto (aegis/pills.py,
         # lybra/kb.py) usa ``requests``. Una sonda de seguridad necesita
@@ -1117,7 +1195,7 @@ class HttpProbe:
         HTTPS uses an unverified TLS context, since we are scanning arbitrary
         hosts whose certificates we do not control.
         """
-        scheme = "https" if port in _TLS_PORTS else "http"
+        scheme = self._scheme_for(host, port)
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
         try:
@@ -1130,6 +1208,20 @@ class HttpProbe:
         except Exception as err:  # noqa: BLE001 - transport failure: abandon this check
             logger.debug("HTTP probe failed for %s: %s", url, err)
             return None
+
+    def _scheme_for(self, host: str, port: Optional[int]) -> str:
+        """Return ``"https"`` or ``"http"`` for a service, observing it once.
+
+        A service with no port at all (an inventory entry, say) is not
+        something to shake hands with, so it keeps the plain default rather
+        than paying for a probe that has nowhere to connect.
+        """
+        if port is None:
+            return "http"
+        key = (host, port)
+        if key not in self._schemes:
+            self._schemes[key] = "https" if self._detect_scheme(host, port) else "http"
+        return self._schemes[key]
 
     @staticmethod
     def _to_response(status: int, body: bytes, headers) -> Response:

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,127 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# ------------------------------------------- esquema observado, no deducido
+#
+# El motor decidía si hablar HTTP o HTTPS mirando si el puerto estaba en un
+# conjunto de dos elementos (443 y 8443). Un panel HTTPS en 9443 se sondeaba en
+# claro: el GET fallaba o devolvía basura, el dissector no identificaba nada y
+# los checks de cabeceras no corrían. Y al revés, un HTTP en claro en 8443 se
+# sondeaba como TLS y no contestaba nada.
+
+class _RespuestaFalsaHttp:
+    """Lo mínimo que `_request` consulta de lo que devuelve el opener."""
+
+    status = 200
+    headers = {"Server": "nginx"}
+
+    def read(self, _n=None):
+        return b"<html>"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _OpenerFalso:
+    """Apunta la URL que se pidió, que es lo que este bloque comprueba."""
+
+    def __init__(self):
+        self.urls = []
+
+    def open(self, request, timeout=None):
+        self.urls.append(request.full_url)
+        return _RespuestaFalsaHttp()
+
+
+def _probe_con_opener(monkeypatch, detect_scheme):
+    from src.modules.features.themis.lybra import HttpProbe
+
+    probe = HttpProbe(detect_scheme=detect_scheme)
+    opener = _OpenerFalso()
+    monkeypatch.setattr(probe, "_opener", opener)
+    return probe, opener
+
+
+def test_a_tls_service_on_a_non_canonical_port_is_reached_over_https(monkeypatch):
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: True)
+
+    probe.fetch("10.0.0.5", 9443, "GET", "/")
+
+    assert opener.urls == ["https://10.0.0.5:9443/"]
+
+
+def test_a_plaintext_service_on_a_tls_port_is_not_forced_into_https(monkeypatch):
+    # El caso inverso, y tan real como el otro: un HTTP en claro en 8443.
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: False)
+
+    probe.fetch("10.0.0.5", 8443, "GET", "/")
+
+    assert opener.urls == ["http://10.0.0.5:8443/"]
+
+
+def test_the_scheme_is_observed_once_per_service(monkeypatch):
+    # La pregunta es sobre el servicio, no sobre la petición: no cambia entre
+    # una ruta y otra dentro del mismo escaneo.
+    observaciones = []
+
+    def detectar(host, port):
+        observaciones.append((host, port))
+        return True
+
+    probe, _opener = _probe_con_opener(monkeypatch, detectar)
+
+    probe.fetch("10.0.0.5", 9443, "GET", "/")
+    probe.fetch("10.0.0.5", 9443, "GET", "/.git/config")
+    probe.fetch("10.0.0.5", 4443, "GET", "/")
+
+    assert observaciones == [("10.0.0.5", 9443), ("10.0.0.5", 4443)]
+
+
+def test_a_service_without_a_port_is_never_probed_for_tls(monkeypatch):
+    # Una entrada de inventario no tiene a dónde conectarse: no se paga una
+    # sonda que no puede salir a ninguna parte.
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: pytest.fail("no debería sondear"))
+
+    probe.fetch("10.0.0.5", None, "GET", "/")
+
+    assert opener.urls == ["http://10.0.0.5/"]
+
+
+def test_negotiates_tls_is_false_when_the_connection_fails():
+    from src.modules.features.themis.lybra.checks import negotiates_tls
+
+    def connect_que_falla(address, timeout):
+        raise OSError("connection refused")
+
+    assert negotiates_tls("10.0.0.5", 9443, connect=connect_que_falla) is False
+
+
+def test_the_usual_tls_ports_are_candidates_for_hygiene_checks():
+    from src.modules.features.themis.lybra import is_tls_service
+
+    for puerto in (443, 8443, 9443, 10443, 8834):
+        servicio = Service(puerto, "tcp", "", "", "", None)
+        assert is_tls_service(servicio) is True, puerto
+        # Y entran por la puerta de HTTP, que antes tampoco los dejaba pasar.
+        assert is_http_service(servicio) is True, puerto
+
+
+def test_a_tls_service_on_an_arbitrary_port_still_misses_the_hygiene_checks():
+    """El límite que queda, escrito para que no se dé por cerrado.
+
+    El esquema ya se observa, así que un TLS en 7777 se sondea bien y recibe
+    los checks de cabeceras. Lo que no recibe son los de higiene de
+    certificado: su candidatura sigue decidiéndose por número de puerto.
+    Hacerla observada del todo es #283.
+    """
+    from src.modules.features.themis.lybra import is_tls_service
+
+    assert is_tls_service(Service(7777, "tcp", "", "", "", None)) is False
+
+
 # --------------------------------- sondas compartidas dentro de una ejecución
 #
 # Cada check corre por su cuenta, que es lo que los mantiene simples, pero el


### PR DESCRIPTION
## El problema, en lenguaje llano

Antes de pedirle nada a un servicio web hay que saber si se le habla en claro (HTTP) o cifrado (HTTPS). Lybra lo decidía mirando si el puerto estaba en un conjunto de **dos** elementos: 443 y 8443.

Cualquier otro puerto se sondeaba en claro. Un panel de administración HTTPS en 9443, en 10443, en 8834 (el de Nessus), o simplemente en un puerto que alguien eligió a mano, quedaba fuera.

Y el resultado no era un error visible sino un vacío. El `GET` fallaba o devolvía basura, así que el identificador de servicios no reconocía nada, los checks de cabeceras de seguridad no llegaban a ejecutarse, y los checks de higiene del certificado **ni siquiera se consideraban** — porque ese mismo conjunto de dos puertos gobernaba también esa segunda decisión. Para Lybra, un panel HTTPS en un puerto no canónico era un puerto abierto y nada más.

El error tiene además su reverso, igual de real: un servidor HTTP **en claro** escuchando en 8443 se sondeaba como si fuera TLS, y no contestaba nada.

## Issue relacionado

Closes #268.

## Comprobado contra servidores reales

Dos contenedores nginx: uno con TLS en 9443 y otro sirviendo HTTP en claro en 8443.

| Puerto | Qué hay ahí | Antes | Ahora |
|---|---|---|---|
| 9443 | nginx con TLS | **400** | **200** |
| 8443 | nginx HTTP en claro | **sin respuesta** | **200** |

El 400 del primer caso merece un comentario, porque es peor que un fallo limpio: es la respuesta que da un servidor TLS cuando recibe una petición en claro, y como *es* una respuesta, el resto del motor la trata como tal — el identificador la analiza, los matchers la evalúan. No es que faltara información: es que había información falsa.

Y con el arreglo, ese HTTPS en 9443 recibe ya los tres checks de cabeceras **y** el de certificado autofirmado, que es el criterio de cierre del issue.

## La corrección

**El esquema se observa.** `negotiates_tls` intenta el handshake y responde sí o no. Es una sonda por servicio, y se recuerda: la pregunta es sobre el servicio, no sobre cada petición.

**Por qué no se reutiliza `TlsProbe`**, que hace exactamente ese handshake y además analiza el certificado: `checks.py` no puede importar el paquete de fingerprinting, porque los dissectors de ese paquete importan de aquí sus predicados de aplicabilidad y los dos imports cerrarían un ciclo. Es la misma razón por la que las reglas TLS de este módulo consultan el `TlsInfo` por *duck typing* en vez de importar su tipo. Lo que se comparte es el razonamiento, no el código — y lo que aquí hace falta es un sí o un no, no un certificado.

**Los dos conjuntos de puertos dejan de responder a la misma pregunta.** Antes, `_TLS_PORTS` contestaba a la vez a "¿esto habla TLS?" y a "¿esto merece checks de higiene TLS?", que no son la misma pregunta. La primera ya no se contesta con un conjunto: se observa. El conjunto que queda decide sólo **candidatura** —a qué servicios merece la pena acercarse—, y se amplía con los puertos TLS habituales (9443, 10443, 4443, 7443, 8834, 9091, 5986), tanto para los checks de higiene como para que entren siquiera por la puerta de HTTP, que antes tampoco los dejaba pasar.

## Validación

- Un servicio TLS en 9443 se alcanza por `https`.
- Un HTTP en claro en 8443 **no** se fuerza a TLS.
- El esquema se observa una vez por servicio, no por petición.
- Una entrada sin puerto (un paquete de inventario) no paga una sonda que no tiene a dónde salir.
- `negotiates_tls` responde `False` ante cualquier fallo, que es lo que significa "esto no es TLS".
- Los puertos TLS habituales son candidatos a los checks de higiene y entran como servicio HTTP.
- La comprobación contra los dos contenedores reales de la tabla de arriba.

`pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas y lo que queda fuera

- **El límite que queda, escrito en un test para que no se dé por cerrado.** Un TLS en un puerto arbitrario (7777, pongamos) ya se sondea bien y recibe los checks de cabeceras, porque el esquema se observa. Lo que no recibe son los de higiene de certificado: esa candidatura sigue decidiéndose por número de puerto. Hacerla observada del todo significaría intentar un handshake contra cada puerto abierto, que es ruido en el objetivo y trabajo de #283 — el hermano de este issue, que ataca la misma enfermedad desde el otro lado.
- **Coste añadido: una sonda por servicio HTTP.** Es lo que cuesta observar en vez de suponer. Se compensa en parte con #274, que acaba de entrar y quita cuatro sondas por servicio HTTPS; el saldo sigue siendo favorable.
- **`is_http_service` e `is_tls_service` siguen siendo funciones puras**, sin efectos de red. La observación vive en el probe, que es el borde. Eso mantiene los predicados usables desde el paquete de fingerprinting, que es quien más los llama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
