### PR TITLE
feat(themis): que el feed_version describa el estado de la base de conocimiento (#270)

### DIFF
--- a/API/alembic/versions/d7e8f9a0b1c2_finding_feed_version_64.py
+++ b/API/alembic/versions/d7e8f9a0b1c2_finding_feed_version_64.py
@@ -1,0 +1,61 @@
+"""Finding.feed_version a 64 caracteres para la marca del estado de la KB (#270)
+
+Revision ID: d7e8f9a0b1c2
+Revises: c7d8e9f0a1b2
+Create Date: 2026-08-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7e8f9a0b1c2'
+down_revision: Union[str, Sequence[str], None] = 'c7d8e9f0a1b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    La marca de reproducibilidad de la detección por versión era la constante
+    ``"lybra-0"`` y no cambiaba nunca, así que un hallazgo guardado no podía
+    decir contra qué estado de la base de conocimiento se había resuelto.
+    Ahora describe ese estado —``lybra-kb:nvd=2026-08-29,kev=2026-08-27,
+    epss=2026-08-30``—, que ocupa hasta 54 caracteres y no cabía en los 32 de
+    la columna.
+
+    Se escribe entera en vez de resumirla en un hash corto porque el objetivo
+    es justamente que un hallazgo siga siendo legible por sí solo dentro de un
+    año; un hash sólo dice "no es el mismo que aquel otro" y necesitaría una
+    tabla de consulta que todavía no existe (#302).
+
+    Ampliar un ``varchar`` no reescribe la tabla en PostgreSQL (es un cambio de
+    metadatos) y no toca ni un dato existente: los hallazgos ya guardados
+    conservan su ``lybra-0``, que sigue siendo cierto para ellos.
+    """
+    op.alter_column(
+        'Finding', 'feed_version',
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=64),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Estrechar la columna sí puede perder datos: cualquier marca escrita después
+    de la subida mide más de 32 caracteres. Se truncan explícitamente antes de
+    alterar el tipo, en vez de dejar que la base de datos falle a mitad.
+    """
+    op.execute('UPDATE "Finding" SET feed_version = left(feed_version, 32)')
+    op.alter_column(
+        'Finding', 'feed_version',
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=32),
+        existing_nullable=True,
+    )

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -57,6 +57,7 @@ from .engine import (
 from .kb import (
     version_compare,
     split_distro_version,
+    kb_feed_version,
     version_in_range,
     normalize_cpe_to_23,
     normalize_product_name,
@@ -194,6 +195,7 @@ __all__ = [
     "QOD_INVENTORY_MATCH",
     "version_compare",
     "split_distro_version",
+    "kb_feed_version",
     "version_in_range",
     "normalize_cpe_to_23",
     "normalize_product_name",

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -138,6 +138,16 @@ class LybraEngine:
             ``CpeMatch`` rows (Fase I-b, paso 2), consulted only when neither an
             embedded CPE nor :data:`CPE_PRODUCT_OVERRIDES` resolved the service.
             ``None`` disables this third strategy, leaving the first two.
+        feed_version: The reproducibility mark stamped on every finding this
+            engine emits. The caller passes one describing the state of the
+            knowledge base the findings were resolved against; omitting it
+            keeps :data:`FEED_VERSION`, the constant every stored finding
+            carried before this became injectable.
+
+            Why it is injected and not read here: the mark describes the
+            contents of the database, and this package is deliberately free of
+            the ORM. The manager knows the KB's state; the engine only stamps
+            what it is told.
     """
 
     FEED_VERSION = "lybra-0"
@@ -148,11 +158,13 @@ class LybraEngine:
         kev_lookup: Optional[Callable[[str], bool]] = None,
         epss_lookup: Optional[Callable[[str], Optional[float]]] = None,
         product_alias_lookup: Optional[Callable[[str], Optional[Tuple[str, str]]]] = None,
+        feed_version: Optional[str] = None,
     ) -> None:
         self._cve_lookup = cve_lookup
         self._kev_lookup = kev_lookup
         self._epss_lookup = epss_lookup
         self._product_alias_lookup = product_alias_lookup
+        self._feed_version = feed_version or self.FEED_VERSION
 
     def analyze(self, services: Iterable[Service]) -> List[dict]:
         """Produce the findings for a set of services.
@@ -224,7 +236,7 @@ class LybraEngine:
             "required_os":  getattr(cve, "required_os", None),
             "source":       "lybra",
             "check_id":     "lybra:version-match@1",
-            "feed_version": self.FEED_VERSION,
+            "feed_version": self._feed_version,
             "qod":          QOD_INVENTORY_MATCH if is_verified else QOD_VERSION_MATCH,
             "confirmed":    is_verified,   # a network-inferred match stays a hypothesis; Fase R confirms it actively
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
@@ -282,7 +294,7 @@ class LybraEngine:
             "cpe":          normalize_cpe_to_23(service.cpe) if service.cpe else None,
             "source":       "lybra",
             "check_id":     "lybra:open-port@1",
-            "feed_version": self.FEED_VERSION,
+            "feed_version": self._feed_version,
             "qod":          QOD_OPEN_PORT,
             "confirmed":    False,
             "cpe_resolved": resolved is not None,

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -205,6 +205,41 @@ def version_compare(a: str, b: str) -> int:
     return 0
 
 
+def kb_feed_version(state: Dict[str, Optional[datetime]]) -> str:
+    """Build the reproducibility mark for findings resolved against the KB.
+
+    Every version-detection finding used to carry the constant ``"lybra-0"``,
+    which never changed. Two findings emitted six months apart —one against a
+    knowledge base with the full catalogue, another against one half
+    populated— were stamped identically, so a stored finding could not say what
+    it had been compared against. That breaks three things at once: an old
+    report cannot be reproduced, a finding that disappeared cannot be
+    explained (was the host fixed, or did the KB change?), and the lifecycle
+    can mark something ``fixed`` that merely stopped matching because NVD
+    rewrote a range.
+
+    The mark reads ``lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30``.
+    Spelled out rather than hashed on purpose: the point is that someone
+    reading a finding a year from now can tell what it was resolved against,
+    and a hash only says "not the same as that other one" — it needs a lookup
+    table that does not exist yet (#302). A source with no date reports
+    ``none``, which is honest: an empty knowledge source is exactly the thing
+    this mark exists to make visible.
+
+    Args:
+        state: ``{"nvd": datetime | None, "kev": ..., "epss": ...}``, as
+            :meth:`KbRepository.knowledge_state` returns it.
+
+    Returns:
+        The mark, e.g. ``"lybra-kb:nvd=2026-08-29,kev=none,epss=2026-08-30"``.
+    """
+    parts = []
+    for source in ("nvd", "kev", "epss"):
+        moment = state.get(source)
+        parts.append(f"{source}={moment.date().isoformat() if moment else 'none'}")
+    return "lybra-kb:" + ",".join(parts)
+
+
 def _bound(match, name: str) -> Optional[str]:
     """Read one range-bound field off a match, whether it is an ORM row or a dict.
 
@@ -744,7 +779,16 @@ def parse_epss_rows(csv_text: str) -> Iterator[dict]:
 def _epss_scored_at(csv_text: str) -> Optional[datetime]:
     """Read the scoring date out of the EPSS file's comment header.
 
-    The header looks like ``#model_version:...,score_date=2026-07-01T...``.
+    The header looks like ``#model_version:v2026.06.15,score_date:2026-08-30T...``.
+
+    **Both separators are accepted, and that is not defensive coding.** This
+    used to look for ``score_date=`` only, and the feed publishes
+    ``score_date:`` — so the date came back ``None`` every single time, and the
+    column silently stayed empty: 353.521 EPSS rows in a full mirror, not one
+    of them with a scoring date. Nothing failed, because a missing date is
+    indistinguishable from a feed that does not carry one. Accepting either
+    character costs nothing and removes a whole class of "the header changed a
+    punctuation mark and we lost the field".
 
     Args:
         csv_text: The full decoded text of the EPSS CSV file.
@@ -752,7 +796,7 @@ def _epss_scored_at(csv_text: str) -> Optional[datetime]:
     Returns:
         The parsed scoring date, or ``None`` if the header does not carry one.
     """
-    match = re.search(r"score_date=(\d{4}-\d{2}-\d{2})", csv_text[:512])
+    match = re.search(r"score_date[=:](\d{4}-\d{2}-\d{2})", csv_text[:512])
     return _parse_dt(match.group(1)) if match else None
 
 

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -33,6 +33,7 @@ from ...lybra import (
     default_dissectors,
     agrees_with_nmap,
     HostRateLimiter,
+    kb_feed_version,
     load_checks,
     CheckRuntime,
     HttpProbe,
@@ -275,6 +276,7 @@ class LybraEngineManager(ScanManager):
                     kev_lookup=lambda cve_id: kb_repo.get_kev(cve_id) is not None,
                     epss_lookup=lambda cve_id: getattr(kb_repo.get_epss(cve_id), "score", None),
                     product_alias_lookup=kb_repo.resolve_product_alias,
+                    feed_version=kb_feed_version(kb_repo.knowledge_state()),
                 )
                 findings_data = engine.analyze(services)
                 findings_data.extend(fingerprint_findings)

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -831,7 +831,12 @@ class Finding(Base):
     # Quality / provenance
     source       = Column(String(32), index=True)
     check_id     = Column(String(128))
-    feed_version = Column(String(32))
+    # 64 y no 32: desde #270 la marca de la detección por versión describe el
+    # estado de la base de conocimiento ("lybra-kb:nvd=2026-08-29,kev=...,
+    # epss=..."), que ocupa hasta 54 caracteres. Se escribe entera en vez de
+    # resumirla en un hash para que un hallazgo guardado siga diciendo, por sí
+    # solo, contra qué se resolvió.
+    feed_version = Column(String(64))
     dedup_key    = Column(String(64), index=True)
     qod          = Column(Integer)
     confirmed    = Column(Boolean, default=False)

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -1153,6 +1153,30 @@ class KbRepository(BaseRepository[CveEntry]):
             .all()
         )
 
+    def knowledge_state(self) -> dict:
+        """The newest date each KB source carries, as the mirror stands right now.
+
+        This is what makes a finding reproducible: two scans of the same target
+        can disagree because the target changed **or** because the knowledge
+        base learned something in between, and without this there is no way to
+        tell those two apart after the fact.
+
+        Read from the data itself rather than from a sync log, because there is
+        no sync log — recording when each source was last synchronised is
+        #302. These dates are the closest honest proxy: not "when did we last
+        ask NVD", but "how recent is the newest thing we know". A source with
+        no rows, or whose rows carry no date, reports ``None``, which is
+        information too and must not be dressed up as a date.
+
+        Returns:
+            ``{"nvd": datetime | None, "kev": ..., "epss": ...}``.
+        """
+        return {
+            "nvd":  self._session.query(func.max(CveEntry.last_modified)).scalar(),
+            "kev":  self._session.query(func.max(KevEntry.date_added)).scalar(),
+            "epss": self._session.query(func.max(EpssScore.scored_at)).scalar(),
+        }
+
     def counts(self) -> dict:
         """Row counts per KB table (for the sync summary / health checks)."""
         return {

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import pytest
 
 from src.modules.infrastructure import UnitOfWork
-from src.modules.features.themis.model import NmapScan, NiktoScan, ScanStatus
+from src.modules.features.themis.model import Finding, NmapScan, NiktoScan, ScanStatus
 from src.modules.features.themis.repositories import ScanRepository, KbRepository
 from src.modules.features.themis.managers import LybraEngineManager, ScanManager, AuthorizedTargetManager
 from src.modules.features.themis.lybra import Service
@@ -506,6 +506,49 @@ def _seed_kb_apache_cve(app):
                              "date_added": None, "due_date": None})
             repo.upsert_epss({"cve_id": "CVE-2021-41773", "score": 0.97,
                               "percentile": 0.99, "scored_at": None})
+
+
+def test_a_scan_stamps_findings_with_the_state_of_the_knowledge_base(app, admin_user):
+    """#270: la marca de reproducibilidad sale del estado real de la KB.
+
+    Era la constante ``"lybra-0"`` para todos los hallazgos por versión, así que
+    un hallazgo guardado no podía decir contra qué conocimiento se resolvió.
+    Aquí se siembra la KB con fechas conocidas en las tres fuentes y se
+    comprueba que el escaneo las estampa.
+    """
+    from datetime import datetime
+
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            repo.upsert_kev({"cve_id": "CVE-2021-41773", "known_ransomware": False,
+                             "date_added": datetime(2026, 8, 27), "due_date": None})
+            repo.upsert_epss({"cve_id": "CVE-2021-41773", "score": 0.97, "percentile": 0.99,
+                              "scored_at": datetime(2026, 8, 30)})
+            repo.upsert_cve(
+                {"cve_id": "CVE-2021-41773", "cvss_score": 7.5, "cvss_vector": "CVSS:3.1/AV:N",
+                 "severity": "HIGH", "description": "Path traversal", "cwe_ids": ["CWE-22"],
+                 "source": "nvd", "last_modified": datetime(2026, 8, 29, 13, 19)},
+                [{"vendor": "apache", "product": "http_server", "exact_version": "2.4.49",
+                  "version_start_including": None, "version_start_excluding": None,
+                  "version_end_including": None, "version_end_excluding": None}],
+            )
+
+    nmap_id = _seed_nmap_scan(app, admin_user.id)
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id,
+                                        source_scan_id=nmap_id)
+        mgr._run_lybra(escan.id, nmap_id)
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    vuln = next(f for f in findings if f.category == "outdated_software")
+    assert vuln.feed_version == "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30"
+    # Y la marca cabe entera en la columna, sin recortes silenciosos.
+    assert len(vuln.feed_version) <= Finding.__table__.c.feed_version.type.length
 
 
 def _seed_kb_vsftpd_cve(app):

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -321,6 +321,79 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["confirmed"] is True
 
 
+# ------------------------------------------- marca de reproducibilidad (#270)
+#
+# Cada hallazgo lleva una marca que dice contra qué se resolvió. Para los checks
+# activos era cierta (sube cada vez que cambia el feed); para la detección por
+# versión —que produce la mayoría de los hallazgos con CVE— era la constante
+# "lybra-0" y no cambió nunca. Dos hallazgos separados por seis meses, uno
+# contra el catálogo completo y otro contra una KB a medio poblar, llevaban la
+# misma marca.
+
+def test_the_engine_stamps_the_mark_it_is_given():
+    engine = LybraEngine(
+        cve_lookup=_lookup_for(("openbsd", "openssh")),
+        feed_version="lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30",
+    )
+
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert {f["feed_version"] for f in findings} == {
+        "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30"
+    }
+
+
+def test_without_a_mark_the_engine_keeps_the_old_constant():
+    # Compatibilidad con los hallazgos ya almacenados: quien no inyecte nada
+    # sigue estampando exactamente lo que estampaba antes.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert {f["feed_version"] for f in findings} == {"lybra-0"}
+
+
+def test_two_states_of_the_knowledge_base_produce_different_marks():
+    """El criterio de cierre: dos escaneos separados por una sincronización
+    tienen que distinguirse por la marca."""
+    from datetime import datetime
+
+    from src.modules.features.themis.lybra import kb_feed_version
+
+    antes = kb_feed_version({
+        "nvd": datetime(2026, 8, 29, 13, 19), "kev": datetime(2026, 8, 27), "epss": None,
+    })
+    despues = kb_feed_version({
+        "nvd": datetime(2026, 8, 30, 4, 0), "kev": datetime(2026, 8, 27),
+        "epss": datetime(2026, 8, 30),
+    })
+
+    assert antes == "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=none"
+    assert despues == "lybra-kb:nvd=2026-08-30,kev=2026-08-27,epss=2026-08-30"
+    assert antes != despues
+
+
+def test_a_source_with_no_data_says_so_instead_of_pretending():
+    # Una fuente vacía es información, no un hueco que rellenar con la fecha de
+    # otra cosa: es justo lo que esta marca existe para hacer visible.
+    from src.modules.features.themis.lybra import kb_feed_version
+
+    assert kb_feed_version({}) == "lybra-kb:nvd=none,kev=none,epss=none"
+
+
+def test_the_mark_fits_in_the_column_that_stores_it():
+    from datetime import datetime
+
+    from src.modules.features.themis.lybra import kb_feed_version
+    from src.modules.features.themis.model import Finding
+
+    peor_caso = kb_feed_version({
+        "nvd": datetime(2026, 12, 31), "kev": datetime(2026, 12, 31),
+        "epss": datetime(2026, 12, 31),
+    })
+
+    assert len(peor_caso) <= Finding.__table__.c.feed_version.type.length
+
+
 def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
     """El criterio de cierre de #267, extremo a extremo dentro del motor.
 

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -432,6 +432,36 @@ def test_parse_epss_rows_skips_comment_header():
     assert rows[0]["scored_at"].year == 2026
 
 
+def test_the_scoring_date_is_read_from_the_header_the_feed_actually_publishes():
+    """La cabecera real usa dos puntos, no un igual, y eso costaba el campo entero.
+
+    El test de arriba —y sólo él— cubría este parser, con una cabecera escrita
+    a mano que usa ``score_date=``. El feed publica
+    ``#model_version:v2026.06.15,score_date:2026-08-30T12:03:42Z``. Con el
+    parser buscando únicamente el ``=``, la fecha salía ``None`` **siempre**:
+    353.521 filas en un espejo completo, ninguna con fecha, y sin un solo
+    error por el camino — una fecha ausente es indistinguible de un feed que
+    no la trae.
+
+    Es el motivo de que este caso exista: una fixture inventada valida el
+    código contra sí misma, no contra el mundo.
+    """
+    csv_text = (
+        "#model_version:v2026.06.15,score_date:2026-08-30T12:03:42Z\n"
+        "cve,epss,percentile\n"
+        "CVE-2021-41773,0.97,0.995\n"
+    )
+
+    rows = list(parse_epss_rows(csv_text))
+
+    assert rows[0]["scored_at"].date().isoformat() == "2026-08-30"
+
+
+def test_a_header_without_a_date_leaves_the_field_empty():
+    csv_text = "#model_version:v2026.06.15\ncve,epss,percentile\nCVE-2021-41773,0.97,0.995\n"
+    assert list(parse_epss_rows(csv_text))[0]["scored_at"] is None
+
+
 # --------------------------------------- product name normalization (Fase I-b)
 
 @pytest.mark.parametrize("raw,expected", [


### PR DESCRIPTION
## El problema, en lenguaje llano

Cada hallazgo que produce Lybra lleva una marca que dice **contra qué conocimiento se resolvió**: el `feed_version`. Sirve para poder reproducir un informe más adelante y para saber, cuando un hallazgo desaparece, si fue porque el host se arregló o porque cambió lo que sabíamos.

Para los checks activos esa marca era cierta: sube cada vez que cambia el feed de checks. Para el otro camino —la detección por versión, que es la que produce **la mayoría** de los hallazgos con CVE— era la constante `"lybra-0"`, y no cambió nunca.

Es decir: un hallazgo emitido hoy contra la base de conocimiento completa y otro emitido hace seis meses contra una base a medio poblar llevan exactamente la misma marca. Mirando un hallazgo guardado no hay forma de saber contra qué estado del conocimiento se resolvió.

Eso rompe tres cosas a la vez:

- **No se puede reproducir un informe.** Volver a ejecutarlo hoy da otro resultado y nada explica la diferencia.
- **No se puede explicar por qué un hallazgo desapareció.** ¿Se arregló el host, o NVD reescribió el rango de versiones afectadas?
- **El ciclo de vida puede mentir**: marcar como `fixed` algo que sólo dejó de casar porque cambió el catálogo, no porque nadie parcheara nada.

## Issue relacionado

Closes #270.

## La corrección

**La marca pasa a ser un parámetro de construcción del motor**, con el valor actual por defecto: quien no inyecte nada estampa exactamente lo de antes, así que los hallazgos ya almacenados siguen siendo coherentes.

**Y el manager le inyecta una que describe el estado real de la base de conocimiento**: la fecha más reciente que trae cada fuente — la última modificación de NVD, el último alta de CISA-KEV, la última puntuación de EPSS.

```
lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30
```

Tres decisiones que merecen explicación:

- **Se escribe entera, no como un hash corto.** El issue contemplaba resumirla si la longitud molestaba. No se ha hecho, porque el criterio de cierre es que *ese valor baste* para saber contra qué se resolvió el hallazgo, y un hash sólo dice "no es el mismo que aquel otro": para explicar algo necesitaría una tabla de consulta que no existe todavía (#302).
- **Se lee del propio dato, no de un registro de sincronización**, porque ese registro no existe — anotarlo es justamente #302. Estas fechas son la aproximación honesta que se puede dar hoy: no dicen "cuándo preguntamos a NVD por última vez" sino "de cuándo es lo más reciente que sabemos". Cuando #302 exista, sólo cambia de dónde salen los tres valores.
- **Una fuente sin fecha dice `none`.** No se rellena con la fecha de otra cosa ni se omite: una fuente vacía es exactamente lo que esta marca existe para hacer visible.

El motor sigue sin tocar la base de datos: la marca describe el contenido de la BD, así que la compone el manager (vía repositorio, como manda la guía) y el motor sólo estampa lo que le dan.

## Dos cosas que aparecieron por el camino

### Un campo que llevaba vacío desde siempre

Al construir la marca resultó que **las 353.521 filas de EPSS del espejo local no tienen fecha de puntuación**. Ninguna.

La causa: el parser buscaba `score_date=` y el feed publica `score_date:`, con dos puntos. Consultada la cabecera real hoy mismo:

```
#model_version:v2026.06.15,score_date:2026-08-30T12:03:42Z
```

Nunca falló nada, porque una fecha ausente es indistinguible de un feed que no la trae. Y el único test que cubría ese parser usaba una cabecera **escrita a mano** con un `=`, así que validaba el código contra sí mismo y no contra el mundo.

Se corrige aquí porque sin ello una de las tres fuentes de la marca sería `none` para siempre, y se añade el caso con la cabecera real. `bulk_upsert_epss` ya conservaba la columna, así que el atraso se cura solo en la siguiente sincronización nocturna.

### Una migración, que el issue no preveía

`Finding.feed_version` era `String(32)` y la marca ocupa hasta 54 caracteres. Hay migración (`d7e8f9a0b1c2`), y es una desviación consciente del «Nuevos artefactos: ninguno propio» del issue: la alternativa era acortar la marca hasta hacerla ilegible, que contradice el criterio de cierre.

Ampliar un `varchar` en PostgreSQL es un cambio de metadatos — no reescribe la tabla ni toca un dato. Los hallazgos ya guardados conservan su `"lybra-0"`, que sigue siendo cierto para ellos. La bajada trunca explícitamente antes de estrechar la columna, en vez de dejar que la base de datos falle a mitad.

## Validación

- El motor estampa la marca que se le inyecta; sin inyección mantiene `"lybra-0"` (compatibilidad con lo ya almacenado).
- **Dos estados distintos de la KB producen marcas distintas** — el criterio de cierre del issue.
- Una fuente vacía lo dice en vez de disimularlo.
- El peor caso de la marca cabe en la columna.
- **Integración**: un escaneo real sobre una KB sembrada con fechas conocidas en las tres fuentes estampa `lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30` en el hallazgo guardado.
- El parser de EPSS lee la cabecera que el feed publica de verdad, y una sin fecha deja el campo vacío.
- La cadena de migraciones queda con una sola cabeza (`alembic heads`).

`pytest tests/unit tests/integration`: en verde.

`pylint` no se ejecutó: no está instalado en este entorno. El CI corre `pytest`.

## Notas

- **Lo que esto cierra y lo que no.** El criterio del issue —dos escaneos separados por una sincronización producen `feed_version` distintos— queda cumplido. Lo que sigue faltando es saber **cuándo se intentó** sincronizar y si funcionó: estas fechas dicen qué sabemos, no cuándo lo preguntamos. Un job de sincronización que lleve tres semanas fallando sigue siendo invisible. Eso es #302, y cuando llegue sólo cambia la fuente de los tres valores, no el resto.
- **Los hallazgos anteriores no se reescriben.** Su `"lybra-0"` es la verdad de cuando se emitieron: se resolvieron contra una KB cuyo estado nadie registró. Inventarles una marca ahora sería exactamente la clase de mentira que este issue viene a quitar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
