### PR TITLE
Fase 0 del motor Lybra: el motor no miente (appVersion 0.5.11)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.10",
+  "appVersion": "0.5.11",
   "general": {
     "directories": {
       "logdir": "..",

--- a/API/alembic/versions/d7e8f9a0b1c2_finding_feed_version_64.py
+++ b/API/alembic/versions/d7e8f9a0b1c2_finding_feed_version_64.py
@@ -1,0 +1,61 @@
+"""Finding.feed_version a 64 caracteres para la marca del estado de la KB (#270)
+
+Revision ID: d7e8f9a0b1c2
+Revises: c7d8e9f0a1b2
+Create Date: 2026-08-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7e8f9a0b1c2'
+down_revision: Union[str, Sequence[str], None] = 'c7d8e9f0a1b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    La marca de reproducibilidad de la detección por versión era la constante
+    ``"lybra-0"`` y no cambiaba nunca, así que un hallazgo guardado no podía
+    decir contra qué estado de la base de conocimiento se había resuelto.
+    Ahora describe ese estado —``lybra-kb:nvd=2026-08-29,kev=2026-08-27,
+    epss=2026-08-30``—, que ocupa hasta 54 caracteres y no cabía en los 32 de
+    la columna.
+
+    Se escribe entera en vez de resumirla en un hash corto porque el objetivo
+    es justamente que un hallazgo siga siendo legible por sí solo dentro de un
+    año; un hash sólo dice "no es el mismo que aquel otro" y necesitaría una
+    tabla de consulta que todavía no existe (#302).
+
+    Ampliar un ``varchar`` no reescribe la tabla en PostgreSQL (es un cambio de
+    metadatos) y no toca ni un dato existente: los hallazgos ya guardados
+    conservan su ``lybra-0``, que sigue siendo cierto para ellos.
+    """
+    op.alter_column(
+        'Finding', 'feed_version',
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=64),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Estrechar la columna sí puede perder datos: cualquier marca escrita después
+    de la subida mide más de 32 caracteres. Se truncan explícitamente antes de
+    alterar el tipo, en vez de dejar que la base de datos falle a mitad.
+    """
+    op.execute('UPDATE "Finding" SET feed_version = left(feed_version, 32)')
+    op.alter_column(
+        'Finding', 'feed_version',
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=32),
+        existing_nullable=True,
+    )

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -57,6 +57,7 @@ from .engine import (
 from .kb import (
     version_compare,
     split_distro_version,
+    kb_feed_version,
     version_in_range,
     normalize_cpe_to_23,
     normalize_product_name,
@@ -194,6 +195,7 @@ __all__ = [
     "QOD_INVENTORY_MATCH",
     "version_compare",
     "split_distro_version",
+    "kb_feed_version",
     "version_in_range",
     "normalize_cpe_to_23",
     "normalize_product_name",

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -56,6 +56,7 @@ from .engine import (
 )
 from .kb import (
     version_compare,
+    split_distro_version,
     version_in_range,
     normalize_cpe_to_23,
     normalize_product_name,
@@ -192,6 +193,7 @@ __all__ = [
     "QOD_OPEN_PORT",
     "QOD_INVENTORY_MATCH",
     "version_compare",
+    "split_distro_version",
     "version_in_range",
     "normalize_cpe_to_23",
     "normalize_product_name",

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -701,6 +701,10 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
+        # Sondas compartidas dentro de una ejecución; :meth:`run` las vacía al
+        # empezar. Aquí sólo para que el objeto esté completo desde que nace.
+        self._responses: Dict[tuple, Optional[Response]] = {}
+        self._handshakes: Dict[tuple, object] = {}
         self._families: Tuple[_CheckFamily, ...] = (
             _CheckFamily(
                 applies_to_service=is_http_service,
@@ -727,6 +731,11 @@ class CheckRuntime:
     def run(self, host: str, services: Iterable[Service]) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
+        Probes are shared within one call: several checks reading the same
+        evidence make one request between them, not one each. See
+        :meth:`_probe_response` for why that is a property of this loop and not
+        a caching layer.
+
         Args:
             host: The target host.
             services: The host's discovered services (non-applicable ones are
@@ -735,6 +744,12 @@ class CheckRuntime:
         Returns:
             A finding dict for each check that fired.
         """
+        # La caché nace y muere con la ejecución: dos escaneos del mismo
+        # objetivo tienen que volver a mirar, porque entre uno y otro el
+        # objetivo ha podido cambiar — que es justo lo que un escáner mide.
+        self._responses: Dict[tuple, Optional[Response]] = {}
+        self._handshakes: Dict[tuple, object] = {}
+
         findings: List[dict] = []
         for service in services:
             for family in self._families:
@@ -815,12 +830,53 @@ class CheckRuntime:
         nothing.
         """
         for request in check.requests:
-            if self._rl is not None:
-                self._rl.acquire(host)
-            response = self._fetch(host, service.port, request.method, request.path)
+            response = self._probe_response(host, service, request.method, request.path)
             if response is None or not request.evaluate(response):
                 return None
         return self._finding(check, service)
+
+    def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
+        """Return the response for one request, asking the target only once.
+
+        Every check runs independently, which is what keeps them simple, but
+        the feed has three ``security_header`` checks and all three inspect the
+        headers of the same ``GET /``. Run literally, that is three identical
+        requests, three rate-limiter waits, and three entries in the target's
+        access log for one bit of information.
+
+        Noise on the target is not a side issue for a security scanner: it
+        shows up in the SIEM of whoever hired us. So a response is fetched once
+        per ``(method, path)`` and shared by every check that asks for it,
+        within one :meth:`run`.
+
+        A transport failure is remembered too. Not caching it would mean three
+        attempts against a service that is down — the case where retrying costs
+        the most and informs the least.
+        """
+        key = (host, service.port, method, path)
+        if key in self._responses:
+            return self._responses[key]
+        if self._rl is not None:
+            self._rl.acquire(host)
+        response = self._fetch(host, service.port, method, path)
+        self._responses[key] = response
+        return response
+
+    def _probe_handshake(self, host: str, service: Service):
+        """Return the TLS handshake facts for one service, negotiating once.
+
+        Same reasoning as :meth:`_probe_response`: the three ``tls`` checks in
+        the feed evaluate three different rules over the **same** ``TlsInfo``,
+        so there is no reason to shake hands three times with the same port.
+        """
+        key = (host, service.port)
+        if key in self._handshakes:
+            return self._handshakes[key]
+        if self._rl is not None:
+            self._rl.acquire(host)
+        info = self._tls_fetch(host, service.port)
+        self._handshakes[key] = info
+        return info
 
     def _run_tls_check(self, check: Check, host: str, service: Service) -> Optional[dict]:
         """Run one TLS hygiene check against one service's handshake.
@@ -828,9 +884,7 @@ class CheckRuntime:
         A transport failure (unreachable, handshake error) abandons the check —
         no evidence means no finding, the same rule ``_run_check`` follows.
         """
-        if self._rl is not None:
-            self._rl.acquire(host)
-        info = self._tls_fetch(host, service.port)
+        info = self._probe_handshake(host, service)
         if info is None or not _TLS_RULES[check.tls_rule](info):
             return None
         return self._finding(check, service)

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -920,17 +920,40 @@ class HostRateLimiter:
     """Enforces a minimum interval between requests to the same host.
 
     Thread-safe, so it can be shared across concurrent probes without letting any
-    single host be hit faster than the configured rate.
+    single host be hit faster than the configured rate — and **without holding
+    anyone else up while it waits**. The waiting happens outside the lock: the
+    turn is reserved under it (a few microseconds of bookkeeping), and the
+    sleeping is done after releasing it.
+
+    That distinction is the whole point of this class's shape. With the sleep
+    inside the lock, a probe waiting its turn for host A also blocked every
+    probe heading for host B — a limiter meant to protect *one* host at a time
+    was throttling all of them at once, and the wait bought nobody any
+    protection.
+
+    Reserving the turn before sleeping (writing the *future* timestamp, not the
+    current one) is what makes concurrent callers for the same host stagger
+    instead of all waking up at the same instant and firing together.
 
     Args:
         min_interval: The minimum time, in seconds, between two requests to the
             same host.
+        clock: An injectable monotonic clock, so a test can assert the schedule
+            instead of waiting for it.
+        sleeper: An injectable sleep, same reason.
     """
 
-    def __init__(self, min_interval: float = 0.2) -> None:
+    def __init__(
+        self,
+        min_interval: float = 0.2,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._min = min_interval
         self._last: Dict[str, float] = {}
         self._lock = threading.Lock()
+        self._clock = clock
+        self._sleeper = sleeper
 
     def acquire(self, host: str) -> None:
         """Block, if necessary, until it is safe to hit ``host`` again.
@@ -939,10 +962,21 @@ class HostRateLimiter:
             host: The host about to be requested.
         """
         with self._lock:
-            wait = self._min - (time.monotonic() - self._last.get(host, 0.0))
-            if wait > 0:
-                time.sleep(wait)
-            self._last[host] = time.monotonic()
+            now = self._clock()
+            # El turno se reserva escribiendo la marca *futura*, no la actual:
+            # así dos hilos que piden el mismo host se escalonan en vez de
+            # despertarse a la vez y disparar juntos.
+            #
+            # Un host que no se ha visto nunca se distingue con None y no con
+            # un 0.0 por defecto: contra un reloj real da igual (0.0 queda
+            # infinitamente atrás), pero contra uno inyectado que empiece en
+            # cero, ese 0.0 haría esperar a la primera petición de cada host.
+            last_turn = self._last.get(host)
+            earliest = now if last_turn is None else max(now, last_turn + self._min)
+            self._last[host] = earliest
+        wait = earliest - now
+        if wait > 0:
+            self._sleeper(wait)
 
 
 class HttpProbe:

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -358,7 +358,7 @@ def _parse_check(c: dict) -> Check:
         )
         for request in c.get("requests", [])
     )
-    return Check(
+    check = Check(
         id=c["id"],
         version=c.get("version", 1),
         type=c.get("type", "http"),
@@ -371,6 +371,36 @@ def _parse_check(c: dict) -> Check:
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
+    )
+    _assert_service_is_reachable(check)
+    return check
+
+
+def _assert_service_is_reachable(check: Check) -> None:
+    """Fail loudly when a ``network`` check names a protocol nobody can match.
+
+    A check whose ``service`` has no predicate can never apply to anything: it
+    is a bug in the feed, not a runtime case. Left to fall through it looks
+    exactly like "this check simply did not fire against this host", which is
+    normal and unremarkable — so nobody ever finds out. Raising here puts the
+    error where a human is looking, at load time.
+
+    Only ``network`` checks are validated: the other families do not dispatch
+    on this field (``http`` and ``tls`` decide by service shape, ``script``
+    delegates to its plugin), so an odd ``service`` there is a label and not a
+    routing decision.
+
+    Args:
+        check: The freshly parsed check.
+
+    Raises:
+        ValueError: If a ``network`` check names an unknown protocol.
+    """
+    if check.type != "network" or check.service in _NETWORK_SERVICE_MATCHERS:
+        return
+    raise ValueError(
+        f"Check {check.id!r}: el servicio {check.service!r} no tiene predicado "
+        f"(disponibles: {', '.join(sorted(_NETWORK_SERVICE_MATCHERS))})"
     )
 
 
@@ -496,14 +526,34 @@ def is_snmp_service(service: Service) -> bool:
     return (service.name or "").lower() in _SNMP_SERVICE_NAMES or service.port in _SNMP_PORTS
 
 
-# Maps a ``type: "network"`` check's declared ``service`` (the feed's plain
-# string, e.g. ``"ftp"``) to the predicate that decides whether a discovered
-# Service is that protocol. One entry per protocol Fase N adds — the runtime
-# itself (``CheckRuntime._applies_network``) stays protocol-agnostic.
-_NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = {
-    "ftp": is_ftp_service,
-    "redis": is_redis_service,
-}
+def _network_service_matchers() -> Dict[str, Callable[[Service], bool]]:
+    """Derive the ``service`` → predicate map from this module's own predicates.
+
+    A ``type: "network"`` check declares which protocol it targets as a plain
+    string (``service: ftp``), and the runtime needs the predicate that decides
+    whether a discovered service *is* that protocol. That map used to be
+    written out by hand and had **two** entries while the module already
+    defined eleven predicates: a check for SMTP, MySQL or VNC loaded fine,
+    validated fine, and was then dropped without a word.
+
+    Deriving it removes the second edit entirely — defining
+    ``is_mongodb_service`` is all it takes for ``service: mongodb`` to work.
+
+    Introspection rather than the ``@register_dissector`` decorator the
+    fingerprinting package uses, and for a reason: a decorator would have to
+    restate the protocol name (``@service_predicate("ftp")``) that the
+    function name already carries, which is one more place for the two to
+    disagree. Here the naming convention *is* the registration.
+    """
+    suffix = "_service"
+    return {
+        name[len("is_"):-len(suffix)]: predicate
+        for name, predicate in globals().items()
+        if name.startswith("is_") and name.endswith(suffix) and callable(predicate)
+    }
+
+
+_NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = _network_service_matchers()
 
 
 # Protocol versions considered deprecated/weak for a service exposed today.
@@ -717,11 +767,25 @@ class CheckRuntime:
         :data:`_NETWORK_SERVICE_MATCHERS`, so the runtime itself never needs to
         know about a specific protocol — only each protocol's applicability
         predicate does.
+
+        A check the feed loader already rejected cannot reach this point, so an
+        unknown protocol here means a check that never went through it — one
+        translated from a Nuclei template, whose ``service`` is whatever the
+        upstream document said. It is still a check that can never fire, so it
+        is logged rather than silently skipped: the two cases (unknown protocol
+        / protocol that does not apply to this service) are not the same thing
+        and must not look the same.
         """
         if check.type != "network":
             return False
         matches = _NETWORK_SERVICE_MATCHERS.get(check.service)
-        if matches is None or not matches(service):
+        if matches is None:
+            logger.warning(
+                "Check %s declara el servicio %r, que no tiene predicado: no se ejecutará",
+                check.check_id, check.service,
+            )
+            return False
+        if not matches(service):
             return False
         return self._applies_mode(check)
 

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -72,11 +72,30 @@ QOD_CONFIRMED = 99
 # detection rules is the difference between being able to explain why a check
 # exists and not.
 _BUNDLED_FEED = Path(__file__).parent / "feeds" / "checks_feed.yaml"
-# Service names and ports that indicate an HTTP-speaking service worth probing.
+# Un mismo conjunto de puertos respondía antes a dos preguntas que no son la
+# misma —"¿esto habla TLS?" y "¿esto merece checks de higiene TLS?"— y las
+# respondía mal a las dos: tenía dos elementos, 443 y 8443. Un panel de
+# administración HTTPS en 9443 se sondeaba en claro y no recibía ningún check
+# de certificado.
+#
+# Ahora cada pregunta se responde por su lado. El **esquema** (http o https) ya
+# no se deduce del puerto: se observa, intentando el handshake (ver
+# :func:`negotiates_tls`). Lo que queda aquí es sólo la **candidatura**: a qué
+# servicios merece la pena acercarse siquiera.
 _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
-_HTTP_PORTS = {80, 443, 8080, 8443, 8000, 8888, 8008}
-# Ports we should reach over TLS.
-_TLS_PORTS = {443, 8443}
+
+# Puertos donde es habitual encontrar TLS. Deciden qué servicios reciben los
+# checks de higiene de certificado, no cómo se habla con ellos. La lista es una
+# red de seguridad barata, no una verdad: un TLS en un puerto que no esté aquí
+# se sondea igual de bien (el esquema se observa), pero no recibe los checks de
+# certificado. Ampliarla es gratis; hacerla innecesaria es #283, que ataca la
+# misma enfermedad —decidir por número de puerto— desde el otro lado.
+_TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986}
+
+# Puertos que se consideran servicio HTTP. Incluye los de TLS: un HTTPS en 9443
+# tampoco entraba por esta puerta, así que ampliar sólo la lista de TLS no
+# habría servido de nada.
+_HTTP_PORTS = {80, 8080, 8000, 8888, 8008} | _TLS_HYGIENE_PORTS
 # Service names and ports for FTP — Fase N's first ``type: "network"`` family.
 _FTP_SERVICE_NAMES = {"ftp"}
 _FTP_PORTS = {21}
@@ -451,15 +470,22 @@ def is_http_service(service: Service) -> bool:
 
 
 def is_tls_service(service: Service) -> bool:
-    """Return whether a service should be probed by TLS hygiene checks.
+    """Return whether a service is a candidate for the TLS hygiene checks.
+
+    Candidacy, not identification: this says "merece la pena intentar el
+    handshake aquí", and the checks themselves abandon quietly if there is no
+    TLS on the other side. It is deliberately *not* the function that decides
+    whether to speak HTTPS to a service — that is observed, not guessed (see
+    :func:`negotiates_tls`).
 
     Args:
         service: The service to test.
 
     Returns:
-        ``True`` if the service's port is one we reach over TLS.
+        ``True`` if the service's port is one where TLS is common enough to be
+        worth a handshake.
     """
-    return service.port in _TLS_PORTS
+    return service.port in _TLS_HYGIENE_PORTS
 
 
 def is_ftp_service(service: Service) -> bool:
@@ -1033,6 +1059,45 @@ class HostRateLimiter:
             self._sleeper(wait)
 
 
+def negotiates_tls(host: str, port: int, timeout: float = 5.0, connect: Optional[Callable] = None) -> bool:
+    """Return whether ``host:port`` completes a TLS handshake.
+
+    The question "is this HTTPS?" used to be answered by looking the port up in
+    a set of two. This asks the service instead, which is the only way to be
+    right about a panel someone chose to publish on 9443, or about a plain HTTP
+    server sitting on 8443 — the inverse mistake, and just as real.
+
+    Deliberately implemented here with ``ssl`` rather than by reusing
+    ``fingerprinting.tls.TlsProbe``, which does exactly this handshake plus
+    certificate parsing: this module must not import the fingerprinting
+    package, because the dissectors in it import their applicability predicates
+    from here and the two imports would close a cycle (the same reason
+    ``_TLS_RULES`` is duck-typed). What is shared is the reasoning, not the
+    code — and what this needs is a yes/no, not a certificate.
+
+    Args:
+        host: The target host.
+        port: The target port.
+        timeout: The connection timeout, in seconds.
+        connect: An injectable ``(address, timeout) -> socket`` callable, the
+            same pattern the probes use.
+
+    Returns:
+        ``True`` if the handshake completed, ``False`` on any failure —
+        including a plaintext server, which answers a TLS ``ClientHello`` with
+        something that is not a ``ServerHello`` and fails the handshake.
+    """
+    connect = connect or socket.create_connection
+    context = ssl._create_unverified_context()
+    try:
+        with connect((host, port), timeout) as sock:
+            with context.wrap_socket(sock, server_hostname=host):
+                return True
+    except Exception as err:  # noqa: BLE001 - cualquier fallo significa "no es TLS"
+        logger.debug("Scheme detection: %s:%s does not speak TLS (%s)", host, port, err)
+        return False
+
+
 class HttpProbe:
     """Performs the runtime's actual HTTP requests — safe, read-only GETs.
 
@@ -1045,11 +1110,24 @@ class HttpProbe:
     Args:
         timeout: The per-request timeout, in seconds.
         max_bytes: The maximum number of response body bytes to read.
+        detect_scheme: An injectable ``(host, port) -> bool`` telling whether
+            the service speaks TLS. Defaults to :func:`negotiates_tls`; a test
+            passes a stub instead of opening a socket.
     """
 
-    def __init__(self, timeout: int = 8, max_bytes: int = 131072) -> None:
+    def __init__(
+        self,
+        timeout: int = 8,
+        max_bytes: int = 131072,
+        detect_scheme: Optional[Callable[[str, Optional[int]], bool]] = None,
+    ) -> None:
         self._timeout = timeout
         self._max_bytes = max_bytes
+        self._detect_scheme = detect_scheme or (lambda host, port: negotiates_tls(host, port, timeout))
+        # El esquema se observa una vez por servicio y se recuerda: la pregunta
+        # es sobre el servicio, no sobre la petición, y no cambia entre una y
+        # otra dentro del mismo escaneo.
+        self._schemes: Dict[tuple, str] = {}
         # E7: este probe se queda deliberadamente en ``urllib`` mientras el
         # resto del tráfico HTTP ordinario del proyecto (aegis/pills.py,
         # lybra/kb.py) usa ``requests``. Una sonda de seguridad necesita
@@ -1117,7 +1195,7 @@ class HttpProbe:
         HTTPS uses an unverified TLS context, since we are scanning arbitrary
         hosts whose certificates we do not control.
         """
-        scheme = "https" if port in _TLS_PORTS else "http"
+        scheme = self._scheme_for(host, port)
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
         try:
@@ -1130,6 +1208,20 @@ class HttpProbe:
         except Exception as err:  # noqa: BLE001 - transport failure: abandon this check
             logger.debug("HTTP probe failed for %s: %s", url, err)
             return None
+
+    def _scheme_for(self, host: str, port: Optional[int]) -> str:
+        """Return ``"https"`` or ``"http"`` for a service, observing it once.
+
+        A service with no port at all (an inventory entry, say) is not
+        something to shake hands with, so it keeps the plain default rather
+        than paying for a probe that has nowhere to connect.
+        """
+        if port is None:
+            return "http"
+        key = (host, port)
+        if key not in self._schemes:
+            self._schemes[key] = "https" if self._detect_scheme(host, port) else "http"
+        return self._schemes[key]
 
     @staticmethod
     def _to_response(status: int, body: bytes, headers) -> Response:

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -54,9 +54,13 @@ logger = logging.getLogger(__name__)
 # ``type: "network"`` check; checks-3: "redis-unauthenticated-access", the
 # second ``network`` protocol; checks-4: "smb-signing-not-required", the first
 # ``type: "script"`` check; checks-5: "snmp-default-community", the first
-# check over UDP) — never for a fix to an existing check, which bumps that
-# check's own ``version`` instead (see ``Check.check_id``).
-CHECKS_FEED_VERSION = "lybra-checks-5"
+# check over UDP; checks-6: el vocabulario ``read``/``expectBanner``, que es
+# capacidad nueva del esquema y no el arreglo de un check suelto) — nunca por
+# arreglar un check ya existente, que sube su propio ``version`` (ver
+# ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
+# en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
+# decir cuál de las dos formas lo produjo.
+CHECKS_FEED_VERSION = "lybra-checks-6"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -193,12 +197,18 @@ class Request:
         send: For ``type: "network"``, the raw payload to write before
             reading a reply (e.g. ``"USER anonymous\\r\\n"``). ``None`` reads
             without writing anything first. Unused by ``type: "http"``.
+        read: For ``type: "network"``, how the reply *ends* — see
+            :data:`NETWORK_READ_MODES`. The transport cannot know this on its
+            own: where a reply stops is a fact about the protocol, so the feed
+            declares it. Defaults to ``"line"``, the original behaviour.
+            Unused by ``type: "http"``.
     """
     method: str = "GET"
     path: str = "/"
     matchers: tuple = ()
     condition: str = "and"
     send: Optional[str] = None
+    read: str = "line"
 
     def evaluate(self, response: Response) -> bool:
         """Return whether this request's matchers are satisfied by a response.
@@ -247,6 +257,14 @@ class Check:
             to fall back to :data:`CHECKS_FEED_VERSION`. A single global
             constant stopped being truthful once checks could come from two
             feeds with independent version lines.
+        expect_banner: For ``type: "network"``, whether the server volunteers a
+            greeting the moment the connection opens (FTP, SMTP, POP3 and IMAP
+            all do; Redis and MySQL do not). When set, the runtime reads and
+            **discards** that greeting before writing the check's first
+            payload. Without it the greeting is still sitting in the socket
+            buffer and every subsequent read comes back one reply out of step
+            — the whole check then matches against the wrong text and silently
+            never fires.
         tags: Free-form labels (Nuclei's ``info.tags``, plus vendor/product
             metadata). Not used by the runtime, which runs whatever it is
             given: they exist so a *selector* can decide which of thousands of
@@ -266,6 +284,7 @@ class Check:
     script: Optional[str] = None
     namespace: str = "lybra"
     feed_version: Optional[str] = None
+    expect_banner: bool = False
     tags: tuple = ()
 
     @property
@@ -326,6 +345,7 @@ def _parse_check(c: dict) -> Check:
             path=request.get("path", "/"),
             condition=request.get("matchers-condition", "and"),
             send=request.get("send"),
+            read=_parse_read_mode(request.get("read"), c.get("id")),
             matchers=tuple(
                 Matcher(
                     type=matcher["type"],
@@ -350,7 +370,38 @@ def _parse_check(c: dict) -> Check:
         finding=c.get("finding", {}),
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
+        expect_banner=bool(c.get("expectBanner", False)),
     )
+
+
+def _parse_read_mode(declared: Optional[str], check_id: Optional[str]) -> str:
+    """Validate a request's declared ``read`` mode, defaulting to ``"line"``.
+
+    A mode nobody implements is a feed bug, not a runtime case: left to fall
+    back silently it would read one line where the protocol needs a block and
+    the check would simply never fire — the same class of silent false
+    negative this whole change exists to remove. So it raises at load time,
+    where a human is looking.
+
+    Args:
+        declared: The feed's ``read`` value, or ``None`` when absent.
+        check_id: The check being parsed, for the error message.
+
+    Returns:
+        The validated mode name.
+
+    Raises:
+        ValueError: If ``declared`` names a mode that does not exist.
+    """
+    if declared is None:
+        return "line"
+    mode = str(declared).strip().lower()
+    if mode not in NETWORK_READ_MODES:
+        raise ValueError(
+            f"Check {check_id!r}: modo de lectura {declared!r} desconocido "
+            f"(disponibles: {', '.join(sorted(NETWORK_READ_MODES))})"
+        )
+    return mode
 
 
 # =========================================================================
@@ -727,6 +778,12 @@ class CheckRuntime:
         over it in order (combined with AND, same as ``_run_check``) — the
         session, not a fresh connection per request, is what lets a login
         sequence like FTP's ``USER``/``PASS`` see its own prior state.
+
+        When the check declares ``expectBanner``, the server's unprompted
+        greeting is read and thrown away first. It has to be: the greeting is
+        already in the socket buffer at connect time, so leaving it there would
+        put every later read one reply out of step — the check would evaluate
+        ``USER``'s matchers against the greeting and never fire.
         """
         if self._rl is not None:
             self._rl.acquire(host)
@@ -734,8 +791,12 @@ class CheckRuntime:
         if session is None:
             return None
         try:
+            if check.expect_banner:
+                # Read as a block: a greeting may span several continuation
+                # lines, and a single-line one ends the block immediately.
+                session.exchange(None, read="block")
             for request in check.requests:
-                response = session.exchange(request.send)
+                response = session.exchange(request.send, read=request.read)
                 if response is None or not request.evaluate(response):
                     return None
             return self._finding(check, service)
@@ -930,45 +991,81 @@ class HttpProbe:
 # NETWORK PROBE (the network edge for ``type: "network"`` checks — Fase N)
 # =========================================================================
 
+# How a reply ends, declared per request by the feed (``read:``). The transport
+# cannot infer this: "one line" is a property of some protocols and of no
+# others, and guessing it wrong does not raise — it just reads the wrong bytes
+# and the check never fires.
+#
+#   line       One line, terminated by LF. The original behaviour and the
+#              default: right for a protocol whose every reply is one line.
+#   block      A multi-line status block, the shape FTP/SMTP/POP3 use: lines
+#              whose status code is followed by "-" are continuations, and the
+#              first line *without* that dash closes the block. Degrades to a
+#              single line when the server does not use continuations, which is
+#              what makes it safe as the banner reader for any protocol.
+#   resp-bulk  Redis' RESP bulk string: a "$<n>" header line followed by
+#              exactly n bytes of payload. Any other first line (an error like
+#              "-NOAUTH ...", a simple "+OK") is returned as-is, because that
+#              *is* the whole reply.
+NETWORK_READ_MODES = ("line", "block", "resp-bulk")
+
+# A status line whose code is followed by "-" instead of a space: the reply
+# continues on the next line (RFC 959 §4.2 for FTP, RFC 5321 §4.2 for SMTP).
+_STATUS_CONTINUATION_RE = re.compile(rb"^\d{3}-")
+
+
 class NetworkSession:
     """One TCP connection, shared across every request of a single check run.
 
-    Deliberately protocol-agnostic: it knows nothing about FTP, SMB or any
-    other protocol a future check targets — it only writes a payload (if any)
-    and reads back one line, decoded as text so the existing word/regex
-    matchers can evaluate it exactly like an HTTP response (``status=0`` and
-    empty ``headers``, since neither concept exists here).
+    Deliberately protocol-agnostic: it knows nothing about FTP, Redis or any
+    other protocol a check targets. What it does know is that *where a reply
+    ends* is a protocol decision, so the feed declares it per request (see
+    :data:`NETWORK_READ_MODES`) and this class only implements the mechanics.
+    The reply comes back decoded as text, so the existing word/regex matchers
+    evaluate it exactly like an HTTP response (``status=0`` and empty
+    ``headers``, since neither concept exists here).
+
+    Reads are buffered: whatever a read mode does not consume stays for the
+    next one, which is what lets a bulk-string read hand back the leftovers
+    instead of losing them. It also stops the previous byte-at-a-time
+    ``recv(1)`` loop, one system call per byte received.
 
     Args:
         sock: The connected socket this session wraps.
-        max_bytes: The maximum number of bytes to read per line.
+        max_bytes: The maximum number of bytes to read for a single reply. A
+            hostile or broken server must not be able to make us read forever.
     """
 
-    def __init__(self, sock, max_bytes: int = 4096) -> None:
+    _CHUNK = 4096
+
+    def __init__(self, sock, max_bytes: int = 65536) -> None:
         self._sock = sock
         self._max_bytes = max_bytes
+        self._buffer = b""
 
-    def exchange(self, send: Optional[str]) -> Optional[Response]:
-        """Write ``send`` (if any), then read and return one line of reply.
+    def exchange(self, send: Optional[str], read: str = "line") -> Optional[Response]:
+        """Write ``send`` (if any), then read one reply under the given mode.
 
         Args:
             send: The raw payload to write first, or ``None`` to only read —
-                the shape a banner-only check needs, since some protocols
-                (FTP) volunteer a line unprompted right after connecting.
+                the shape a banner-only read needs, since some protocols (FTP)
+                volunteer a greeting unprompted right after connecting.
+            read: How the reply ends — one of :data:`NETWORK_READ_MODES`.
 
         Returns:
-            A :class:`Response` wrapping the decoded line (``status=0``,
-            empty ``headers``), or ``None`` on any transport failure.
+            A :class:`Response` wrapping the decoded reply (``status=0``,
+            empty ``headers``), or ``None`` on a transport failure or an empty
+            reply.
         """
         try:
             if send is not None:
                 self._sock.sendall(send.encode("utf-8"))
-            data = b""
-            while not data.endswith(b"\n") and len(data) < self._max_bytes:
-                chunk = self._sock.recv(1)
-                if not chunk:
-                    break
-                data += chunk
+            if read == "block":
+                data = self._read_block()
+            elif read == "resp-bulk":
+                data = self._read_resp_bulk()
+            else:
+                data = self._read_line()
         except OSError as err:
             logger.debug("Network check exchange failed: %s", err)
             return None
@@ -983,6 +1080,74 @@ class NetworkSession:
             self._sock.close()
         except OSError:
             pass
+
+    def _fill(self) -> bool:
+        """Pull one more chunk off the socket into the buffer.
+
+        Returns:
+            ``False`` when the peer closed the connection (nothing more will
+            ever arrive), ``True`` otherwise.
+        """
+        chunk = self._sock.recv(self._CHUNK)
+        if not chunk:
+            return False
+        self._buffer += chunk
+        return True
+
+    def _read_line(self) -> bytes:
+        """Read up to and including the next LF, or whatever arrived before EOF."""
+        while b"\n" not in self._buffer and len(self._buffer) < self._max_bytes:
+            if not self._fill():
+                break
+        line, separator, rest = self._buffer.partition(b"\n")
+        self._buffer = rest
+        return line + separator
+
+    def _read_block(self) -> bytes:
+        """Read a status block: continuation lines plus the line that closes it."""
+        block = b""
+        while len(block) < self._max_bytes:
+            line = self._read_line()
+            if not line:
+                break
+            block += line
+            if not _STATUS_CONTINUATION_RE.match(line):
+                break
+        return block
+
+    def _read_resp_bulk(self) -> bytes:
+        """Read a RESP bulk string, or hand back a non-bulk reply untouched.
+
+        A bulk string announces its own length (``$3116``), so unlike every
+        other reply here its end is a byte count and not a delimiter. A reply
+        that is not a bulk string — an error, a simple string — is complete as
+        the single line it already is.
+        """
+        header = self._read_line()
+        if not header.startswith(b"$"):
+            return header
+        try:
+            length = int(header[1:].strip())
+        except ValueError:
+            return header
+        if length < 0:                      # "$-1" is RESP's null bulk string
+            return header
+        length = min(length, self._max_bytes)
+        while len(self._buffer) < length:
+            if not self._fill():
+                break
+        payload, self._buffer = self._buffer[:length], self._buffer[length:]
+        # RESP cierra el bulk con un CRLF que no cuenta en la longitud
+        # anunciada. Se descarta si ya está en el buffer, para que no se cuele
+        # como una línea vacía en la lectura siguiente. Deliberadamente no se
+        # pide más al socket para conseguirlo: el servidor manda ese CRLF
+        # pegado al contenido, y un recv extra sólo podría bloquear hasta el
+        # timeout — perdiendo una respuesta que ya teníamos entera.
+        if self._buffer.startswith(b"\r\n"):
+            self._buffer = self._buffer[2:]
+        elif self._buffer.startswith(b"\n"):
+            self._buffer = self._buffer[1:]
+        return payload
 
 
 class NetworkProbe:

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -24,7 +24,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Iterable, List, Optional, Tuple
 
-from .kb import load_product_aliases, normalize_cpe_to_23, normalize_product_name, parse_cpe23
+from .kb import (
+    load_product_aliases,
+    normalize_cpe_to_23,
+    normalize_product_name,
+    parse_cpe23,
+    split_distro_version,
+)
 
 
 # Quality of Detection for a bare "the port is open" observation. It is low
@@ -193,11 +199,18 @@ class LybraEngine:
         banner guess, so it earns a higher ``qod`` and is born ``confirmed`` —
         there is no back-port ambiguity to hedge against when the version came
         straight from the package manager.
+
+        When the discovered version is a distro package version, the title says
+        which upstream release it was matched as. Otherwise the finding is
+        unexplainable on its face: nothing in it would account for why a host
+        running ``2.4.49-1ubuntu1`` is reported against a CVE whose range ends
+        at ``2.4.49``, and "the matcher normalized it" is not something a
+        reader can be expected to know.
         """
         cve_id = cve.cve_id
         is_verified = service.origin == "inventory"
         return {
-            "title":        f"{service.label} — {cve_id}",
+            "title":        f"{self._version_label(service)} — {cve_id}",
             "category":     "outdated_software",
             "port":         service.port,
             "service":      service.name or service.product or None,
@@ -217,6 +230,27 @@ class LybraEngine:
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
             "state":        "open",
         }
+
+    @staticmethod
+    def _version_label(service: Service) -> str:
+        """The service's label, naming the upstream release when they differ.
+
+        ``apache2 1:2.4.49-1ubuntu1`` becomes
+        ``apache2 1:2.4.49-1ubuntu1 (upstream 2.4.49)``. A vendor banner, an
+        NVD-shaped version or anything else that carries no epoch or revision
+        is left exactly as it was — the note only appears where there is
+        actually something to explain.
+
+        Args:
+            service: The service the finding is about.
+
+        Returns:
+            The label to put in the finding's title.
+        """
+        _epoch, upstream, _revision = split_distro_version(service.version or "")
+        if not upstream or upstream == (service.version or "").strip():
+            return service.label
+        return f"{service.label} (upstream {upstream})"
 
     def _informational_finding(self, service: Service, resolved) -> dict:
         """Build the baseline informational finding for one service.

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -138,6 +138,16 @@ class LybraEngine:
             ``CpeMatch`` rows (Fase I-b, paso 2), consulted only when neither an
             embedded CPE nor :data:`CPE_PRODUCT_OVERRIDES` resolved the service.
             ``None`` disables this third strategy, leaving the first two.
+        feed_version: The reproducibility mark stamped on every finding this
+            engine emits. The caller passes one describing the state of the
+            knowledge base the findings were resolved against; omitting it
+            keeps :data:`FEED_VERSION`, the constant every stored finding
+            carried before this became injectable.
+
+            Why it is injected and not read here: the mark describes the
+            contents of the database, and this package is deliberately free of
+            the ORM. The manager knows the KB's state; the engine only stamps
+            what it is told.
     """
 
     FEED_VERSION = "lybra-0"
@@ -148,11 +158,13 @@ class LybraEngine:
         kev_lookup: Optional[Callable[[str], bool]] = None,
         epss_lookup: Optional[Callable[[str], Optional[float]]] = None,
         product_alias_lookup: Optional[Callable[[str], Optional[Tuple[str, str]]]] = None,
+        feed_version: Optional[str] = None,
     ) -> None:
         self._cve_lookup = cve_lookup
         self._kev_lookup = kev_lookup
         self._epss_lookup = epss_lookup
         self._product_alias_lookup = product_alias_lookup
+        self._feed_version = feed_version or self.FEED_VERSION
 
     def analyze(self, services: Iterable[Service]) -> List[dict]:
         """Produce the findings for a set of services.
@@ -224,7 +236,7 @@ class LybraEngine:
             "required_os":  getattr(cve, "required_os", None),
             "source":       "lybra",
             "check_id":     "lybra:version-match@1",
-            "feed_version": self.FEED_VERSION,
+            "feed_version": self._feed_version,
             "qod":          QOD_INVENTORY_MATCH if is_verified else QOD_VERSION_MATCH,
             "confirmed":    is_verified,   # a network-inferred match stays a hypothesis; Fase R confirms it actively
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
@@ -282,7 +294,7 @@ class LybraEngine:
             "cpe":          normalize_cpe_to_23(service.cpe) if service.cpe else None,
             "source":       "lybra",
             "check_id":     "lybra:open-port@1",
-            "feed_version": self.FEED_VERSION,
+            "feed_version": self._feed_version,
             "qod":          QOD_OPEN_PORT,
             "confirmed":    False,
             "cpe_resolved": resolved is not None,

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-5
+feedVersion: lybra-checks-6
 checks:
   - id: git-config-exposure
     version: 1
@@ -290,15 +290,24 @@ checks:
       title: Protocolo TLS obsoleto negociado (SSLv3/TLSv1.0/TLSv1.1)
       qod: 99
       confirmed: true
+  # expectBanner: un servidor FTP saluda (220 ...) en cuanto se abre la
+  # conexion, sin que el cliente pida nada. Ese saludo hay que consumirlo antes
+  # de escribir USER; si se deja en el buffer, la respuesta que se lee tras
+  # USER es el saludo y no el 331, y el check no dispara jamas.
+  # read: block — el saludo y las respuestas de FTP pueden venir en varias
+  # lineas (220-... / 220 ...), asi que el fin de la respuesta es "la primera
+  # linea cuyo codigo NO lleva guion", no "el primer salto de linea".
   - id: ftp-anonymous-login
-    version: 1
+    version: 2
     type: network
     category: default_credentials
     severity: HIGH
     service: ftp
     mode: safe
+    expectBanner: true
     requests:
       - send: "USER anonymous\r\n"
+        read: block
         matchers-condition: and
         matchers:
           - type: word
@@ -306,6 +315,7 @@ checks:
             words:
               - '331'
       - send: "PASS anonymous@lybra.local\r\n"
+        read: block
         matchers-condition: and
         matchers:
           - type: word
@@ -316,8 +326,14 @@ checks:
       title: 'FTP: login anónimo permitido'
       qod: 99
       confirmed: true
+  # Redis no saluda: no lleva expectBanner. Lo que si tiene es una respuesta
+  # que no termina en el primer salto de linea — INFO devuelve un "bulk string"
+  # RESP, es decir una linea con la longitud ($3116) seguida de esos bytes. Con
+  # read: line se leia "$3116" y se buscaba redis_version ahi dentro, que
+  # nunca esta. Una respuesta que no sea bulk (el error -NOAUTH, por ejemplo)
+  # vuelve tal cual, que es justo lo que el matcher negativo necesita ver.
   - id: redis-unauthenticated-access
-    version: 1
+    version: 2
     type: network
     category: default_credentials
     severity: CRITICAL
@@ -325,6 +341,7 @@ checks:
     mode: safe
     requests:
       - send: "INFO\r\n"
+        read: resp-bulk
         matchers-condition: and
         matchers:
           - type: word

--- a/API/src/modules/features/themis/lybra/fingerprinting/smb.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/smb.py
@@ -55,7 +55,14 @@ _DIALECT_LABELS = {
 }
 
 # SMB2_NEGOTIATE_SIGNING_REQUIRED (MS-SMB2 §2.2.4, SecurityMode bit 0x0002).
-_SIGNING_REQUIRED_BIT = 0x0002
+#
+# Público a propósito: es el hecho de seguridad que el servidor declara sobre
+# sí mismo, y quien tenga que decidir sobre él —el fingerprint de aquí abajo,
+# el plugin `smb-signing-not-required` de ``script_checks``— debe leer este
+# bit y no la etiqueta legible que se deriva de él. Una etiqueta es prosa para
+# humanos; convertirla en el protocolo entre dos piezas de código hace que
+# retocar el texto apague un check en silencio.
+SIGNING_REQUIRED_BIT = 0x0002
 
 _SMB2_HEADER_LEN = 64
 _PROTOCOL_ID = b"\xfeSMB"
@@ -157,7 +164,7 @@ def fingerprint_smb(dialect_revision: int, security_mode: int) -> SmbFingerprint
     version = _DIALECT_LABELS.get(dialect_revision)
     if version is None:
         return SmbFingerprint(product=None, version=None, confidence=0.0)
-    signing_required = bool(security_mode & _SIGNING_REQUIRED_BIT)
+    signing_required = bool(security_mode & SIGNING_REQUIRED_BIT)
     product = "SMB2" if signing_required else "SMB2 (firma no requerida)"
     return SmbFingerprint(product=product, version=version, confidence=0.9)
 

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -413,8 +413,21 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
     """Choose the best available CVSS metric from an NVD ``metrics`` block.
 
     A CVE may carry several CVSS versions at once; we prefer the newest
-    (v3.1 over v3.0 over v2), since that is the most accurate scoring the entry
-    offers.
+    (v4.0 over v3.1 over v3.0 over v2), since that is the most accurate scoring
+    the entry offers.
+
+    **v4.0 goes first, and that is the whole point of the order.** It is the
+    most recent and most precise metric an entry can carry, which is the same
+    rule the rest of the chain already followed — but until it was listed here
+    a CVE whose *only* published metric was v4 came back empty, and empty is
+    not a cosmetic gap downstream: ``_cvss_band`` reads a missing score as
+    ``0.0``, which is INFO. A critical vulnerability published only with v4
+    was landing in reports as informational, and the AI summary described it
+    as such.
+
+    The v4 ``cvssData`` block exposes ``baseScore``, ``vectorString`` and
+    ``baseSeverity`` under the very same names as v3.x, so nothing below this
+    line has to know which version it is reading.
 
     Args:
         metrics: The ``metrics`` object of an NVD CVE record.
@@ -423,7 +436,7 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
         A ``(base_score, vector_string, severity)`` tuple. Each element is
         ``None`` if no CVSS metric of any version is present.
     """
-    for key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+    for key in ("cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
         entries = metrics.get(key) or []
         if not entries:
             continue

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -54,6 +54,68 @@ logger = logging.getLogger(__name__)
 # VERSION LOGIC
 # =========================================================================
 
+# Una revisión de distribución empieza por dígito ("1ubuntu1", "2",
+# "1+deb11u1") o es la forma de Alpine ("r0"). Lo que va tras un guion y no
+# encaja aquí —"rc1", "beta", "pre"— es una preversión del fabricante, que
+# significa lo contrario: no acompaña a una versión, la precede. Distinguirlas
+# importa porque se tratan al revés (la revisión no cuenta frente a NVD; la
+# preversión ordena por debajo de su versión final).
+_DISTRO_REVISION_RE = re.compile(r"^(?:\d|r\d+$)")
+
+
+def split_distro_version(version: str) -> Tuple[Optional[int], str, Optional[str]]:
+    """Split a distribution package version into ``(epoch, upstream, revision)``.
+
+    A distro package version is not the vendor's version: Debian and its
+    derivatives write ``1:2.4.49-1ubuntu1``, where ``1:`` is the *epoch* (a
+    counter the distribution bumps when it has to renumber downwards) and
+    ``-1ubuntu1`` is the *revision* (which packaging of that same upstream
+    release this is). Alpine writes ``2.4.49-r0``. Only the middle part —
+    ``2.4.49`` — is the version the vendor released, and the only one NVD ever
+    talks about.
+
+    Both extras break comparison in *opposite* directions, which is why they
+    have to come off before comparing rather than be tolerated:
+
+    * The epoch is read as a leading component, so ``1:2.4.49`` compares as
+      ``[1, 2, 4, 49]`` and lands *below* ``2.4.49``.
+    * The revision is read as a trailing component, so ``2.4.49-1ubuntu1``
+      compares *above* ``2.4.49`` and falls outside a range that ends there.
+
+    Anything after a ``+`` is packaging or build metadata (``2.4.49+dfsg``,
+    ``1.0.0+20130313144700``) and is dropped from the upstream part, following
+    the same rule semver §10 states for build metadata: it never affects
+    precedence.
+
+    Args:
+        version: A raw version string, distro-flavoured or not.
+
+    Returns:
+        ``(epoch, upstream, revision)``. ``epoch`` and ``revision`` are
+        ``None`` when the string does not carry them — which is the normal
+        case for a vendor banner or an NVD bound, and is exactly what tells
+        the comparator it is not looking at a distro version.
+    """
+    remainder = version.strip()
+
+    epoch: Optional[int] = None
+    head, colon, tail = remainder.partition(":")
+    if colon and head.isdigit():
+        epoch = int(head)
+        remainder = tail
+
+    revision: Optional[str] = None
+    if "-" in remainder:
+        # El último guion es el que separa: una versión upstream puede llevar
+        # guiones propios, la revisión de distribución nunca.
+        upstream, _, candidate = remainder.rpartition("-")
+        if _DISTRO_REVISION_RE.match(candidate):
+            revision = candidate
+            remainder = upstream
+
+    return epoch, remainder.split("+", 1)[0], revision
+
+
 def _version_key(version: str) -> List[tuple]:
     """Break a version string into components that sort correctly.
 
@@ -78,6 +140,18 @@ def _version_key(version: str) -> List[tuple]:
     return key
 
 
+def _compare_keys(key_a: List[tuple], key_b: List[tuple]) -> int:
+    """Compare two component lists, padding the shorter one with zeros."""
+    for index in range(max(len(key_a), len(key_b))):
+        token_a = key_a[index] if index < len(key_a) else (1, 0, "")
+        token_b = key_b[index] if index < len(key_b) else (1, 0, "")
+        if token_a < token_b:
+            return -1
+        if token_a > token_b:
+            return 1
+    return 0
+
+
 def version_compare(a: str, b: str) -> int:
     """Compare two version strings component by component.
 
@@ -87,6 +161,27 @@ def version_compare(a: str, b: str) -> int:
     are treated as equal. This is good enough for the dotted vendor versions the
     matcher sees; it is not a full PEP 440 / semver implementation.
 
+    **Distro package versions are normalized first** (see
+    :func:`split_distro_version`), because the matcher's two inputs are not the
+    same kind of string: one side is a package version from an agent inventory
+    (``1:2.4.49-1ubuntu1``), the other is a bound NVD published, and NVD only
+    ever speaks upstream. Comparing the extras against something that cannot
+    have them is a category error, and it broke in both directions at once —
+    an epoch produced false positives by dragging the version down, a revision
+    produced false negatives by pushing it past the top of a range.
+
+    Two deliberate asymmetries, both following from that:
+
+    * **Epochs count only when both sides have one.** Between two distro
+      versions the epoch is the most significant component and is honoured.
+      Against an NVD bound, which never carries one, it is dropped from both
+      sides rather than compared against an implicit zero.
+    * **Revisions count only as a tiebreaker, and only when both sides have
+      one.** ``2.4.49-1`` is older than ``2.4.49-2``, which matters when
+      ordering packages among themselves; but ``2.4.49-1ubuntu1`` against the
+      plain ``2.4.49`` compares *equal*, which is what makes a package land
+      inside the range its upstream release belongs to.
+
     Args:
         a: The first version string.
         b: The second version string.
@@ -95,14 +190,18 @@ def version_compare(a: str, b: str) -> int:
         ``-1`` if ``a`` is older than ``b``, ``0`` if they are equal, ``1`` if
         ``a`` is newer.
     """
-    ka, kb = _version_key(a), _version_key(b)
-    for i in range(max(len(ka), len(kb))):
-        token_a = ka[i] if i < len(ka) else (1, 0, "")
-        token_b = kb[i] if i < len(kb) else (1, 0, "")
-        if token_a < token_b:
-            return -1
-        if token_a > token_b:
-            return 1
+    epoch_a, upstream_a, revision_a = split_distro_version(a)
+    epoch_b, upstream_b, revision_b = split_distro_version(b)
+
+    if epoch_a is not None and epoch_b is not None and epoch_a != epoch_b:
+        return -1 if epoch_a < epoch_b else 1
+
+    upstream_order = _compare_keys(_version_key(upstream_a), _version_key(upstream_b))
+    if upstream_order != 0:
+        return upstream_order
+
+    if revision_a is not None and revision_b is not None:
+        return _compare_keys(_version_key(revision_a), _version_key(revision_b))
     return 0
 
 

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -205,6 +205,41 @@ def version_compare(a: str, b: str) -> int:
     return 0
 
 
+def kb_feed_version(state: Dict[str, Optional[datetime]]) -> str:
+    """Build the reproducibility mark for findings resolved against the KB.
+
+    Every version-detection finding used to carry the constant ``"lybra-0"``,
+    which never changed. Two findings emitted six months apart —one against a
+    knowledge base with the full catalogue, another against one half
+    populated— were stamped identically, so a stored finding could not say what
+    it had been compared against. That breaks three things at once: an old
+    report cannot be reproduced, a finding that disappeared cannot be
+    explained (was the host fixed, or did the KB change?), and the lifecycle
+    can mark something ``fixed`` that merely stopped matching because NVD
+    rewrote a range.
+
+    The mark reads ``lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30``.
+    Spelled out rather than hashed on purpose: the point is that someone
+    reading a finding a year from now can tell what it was resolved against,
+    and a hash only says "not the same as that other one" — it needs a lookup
+    table that does not exist yet (#302). A source with no date reports
+    ``none``, which is honest: an empty knowledge source is exactly the thing
+    this mark exists to make visible.
+
+    Args:
+        state: ``{"nvd": datetime | None, "kev": ..., "epss": ...}``, as
+            :meth:`KbRepository.knowledge_state` returns it.
+
+    Returns:
+        The mark, e.g. ``"lybra-kb:nvd=2026-08-29,kev=none,epss=2026-08-30"``.
+    """
+    parts = []
+    for source in ("nvd", "kev", "epss"):
+        moment = state.get(source)
+        parts.append(f"{source}={moment.date().isoformat() if moment else 'none'}")
+    return "lybra-kb:" + ",".join(parts)
+
+
 def _bound(match, name: str) -> Optional[str]:
     """Read one range-bound field off a match, whether it is an ORM row or a dict.
 
@@ -744,7 +779,16 @@ def parse_epss_rows(csv_text: str) -> Iterator[dict]:
 def _epss_scored_at(csv_text: str) -> Optional[datetime]:
     """Read the scoring date out of the EPSS file's comment header.
 
-    The header looks like ``#model_version:...,score_date=2026-07-01T...``.
+    The header looks like ``#model_version:v2026.06.15,score_date:2026-08-30T...``.
+
+    **Both separators are accepted, and that is not defensive coding.** This
+    used to look for ``score_date=`` only, and the feed publishes
+    ``score_date:`` — so the date came back ``None`` every single time, and the
+    column silently stayed empty: 353.521 EPSS rows in a full mirror, not one
+    of them with a scoring date. Nothing failed, because a missing date is
+    indistinguishable from a feed that does not carry one. Accepting either
+    character costs nothing and removes a whole class of "the header changed a
+    punctuation mark and we lost the field".
 
     Args:
         csv_text: The full decoded text of the EPSS CSV file.
@@ -752,7 +796,7 @@ def _epss_scored_at(csv_text: str) -> Optional[datetime]:
     Returns:
         The parsed scoring date, or ``None`` if the header does not carry one.
     """
-    match = re.search(r"score_date=(\d{4}-\d{2}-\d{2})", csv_text[:512])
+    match = re.search(r"score_date[=:](\d{4}-\d{2}-\d{2})", csv_text[:512])
     return _parse_dt(match.group(1)) if match else None
 
 

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -37,7 +37,7 @@ from typing import Dict, Optional
 
 from .checks import ScriptContext, ScriptPlugin, is_smb_service, is_snmp_service
 from .engine import Service
-from .fingerprinting.smb import SmbProbe, fingerprint_smb
+from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
 from .fingerprinting.snmp import SnmpProbe
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,15 @@ class SmbSigningNotRequiredPlugin(ScriptPlugin):
     manipular el tráfico SMB (la familia de ataques de relay). El dato no se
     infiere: sale del ``SecurityMode`` que el propio servidor devuelve en su
     respuesta NEGOTIATE, así que el hallazgo nace ``confirmed``.
+
+    **La decisión se toma sobre el bit, no sobre la etiqueta.** Este plugin
+    llegó a resolverse buscando la subcadena ``"firma no requerida"`` dentro
+    del texto legible que produce ``fingerprint_smb``. Eso ataba una decisión
+    de seguridad a una cadena de interfaz: traducir esa etiqueta, corregirle
+    una tilde o cambiarle el fraseo apagaba el check **en silencio** —seguía
+    ejecutándose, seguía devolviendo ``False``, y nadie se enteraba de que
+    había dejado de detectar nada—. El dato crudo estaba dos líneas más
+    arriba, en la misma tupla.
 
     Args:
         probe: Sonda inyectable, para que un test use un socket falso — mismo
@@ -71,12 +80,14 @@ class SmbSigningNotRequiredPlugin(ScriptPlugin):
             # Sin negociación no hay evidencia, y sin evidencia no hay hallazgo.
             return False
         dialect_revision, security_mode = result
-        fingerprint = fingerprint_smb(dialect_revision, security_mode)
-        if fingerprint.product is None:
+        if fingerprint_smb(dialect_revision, security_mode).version is None:
             # Respuesta no reconocible: se ignora en vez de asumir lo peor. Un
             # dialecto desconocido no es prueba de que la firma no se exija.
+            # Se consulta ``version`` —un campo con tipo— y no el texto del
+            # producto: lo que hace falta saber aquí es si la respuesta se
+            # entendió, y eso es justo lo que ese campo significa.
             return False
-        return "firma no requerida" in fingerprint.product
+        return not security_mode & SIGNING_REQUIRED_BIT
 
 
 class SnmpDefaultCommunityPlugin(ScriptPlugin):

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -33,6 +33,7 @@ from ...lybra import (
     default_dissectors,
     agrees_with_nmap,
     HostRateLimiter,
+    kb_feed_version,
     load_checks,
     CheckRuntime,
     HttpProbe,
@@ -275,6 +276,7 @@ class LybraEngineManager(ScanManager):
                     kev_lookup=lambda cve_id: kb_repo.get_kev(cve_id) is not None,
                     epss_lookup=lambda cve_id: getattr(kb_repo.get_epss(cve_id), "score", None),
                     product_alias_lookup=kb_repo.resolve_product_alias,
+                    feed_version=kb_feed_version(kb_repo.knowledge_state()),
                 )
                 findings_data = engine.analyze(services)
                 findings_data.extend(fingerprint_findings)

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -831,7 +831,12 @@ class Finding(Base):
     # Quality / provenance
     source       = Column(String(32), index=True)
     check_id     = Column(String(128))
-    feed_version = Column(String(32))
+    # 64 y no 32: desde #270 la marca de la detección por versión describe el
+    # estado de la base de conocimiento ("lybra-kb:nvd=2026-08-29,kev=...,
+    # epss=..."), que ocupa hasta 54 caracteres. Se escribe entera en vez de
+    # resumirla en un hash para que un hallazgo guardado siga diciendo, por sí
+    # solo, contra qué se resolvió.
+    feed_version = Column(String(64))
     dedup_key    = Column(String(64), index=True)
     qod          = Column(Integer)
     confirmed    = Column(Boolean, default=False)

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -1153,6 +1153,30 @@ class KbRepository(BaseRepository[CveEntry]):
             .all()
         )
 
+    def knowledge_state(self) -> dict:
+        """The newest date each KB source carries, as the mirror stands right now.
+
+        This is what makes a finding reproducible: two scans of the same target
+        can disagree because the target changed **or** because the knowledge
+        base learned something in between, and without this there is no way to
+        tell those two apart after the fact.
+
+        Read from the data itself rather than from a sync log, because there is
+        no sync log — recording when each source was last synchronised is
+        #302. These dates are the closest honest proxy: not "when did we last
+        ask NVD", but "how recent is the newest thing we know". A source with
+        no rows, or whose rows carry no date, reports ``None``, which is
+        information too and must not be dressed up as a date.
+
+        Returns:
+            ``{"nvd": datetime | None, "kev": ..., "epss": ...}``.
+        """
+        return {
+            "nvd":  self._session.query(func.max(CveEntry.last_modified)).scalar(),
+            "kev":  self._session.query(func.max(KevEntry.date_added)).scalar(),
+            "epss": self._session.query(func.max(EpssScore.scored_at)).scalar(),
+        }
+
     def counts(self) -> dict:
         """Row counts per KB table (for the sync summary / health checks)."""
         return {

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -601,24 +601,42 @@ def test_lybra_active_check_persists_confirmed_finding(app, admin_user, monkeypa
 
 def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, admin_user, monkeypatch):
     """Fase N: the runtime's first ``type: "network"`` check, wired end to
-    end through the real manager (not a bare ``CheckRuntime``) — a scripted
-    fake session stands in for the raw TCP connection."""
+    end through the real manager (not a bare ``CheckRuntime``).
+
+    Lo que se sustituye es el **socket**, no la sesión: el ``NetworkSession``
+    real hace su trabajo, saludo incluido. Un doble por encima de la sesión
+    entrega respuestas que el transporte real no produce, y eso fue justo lo
+    que ocultó el bug de #265 (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.lybra import checks as checks_mod
 
     monkeypatch.setattr(CR, "lybra_config", lambda: CR.LybraConfig(active_checks=True))
 
-    class _FakeSession:
-        def __init__(self):
-            self._replies = iter(["331 Please specify the password.", "230 Login successful."])
+    class _FakeFtpSocket:
+        """Un vsftpd de mentira: saluda al conectar y contesta a cada comando."""
 
-        def exchange(self, send):
-            return checks_mod.Response(status=0, body=next(self._replies), headers={})
+        def __init__(self):
+            self._buffer = b"220 (vsFTPd 2.3.4)\r\n"
+            self._replies = [
+                b"331 Please specify the password.\r\n",
+                b"230 Login successful.\r\n",
+            ]
+
+        def recv(self, size):
+            chunk, self._buffer = self._buffer[:size], self._buffer[size:]
+            return chunk
+
+        def sendall(self, data):
+            if self._replies:
+                self._buffer += self._replies.pop(0)
 
         def close(self):
             pass
 
-    monkeypatch.setattr(checks_mod.NetworkProbe, "open", lambda self, host, port: _FakeSession())
+    monkeypatch.setattr(
+        checks_mod.NetworkProbe, "open",
+        lambda self, host, port: checks_mod.NetworkSession(_FakeFtpSocket()),
+    )
 
     ftp_ports = [
         {"protocol": "21/tcp", "reason": "syn-ack", "product": "vsftpd",
@@ -636,7 +654,7 @@ def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, 
         with UnitOfWork() as uow:
             findings = ScanRepository(uow).get_findings_by_scan(escan.id)
 
-    active = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@1"]
+    active = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@2"]
     assert len(active) == 1
     assert active[0].qod == 99
     assert active[0].confirmed is True

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import pytest
 
 from src.modules.infrastructure import UnitOfWork
-from src.modules.features.themis.model import NmapScan, NiktoScan, ScanStatus
+from src.modules.features.themis.model import Finding, NmapScan, NiktoScan, ScanStatus
 from src.modules.features.themis.repositories import ScanRepository, KbRepository
 from src.modules.features.themis.managers import LybraEngineManager, ScanManager, AuthorizedTargetManager
 from src.modules.features.themis.lybra import Service
@@ -506,6 +506,49 @@ def _seed_kb_apache_cve(app):
                              "date_added": None, "due_date": None})
             repo.upsert_epss({"cve_id": "CVE-2021-41773", "score": 0.97,
                               "percentile": 0.99, "scored_at": None})
+
+
+def test_a_scan_stamps_findings_with_the_state_of_the_knowledge_base(app, admin_user):
+    """#270: la marca de reproducibilidad sale del estado real de la KB.
+
+    Era la constante ``"lybra-0"`` para todos los hallazgos por versión, así que
+    un hallazgo guardado no podía decir contra qué conocimiento se resolvió.
+    Aquí se siembra la KB con fechas conocidas en las tres fuentes y se
+    comprueba que el escaneo las estampa.
+    """
+    from datetime import datetime
+
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            repo.upsert_kev({"cve_id": "CVE-2021-41773", "known_ransomware": False,
+                             "date_added": datetime(2026, 8, 27), "due_date": None})
+            repo.upsert_epss({"cve_id": "CVE-2021-41773", "score": 0.97, "percentile": 0.99,
+                              "scored_at": datetime(2026, 8, 30)})
+            repo.upsert_cve(
+                {"cve_id": "CVE-2021-41773", "cvss_score": 7.5, "cvss_vector": "CVSS:3.1/AV:N",
+                 "severity": "HIGH", "description": "Path traversal", "cwe_ids": ["CWE-22"],
+                 "source": "nvd", "last_modified": datetime(2026, 8, 29, 13, 19)},
+                [{"vendor": "apache", "product": "http_server", "exact_version": "2.4.49",
+                  "version_start_including": None, "version_start_excluding": None,
+                  "version_end_including": None, "version_end_excluding": None}],
+            )
+
+    nmap_id = _seed_nmap_scan(app, admin_user.id)
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id,
+                                        source_scan_id=nmap_id)
+        mgr._run_lybra(escan.id, nmap_id)
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    vuln = next(f for f in findings if f.category == "outdated_software")
+    assert vuln.feed_version == "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30"
+    # Y la marca cabe entera en la columna, sin recortes silenciosos.
+    assert len(vuln.feed_version) <= Finding.__table__.c.feed_version.type.length
 
 
 def _seed_kb_vsftpd_cve(app):

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -83,6 +83,50 @@ def _free_tls_port() -> int:
     return _TLS_PORT
 
 
+# Los checks ``network`` se seleccionan por nombre de servicio o por puerto
+# (``is_ftp_service`` / ``is_redis_service`` en checks.py), y el
+# autodescubrimiento sólo aporta el puerto. Así que estos contenedores tienen
+# que publicarse en el puerto canónico de su protocolo o el check ni se
+# consideraría. Son puertos fijos, no elegibles: si algo del host ya los ocupa
+# —un Redis de desarrollo en el 6379, por ejemplo— el caso se salta con un
+# motivo legible en vez de fallar por una colisión que no es del motor.
+_FTP_PORT = 21
+_REDIS_PORT = 6379
+
+
+def _require_free_port(port: int, label: str) -> None:
+    if not port_is_free("127.0.0.1", port):
+        pytest.skip(f"El puerto {port} ({label}) está ocupado en el host")
+
+
+def _vsftpd_container_cmd(anonymous: bool) -> str:
+    """Comando que instala y configura un vsftpd dentro del contenedor.
+
+    Se genera la configuración al arrancar, sin bind mount, por la misma razón
+    que el resto de fixtures de este módulo: evitar la traducción de rutas
+    WSL↔Docker Desktop.
+
+    ``no_anon_password=NO`` es deliberado y no un detalle: con ``YES`` el
+    servidor concede el acceso ya en el ``USER`` (responde 230 directamente) y
+    la secuencia USER→331→PASS→230 que el check espera no llega a existir. El
+    caso negativo mantiene ``local_enable=YES`` para que vsftpd tenga algún
+    modo de acceso habilitado y arranque, aunque no haya ninguna cuenta usable.
+    """
+    anonymous_enable = "YES" if anonymous else "NO"
+    local_enable = "NO" if anonymous else "YES"
+    settings = " ".join([
+        "'listen=YES'", "'listen_ipv6=NO'",
+        f"'anonymous_enable={anonymous_enable}'", f"'local_enable={local_enable}'",
+        "'no_anon_password=NO'", "'seccomp_sandbox=NO'", "'anon_root=/var/lib/ftp'",
+    ])
+    return (
+        "apk add --no-cache vsftpd >/dev/null 2>&1 && "
+        "mkdir -p /var/lib/ftp && chmod 555 /var/lib/ftp && "
+        f"printf '%s\\n' {settings} > /etc/vsftpd/vsftpd.conf && "
+        "vsftpd /etc/vsftpd/vsftpd.conf"
+    )
+
+
 def _tls_container_cmd(days: int, expired: bool) -> str:
     """Shell command that generates a self-signed cert *inside* the container
     at startup (no bind mount, same philosophy as ``git_exposed_port``) and
@@ -186,6 +230,65 @@ def tls_expired_port():
         docker_rm(_DOCKER, name)
 
 
+@pytest.fixture
+def ftp_anonymous_port():
+    """Un vsftpd real con el acceso anónimo **abierto**: el caso positivo."""
+    _require_free_port(_FTP_PORT, "FTP")
+    name = f"lybra-oracle-ftp-anon-{_FTP_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
+            "sh", "-c", _vsftpd_container_cmd(anonymous=True))
+    try:
+        _wait_for_port("127.0.0.1", _FTP_PORT)
+        yield _FTP_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def ftp_no_anonymous_port():
+    """El mismo vsftpd con el acceso anónimo **cerrado**: el control negativo.
+
+    Sin él, el caso positivo no demuestra gran cosa — un check que disparase
+    siempre también pasaría el positivo.
+    """
+    _require_free_port(_FTP_PORT, "FTP")
+    name = f"lybra-oracle-ftp-noanon-{_FTP_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
+            "sh", "-c", _vsftpd_container_cmd(anonymous=False))
+    try:
+        _wait_for_port("127.0.0.1", _FTP_PORT)
+        yield _FTP_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def redis_open_port():
+    """Un ``redis:7`` sin contraseña: cualquiera puede pedirle un INFO."""
+    _require_free_port(_REDIS_PORT, "Redis")
+    name = f"lybra-oracle-redis-open-{_REDIS_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7")
+    try:
+        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        yield _REDIS_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture
+def redis_password_port():
+    """El mismo ``redis:7`` con ``requirepass``: contesta ``-NOAUTH`` al INFO."""
+    _require_free_port(_REDIS_PORT, "Redis")
+    name = f"lybra-oracle-redis-auth-{_REDIS_PORT}"
+    _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7",
+            "redis-server", "--requirepass", "lybra-oracle")
+    try:
+        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        yield _REDIS_PORT
+    finally:
+        docker_rm(_DOCKER, name)
+
+
 def _run_self_discovery(app, admin_user, target: str, port: int, monkeypatch):
     """Lanza un escaneo Lybra de autodescubrimiento real contra ``target:port``.
 
@@ -280,6 +383,57 @@ def test_tls_expired_cert_detected_against_real_container(app, admin_user, tls_e
     tls_findings = {f.check_id for f in findings if f.category == "tls"}
     assert tls_findings == {"lybra:tls-self-signed-cert@1", "lybra:tls-expired-cert@1"}
     assert all(f.confirmed and f.qod == 99 for f in findings if f.category == "tls")
+
+
+# ------------------------------------------- familia network contra servidores reales
+#
+# Los cuatro casos que cierran #265. Hasta aquí, los dos únicos checks no-web
+# del motor sólo se habían ejercitado contra dobles, y por eso nadie vio que el
+# transporte leía una forma de respuesta que ni FTP ni Redis producen: el
+# escaneo terminaba en verde y el FTP anónimo seguía ahí. Un positivo y un
+# negativo por protocolo, contra el servidor de verdad.
+
+def test_ftp_anonymous_login_detected_against_real_vsftpd(app, admin_user, ftp_anonymous_port, monkeypatch):
+    """Con el acceso anónimo abierto, el check tiene que confirmarlo.
+
+    Es la prueba de que el saludo (``220 ...``) se consume antes de escribir
+    ``USER`` y de que la respuesta se lee como bloque de estado: sin las dos
+    cosas, el check evalúa el saludo contra el matcher del ``331`` y calla.
+    """
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", ftp_anonymous_port, monkeypatch)
+
+    ftp = [f for f in findings if f.check_id == "lybra:ftp-anonymous-login@2"]
+    assert len(ftp) == 1, f"hallazgos: {[(f.category, f.title) for f in findings]}"
+    assert ftp[0].confirmed is True and ftp[0].qod == 99
+    assert ftp[0].category == "default_credentials"
+    assert ftp[0].port == 21
+
+
+def test_ftp_anonymous_login_absent_against_a_locked_down_vsftpd(app, admin_user, ftp_no_anonymous_port, monkeypatch):
+    """Con el acceso anónimo cerrado, el mismo check no debe producir nada."""
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", ftp_no_anonymous_port, monkeypatch)
+    assert not any(f.check_id.startswith("lybra:ftp-anonymous-login") for f in findings)
+
+
+def test_redis_unauthenticated_access_detected_against_real_redis(app, admin_user, redis_open_port, monkeypatch):
+    """Un Redis sin contraseña contesta al INFO, y eso es el hallazgo.
+
+    Prueba de que la respuesta se lee como *bulk string*: el contenido va
+    detrás de una línea que sólo trae su longitud, así que leyendo una línea
+    suelta nunca se llegaba a ver ``redis_version``.
+    """
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", redis_open_port, monkeypatch)
+
+    redis_findings = [f for f in findings if f.check_id == "lybra:redis-unauthenticated-access@2"]
+    assert len(redis_findings) == 1, f"hallazgos: {[(f.category, f.title) for f in findings]}"
+    assert redis_findings[0].confirmed is True and redis_findings[0].qod == 99
+    assert redis_findings[0].category == "default_credentials"
+
+
+def test_redis_unauthenticated_access_absent_when_requirepass_is_set(app, admin_user, redis_password_port, monkeypatch):
+    """Con ``requirepass``, el INFO recibe ``-NOAUTH`` y no hay hallazgo."""
+    findings = _run_self_discovery(app, admin_user, "127.0.0.1", redis_password_port, monkeypatch)
+    assert not any(f.check_id.startswith("lybra:redis-unauthenticated-access") for f in findings)
 
 
 @pytest.mark.skipif(_NMAP is None, reason="nmap no disponible")

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -22,7 +22,9 @@ usuario, no como una puerta de cada commit.
 from __future__ import annotations
 
 import shutil
+import socket
 import subprocess
+import time
 
 import pytest
 
@@ -97,6 +99,49 @@ _REDIS_PORT = 6379
 def _require_free_port(port: int, label: str) -> None:
     if not port_is_free("127.0.0.1", port):
         pytest.skip(f"El puerto {port} ({label}) está ocupado en el host")
+
+
+def _wait_until_answering(port: int, expect: bytes, send: bytes = None, timeout: float = 120.0) -> None:
+    """Espera a que el servicio conteste lo que se espera de él, no sólo a que el puerto acepte.
+
+    ``wait_for_port`` no vale para estos dos contenedores. Docker publica el
+    puerto en el host en cuanto arranca el contenedor, así que el TCP acepta a
+    los 0,0 s — medido — mientras dentro todavía se está instalando el
+    servidor. Un escaneo lanzado en ese hueco encuentra una conexión que se
+    cierra sin decir nada, el check se abandona, y el test falla por una
+    carrera de arranque que no tiene nada que ver con el motor. Es exactamente
+    lo que pasó la primera vez que se ejecutaron estas pruebas.
+
+    Exigir además el saludo correcto (``220`` en FTP, ``+PONG`` o ``-NOAUTH``
+    en Redis) hace de paso de comprobación de que el contenedor quedó
+    configurado como el caso pide: un control negativo mal montado falla aquí,
+    en voz alta, en vez de pasar el test sin demostrar nada.
+
+    Args:
+        port: El puerto publicado en 127.0.0.1.
+        expect: El prefijo con el que debe empezar la respuesta.
+        send: Lo que hay que escribir para provocarla, o ``None`` si el
+            protocolo saluda solo.
+        timeout: Cuánto esperar antes de rendirse — generoso, porque la
+            primera ejecución instala paquetes dentro del contenedor.
+    """
+    deadline = time.monotonic() + timeout
+    seen = b""
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=2.0) as sock:
+                sock.settimeout(2.0)
+                if send is not None:
+                    sock.sendall(send)
+                seen = sock.recv(128)
+                if seen.startswith(expect):
+                    return
+        except OSError:
+            pass
+        time.sleep(0.3)
+    raise TimeoutError(
+        f"127.0.0.1:{port} no contestó {expect!r} en {timeout}s (última respuesta: {seen!r})"
+    )
 
 
 def _vsftpd_container_cmd(anonymous: bool) -> str:
@@ -238,7 +283,7 @@ def ftp_anonymous_port():
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=True))
     try:
-        _wait_for_port("127.0.0.1", _FTP_PORT)
+        _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -256,7 +301,7 @@ def ftp_no_anonymous_port():
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=False))
     try:
-        _wait_for_port("127.0.0.1", _FTP_PORT)
+        _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -269,7 +314,7 @@ def redis_open_port():
     name = f"lybra-oracle-redis-open-{_REDIS_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7")
     try:
-        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        _wait_until_answering(_REDIS_PORT, expect=b"+PONG", send=b"PING\r\n")
         yield _REDIS_PORT
     finally:
         docker_rm(_DOCKER, name)
@@ -283,7 +328,7 @@ def redis_password_port():
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7",
             "redis-server", "--requirepass", "lybra-oracle")
     try:
-        _wait_for_port("127.0.0.1", _REDIS_PORT)
+        _wait_until_answering(_REDIS_PORT, expect=b"-NOAUTH", send=b"PING\r\n")
         yield _REDIS_PORT
     finally:
         docker_rm(_DOCKER, name)

--- a/API/tests/unit/test_hygeia_inventory_adapter.py
+++ b/API/tests/unit/test_hygeia_inventory_adapter.py
@@ -121,24 +121,32 @@ def test_other_sources_are_left_alone():
         assert services[0].version == expected, f"{item} -> {services[0].version}"
 
 
-def test_the_stripped_version_matches_an_nvd_range_that_the_raw_one_missed():
+def test_the_stripped_version_matches_an_nvd_range():
     """El motivo de todo esto, comprobado contra el comparador de verdad.
 
     Un rango ``version_start_including="2.39"`` debe casar con la libc de un
-    Ubuntu que reporta "2.39-0ubuntu8.3". Con la versión sin recortar no casa:
-    ``version_compare`` parte la cadena en tramos de dígitos y letras, las
-    letras ordenan por debajo de los números, y el sufijo de empaquetado deja
-    la versión instalada por debajo del inicio del rango.
+    Ubuntu que reporta "2.39-0ubuntu8.3".
+
+    Este test afirmaba también lo contrario para la versión **sin** recortar
+    (``version_compare(raw, "2.39") < 0``), porque entonces era cierto: el
+    comparador partía la cadena en tramos de dígitos y de letras, y el sufijo
+    de empaquetado dejaba la instalada por debajo del inicio del rango. Desde
+    #267 ya no lo es — el comparador reconoce y separa la revisión de
+    distribución él mismo, así que las dos formas comparan igual. Afirmar aquí
+    el fallo antiguo sería congelarlo.
+
+    Que el recorte del adaptador siga existiendo no sobra: es lo que hace que
+    ``Service.version`` sea la versión de origen para el resto del motor. Pero
+    ya no es la única defensa, ni la que decide si la CVE se reporta.
     """
     from src.modules.features.themis.lybra import version_compare
 
     raw = "2.39-0ubuntu8.3"
-    # El fallo que se está corrigiendo: sin recortar, la instalada parece
-    # anterior al inicio del rango y la CVE no se reportaría.
-    assert version_compare(raw, "2.39") < 0
-
     services = services_from_inventory([_deb("libc6", raw)])
+
     assert version_compare(services[0].version, "2.39") == 0
+    # Y la cruda compara igual, sin depender del recorte de aguas arriba.
+    assert version_compare(raw, "2.39") == 0
 
 
 def test_stripping_never_leaves_the_version_empty():

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,127 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# ------------------------------------------- esquema observado, no deducido
+#
+# El motor decidía si hablar HTTP o HTTPS mirando si el puerto estaba en un
+# conjunto de dos elementos (443 y 8443). Un panel HTTPS en 9443 se sondeaba en
+# claro: el GET fallaba o devolvía basura, el dissector no identificaba nada y
+# los checks de cabeceras no corrían. Y al revés, un HTTP en claro en 8443 se
+# sondeaba como TLS y no contestaba nada.
+
+class _RespuestaFalsaHttp:
+    """Lo mínimo que `_request` consulta de lo que devuelve el opener."""
+
+    status = 200
+    headers = {"Server": "nginx"}
+
+    def read(self, _n=None):
+        return b"<html>"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _OpenerFalso:
+    """Apunta la URL que se pidió, que es lo que este bloque comprueba."""
+
+    def __init__(self):
+        self.urls = []
+
+    def open(self, request, timeout=None):
+        self.urls.append(request.full_url)
+        return _RespuestaFalsaHttp()
+
+
+def _probe_con_opener(monkeypatch, detect_scheme):
+    from src.modules.features.themis.lybra import HttpProbe
+
+    probe = HttpProbe(detect_scheme=detect_scheme)
+    opener = _OpenerFalso()
+    monkeypatch.setattr(probe, "_opener", opener)
+    return probe, opener
+
+
+def test_a_tls_service_on_a_non_canonical_port_is_reached_over_https(monkeypatch):
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: True)
+
+    probe.fetch("10.0.0.5", 9443, "GET", "/")
+
+    assert opener.urls == ["https://10.0.0.5:9443/"]
+
+
+def test_a_plaintext_service_on_a_tls_port_is_not_forced_into_https(monkeypatch):
+    # El caso inverso, y tan real como el otro: un HTTP en claro en 8443.
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: False)
+
+    probe.fetch("10.0.0.5", 8443, "GET", "/")
+
+    assert opener.urls == ["http://10.0.0.5:8443/"]
+
+
+def test_the_scheme_is_observed_once_per_service(monkeypatch):
+    # La pregunta es sobre el servicio, no sobre la petición: no cambia entre
+    # una ruta y otra dentro del mismo escaneo.
+    observaciones = []
+
+    def detectar(host, port):
+        observaciones.append((host, port))
+        return True
+
+    probe, _opener = _probe_con_opener(monkeypatch, detectar)
+
+    probe.fetch("10.0.0.5", 9443, "GET", "/")
+    probe.fetch("10.0.0.5", 9443, "GET", "/.git/config")
+    probe.fetch("10.0.0.5", 4443, "GET", "/")
+
+    assert observaciones == [("10.0.0.5", 9443), ("10.0.0.5", 4443)]
+
+
+def test_a_service_without_a_port_is_never_probed_for_tls(monkeypatch):
+    # Una entrada de inventario no tiene a dónde conectarse: no se paga una
+    # sonda que no puede salir a ninguna parte.
+    probe, opener = _probe_con_opener(monkeypatch, lambda host, port: pytest.fail("no debería sondear"))
+
+    probe.fetch("10.0.0.5", None, "GET", "/")
+
+    assert opener.urls == ["http://10.0.0.5/"]
+
+
+def test_negotiates_tls_is_false_when_the_connection_fails():
+    from src.modules.features.themis.lybra.checks import negotiates_tls
+
+    def connect_que_falla(address, timeout):
+        raise OSError("connection refused")
+
+    assert negotiates_tls("10.0.0.5", 9443, connect=connect_que_falla) is False
+
+
+def test_the_usual_tls_ports_are_candidates_for_hygiene_checks():
+    from src.modules.features.themis.lybra import is_tls_service
+
+    for puerto in (443, 8443, 9443, 10443, 8834):
+        servicio = Service(puerto, "tcp", "", "", "", None)
+        assert is_tls_service(servicio) is True, puerto
+        # Y entran por la puerta de HTTP, que antes tampoco los dejaba pasar.
+        assert is_http_service(servicio) is True, puerto
+
+
+def test_a_tls_service_on_an_arbitrary_port_still_misses_the_hygiene_checks():
+    """El límite que queda, escrito para que no se dé por cerrado.
+
+    El esquema ya se observa, así que un TLS en 7777 se sondea bien y recibe
+    los checks de cabeceras. Lo que no recibe son los de higiene de
+    certificado: su candidatura sigue decidiéndose por número de puerto.
+    Hacerla observada del todo es #283.
+    """
+    from src.modules.features.themis.lybra import is_tls_service
+
+    assert is_tls_service(Service(7777, "tcp", "", "", "", None)) is False
+
+
 # --------------------------------- sondas compartidas dentro de una ejecución
 #
 # Cada check corre por su cuenta, que es lo que los mantiene simples, pero el

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,110 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# ------------------------------------------------ limitador de peticiones
+#
+# El limitador existe para no golpear a UN host más rápido de la cuenta. Con el
+# `sleep` dentro del lock limitaba a todos a la vez: mientras una sonda esperaba
+# su turno para el host A, cualquier sonda hacia el host B también estaba
+# bloqueada — una espera que no protegía a nadie.
+#
+# El reloj y el `sleep` se inyectan para poder afirmar el horario en vez de
+# esperarlo: un test que midiera tiempo real sería lento y frágil.
+
+class _RelojFalso:
+    """Un reloj monótono que sólo avanza cuando se le dice, y su `sleep`."""
+
+    def __init__(self, ahora: float = 1000.0):
+        self.ahora = ahora
+        self.esperas: list = []
+
+    def __call__(self) -> float:
+        return self.ahora
+
+    def sleep(self, segundos: float) -> None:
+        self.esperas.append(segundos)
+        self.ahora += segundos
+
+
+def _limiter(reloj, min_interval=0.2):
+    from src.modules.features.themis.lybra import HostRateLimiter
+    return HostRateLimiter(min_interval=min_interval, clock=reloj, sleeper=reloj.sleep)
+
+
+def test_the_first_request_to_a_host_never_waits():
+    reloj = _RelojFalso()
+    _limiter(reloj).acquire("10.0.0.5")
+    assert reloj.esperas == []
+
+
+def test_two_different_hosts_do_not_wait_for_each_other():
+    # El bug: la espera del host A bloqueaba también al host B.
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj)
+
+    limiter.acquire("10.0.0.5")
+    limiter.acquire("10.0.0.6")
+    limiter.acquire("10.0.0.7")
+
+    assert reloj.esperas == []
+
+
+def test_two_requests_to_the_same_host_are_spaced_by_the_interval():
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj, min_interval=0.2)
+
+    limiter.acquire("10.0.0.5")
+    limiter.acquire("10.0.0.5")
+
+    assert reloj.esperas == [pytest.approx(0.2)]
+
+
+def test_a_host_that_had_time_to_cool_down_does_not_wait():
+    reloj = _RelojFalso()
+    limiter = _limiter(reloj, min_interval=0.2)
+
+    limiter.acquire("10.0.0.5")
+    reloj.ahora += 5.0            # la sonda tardó lo suyo; el intervalo ya pasó
+    limiter.acquire("10.0.0.5")
+
+    assert reloj.esperas == []
+
+
+def test_concurrent_requests_to_one_host_get_distinct_increasing_turns():
+    """N hilos sobre el mismo host se reparten N turnos, sin solaparse.
+
+    Es lo que consigue reservar el turno *antes* de dormir: si cada hilo
+    escribiera la marca al despertarse, todos leerían el mismo "último turno",
+    dormirían lo mismo y despertarían juntos — que es exactamente el golpe que
+    el limitador existe para evitar.
+    """
+    import threading
+
+    from src.modules.features.themis.lybra import HostRateLimiter
+
+    esperas: list = []
+    apuntador = threading.Lock()
+
+    def anotar_espera(segundos):
+        with apuntador:
+            esperas.append(segundos)
+
+    # El reloj se queda quieto para que el reparto sea determinista: lo que se
+    # mide es cuánto le toca esperar a cada hilo, no cuánto tarda la máquina.
+    limiter = HostRateLimiter(min_interval=0.2, clock=lambda: 1000.0, sleeper=anotar_espera)
+
+    hilos = [threading.Thread(target=limiter.acquire, args=("10.0.0.5",)) for _ in range(5)]
+    for hilo in hilos:
+        hilo.start()
+    for hilo in hilos:
+        hilo.join()
+
+    # Uno entra sin esperar y los otros cuatro se escalonan de 0,2 en 0,2. Con
+    # el turno reservado al despertar, los cinco habrían esperado lo mismo.
+    assert sorted(esperas) == [pytest.approx(0.2), pytest.approx(0.4),
+                               pytest.approx(0.6), pytest.approx(0.8)]
+
+
 # --------------------------- a qué protocolo aplica un check ``network``
 #
 # Un check `network` dice a qué protocolo va dirigido con una cadena

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -669,6 +669,41 @@ def test_smb_script_check_silent_on_unrecognised_dialect():
     assert findings == []
 
 
+def test_the_smb_verdict_survives_renaming_the_fingerprint_label(monkeypatch):
+    """Invariante: la etiqueta legible no es el protocolo entre dos piezas.
+
+    El plugin decidía buscando la subcadena ``"firma no requerida"`` dentro del
+    texto que produce ``fingerprint_smb``. Con eso, traducir esa etiqueta al
+    inglés —o corregirle una tilde— apagaba el check sin que fallara nada: se
+    ejecutaba, devolvía ``False``, y el SMB sin firma dejaba de aparecer.
+
+    Aquí se renombra la etiqueta a propósito, dejando intacto el dato que sí
+    importa (el ``SecurityMode``), y el veredicto tiene que ser el mismo en los
+    dos sentidos.
+    """
+    from src.modules.features.themis.lybra import script_checks as script_module
+
+    original = script_module.fingerprint_smb
+
+    def renamed(dialect_revision, security_mode):
+        fingerprint = original(dialect_revision, security_mode)
+        etiqueta = None if fingerprint.product is None else "SMB2 (unsigned!)"
+        return type(fingerprint)(
+            product=etiqueta, version=fingerprint.version, confidence=fingerprint.confidence,
+        )
+
+    monkeypatch.setattr(script_module, "fingerprint_smb", renamed)
+
+    sin_firma = _FakeSmbProbe((_DIALECT_302, _SIGNING_ENABLED_ONLY))
+    con_firma = _FakeSmbProbe((_DIALECT_302, _SIGNING_REQUIRED))
+
+    dispara = _script_runtime(sin_firma).run("10.0.0.5", [_SMB])
+    calla = _script_runtime(con_firma).run("10.0.0.5", [_SMB])
+
+    assert [f["check_id"] for f in dispara] == ["lybra:smb-signing-not-required@1"]
+    assert calla == []
+
+
 def test_script_checks_never_run_without_plugins_injected():
     """The default wiring of a caller that knows nothing about scripts."""
     findings = CheckRuntime(load_checks(), _fetcher({})).run("10.0.0.5", [_SMB])

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -3,7 +3,11 @@
 Pure: an injected ``fetch``/``network_open`` returns crafted responses, so no
 real network. Exercises the bundled feed, the matchers, HTTP-service
 selection, the safe/aggressive gate, and the ``type: "network"`` family Fase N
-adds (a fake, in-memory session standing in for a real TCP connection).
+adds.
+
+Para la familia ``network``, el transporte se sustituye **a nivel de socket**
+(bytes) y no a nivel de sesión: la nota al principio de esa sección explica
+por qué, y es la regla que el resto de la casa ya sigue con los dissectors.
 """
 
 import json
@@ -130,14 +134,85 @@ def test_safe_mode_skips_aggressive_checks(tmp_path):
 
 
 # --------------------------------------------------- network checks (Fase N)
+#
+# **Dónde se sustituye el transporte, y por qué ahí.** Los tests de
+# comportamiento de protocolo de esta sección inyectan un *socket* falso y
+# dejan que el ``NetworkSession`` real haga su trabajo — la misma regla que ya
+# siguen los dissectors, que se ejercitan con bytes y no con probes falsos.
+#
+# Un doble que sustituya a ``NetworkSession`` entera acaba siendo más capaz que
+# la pieza real: entrega respuestas multilínea completas que ``exchange`` jamás
+# produciría, y con eso documenta lo que el autor creía que pasaba en vez de lo
+# que pasa. Así es como un bug de transporte sobrevivió a una sección entera de
+# tests en verde.
+#
+# ``_FakeNetworkSession`` se queda **sólo** para la orquestación del runtime
+# (que no se sondee un servicio que no aplica, que sin ``network_open`` no se
+# haga nada, que la sesión se cierre siempre): eso no es comportamiento de
+# protocolo y no necesita bytes.
 
 _FTP = Service(21, "tcp", "ftp", "", "", None)
+_REDIS = Service(6379, "tcp", "redis", "", "", None)
+
+# Saludo que un vsftpd real deja en el buffer en el instante de conectar, antes
+# de que el cliente escriba nada.
+_FTP_BANNER = b"220 (vsFTPd 3.0.3)\r\n"
+# El mismo saludo en su forma multilínea, igual de habitual (RFC 959 §4.2).
+_FTP_MULTILINE_BANNER = b"220-Bienvenido a este FTP\r\n220 (vsFTPd 3.0.3)\r\n"
+# Respuesta real de Redis a INFO: un bulk string RESP cuya primera línea es la
+# longitud, no el contenido.
+_REDIS_INFO = b"$3116\r\n# Server\r\nredis_version:7.0.11\r\nredis_mode:standalone\r\n"
+
+
+class _FakeNetSocket:
+    """Un socket falso a nivel de bytes: entrega un flujo y encola respuestas.
+
+    Modela las dos cosas que un doble por encima de la sesión borra: el saludo
+    ya está en el buffer en el instante de conectar, y cada respuesta aparece
+    **después** de que el cliente escriba su comando. Los trozos que devuelve
+    ``recv`` tampoco tienen por qué coincidir con las líneas del protocolo.
+
+    Args:
+        greeting: Los bytes que el servidor ya tiene puestos al conectar.
+        replies: Un flujo de respuesta por cada escritura del cliente, en orden.
+        chunk_size: El máximo de bytes que devuelve un ``recv``, para poder
+            trocear la respuesta de forma arbitraria.
+    """
+
+    def __init__(self, greeting: bytes = b"", replies=(), chunk_size: int = 65536):
+        self._buffer = greeting
+        self._replies = list(replies)
+        self._chunk = chunk_size
+        self.sent = b""
+        self.closed = False
+
+    def recv(self, size: int) -> bytes:
+        take = min(size, self._chunk)
+        chunk, self._buffer = self._buffer[:take], self._buffer[take:]
+        return chunk
+
+    def sendall(self, data: bytes) -> None:
+        self.sent += data
+        if self._replies:
+            self._buffer += self._replies.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _network_open_over(sock):
+    """Un ``network_open`` que abre el :class:`NetworkSession` **real** sobre ``sock``."""
+    return NetworkProbe(connect=lambda address, timeout: sock).open
 
 
 class _FakeNetworkSession:
-    """A scripted stand-in for a real TCP connection: each ``exchange`` call
-    consumes the next canned reply, in order — exactly what a login sequence
-    like FTP's USER/PASS needs from a single, shared connection."""
+    """Doble de orquestación: apunta lo que se le pidió, sin hablar ningún protocolo.
+
+    Sólo para los tests que verifican *qué* hace el runtime (a qué servicios
+    abre sesión, si la cierra), nunca para los que verifican qué entiende del
+    otro extremo — para eso está :class:`_FakeNetSocket`, que es un nivel más
+    abajo y no puede inventarse capacidades que el transporte real no tiene.
+    """
 
     def __init__(self, replies):
         self._replies = list(replies)
@@ -156,7 +231,7 @@ class _FakeNetworkSession:
 
 
 def _network_open_for(replies):
-    """A ``network_open`` that hands out one fresh scripted session."""
+    """Un ``network_open`` que reparte una única sesión de orquestación."""
     session = _FakeNetworkSession(replies)
 
     def open_(host, port):
@@ -165,23 +240,58 @@ def _network_open_for(replies):
     return open_
 
 
-def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
-    open_ = _network_open_for(["331 Please specify the password.", "230 Login successful."])
-    findings = CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_FTP])
+def _findings_for(check_id, sock, service):
+    """Corre el feed sobre ``service`` con el transporte real y filtra por check."""
+    runtime = CheckRuntime(load_checks(), lambda *a: None, network_open=_network_open_over(sock))
+    return [f for f in runtime.run("h", [service]) if f["check_id"] == check_id]
 
-    ftp = [f for f in findings if f["check_id"] == "lybra:ftp-anonymous-login@1"]
+
+# ------------------------------------------ ftp-anonymous-login (comportamiento)
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#265: exchange lee una línea suelta, y tras USER la línea pendiente "
+           "en el buffer sigue siendo el saludo 220, no el 331",
+)
+def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
+    sock = _FakeNetSocket(
+        greeting=_FTP_BANNER,
+        replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
+    )
+
+    ftp = _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)
+
     assert len(ftp) == 1
     assert ftp[0]["qod"] == 99 and ftp[0]["confirmed"] is True
     assert ftp[0]["category"] == "default_credentials"
     assert ftp[0]["port"] == 21
-    # Both steps of the login sequence went over the same session, in order.
-    assert open_.session.sent == ["USER anonymous\r\n", "PASS anonymous@lybra.local\r\n"]
+    # Los dos pasos de la secuencia de login fueron por la misma sesión, en orden.
+    assert sock.sent == b"USER anonymous\r\nPASS anonymous@lybra.local\r\n"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#265: un saludo multilínea desplaza la ventana de lectura una línea más",
+)
+def test_ftp_anonymous_login_confirmed_with_a_multiline_banner():
+    sock = _FakeNetSocket(
+        greeting=_FTP_MULTILINE_BANNER,
+        replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
+    )
+    assert len(_findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)) == 1
 
 
 def test_ftp_anonymous_login_absent_when_credentials_rejected():
-    open_ = _network_open_for(["331 Please specify the password.", "530 Login incorrect."])
-    findings = CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_FTP])
-    assert not any(f["check_id"] == "lybra:ftp-anonymous-login@1" for f in findings)
+    sock = _FakeNetSocket(
+        greeting=_FTP_BANNER,
+        replies=[b"331 Please specify the password.\r\n", b"530 Login incorrect.\r\n"],
+    )
+    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
+
+
+def test_ftp_anonymous_login_abandoned_when_the_server_says_nothing():
+    sock = _FakeNetSocket(greeting=b"", replies=[])
+    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
 
 
 def test_ftp_anonymous_login_abandoned_on_connect_failure():
@@ -190,6 +300,31 @@ def test_ftp_anonymous_login_abandoned_on_connect_failure():
     ).run("h", [_FTP])
     assert not any(f["check_id"] == "lybra:ftp-anonymous-login@1" for f in findings)
 
+
+# ------------------------------- redis-unauthenticated-access (comportamiento)
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#265: la respuesta a INFO es un bulk string RESP y exchange corta en "
+           "su primera línea, que es la longitud ($3116), no el contenido",
+)
+def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
+    sock = _FakeNetSocket(replies=[_REDIS_INFO])
+
+    redis_findings = _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS)
+
+    assert len(redis_findings) == 1
+    assert redis_findings[0]["qod"] == 99 and redis_findings[0]["confirmed"] is True
+    assert redis_findings[0]["category"] == "default_credentials"
+    assert sock.sent == b"INFO\r\n"
+
+
+def test_redis_unauthenticated_access_absent_when_auth_required():
+    sock = _FakeNetSocket(replies=[b"-NOAUTH Authentication required.\r\n"])
+    assert _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS) == []
+
+
+# ------------------------------------------------- selección y orquestación
 
 def test_network_checks_never_run_without_a_network_open_callable():
     # Mirrors test_only_http_services_are_probed: omitting network_open must
@@ -207,29 +342,6 @@ def test_only_ftp_services_are_probed_by_network_checks():
     assert is_ftp_service(_HTTP) is False
 
 
-# ---------------------------------------- redis-unauthenticated-access (Fase N)
-
-_REDIS = Service(6379, "tcp", "redis", "", "", None)
-
-
-def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
-    reply = "$120\r\n# Server\r\nredis_version:7.0.11\r\nredis_mode:standalone\r\n"
-    open_ = _network_open_for([reply])
-    findings = CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_REDIS])
-
-    redis_findings = [f for f in findings if f["check_id"] == "lybra:redis-unauthenticated-access@1"]
-    assert len(redis_findings) == 1
-    assert redis_findings[0]["qod"] == 99 and redis_findings[0]["confirmed"] is True
-    assert redis_findings[0]["category"] == "default_credentials"
-    assert open_.session.sent == ["INFO\r\n"]
-
-
-def test_redis_unauthenticated_access_absent_when_auth_required():
-    open_ = _network_open_for(["-NOAUTH Authentication required.\r\n"])
-    findings = CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_REDIS])
-    assert not any(f["check_id"] == "lybra:redis-unauthenticated-access@1" for f in findings)
-
-
 def test_only_redis_services_are_probed_by_redis_check():
     open_ = _network_open_for(["$40\r\nredis_version:7.0.11\r\n"])
     CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_HTTP])
@@ -239,58 +351,53 @@ def test_only_redis_services_are_probed_by_redis_check():
     assert is_redis_service(_HTTP) is False
 
 
-# --------------------------------------------- NetworkProbe (fake socket)
+def test_the_session_of_a_network_check_is_always_closed():
+    open_ = _network_open_for([None])
+    CheckRuntime(load_checks(), lambda *a: None, network_open=open_).run("h", [_FTP])
+    assert open_.session.closed is True
 
-class _FakeNetSocket:
-    """A byte-stream-backed stand-in for a real network-check socket."""
 
-    def __init__(self, data: bytes):
-        self._buf = data
-        self.sent = b""
-        self.closed = False
-
-    def recv(self, n: int) -> bytes:
-        chunk, self._buf = self._buf[:n], self._buf[n:]
-        return chunk
-
-    def sendall(self, data: bytes) -> None:
-        self.sent += data
-
-    def close(self) -> None:
-        self.closed = True
-
+# ----------------------------------------------- NetworkProbe (socket falso)
 
 def test_network_probe_session_reads_banner_without_sending():
-    fake_sock = _FakeNetSocket(b"220 (vsFTPd 2.3.4)\r\n")
-    session = NetworkProbe(connect=lambda addr, timeout: fake_sock).open("10.0.0.5", 21)
+    sock = _FakeNetSocket(greeting=_FTP_BANNER)
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
 
-    resp = session.exchange(None)
+    response = session.exchange(None)
 
-    assert resp.body == "220 (vsFTPd 2.3.4)"
-    assert fake_sock.sent == b""               # nothing written for a banner-only read
+    assert response.body == "220 (vsFTPd 3.0.3)"
+    assert sock.sent == b""                    # nothing written for a banner-only read
 
 
 def test_network_probe_session_sends_then_reads():
-    fake_sock = _FakeNetSocket(b"331 Please specify the password.\r\n")
-    session = NetworkProbe(connect=lambda addr, timeout: fake_sock).open("10.0.0.5", 21)
+    sock = _FakeNetSocket(replies=[b"331 Please specify the password.\r\n"])
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
 
-    resp = session.exchange("USER anonymous\r\n")
+    response = session.exchange("USER anonymous\r\n")
 
-    assert fake_sock.sent == b"USER anonymous\r\n"
-    assert resp.body == "331 Please specify the password."
+    assert sock.sent == b"USER anonymous\r\n"
+    assert response.body == "331 Please specify the password."
     session.close()
-    assert fake_sock.closed is True
+    assert sock.closed is True
+
+
+def test_network_probe_session_reads_a_line_split_across_recv_chunks():
+    # Un servidor real no entrega la línea entera de una vez: el criterio de
+    # fin de respuesta es del protocolo, no del tamaño del trozo que llegue.
+    sock = _FakeNetSocket(greeting=_FTP_BANNER, chunk_size=1)
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
+    assert session.exchange(None).body == "220 (vsFTPd 3.0.3)"
 
 
 def test_network_probe_returns_none_on_connect_failure():
-    def failing_connect(addr, timeout):
+    def failing_connect(address, timeout):
         raise OSError("connection refused")
     assert NetworkProbe(connect=failing_connect).open("10.0.0.5", 21) is None
 
 
 def test_network_session_exchange_returns_none_on_empty_read():
-    fake_sock = _FakeNetSocket(b"")
-    session = NetworkProbe(connect=lambda addr, timeout: fake_sock).open("10.0.0.5", 21)
+    sock = _FakeNetSocket(greeting=b"")
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
     assert session.exchange(None) is None
 
 

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -513,6 +513,118 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
         load_checks(str(feed))
 
 
+# --------------------------------- sondas compartidas dentro de una ejecución
+#
+# Cada check corre por su cuenta, que es lo que los mantiene simples, pero el
+# feed tiene tres checks de cabeceras que miran la misma respuesta a `GET /` y
+# tres de TLS que evalúan reglas distintas sobre el mismo handshake. Ejecutado
+# al pie de la letra, eso son cuatro sondas de más por servicio: tiempo de
+# escaneo, esperas del limitador, y ruido en el registro del objetivo — que en
+# un escáner de seguridad no es un detalle, porque aparece en el SIEM de quien
+# nos contrata.
+
+_TLS_SERVICE = Service(443, "tcp", "https", "", "", None)
+
+
+class _TlsInfoFalso:
+    """Lo mínimo que las reglas TLS del feed consultan de un handshake."""
+
+    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3"):
+        self.self_signed = self_signed
+        self.expired = expired
+        self.protocol = protocol
+        self.days_until_expiry = 200
+
+
+def _contador_de_handshakes(info=None):
+    llamadas = []
+
+    def tls_fetch(host, port):
+        llamadas.append((host, port))
+        return info
+
+    tls_fetch.llamadas = llamadas
+    return tls_fetch
+
+
+def test_the_three_header_checks_make_one_request_between_them():
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+
+    findings = CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
+
+    # Los tres checks de cabeceras disparan (el nginx de mentira no manda
+    # ninguna) y aun así "/" se pidió una sola vez.
+    cabeceras = [f for f in findings if f["category"] == "security_header"]
+    assert len(cabeceras) == 3
+    assert [ruta for _h, _p, _m, ruta in fetch.calls].count("/") == 1
+
+
+def test_each_distinct_path_is_still_requested():
+    # Compartir no es dejar de mirar: rutas distintas siguen siendo sondas
+    # distintas, una por ruta.
+    fetch = _fetcher({})
+    CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
+
+    rutas = [ruta for _h, _p, _m, ruta in fetch.calls]
+    assert len(rutas) == len(set(rutas))
+    assert "/.git/config" in rutas and "/" in rutas
+
+
+def test_the_three_tls_checks_share_one_handshake():
+    tls_fetch = _contador_de_handshakes(_TlsInfoFalso(self_signed=True))
+
+    findings = CheckRuntime(
+        load_checks(), _fetcher({}), tls_fetch=tls_fetch
+    ).run("10.0.0.5", [_TLS_SERVICE])
+
+    assert any(f["check_id"] == "lybra:tls-self-signed-cert@1" for f in findings)
+    assert len(tls_fetch.llamadas) == 1
+
+
+def test_a_transport_failure_is_shared_too():
+    # El caso donde reintentar cuesta más y informa menos: un servicio caído.
+    # Sin compartir el fallo, los tres checks de TLS intentarían el handshake
+    # por separado contra algo que ya se sabe que no contesta.
+    tls_fetch = _contador_de_handshakes(None)
+
+    findings = CheckRuntime(
+        load_checks(), _fetcher({}), tls_fetch=tls_fetch
+    ).run("10.0.0.5", [_TLS_SERVICE])
+
+    assert findings == []
+    assert len(tls_fetch.llamadas) == 1
+
+
+def test_two_services_of_the_same_host_are_probed_separately():
+    # La sonda se comparte por (host, puerto, método, ruta): dos servicios
+    # distintos del mismo host son dos objetivos distintos.
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+    otro_http = Service(8080, "tcp", "http", "", "", None)
+
+    CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP, otro_http])
+
+    puertos = {puerto for _h, puerto, _m, ruta in fetch.calls if ruta == "/"}
+    assert puertos == {80, 8080}
+
+
+def test_a_second_run_probes_again():
+    """La caché nace y muere con la ejecución, y eso es deliberado.
+
+    Dos escaneos del mismo objetivo tienen que volver a mirar: entre uno y otro
+    el objetivo ha podido cambiar, que es exactamente lo que un escáner mide.
+    Una caché que sobreviviera al escaneo convertiría el segundo informe en una
+    copia del primero.
+    """
+    fetch = _fetcher({"/": Response(200, "<html>", {})})
+    runtime = CheckRuntime(load_checks(), fetch)
+
+    runtime.run("10.0.0.5", [_HTTP])
+    peticiones_tras_la_primera = len(fetch.calls)
+    runtime.run("10.0.0.5", [_HTTP])
+
+    assert len(fetch.calls) == peticiones_tras_la_primera * 2
+
+
 # ------------------------------------------------ limitador de peticiones
 #
 # El limitador existe para no golpear a UN host más rápido de la cuenta. Con el

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -185,8 +185,10 @@ class _FakeNetSocket:
         self._chunk = chunk_size
         self.sent = b""
         self.closed = False
+        self.recv_calls = 0
 
     def recv(self, size: int) -> bytes:
+        self.recv_calls += 1
         take = min(size, self._chunk)
         chunk, self._buffer = self._buffer[:take], self._buffer[take:]
         return chunk
@@ -219,7 +221,7 @@ class _FakeNetworkSession:
         self.sent: list = []
         self.closed = False
 
-    def exchange(self, send):
+    def exchange(self, send, read="line"):
         self.sent.append(send)
         if not self._replies:
             return None
@@ -248,18 +250,13 @@ def _findings_for(check_id, sock, service):
 
 # ------------------------------------------ ftp-anonymous-login (comportamiento)
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: exchange lee una línea suelta, y tras USER la línea pendiente "
-           "en el buffer sigue siendo el saludo 220, no el 331",
-)
 def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     sock = _FakeNetSocket(
         greeting=_FTP_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
     )
 
-    ftp = _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)
+    ftp = _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP)
 
     assert len(ftp) == 1
     assert ftp[0]["qod"] == 99 and ftp[0]["confirmed"] is True
@@ -269,16 +266,12 @@ def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     assert sock.sent == b"USER anonymous\r\nPASS anonymous@lybra.local\r\n"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: un saludo multilínea desplaza la ventana de lectura una línea más",
-)
 def test_ftp_anonymous_login_confirmed_with_a_multiline_banner():
     sock = _FakeNetSocket(
         greeting=_FTP_MULTILINE_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"230 Login successful.\r\n"],
     )
-    assert len(_findings_for("lybra:ftp-anonymous-login@1", sock, _FTP)) == 1
+    assert len(_findings_for("lybra:ftp-anonymous-login@2", sock, _FTP)) == 1
 
 
 def test_ftp_anonymous_login_absent_when_credentials_rejected():
@@ -286,32 +279,27 @@ def test_ftp_anonymous_login_absent_when_credentials_rejected():
         greeting=_FTP_BANNER,
         replies=[b"331 Please specify the password.\r\n", b"530 Login incorrect.\r\n"],
     )
-    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
+    assert _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP) == []
 
 
 def test_ftp_anonymous_login_abandoned_when_the_server_says_nothing():
     sock = _FakeNetSocket(greeting=b"", replies=[])
-    assert _findings_for("lybra:ftp-anonymous-login@1", sock, _FTP) == []
+    assert _findings_for("lybra:ftp-anonymous-login@2", sock, _FTP) == []
 
 
 def test_ftp_anonymous_login_abandoned_on_connect_failure():
     findings = CheckRuntime(
         load_checks(), lambda *a: None, network_open=lambda host, port: None
     ).run("h", [_FTP])
-    assert not any(f["check_id"] == "lybra:ftp-anonymous-login@1" for f in findings)
+    assert not any(f["check_id"] == "lybra:ftp-anonymous-login@2" for f in findings)
 
 
 # ------------------------------- redis-unauthenticated-access (comportamiento)
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#265: la respuesta a INFO es un bulk string RESP y exchange corta en "
-           "su primera línea, que es la longitud ($3116), no el contenido",
-)
 def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
     sock = _FakeNetSocket(replies=[_REDIS_INFO])
 
-    redis_findings = _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS)
+    redis_findings = _findings_for("lybra:redis-unauthenticated-access@2", sock, _REDIS)
 
     assert len(redis_findings) == 1
     assert redis_findings[0]["qod"] == 99 and redis_findings[0]["confirmed"] is True
@@ -321,7 +309,7 @@ def test_redis_unauthenticated_access_confirmed_when_info_succeeds():
 
 def test_redis_unauthenticated_access_absent_when_auth_required():
     sock = _FakeNetSocket(replies=[b"-NOAUTH Authentication required.\r\n"])
-    assert _findings_for("lybra:redis-unauthenticated-access@1", sock, _REDIS) == []
+    assert _findings_for("lybra:redis-unauthenticated-access@2", sock, _REDIS) == []
 
 
 # ------------------------------------------------- selección y orquestación
@@ -399,6 +387,129 @@ def test_network_session_exchange_returns_none_on_empty_read():
     sock = _FakeNetSocket(greeting=b"")
     session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
     assert session.exchange(None) is None
+
+
+def test_network_session_no_longer_reads_one_byte_per_syscall():
+    # El lector anterior pedía los bytes de uno en uno: una llamada al sistema
+    # por byte recibido. Una línea corta debe costar un puñado de recv, no uno
+    # por carácter.
+    sock = _FakeNetSocket(greeting=_FTP_BANNER)
+    session = NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
+
+    session.exchange(None)
+
+    assert sock.recv_calls < len(_FTP_BANNER)
+
+
+# ------------------------------------------- modos de lectura (``read:``)
+#
+# Dónde termina una respuesta es un hecho del protocolo, no del transporte. Un
+# modo mal elegido no da error: lee los bytes equivocados y el check deja de
+# disparar en silencio, que es el fallo que este bloque existe para impedir.
+
+def _session_over(greeting=b"", replies=()):
+    sock = _FakeNetSocket(greeting=greeting, replies=replies)
+    return NetworkProbe(connect=lambda address, timeout: sock).open("10.0.0.5", 21)
+
+
+def test_read_line_stops_at_the_first_newline():
+    session = _session_over(greeting=b"331 Primera\r\n230 Segunda\r\n")
+    assert session.exchange(None, read="line").body == "331 Primera"
+
+
+def test_read_block_joins_the_continuation_lines_of_a_status_reply():
+    # Un código seguido de "-" anuncia que la respuesta sigue; el mismo código
+    # seguido de espacio la cierra.
+    session = _session_over(greeting=b"220-Primera\r\n220-Segunda\r\n220 Ultima\r\n")
+
+    body = session.exchange(None, read="block").body
+
+    assert "Primera" in body and "Segunda" in body and "Ultima" in body
+
+
+def test_read_block_stops_at_a_line_that_is_not_a_continuation():
+    # Con una respuesta de una sola línea, "block" se comporta como "line": no
+    # se queda esperando más datos que no van a llegar.
+    session = _session_over(greeting=b"220 Unica\r\n331 De la siguiente respuesta\r\n")
+    assert session.exchange(None, read="block").body == "220 Unica"
+
+
+def test_read_block_does_not_over_read_a_banner_without_status_codes():
+    # Un saludo que no usa códigos de estado (SSH, por ejemplo) tampoco es una
+    # continuación, así que cierra el bloque en la primera línea. Sin esta
+    # regla, "block" se quedaría leyendo hasta agotar el tiempo de espera.
+    session = _session_over(greeting=b"SSH-2.0-OpenSSH_8.9\r\nmas cosas\r\n")
+    assert session.exchange(None, read="block").body == "SSH-2.0-OpenSSH_8.9"
+
+
+def test_read_resp_bulk_returns_the_announced_payload_and_not_its_header():
+    session = _session_over(replies=[_REDIS_INFO])
+
+    body = session.exchange("INFO\r\n", read="resp-bulk").body
+
+    assert body.startswith("# Server")
+    assert "redis_version:7.0.11" in body
+    assert "$" not in body                 # la línea de longitud no forma parte del contenido
+
+
+def test_read_resp_bulk_returns_a_non_bulk_reply_untouched():
+    # Un error de Redis es una línea suelta que empieza por "-": ya es la
+    # respuesta entera, y es justo la que el matcher negativo tiene que ver.
+    session = _session_over(replies=[b"-NOAUTH Authentication required.\r\n"])
+    assert session.exchange("INFO\r\n", read="resp-bulk").body == "-NOAUTH Authentication required."
+
+
+def test_read_resp_bulk_leaves_the_trailing_bytes_for_the_next_read():
+    # RESP cierra el bulk con un CRLF que no cuenta en la longitud anunciada.
+    # Ese sobrante se queda en el buffer y no puede comerse la respuesta
+    # siguiente.
+    session = _session_over(replies=[b"$2\r\nOK\r\n+PONG\r\n"])
+
+    assert session.exchange("INFO\r\n", read="resp-bulk").body == "OK"
+    assert session.exchange("PING\r\n", read="line").body == "+PONG"
+
+
+def test_a_truncated_bulk_reply_returns_what_arrived_instead_of_hanging():
+    # El servidor anuncia 3116 bytes y cierra la conexión tras unos pocos.
+    session = _session_over(replies=[b"$3116\r\nredis_version:7.0.11\r\n"])
+    assert "redis_version:7.0.11" in session.exchange("INFO\r\n", read="resp-bulk").body
+
+
+# ------------------------------------ el feed declara cómo termina cada respuesta
+
+def test_the_bundled_network_checks_declare_their_read_semantics():
+    checks = {check.id: check for check in load_checks()}
+
+    ftp = checks["ftp-anonymous-login"]
+    assert ftp.expect_banner is True       # FTP saluda al conectar
+    assert [request.read for request in ftp.requests] == ["block", "block"]
+
+    redis_check = checks["redis-unauthenticated-access"]
+    assert redis_check.expect_banner is False   # Redis no saluda
+    assert [request.read for request in redis_check.requests] == ["resp-bulk"]
+
+
+def test_a_request_without_a_declared_read_mode_keeps_the_original_behaviour():
+    git = next(check for check in load_checks() if check.id == "git-config-exposure")
+    assert git.requests[0].read == "line"
+    assert git.expect_banner is False
+
+
+def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
+    # Un modo que nadie implementa es un bug del feed. Si se ignorase en
+    # silencio, el check leería una línea donde el protocolo necesita un
+    # bloque y no dispararía nunca: exactamente el falso negativo silencioso
+    # que este cambio elimina.
+    feed = tmp_path / "feed.json"
+    feed.write_text(json.dumps({"checks": [{
+        "id": "modo-inventado", "version": 1, "type": "network",
+        "category": "network_config", "severity": "HIGH", "service": "ftp",
+        "requests": [{"send": "PING\r\n", "read": "telepatia", "matchers": []}],
+        "finding": {"title": "x"},
+    }]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="telepatia"):
+        load_checks(str(feed))
 
 
 # --------------------------------------------------- ``type: "script"`` (Fase R)

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -16,6 +16,7 @@ import yaml
 
 import pytest
 
+from src.modules.features.themis.lybra import checks as checks_mod
 from src.modules.features.themis.lybra import (
     load_checks,
     CheckRuntime,
@@ -510,6 +511,95 @@ def test_an_unknown_read_mode_fails_at_load_time(tmp_path):
 
     with pytest.raises(ValueError, match="telepatia"):
         load_checks(str(feed))
+
+
+# --------------------------- a qué protocolo aplica un check ``network``
+#
+# Un check `network` dice a qué protocolo va dirigido con una cadena
+# (`service: ftp`), y el runtime necesita el predicado que decide si un
+# servicio descubierto es de ese protocolo. Ese mapa se mantenía a mano y tenía
+# dos entradas cuando el módulo ya definía once predicados: un check de SMTP o
+# de MySQL se cargaba, se validaba, y se descartaba sin decir nada.
+
+_MYSQL = Service(3306, "tcp", "mysql", "", "", None)
+
+_MYSQL_NETWORK_FEED = {
+    "checks": [{
+        "id": "mysql-saluda", "version": 1, "type": "network",
+        "category": "network_config", "severity": "INFO", "service": "mysql",
+        "mode": "safe",
+        "requests": [{"matchers": [{"type": "word", "part": "body", "words": ["mysql_native_password"]}]}],
+        "finding": {"title": "MySQL contesta"},
+    }]
+}
+
+
+def _feed_file(tmp_path, document):
+    feed = tmp_path / "feed.json"
+    feed.write_text(json.dumps(document), encoding="utf-8")
+    return str(feed)
+
+
+def test_every_service_predicate_is_available_to_a_network_check():
+    # Invariante al estilo de test_config_shape: definir un predicado nuevo
+    # basta para poder escribir checks de ese protocolo. Sin esto, cada
+    # protocolo costaba dos ediciones y olvidar la segunda no daba error.
+    predicates = {
+        name for name in dir(checks_mod)
+        if name.startswith("is_") and name.endswith("_service")
+    }
+    esperados = {name[len("is_"):-len("_service")] for name in predicates}
+
+    assert esperados == set(checks_mod._NETWORK_SERVICE_MATCHERS)
+    assert len(esperados) > 2, "el mapa derivado debe cubrir más que ftp y redis"
+
+
+def test_a_network_check_for_a_protocol_that_nobody_wired_by_hand_runs(tmp_path):
+    # MySQL nunca estuvo en la tabla escrita a mano, y su predicado sí existía.
+    checks = load_checks(_feed_file(tmp_path, _MYSQL_NETWORK_FEED))
+    sock = _FakeNetSocket(greeting=b"5.7.42-log\x00mysql_native_password\n")
+
+    findings = CheckRuntime(
+        checks, lambda *a: None, network_open=_network_open_over(sock)
+    ).run("h", [_MYSQL])
+
+    assert [f["check_id"] for f in findings] == ["lybra:mysql-saluda@1"]
+
+
+def test_an_unknown_service_fails_at_load_time(tmp_path):
+    # Un check que no puede aplicar a nada es un bug del feed. Si se ignora,
+    # se confunde con "no ha disparado contra este host", que es normal — y
+    # así nadie se entera nunca.
+    document = {"checks": [dict(_MYSQL_NETWORK_FEED["checks"][0], id="protocolo-inventado",
+                                service="noexiste")]}
+
+    with pytest.raises(ValueError, match="noexiste"):
+        load_checks(_feed_file(tmp_path, document))
+
+
+def test_every_network_service_in_the_bundled_feed_has_a_predicate():
+    network_services = {check.service for check in load_checks() if check.type == "network"}
+    assert network_services <= set(checks_mod._NETWORK_SERVICE_MATCHERS)
+
+
+def test_a_check_that_skipped_the_loader_with_an_unknown_service_is_logged(caplog):
+    # Los checks traducidos de plantillas de Nuclei se construyen directamente,
+    # sin pasar por el cargador, así que su `service` es lo que dijera el
+    # documento de origen. Ahí el aviso lo tiene que dar el runtime.
+    translated = checks_mod.Check(
+        id="traducido", version=1, type="network", category="network_config",
+        severity="INFO", service="protocolo-de-otro-mundo", mode="safe",
+        requests=(), finding={}, namespace="nuclei",
+    )
+    sock = _FakeNetSocket(greeting=b"lo que sea\r\n")
+
+    with caplog.at_level("WARNING"):
+        findings = CheckRuntime(
+            [translated], lambda *a: None, network_open=_network_open_over(sock)
+        ).run("h", [_FTP])
+
+    assert findings == []
+    assert "protocolo-de-otro-mundo" in caplog.text
 
 
 # --------------------------------------------------- ``type: "script"`` (Fase R)

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -321,6 +321,79 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["confirmed"] is True
 
 
+# ------------------------------------------- marca de reproducibilidad (#270)
+#
+# Cada hallazgo lleva una marca que dice contra qué se resolvió. Para los checks
+# activos era cierta (sube cada vez que cambia el feed); para la detección por
+# versión —que produce la mayoría de los hallazgos con CVE— era la constante
+# "lybra-0" y no cambió nunca. Dos hallazgos separados por seis meses, uno
+# contra el catálogo completo y otro contra una KB a medio poblar, llevaban la
+# misma marca.
+
+def test_the_engine_stamps_the_mark_it_is_given():
+    engine = LybraEngine(
+        cve_lookup=_lookup_for(("openbsd", "openssh")),
+        feed_version="lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30",
+    )
+
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert {f["feed_version"] for f in findings} == {
+        "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=2026-08-30"
+    }
+
+
+def test_without_a_mark_the_engine_keeps_the_old_constant():
+    # Compatibilidad con los hallazgos ya almacenados: quien no inyecte nada
+    # sigue estampando exactamente lo que estampaba antes.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert {f["feed_version"] for f in findings} == {"lybra-0"}
+
+
+def test_two_states_of_the_knowledge_base_produce_different_marks():
+    """El criterio de cierre: dos escaneos separados por una sincronización
+    tienen que distinguirse por la marca."""
+    from datetime import datetime
+
+    from src.modules.features.themis.lybra import kb_feed_version
+
+    antes = kb_feed_version({
+        "nvd": datetime(2026, 8, 29, 13, 19), "kev": datetime(2026, 8, 27), "epss": None,
+    })
+    despues = kb_feed_version({
+        "nvd": datetime(2026, 8, 30, 4, 0), "kev": datetime(2026, 8, 27),
+        "epss": datetime(2026, 8, 30),
+    })
+
+    assert antes == "lybra-kb:nvd=2026-08-29,kev=2026-08-27,epss=none"
+    assert despues == "lybra-kb:nvd=2026-08-30,kev=2026-08-27,epss=2026-08-30"
+    assert antes != despues
+
+
+def test_a_source_with_no_data_says_so_instead_of_pretending():
+    # Una fuente vacía es información, no un hueco que rellenar con la fecha de
+    # otra cosa: es justo lo que esta marca existe para hacer visible.
+    from src.modules.features.themis.lybra import kb_feed_version
+
+    assert kb_feed_version({}) == "lybra-kb:nvd=none,kev=none,epss=none"
+
+
+def test_the_mark_fits_in_the_column_that_stores_it():
+    from datetime import datetime
+
+    from src.modules.features.themis.lybra import kb_feed_version
+    from src.modules.features.themis.model import Finding
+
+    peor_caso = kb_feed_version({
+        "nvd": datetime(2026, 12, 31), "kev": datetime(2026, 12, 31),
+        "epss": datetime(2026, 12, 31),
+    })
+
+    assert len(peor_caso) <= Finding.__table__.c.feed_version.type.length
+
+
 def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
     """El criterio de cierre de #267, extremo a extremo dentro del motor.
 

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -16,6 +16,7 @@ from src.modules.features.themis.lybra import (
     services_from_payload,
     QOD_OPEN_PORT,
     QOD_INVENTORY_MATCH,
+    version_in_range,
 )
 from src.modules.features.themis.services.processors import NmapResultProcessor
 
@@ -318,6 +319,58 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["category"] == "outdated_software"
     assert vuln["qod"] == QOD_INVENTORY_MATCH == 95
     assert vuln["confirmed"] is True
+
+
+def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
+    """El criterio de cierre de #267, extremo a extremo dentro del motor.
+
+    El inventario de un agente entrega versiones de paquete de distribución
+    (`1:7.4-1ubuntu1`), y NVD sólo publica rangos sobre versiones de
+    fabricante (`7.4`). Si el paquete no cae en los mismos rangos que su
+    versión upstream, la Fase I entera —el sustituto del escaneo autenticado—
+    mide otra cosa.
+
+    La búsqueda que se inyecta aquí usa `version_in_range` de verdad, no una
+    tabla de respuestas: lo que se comprueba es el camino completo, no que el
+    doble diga que sí.
+    """
+    afectado = {"version_start_including": "7.0", "version_end_including": "7.4"}
+
+    def lookup(vendor, product, version):
+        return [_fake_cve()] if version_in_range(version, afectado) else []
+
+    engine = LybraEngine(cve_lookup=lookup)
+    upstream = Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)
+    paquete = Service(port=None, protocol="", name="", product="OpenSSH",
+                      version="1:7.4-1ubuntu1", cpe=None, origin="inventory")
+
+    del_banner = [f for f in engine.analyze([upstream]) if f["category"] == "outdated_software"]
+    del_paquete = [f for f in engine.analyze([paquete]) if f["category"] == "outdated_software"]
+
+    assert len(del_banner) == 1
+    assert [f["cve_ids"] for f in del_paquete] == [f["cve_ids"] for f in del_banner]
+
+
+def test_a_normalized_version_says_so_in_the_finding():
+    # Sin esto, el hallazgo es inexplicable de puertas afuera: nada en él da
+    # cuenta de por qué un host con 1:7.4-1ubuntu1 sale contra un CVE cuyo
+    # rango termina en 7.4.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    paquete = Service(port=None, protocol="", name="", product="OpenSSH",
+                      version="1:7.4-1ubuntu1", cpe=None, origin="inventory")
+
+    vuln = [f for f in engine.analyze([paquete]) if f["category"] == "outdated_software"][0]
+
+    assert "1:7.4-1ubuntu1" in vuln["title"]      # lo que se descubrió, tal cual
+    assert "(upstream 7.4)" in vuln["title"]      # y contra qué se comparó
+
+
+def test_a_plain_vendor_version_gets_no_normalization_note():
+    # La nota sólo aparece donde hay algo que explicar.
+    engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
+    findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
+
+    assert "upstream" not in findings[1]["title"]
 
 
 def test_version_finding_from_network_origin_stays_a_hypothesis():

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -177,6 +177,93 @@ def test_ingest_nvd_cve_malformed_returns_none():
     assert ingest_nvd_cve({"cve": {}}) is None
 
 
+# ------------------------------------------------------- elección de métrica CVSS
+#
+# Un CVE puede publicar varias versiones de CVSS a la vez, y se coge la más
+# reciente porque es la más precisa. La v4.0 no estaba en esa cadena, así que un
+# CVE que sólo publicara v4 entraba sin puntuación — y aguas abajo "sin
+# puntuación" no es un hueco cosmético: se lee como 0.0, que es INFO. Una
+# vulnerabilidad crítica aparecía en el informe como informativa.
+
+def _nvd_item_with(metrics: dict) -> dict:
+    return {"cve": {
+        "id": "CVE-2026-0001",
+        "descriptions": [{"lang": "en", "value": "x"}],
+        "metrics": metrics,
+        "configurations": [{"nodes": [{"cpeMatch": [{
+            "vulnerable": True,
+            "criteria": "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*",
+        }]}]}],
+    }}
+
+
+_CVSS_V40 = {"cvssMetricV40": [{"cvssData": {
+    "baseScore": 9.3,
+    "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+    "baseSeverity": "CRITICAL",
+}}]}
+
+_CVSS_V31 = {"cvssMetricV31": [{"cvssData": {
+    "baseScore": 7.5, "vectorString": "CVSS:3.1/AV:N", "baseSeverity": "HIGH",
+}}]}
+
+
+def test_a_cve_published_only_with_cvss_v4_is_scored():
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with(_CVSS_V40))
+
+    assert cve_row["cvss_score"] == 9.3
+    assert cve_row["severity"] == "CRITICAL"
+    assert cve_row["cvss_vector"].startswith("CVSS:4.0/")
+
+
+def test_v4_wins_over_v31_when_a_cve_publishes_both():
+    # La regla de la cadena es "la métrica más reciente que ofrezca la entrada",
+    # y v4 es más precisa que v3.1 sobre el mismo CVE.
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with({**_CVSS_V31, **_CVSS_V40}))
+
+    assert cve_row["cvss_score"] == 9.3
+    assert cve_row["severity"] == "CRITICAL"
+
+
+def test_v31_still_wins_when_there_is_no_v4():
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with(_CVSS_V31))
+    assert cve_row["cvss_score"] == 7.5
+    assert cve_row["severity"] == "HIGH"
+
+
+def test_a_cve_with_no_metric_at_all_stays_unscored():
+    # Regresión: no tener métrica sigue siendo distinto de tener una de cero.
+    cve_row, _matches = ingest_nvd_cve(_nvd_item_with({}))
+    assert (cve_row["cvss_score"], cve_row["cvss_vector"], cve_row["severity"]) == (None, None, None)
+
+
+def test_the_longest_possible_v4_vector_fits_in_the_column():
+    """Un vector v4 es bastante más largo que uno de v3.1, y se guarda entero.
+
+    El peor caso de la especificación —base completa, más amenaza, más entorno,
+    más suplementarias, cogiendo en cada métrica el valor más largo— se
+    construye aquí en vez de fiarse de un ejemplo suelto: un ejemplo corto que
+    quepa no demuestra nada sobre el que no quepa. Son 188 caracteres, así que
+    ``String(255)`` vale y no hace falta migración; si alguien acorta la
+    columna, este test lo dice.
+    """
+    from src.modules.features.themis.model import CveEntry
+
+    metricas = [
+        ("AV", "N"), ("AC", "L"), ("AT", "P"), ("PR", "N"), ("UI", "A"),
+        ("VC", "H"), ("VI", "H"), ("VA", "H"), ("SC", "H"), ("SI", "H"), ("SA", "H"),
+        ("E", "U"),
+        ("CR", "H"), ("IR", "H"), ("AR", "H"),
+        ("MAV", "N"), ("MAC", "L"), ("MAT", "P"), ("MPR", "N"), ("MUI", "A"),
+        ("MVC", "H"), ("MVI", "H"), ("MVA", "H"),
+        ("MSC", "H"), ("MSI", "Safety"), ("MSA", "Safety"),
+        ("S", "P"), ("AU", "Y"), ("R", "I"), ("V", "C"), ("RE", "M"), ("U", "Clear"),
+    ]
+    peor_caso = "/".join(["CVSS:4.0"] + [f"{metrica}:{valor}" for metrica, valor in metricas])
+
+    assert len(peor_caso) <= CveEntry.__table__.c.cvss_vector.type.length
+
+
 # ------------------------------------------------- platform-gated CVEs (#118)
 
 def _and_node_item(platform_cpe: str) -> dict:

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -432,6 +432,36 @@ def test_parse_epss_rows_skips_comment_header():
     assert rows[0]["scored_at"].year == 2026
 
 
+def test_the_scoring_date_is_read_from_the_header_the_feed_actually_publishes():
+    """La cabecera real usa dos puntos, no un igual, y eso costaba el campo entero.
+
+    El test de arriba —y sólo él— cubría este parser, con una cabecera escrita
+    a mano que usa ``score_date=``. El feed publica
+    ``#model_version:v2026.06.15,score_date:2026-08-30T12:03:42Z``. Con el
+    parser buscando únicamente el ``=``, la fecha salía ``None`` **siempre**:
+    353.521 filas en un espejo completo, ninguna con fecha, y sin un solo
+    error por el camino — una fecha ausente es indistinguible de un feed que
+    no la trae.
+
+    Es el motivo de que este caso exista: una fixture inventada valida el
+    código contra sí misma, no contra el mundo.
+    """
+    csv_text = (
+        "#model_version:v2026.06.15,score_date:2026-08-30T12:03:42Z\n"
+        "cve,epss,percentile\n"
+        "CVE-2021-41773,0.97,0.995\n"
+    )
+
+    rows = list(parse_epss_rows(csv_text))
+
+    assert rows[0]["scored_at"].date().isoformat() == "2026-08-30"
+
+
+def test_a_header_without_a_date_leaves_the_field_empty():
+    csv_text = "#model_version:v2026.06.15\ncve,epss,percentile\nCVE-2021-41773,0.97,0.995\n"
+    assert list(parse_epss_rows(csv_text))[0]["scored_at"] is None
+
+
 # --------------------------------------- product name normalization (Fase I-b)
 
 @pytest.mark.parametrize("raw,expected", [

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -10,6 +10,7 @@ import pytest
 from src.modules.features.themis.lybra import (
     version_compare,
     version_in_range,
+    split_distro_version,
     normalize_cpe_to_23,
     normalize_product_name,
     extract_trailing_version,
@@ -37,6 +38,70 @@ pytestmark = pytest.mark.unit
 ])
 def test_version_compare(a, b, expected):
     assert version_compare(a, b) == expected
+
+
+# ------------------------------------------- versiones de paquete de distribución
+#
+# La versión de un paquete de distribución no es la del fabricante. Debian y sus
+# derivadas escriben `1:2.4.49-1ubuntu1`: el `1:` es el *epoch* (un contador que
+# la distribución sube cuando tiene que renumerar hacia abajo) y el `-1ubuntu1`
+# es la *revisión* (qué empaquetado de esa misma versión es). Alpine escribe
+# `2.4.49-r0`. Sólo el trozo del medio es lo que publicó el fabricante, y es lo
+# único de lo que habla NVD.
+#
+# Los dos extras rompían la comparación en direcciones opuestas: el epoch
+# arrastraba la versión hacia abajo (falsos positivos) y la revisión la
+# empujaba por encima del final del rango (CVEs perdidos).
+
+@pytest.mark.parametrize("raw,expected", [
+    ("1:2.4.49-1ubuntu1", (1, "2.4.49", "1ubuntu1")),   # Debian/Ubuntu completo
+    ("2.4.49-1ubuntu1", (None, "2.4.49", "1ubuntu1")),  # sin epoch
+    ("2.4.49-r0", (None, "2.4.49", "r0")),              # Alpine
+    ("2.4.49+dfsg-1", (None, "2.4.49", "1")),           # Debian con metadato de empaquetado
+    ("7.0.11", (None, "7.0.11", None)),                 # versión de fabricante, intacta
+    ("1.0.0-rc1", (None, "1.0.0-rc1", None)),           # preversión, NO es una revisión
+])
+def test_split_distro_version(raw, expected):
+    assert split_distro_version(raw) == expected
+
+
+@pytest.mark.parametrize("a,b,expected", [
+    # El caso que perdía CVEs: la revisión empujaba el paquete por encima del
+    # final del rango, así que un versionEndIncluding: 2.4.49 no casaba.
+    ("2.4.49-1ubuntu1", "2.4.49", 0),
+    ("1:2.4.49-1ubuntu1", "2.4.49", 0),
+    ("2.4.49-r0", "2.4.49", 0),
+    ("2.4.49+dfsg-1", "2.4.49", 0),
+    # El caso que producía falsos positivos: el epoch se leía como primer
+    # componente, así que 1:1.2.3 se ordenaba por debajo de 1.0.0.
+    ("1:1.2.3", "1.0.0", 1),
+    # Entre dos versiones de distribución sí mandan epoch y revisión.
+    ("1:1.0", "2:0.9", -1),
+    ("2.4.49-1", "2.4.49-2", -1),
+    ("2.4.49-2", "2.4.49-1", 1),
+    # Regresión: una preversión sigue ordenando por debajo de su versión final.
+    ("1.0.0-rc1", "1.0.0", -1),
+])
+def test_version_compare_with_distro_versions(a, b, expected):
+    assert version_compare(a, b) == expected
+
+
+def test_a_distro_package_lands_in_the_range_of_its_upstream_release():
+    """El criterio de cierre: un paquete de distribución tiene que casar los
+    mismos rangos que su versión upstream, ni más ni menos."""
+    rango = {"version_start_including": "2.4.0", "version_end_including": "2.4.49"}
+
+    assert version_in_range("2.4.49", rango) is True            # referencia
+    assert version_in_range("1:2.4.49-1ubuntu1", rango) is True  # el mismo paquete, empaquetado
+    assert version_in_range("2.4.49-r0", rango) is True          # y en Alpine
+
+    # Y sigue quedándose fuera lo que tiene que quedarse fuera.
+    assert version_in_range("2.4.50-1ubuntu1", rango) is False
+    assert version_in_range("2.3.9-1ubuntu1", rango) is False
+
+
+def test_an_exact_pinned_version_also_matches_the_packaged_form():
+    assert version_in_range("1:2.4.49-1ubuntu1", {"exact_version": "2.4.49"}) is True
 
 
 # --------------------------------------------------------------- version range

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,29 @@ despliega.
 > `appVersion` de `SecOpsConfig.json` puede ir por detrás del nombre de la rama. Ninguna de las
 > dos cosas es un error, pero conviene mirarlas antes de afirmar «esto ya está en producción».
 
+## Cómo se escriben los PR, los issues y sus comentarios
+
+Se escriben para **alguien que no conoce el módulo que se está tocando**. Quien abre un PR de
+Themis puede no saber qué es Lybra, qué hace el runtime de checks o qué significa `feed_version`, y
+una descripción comprimida sólo la entiende quien ya sabía la respuesta: no informa a nadie, es un
+recordatorio para el autor disfrazado de documentación.
+
+Tres reglas concretas:
+
+- **Primero el problema en lenguaje llano, después el símbolo.** Antes de nombrar
+  `xfail(strict=True)`, `NetworkSession.exchange` o «bulk string RESP», di qué es y por qué importa
+  aquí. «Un *bulk string* de Redis es una respuesta que empieza por una línea con la longitud del
+  contenido, así que la primera línea no trae datos» cuesta una frase y ahorra el viaje al código.
+- **Nada de taquigrafía ni de explicaciones planas.** Una tabla o una lista siguen valiendo, pero
+  cada fila necesita su frase de contexto; una fila que sólo repite el nombre del test no explica
+  por qué falla.
+- **Vale alargarse; no vale dar por supuesto.** El coste de leer un párrafo de más es mucho menor
+  que el de reconstruir el contexto entrando al código.
+
+Esto aplica a los cuerpos de PR, a los issues que se abran y a los comentarios de seguimiento. No
+aplica al **código**: ahí manda la concisión de siempre (nombres completos, comentarios que
+explican el *por qué*, no el *qué*).
+
 ## Deuda técnica
 
 `plans/deuda-tecnica-y-calidad.md` es la auditoría de origen (fechada 2026-08-03) y `plans/` en


### PR DESCRIPTION
## Qué entra aquí

La **Fase 0 del backlog del motor Lybra** completa: los diez defectos que hacían que el motor *informara mal*. No hay funcionalidad nueva y no cambia nada de cómo se usa la API — cambia lo que el escáner dice, que es distinto y más importante.

La fase se llama "El motor no miente" por una razón concreta: la Fase 1 construye la vara de medir la precisión del motor, y una vara sobre un motor que no dispara sus checks mide la mentira. Esto va primero para que lo que se mida después signifique algo.

`appVersion` sube a **0.5.11**.

## Los diez arreglos

| Issue | Qué estaba mal | Qué cambia |
|---|---|---|
| [#269](https://github.com/ProjectEllysia/EllysiaServer/issues/269) | Los tests de la familia `network` sustituían la sesión de red entera por un doble más capaz que la pieza real, y por eso un bug de transporte vivía con la suite en verde | El transporte se sustituye a nivel de socket (bytes); la sesión real hace su trabajo |
| [#265](https://github.com/ProjectEllysia/EllysiaServer/issues/265) | Los dos únicos checks no-web —FTP anónimo y Redis sin contraseña— **no podían producir un hallazgo contra un servidor real** | El feed declara dónde termina una respuesta (`read:`) y si el protocolo saluda (`expectBanner`) |
| [#272](https://github.com/ProjectEllysia/EllysiaServer/issues/272) | Un check de red para SMTP, MySQL o VNC se cargaba, se validaba y se descartaba sin decir nada | El mapa de protocolos se deriva del módulo: de 2 disponibles a 11, y un `service` desconocido falla en voz alta |
| [#266](https://github.com/ProjectEllysia/EllysiaServer/issues/266) | Un CVE que sólo publicara CVSS v4.0 entraba sin puntuación, y "sin puntuación" se lee como cero, que es INFO | v4.0 entra en la cadena de preferencia |
| [#267](https://github.com/ProjectEllysia/EllysiaServer/issues/267) | El comparador de versiones se equivocaba con paquetes de distribución en **las dos direcciones** | El epoch y la revisión se separan antes de comparar |
| [#271](https://github.com/ProjectEllysia/EllysiaServer/issues/271) | El check de firma SMB decidía buscando la subcadena `"firma no requerida"` en un texto de interfaz | Decide sobre el bit `SecurityMode` |
| [#273](https://github.com/ProjectEllysia/EllysiaServer/issues/273) | El limitador dormía dentro del candado: esperar por el host A bloqueaba las sondas hacia el host B | Se reserva el turno bajo el candado y se duerme fuera |
| [#274](https://github.com/ProjectEllysia/EllysiaServer/issues/274) | Tres handshakes TLS y tres peticiones a `/` por servicio para leer exactamente lo mismo | Cada sonda se comparte entre los checks que leen la misma evidencia |
| [#268](https://github.com/ProjectEllysia/EllysiaServer/issues/268) | El esquema (HTTP/HTTPS) se deducía de un conjunto de dos puertos: un HTTPS en 9443 se sondeaba en claro | El esquema se observa intentando el handshake |
| [#270](https://github.com/ProjectEllysia/EllysiaServer/issues/270) | La marca de reproducibilidad de la detección por versión era la constante `lybra-0` y no cambió nunca | Describe el estado real de la base de conocimiento |

## Lo que se midió, no se supuso

Cada arreglo se comprobó contra datos o servidores reales, no sólo con tests:

- **#265** — vsftpd y `redis:7` en contenedores: el check dispara con el servicio expuesto y calla con el control negativo, los cuatro casos.
- **#267** — sobre las 2.005 reglas de aplicabilidad reales de `apache/http_server` de la base de conocimiento: un `1:2.4.49-1ubuntu1` perdía **43 CVEs** y se inventaba **25**. Y `2.4.49-r0` daba el **recuento correcto con el contenido equivocado** (tres fuera, tres ajenos dentro).
- **#266** — 23.971 de 371.104 CVEs almacenados sin puntuación; una muestra consultada contra NVD confirmó un caso exacto de CVE publicado sólo con v4.
- **#273** — la primera petición a un host no limitado tardaba **150 ms** en pasar detrás de otro host; ahora 0.
- **#274** — 13 sondas por servicio HTTPS con el feed completo, ahora 9.
- **#268** — nginx con TLS en 9443 devolvía **400** (una respuesta basura que el motor analizaba como buena); ahora 200. Y un nginx HTTP en claro en 8443 no devolvía **nada**; ahora 200.

## Un patrón que se repite, y que conviene reconocer

Nueve de los diez fallos comparten forma: **no fallaban**. No había excepciones, ni logs, ni tests en rojo. El escaneo terminaba en verde y el problema seguía ahí — un FTP anónimo abierto, un CVE crítico en la banda INFO, un check apagado porque alguien tradujo una etiqueta.

De ahí que la mayor parte del esfuerzo de esta fase esté en los tests que hacen **imposible** volver a ese estado en silencio: invariantes que atan un registro a los predicados que existen, un test que renombra una etiqueta a propósito para comprobar que nada depende de ella, otro que exige que una segunda ejecución vuelva a sondear.

Y dos casos donde el propio test era parte del problema, ambos con la misma forma: una fixture escrita a mano más amable que la realidad (el doble de red de #269, la cabecera inventada del feed EPSS en #270). Un test así valida el código contra sí mismo.

## Dos hallazgos laterales

Al medir el alcance de dos issues aparecieron cosas que no estaban en ningún diagnóstico:

- **353.521 filas de EPSS sin fecha de puntuación**, por un separador de un carácter en la cabecera (`score_date:` frente a `score_date=`). Corregido dentro de #270, que necesitaba ese dato.
- **CVEs con puntuación en NVD desde hace tiempo que en nuestra copia siguen sin ella.** No es un bug del motor: es frescura de la base de conocimiento, y está documentado como evidencia de campo en [#302](https://github.com/ProjectEllysia/EllysiaServer/issues/302).

## Validación

- `pytest tests/unit tests/integration`: en verde en cada uno de los diez PRs.
- Banco oracle (`tests/oracle`, marcador `oracle`, fuera del CI por defecto): cuatro casos nuevos con contenedores reales para la familia `network`.
- La cadena de migraciones queda con una sola cabeza.
- `pylint` no se ejecutó en ningún PR: no está instalado en el entorno de trabajo. El CI corre `pytest`.

## Cambios de esquema y de datos

- **Una migración** (`d7e8f9a0b1c2`): `Finding.feed_version` de 32 a 64 caracteres. Ampliar un `varchar` en PostgreSQL es un cambio de metadatos — no reescribe la tabla ni toca un dato existente.
- **Los hallazgos ya almacenados no se reescriben.** Su `feed_version = "lybra-0"` es la verdad de cuando se emitieron.
- **Los dos checks de red suben a `version: 2`** y el feed a `lybra-checks-6`: su comportamiento cambia, y un hallazgo guardado tiene que poder decir cuál de las dos formas lo produjo. Sus identificadores pasan de `@1` a `@2`.

## Notas

- **El README no necesita cambios.** En toda la fase no se ha tocado ningún endpoint, categoría de TaskQueue, clave de configuración, variable de entorno, perfil de Docker ni puerto.
- **`CLAUDE.md` gana una sección** sobre cómo se escriben los PR, los issues y sus comentarios: se escriben para alguien que no conoce el módulo.
- **Trabajo anotado para otros issues** durante la fase: #275 (validación del feed en CI), #283 (dissectors por observación en vez de por puerto), #284 (SMB contra un servidor real), #297 (los checks de red que faltan, ahora desbloqueados por #272), #302 (frescura de la KB, con dos evidencias nuevas) y #307 (`min_interval` a configuración).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
