### PR TITLE
El feed de checks se valida en CI: un check que no puede ejecutarse deja de ser invisible (#275)

### DIFF
--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -72,6 +72,7 @@ from .kb import (
 )
 from .checks import (
     load_checks,
+    validate_checks,
     CheckRuntime,
     HttpProbe,
     HostRateLimiter,
@@ -205,6 +206,7 @@ __all__ = [
     "fetch_epss",
     "iter_nvd_pages",
     "load_checks",
+    "validate_checks",
     "CheckRuntime",
     "HttpProbe",
     "HostRateLimiter",

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -45,6 +45,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple
 import yaml
 
 from .engine import Service
+from .correlation import PRIORITY_LADDER
 
 logger = logging.getLogger(__name__)
 
@@ -451,6 +452,138 @@ def _parse_read_mode(declared: Optional[str], check_id: Optional[str]) -> str:
             f"(disponibles: {', '.join(sorted(NETWORK_READ_MODES))})"
         )
     return mode
+
+
+# =========================================================================
+# FEED VALIDATION
+# =========================================================================
+
+# Las familias de check que el runtime sabe despachar. Un ``type`` fuera de
+# esta lista no lanza: cae por los cuatro ``_applies_*`` y desaparece.
+CHECK_TYPES = ("http", "tls", "network", "script")
+
+# Los modos de ejecución. ``aggressive`` sólo corre cuando el runtime lo
+# autoriza explícitamente; cualquier otra palabra deja el check sin modo
+# reconocible.
+CHECK_MODES = ("safe", "aggressive")
+
+# Las familias de hallazgo que un check puede declarar. No es el vocabulario
+# entero de ``Finding.category`` —el motor emite además ``open_port``,
+# ``outdated_software``, ``fingerprint`` y ``surface_change`` por su cuenta,
+# sin pasar por el feed—, sino lo que tiene sentido que declare una regla de
+# detección. Una categoría inventada no rompe nada visible: el hallazgo se
+# guarda igual y aparece bajo una familia que ningún filtro de la interfaz
+# conoce.
+CHECK_CATEGORIES = (
+    "exposed_path",
+    "default_credentials",
+    "security_header",
+    "network_config",
+    "tls",
+    "vulnerability",
+    "web_finding",
+)
+
+# Los tipos de matcher que ``Matcher._raw_match`` implementa. Cualquier otro
+# devuelve ``False`` sin decir nada, que en un matcher negativo significa
+# además lo contrario de lo que el autor quería.
+MATCHER_TYPES = ("status", "word", "regex")
+
+# Las partes de la respuesta que ``Matcher._part_text`` sabe leer. Una parte
+# desconocida cae en el defecto (``body``), así que un ``part: "headers"`` en
+# plural busca en el cuerpo y nunca encuentra la cabecera.
+MATCHER_PARTS = ("body", "header", "status")
+
+
+def validate_checks(checks: Iterable[Check]) -> List[str]:
+    """Comprobar que ningún check está muerto por construcción.
+
+    El feed son **datos que se ejecutan**: reglas que deciden si un hallazgo de
+    seguridad existe. Y su forma de fallar es siempre la misma, la peor: en
+    silencio. Un ``tlsRule`` mal escrito cae por ``check.tls_rule not in
+    _TLS_RULES`` y el check no aplica nunca; un ``script`` que no existe cae
+    por ``plugin is None``; un ``type`` con un typo no lo reconoce ninguno de
+    los cuatro ``_applies_*``. En los tres casos el escaneo termina en verde y
+    lo único que ocurre es que una vulnerabilidad deja de detectarse.
+
+    Esta función no juzga si un check es *bueno* —eso lo miden los bancos de la
+    Fase 1—, sólo si puede llegar a ejecutarse. Devuelve los problemas en vez
+    de lanzar, para poder revisar un feed entero de una pasada en lugar de
+    arreglar de uno en uno; el test que la usa afirma que la lista está vacía.
+
+    Args:
+        checks: Los checks ya parseados (``load_checks`` o ``translate_all``).
+
+    Returns:
+        Una lista de problemas legibles, vacía si el feed está sano.
+    """
+    # Importación diferida a propósito: ``script_checks`` importa predicados de
+    # este módulo, así que un import arriba cerraría el ciclo. Es el mismo
+    # motivo por el que ``ScriptContext`` vive aquí y no junto a los plugins.
+    from .script_checks import default_script_plugins
+
+    script_ids = set(default_script_plugins())
+    problems: List[str] = []
+    seen: set = set()
+
+    for check in checks:
+        name = check.id or "<sin id>"
+
+        if not check.id:
+            problems.append("Un check no declara 'id'")
+        if (check.id, check.version) in seen:
+            problems.append(f"Check {name!r}: duplicado en (id, version)={(check.id, check.version)}")
+        seen.add((check.id, check.version))
+
+        if not isinstance(check.version, int) or isinstance(check.version, bool) or check.version < 1:
+            problems.append(f"Check {name!r}: 'version' debe ser un entero positivo, no {check.version!r}")
+        if check.type not in CHECK_TYPES:
+            problems.append(f"Check {name!r}: tipo {check.type!r} desconocido (disponibles: {', '.join(CHECK_TYPES)})")
+        if check.mode not in CHECK_MODES:
+            problems.append(f"Check {name!r}: modo {check.mode!r} desconocido (disponibles: {', '.join(CHECK_MODES)})")
+        if check.severity not in PRIORITY_LADDER:
+            problems.append(f"Check {name!r}: severidad {check.severity!r} fuera de la escalera ({', '.join(PRIORITY_LADDER)})")
+        if check.category not in CHECK_CATEGORIES:
+            problems.append(f"Check {name!r}: categoría {check.category!r} desconocida (disponibles: {', '.join(CHECK_CATEGORIES)})")
+
+        if check.type == "tls" and check.tls_rule not in _TLS_RULES:
+            problems.append(
+                f"Check {name!r}: regla TLS {check.tls_rule!r} sin implementación "
+                f"(disponibles: {', '.join(sorted(_TLS_RULES))})"
+            )
+        if check.type == "script" and check.script not in script_ids:
+            problems.append(
+                f"Check {name!r}: script {check.script!r} sin plugin "
+                f"(disponibles: {', '.join(sorted(script_ids))})"
+            )
+        if check.type == "network" and check.service not in _NETWORK_SERVICE_MATCHERS:
+            problems.append(
+                f"Check {name!r}: el servicio {check.service!r} no tiene predicado "
+                f"(disponibles: {', '.join(sorted(_NETWORK_SERVICE_MATCHERS))})"
+            )
+
+        # Un check http/network sin peticiones no puede casar nada: el runtime
+        # exige que **todas** las peticiones acierten, y sobre cero peticiones
+        # eso es vacuamente cierto o directamente inalcanzable según el camino.
+        # Los tls y los script no las usan.
+        if check.type in ("http", "network") and not check.requests:
+            problems.append(f"Check {name!r}: de tipo {check.type!r} y sin ninguna petición")
+
+        for position, request in enumerate(check.requests):
+            where = f"Check {name!r}, petición {position}"
+            if request.read not in NETWORK_READ_MODES:
+                problems.append(f"{where}: modo de lectura {request.read!r} desconocido")
+            if not request.matchers:
+                problems.append(f"{where}: sin ningún matcher, así que nunca decide nada")
+            for matcher in request.matchers:
+                if matcher.type not in MATCHER_TYPES:
+                    problems.append(f"{where}: matcher de tipo {matcher.type!r} desconocido")
+                if matcher.part not in MATCHER_PARTS:
+                    problems.append(f"{where}: matcher sobre la parte {matcher.part!r}, que no existe")
+                if not matcher.values:
+                    problems.append(f"{where}: matcher {matcher.type!r} sin valores que buscar")
+
+    return problems
 
 
 # =========================================================================

--- a/API/tests/unit/test_lybra_feed_shape.py
+++ b/API/tests/unit/test_lybra_feed_shape.py
@@ -1,0 +1,156 @@
+"""El feed de checks está bien formado (L27).
+
+El feed son **datos que se ejecutan**: diecisiete reglas en YAML que deciden si
+un hallazgo de seguridad existe. Hasta ahora ningún test comprobaba que
+estuvieran bien formadas, y su modo de fallo es el peor posible — el silencio.
+Un ``tlsRule`` mal escrito, un ``script`` que no existe, un ``type`` con un
+typo: en los tres casos el check no aplica nunca, el escaneo termina en verde,
+y lo único que pasa es que una vulnerabilidad deja de detectarse.
+
+Este fichero hace con el feed lo que ``test_config_shape.py`` hace con el enum
+``ScanType`` y ``test_config_view_paths.py`` con las rutas de configuración:
+convertir en fallo de CI algo que hasta ahora sólo se detectaba leyendo.
+
+Dos bloques, y el segundo importa tanto como el primero:
+
+1. El feed empaquetado pasa la validación entera.
+2. La validación **encuentra** cada tipo de rotura cuando se la mete a
+   propósito. Sin esto, un validador que devolviera siempre una lista vacía
+   dejaría el primer bloque en verde para siempre.
+"""
+
+from dataclasses import replace
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CHECKS_FEED_VERSION,
+    Matcher,
+    Request,
+    load_checks,
+    validate_checks,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def feed():
+    return load_checks()
+
+
+# ============================================================ el feed de serie
+
+def test_the_bundled_feed_is_completely_well_formed(feed):
+    """La afirmación de fondo: ningún check del feed está muerto por
+    construcción. No dice que los checks sean *buenos* —eso lo miden los bancos
+    de precisión—, sino que todos pueden llegar a ejecutarse."""
+    assert validate_checks(feed) == []
+
+
+def test_the_feed_is_not_empty_and_declares_its_version(feed):
+    """Un feed vacío pasaría todas las validaciones de forma vacua. Y sin
+    ``CHECKS_FEED_VERSION`` un hallazgo guardado no puede decir con qué reglas
+    se produjo."""
+    assert feed
+    assert CHECKS_FEED_VERSION.startswith("lybra-checks-")
+
+
+def test_no_two_checks_share_an_identifier(feed):
+    """``check_id`` es ``namespace:id@version`` y viaja hasta el hallazgo
+    guardado. Dos checks con el mismo par serían indistinguibles en el informe,
+    y el ciclo de vida (que correlaciona hallazgos entre escaneos por su
+    identidad) los trataría como uno solo."""
+    identifiers = [check.check_id for check in feed]
+    assert len(identifiers) == len(set(identifiers))
+
+
+# ===================================================== la validación sí detecta
+#
+# Cada caso rompe un campo de un check real y comprueba que el problema sale
+# nombrado. Un validador que no distinguiera estos casos dejaría el bloque de
+# arriba en verde diciendo nada.
+
+def _first_of_type(feed, check_type):
+    return next(check for check in feed if check.type == check_type)
+
+
+@pytest.mark.parametrize("field,value,needle", [
+    ("type",     "htpp",      "tipo"),
+    ("mode",     "agresivo",  "modo"),
+    ("severity", "GRAVE",     "severidad"),
+    ("category", "exposicion", "categoría"),
+    ("version",  0,           "entero positivo"),
+])
+def test_a_broken_field_is_reported(feed, field, value, needle):
+    broken = replace(_first_of_type(feed, "http"), **{field: value})
+    problems = validate_checks([broken])
+    assert any(needle in problem for problem in problems), problems
+
+
+def test_an_unimplemented_tls_rule_is_reported(feed):
+    """Un ``tlsRule`` inválido cae por ``check.tls_rule not in _TLS_RULES`` en
+    ``_applies_tls``, que es exactamente igual que "este check no aplicaba a
+    este host": normal, esperable, invisible."""
+    broken = replace(_first_of_type(feed, "tls"), tls_rule="caducado")
+    assert any("regla TLS" in problem for problem in validate_checks([broken]))
+
+
+def test_a_script_without_plugin_is_reported(feed):
+    """Igual que el anterior pero por ``plugin is None`` en ``_applies_script``:
+    el check se carga, se valida, y no corre jamás."""
+    broken = replace(_first_of_type(feed, "script"), script="smb-signing")
+    assert any("script" in problem for problem in validate_checks([broken]))
+
+
+def test_a_network_service_without_predicate_is_reported(feed):
+    """El caso de #272: un check ``network`` para un protocolo que ningún
+    predicado reconoce. Aquel arreglo lo hizo fallar al cargar; esta validación
+    lo encuentra además sobre un feed externo, que no pasa por ese camino."""
+    broken = replace(_first_of_type(feed, "network"), service="postgres")
+    assert any("predicado" in problem for problem in validate_checks([broken]))
+
+
+def test_a_check_without_requests_is_reported(feed):
+    broken = replace(_first_of_type(feed, "http"), requests=())
+    assert any("sin ninguna petición" in problem for problem in validate_checks([broken]))
+
+
+def test_a_request_without_matchers_is_reported(feed):
+    """Una petición sin matchers no decide nada: se hace el viaje a la red y no
+    se mira la respuesta."""
+    broken = replace(_first_of_type(feed, "http"),
+                     requests=(Request(method="GET", path="/", matchers=()),))
+    assert any("sin ningún matcher" in problem for problem in validate_checks([broken]))
+
+
+@pytest.mark.parametrize("matcher,needle", [
+    (Matcher(type="palabra", part="body", values=("x",)), "tipo"),
+    (Matcher(type="word", part="headers", values=("x",)), "parte"),
+    (Matcher(type="word", part="body", values=()),        "sin valores"),
+])
+def test_a_broken_matcher_is_reported(feed, matcher, needle):
+    """Los tres modos de romper un matcher, y el segundo es el más traicionero:
+    ``part: "headers"`` en plural no es un error, es una búsqueda en el cuerpo
+    —el defecto— que nunca encuentra la cabecera que el autor buscaba."""
+    broken = replace(_first_of_type(feed, "http"),
+                     requests=(Request(method="GET", path="/", matchers=(matcher,)),))
+    assert any(needle in problem for problem in validate_checks([broken]))
+
+
+def test_a_duplicated_identifier_is_reported(feed):
+    check = _first_of_type(feed, "http")
+    assert any("duplicado" in problem for problem in validate_checks([check, check]))
+
+
+def test_an_unknown_read_mode_is_reported(feed):
+    """El parseo ya rechaza un ``read`` desconocido al cargar el feed, así que
+    aquí hay que construir la petición a mano. La validación lo cubre igual
+    porque también se le pueden pasar checks que no vinieron de ``load_checks``
+    — los traducidos de plantillas de Nuclei, por ejemplo."""
+    broken = replace(
+        _first_of_type(feed, "network"),
+        requests=(Request(method="GET", path="/", read="parrafo",
+                          matchers=(Matcher(type="word", values=("x",)),)),),
+    )
+    assert any("modo de lectura" in problem for problem in validate_checks([broken]))


### PR DESCRIPTION
Cierra #275.

## De qué va esto

El feed de checks de Lybra es un fichero YAML con diecisiete reglas de detección. No es configuración ni documentación: **son datos que se ejecutan**. Cada entrada decide si un hallazgo de seguridad existe o no.

Hasta ahora ningún test comprobaba que estuvieran bien formadas. Y lo que hace esto grave no es que se pudiera colar un error —eso pasa en cualquier fichero— sino **cómo falla** un check mal escrito: en silencio, siempre.

Tres ejemplos reales de la forma que tiene el código:

- Un `tlsRule` con un typo cae por `check.tls_rule not in _TLS_RULES` dentro de `_applies_tls`, y esa comprobación devuelve `False`. Pero `False` ahí significa exactamente lo mismo que «este check no aplicaba a este host», que es lo normal y esperable en casi todos los checks de casi todos los escaneos.
- Un `script` que no existe en el registro de plugins cae por `plugin is None` en `_applies_script`. Mismo resultado.
- Un `type` mal escrito no lo reconoce ninguno de los cuatro `_applies_*`, así que el check se carga, ocupa memoria, y nunca lanza.

En los tres casos el escaneo termina en verde, no hay excepción, no hay log, y lo único que ocurre es que una vulnerabilidad deja de detectarse. Es el mismo patrón que salió nueve veces de diez en la Fase 0.

El proyecto ya sabe protegerse de esto en otros sitios: `test_config_shape.py` ata el enum `ScanType` a los cuatro registros que lo hacen funcionar, y `test_config_view_paths.py` convierte en fallo de CI que una ruta de configuración diverja del `.vue`. El feed de Lybra —más crítico que ambos, porque una regla rota es un falso negativo de seguridad— no tenía equivalente.

## Qué se añade

### `validate_checks(checks)` en `checks.py`

Recorre los checks ya parseados y comprueba lo único que se puede comprobar sin ejecutarlos: **que ninguno esté muerto por construcción**.

- Identificador único y no vacío, y versión entera positiva.
- `type`, `mode`, `severity` y `category` dentro de su vocabulario.
- Si es `tls`, que su regla esté implementada; si es `script`, que su plugin exista; si es `network`, que su servicio tenga predicado (el caso de #272).
- Que un check `http` o `network` tenga al menos una petición, que cada petición tenga al menos un matcher, y que cada matcher busque algo (`values` no vacío) de una forma que existe (`type`) en una parte que existe (`part`).

**Devuelve la lista de problemas en vez de lanzar.** Así se revisa un feed entero de una pasada en lugar de arreglar de uno en uno, y la función sirve igual para un feed externo o para los checks traducidos de plantillas de Nuclei, que no pasan por `load_checks`.

Dos decisiones pequeñas que conviene explicar:

- **La escalera de severidades se importa de `correlation`**, no se copia. Dos listas de lo mismo derivan, y la que se queda atrás es la que alguien acaba leyendo. `correlation.py` no importa nada del paquete, así que no hay ciclo.
- **El registro de plugins se importa dentro de la función.** `script_checks.py` importa predicados de `checks.py`, así que un import arriba cerraría el ciclo. Es el mismo motivo por el que `ScriptContext` vive en `checks.py` y no junto a los plugins.

### `tests/unit/test_lybra_feed_shape.py`

Dos bloques, y el segundo importa tanto como el primero.

**El primero** afirma que el feed empaquetado pasa la validación entera, que no hay dos checks con el mismo `check_id` y que el feed ni está vacío ni ha perdido su versión.

Lo del identificador duplicado merece una frase: `check_id` es `namespace:id@version` y viaja hasta el hallazgo guardado en base de datos. El seguimiento del ciclo de vida —lo que decide si una vulnerabilidad sigue abierta, se corrigió o reapareció— correlaciona hallazgos entre escaneos por esa identidad. Dos checks distintos con el mismo par se fusionarían en uno sin que nada avisara.

**El segundo bloque rompe a propósito cada campo de un check real** y comprueba que el problema sale nombrado: un `type` con typo, una regla TLS inventada, un script sin plugin, un servicio de red sin predicado, una petición sin matchers, un matcher sin valores…

Ese bloque no es adorno. Sin él, un validador que devolviera siempre una lista vacía dejaría el primer bloque en verde para siempre: estaríamos probando que el feed no tiene problemas *que sepamos buscar*, sin haber comprobado nunca que sabemos buscarlos. Es exactamente la lección que dejaron dos issues de la Fase 0 (#269 y #270), donde el test era parte del problema porque la fixture escrita a mano era más amable que la realidad.

Un caso del segundo bloque vale la pena por sí solo: `part: "headers"`, en plural. No es un error que salte — es una parte desconocida que cae en el defecto (`body`), así que el matcher busca en el cuerpo la cabecera que el autor quería encontrar, y no la encuentra nunca.

## Sobre el criterio de cierre del issue

El issue pedía que la validación, aplicada hoy, detectara al menos un problema real: el `service` sin predicado que describía #272. **Ese problema ya no existe** — #272 se arregló en la Fase 0 y añadió `_assert_service_is_reachable`, que lo hace fallar al cargar el feed.

Así que el feed sale limpio a la primera, y la demostración de que el validador no es vacuo tiene que venir de otro lado: de los once casos del segundo bloque, que rompen cada campo y comprueban que se detecta. La validación cubre además un camino que el arreglo de #272 no alcanza: los checks que **no** vienen de `load_checks`, como los traducidos de plantillas de Nuclei.

## Validación

- `pytest tests/unit tests/integration`: en verde, sin fallos. Los 18 casos nuevos corren en CI (son puros: sin red, sin base de datos, sin Docker).
- `validate_checks(load_checks())` sobre el feed empaquetado devuelve una lista vacía.
- El README no necesita cambios: no se ha tocado ningún endpoint, categoría de TaskQueue, clave de configuración ni variable de entorno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
