### PR TITLE
fix(iris): estado terminal con motivo cuando el análisis se rompe (B03)

### DIFF
--- a/API/alembic/versions/b46e50206411_add_iris_analysis_failure_reason.py
+++ b/API/alembic/versions/b46e50206411_add_iris_analysis_failure_reason.py
@@ -1,0 +1,46 @@
+"""Motivo terminal de un análisis de Iris fallido (#207)
+
+Revision ID: b46e50206411
+Revises: d7e8f9a0b1c2
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b46e50206411'
+down_revision: Union[str, Sequence[str], None] = 'd7e8f9a0b1c2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Un análisis que acababa en ``failed`` no decía por qué. Las dos causas son
+    muy distintas para quien lo mira —el texto enviado no era un correo
+    analizable, o el motor se rompió por dentro— y sin distinguirlas el estado
+    terminal no es accionable: el usuario no sabe si reintentar o corregir su
+    entrada.
+
+    ``failure_code`` guarda esa distinción (``invalid_input`` /
+    ``internal_error``) y ``failure_reason`` el mensaje legible que la
+    acompaña. Ambas son NULL para cualquier análisis que no haya fallado, así
+    que las filas existentes no necesitan relleno.
+    """
+    op.add_column("IrisAnalysis", sa.Column("failure_code", sa.String(length=32), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("failure_reason", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierden los motivos ya registrados; los análisis fallidos vuelven a
+    quedarse en un ``failed`` sin explicación, que es el estado previo.
+    """
+    op.drop_column("IrisAnalysis", "failure_reason")
+    op.drop_column("IrisAnalysis", "failure_code")

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -139,6 +139,11 @@ def get_analysis_status(args: dict):
         "status": status,
         "totalScore": analysis.total_score if analysis else None,
         "verdict": analysis.verdict if analysis else None,
+        # B03: el motivo solo tiene sentido cuando el análisis murió. Enviarlo
+        # siempre dejaría un `failureReason` colgando de un análisis que
+        # terminó bien tras un reintento y confundiría a quien lea el estado.
+        "failureCode": analysis.failure_code if analysis else None,
+        "failureReason": analysis.failure_reason if analysis else None,
     }
     if progress is not None:
         response["progress"] = progress

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -39,6 +39,7 @@ from ..repositories import IrisAnalysisRepository, IrisRuleResultRepository
 from ..services.rules import iris_rules, RuleResult
 from ..services.text import extract_domain, is_free_provider, url_host
 from ..services import parse_raw_message
+from ..services.failures import AnalysisFailure, classify_failure
 from ..services.parsers import build_path, parse_received_line
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
@@ -282,6 +283,8 @@ class IrisManager(TaskTrackingMixin):
             "wrapperSubject": context.wrapper_subject or None,
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
+            "failureCode": analysis.failure_code,
+            "failureReason": analysis.failure_reason,
             "user": username,
             "rules": rules_data,
             "recommendations": recommendations,
@@ -566,6 +569,7 @@ class IrisManager(TaskTrackingMixin):
                 "analysisId": analysis_record.id,
                 "title": analysis_record.title,
                 "status": analysis_record.status,
+                "failureCode": analysis_record.failure_code,
                 "totalScore": analysis_record.total_score,
                 "verdict": analysis_record.verdict,
                 "startedAt": isoformat_utc(analysis_record.started_at), # type: ignore
@@ -656,7 +660,7 @@ class IrisManager(TaskTrackingMixin):
         3. Runs every registered rule against the message (N1: against
            *both* the message and its ``message/rfc822`` wrapper when one
            is present, keeping the worse verdict — see
-           ``_evaluate_context``).
+           ``_evaluate_contexts``).
         4. Persists the winning context's rule results and the final
            score/verdict in a single transaction (C2/C3: no partial rows
            survive a mid-run cancellation, and there's one commit per
@@ -669,96 +673,127 @@ class IrisManager(TaskTrackingMixin):
                 self._update_analysis(analysis_id, status="running", started_at=utcnow_naive())
             except Exception as e:
                 logger.error(f"Failed to mark analysis {analysis_id} as running: {e}", exc_info=True)
-                self._fail_analysis(analysis_id)
+                self._fail_analysis(analysis_id, classify_failure(e))
                 return
 
-            # A single parse feeds both header-only and needs_context rules:
-            # when raw_input is a "report phishing" forward (message/rfc822
-            # attachment), context.headers already describes the *unwrapped
-            # original*, not the forwarding envelope — a separate
-            # parse_raw_headers(raw_input) here would silently re-introduce
-            # the envelope's headers and analyze the wrong message.
-            context = parse_raw_message(raw_input)
-            self._validate_headers_parsed(context.headers)
-
-            # N1: a "report phishing" forward is safe to unwrap unconditionally
-            # for a human-submitted analysis, but the same message/rfc822
-            # mechanism lets an attacker send their own phishing as the outer
-            # message and staple a benign .eml on as an attachment — analyzing
-            # only the unwrapped inner message would then score the wrong
-            # mail entirely. Evaluate both when a wrapper exists and keep the
-            # worse verdict; this matters most for unattended ingestion
-            # (Fase 3+), where there is no human eyeballing the wrapper first.
-            contexts_to_evaluate = [context]
-            if context.wrapper_context is not None:
-                contexts_to_evaluate.append(context.wrapper_context)
-
-            rules_defs = iris_rules.get_rules()
-            total_steps = len(rules_defs) * len(contexts_to_evaluate)
-            completed_steps = 0
-
-            evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
-            for evaluated_context in contexts_to_evaluate:
-                results: List[RuleResult] = []
-                named_results: Dict[str, RuleResult] = {}
-
-                for rule_def in rules_defs:
-                    if job.cancelled():
-                        logger.info(f"Analysis {analysis_id} was cancelled")
-                        return
-
-                    try:
-                        rule_input = (evaluated_context if rule_def.get("needs_context")
-                                      else evaluated_context.headers)
-                        result = rule_def["func"](rule_input)
-                    except Exception as e:
-                        logger.error(f"Rule '{rule_def['name']}' failed for analysis {analysis_id}: {e}", exc_info=True)
-                        result = RuleResult(
-                            score=0, verdict="error",
-                            details={"error": str(e)},
-                            recommendation=f"La regla '{rule_def['name']}' falló durante la ejecución.",
-                        )
-
-                    # Subtractive contract: a rule can only *subtract*. Whatever a
-                    # rule returns on a pass (historically +5/+3/+1 "credibility"
-                    # bonuses), the score it contributes — and the score shown in
-                    # the UI — is clamped to <= 0. Passing a rule means "no
-                    # deduction", never a bonus. The verdict/details are untouched.
-                    result = replace(result, score=min(0.0, float(result.score)))
-
-                    results.append(result)
-                    named_results[rule_def["name"]] = result
-
-                    completed_steps += 1
-                    job.progress(int((completed_steps / total_steps) * 100))
-
-                total_score = self._aggregate_score(rules_defs, results)
-                base_verdict = self._determine_verdict(total_score)
-                verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
-                evaluations.append((verdict, total_score, gate_reasons, results))
-
-            # Worse verdict wins across contexts; on a tie, keep the first
-            # (the unwrapped/inner message — the one ``contexts_to_evaluate``
-            # is ordered by, and the one every other persisted field
-            # describes) rather than the wrapper.
-            chosen = evaluations[0]
-            for evaluation in evaluations[1:]:
-                if _VERDICT_SEVERITY[evaluation[0]] > _VERDICT_SEVERITY[chosen[0]]:
-                    chosen = evaluation
-            verdict, total_score, gate_reasons, results = chosen
-
+            # B03: parseo, validación y evaluación comparten manejador con la
+            # persistencia. Estaban fuera de todo `try`, así que un parser roto
+            # o un `.eml` que no lo era dejaban la fila en `running` para
+            # siempre: RQ marcaba el job como fallido, pero nadie tocaba la
+            # base de datos y el usuario veía un análisis que no terminaba
+            # nunca. Ahora cualquier excepción de esta ventana acaba en un
+            # estado terminal con motivo consultable.
             try:
+                # A single parse feeds both header-only and needs_context rules:
+                # when raw_input is a "report phishing" forward (message/rfc822
+                # attachment), context.headers already describes the *unwrapped
+                # original*, not the forwarding envelope — a separate
+                # parse_raw_headers(raw_input) here would silently re-introduce
+                # the envelope's headers and analyze the wrong message.
+                context = parse_raw_message(raw_input)
+                self._validate_headers_parsed(context.headers)
+
+                # Un solo `get_rules()` para evaluar y para persistir: son dos
+                # recorridos que se emparejan por posición (`zip` en
+                # `_persist_analysis_results`), y leer el registro dos veces
+                # los desalinearía si alguien registrara una regla entremedias.
+                rules_defs = iris_rules.get_rules()
+                chosen = self._evaluate_contexts(analysis_id, context, job, rules_defs)
+                if chosen is None:
+                    return  # cancelado: no es un fallo, no hay nada que persistir
+                verdict, total_score, gate_reasons, results = chosen
+
                 self._persist_analysis_results(analysis_id, rules_defs, results,
-                                                verdict, total_score, gate_reasons)
+                                               verdict, total_score, gate_reasons)
             except Exception as e:
-                logger.error(f"Failed to finalise analysis {analysis_id}: {e}", exc_info=True)
-                self._fail_analysis(analysis_id)
+                logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
+                self._fail_analysis(analysis_id, classify_failure(e))
                 return
 
             if verdict == "Phishing":
                 self._enqueue_phishing_notification(analysis_id, verdict)
 
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
+
+    def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
+                           ) -> Optional[tuple[str, float, list[str], List[RuleResult]]]:
+        """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
+
+        Extraído de :meth:`_run_analysis` al envolver esa función en un único
+        manejador de ciclo de vida (`B03`): el bucle es la parte larga, y
+        dejarlo en línea dentro del ``try`` habría escondido qué se está
+        protegiendo exactamente.
+
+        Returns:
+            La tupla ``(verdict, total_score, gate_reasons, results)`` de la
+            evaluación ganadora, o ``None`` si la tarea fue cancelada a mitad
+            (que no es un fallo: no se persiste nada y la cancelación ya dejó
+            su propio estado terminal).
+        """
+        # N1: a "report phishing" forward is safe to unwrap unconditionally
+        # for a human-submitted analysis, but the same message/rfc822
+        # mechanism lets an attacker send their own phishing as the outer
+        # message and staple a benign .eml on as an attachment — analyzing
+        # only the unwrapped inner message would then score the wrong
+        # mail entirely. Evaluate both when a wrapper exists and keep the
+        # worse verdict; this matters most for unattended ingestion
+        # (Fase 3+), where there is no human eyeballing the wrapper first.
+        contexts_to_evaluate = [context]
+        if context.wrapper_context is not None:
+            contexts_to_evaluate.append(context.wrapper_context)
+
+        total_steps = len(rules_defs) * len(contexts_to_evaluate)
+        completed_steps = 0
+
+        evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
+        for evaluated_context in contexts_to_evaluate:
+            results: List[RuleResult] = []
+            named_results: Dict[str, RuleResult] = {}
+
+            for rule_def in rules_defs:
+                if job.cancelled():
+                    logger.info(f"Analysis {analysis_id} was cancelled")
+                    return None
+
+                try:
+                    rule_input = (evaluated_context if rule_def.get("needs_context")
+                                  else evaluated_context.headers)
+                    result = rule_def["func"](rule_input)
+                except Exception as e:
+                    logger.error(f"Rule '{rule_def['name']}' failed for analysis {analysis_id}: {e}", exc_info=True)
+                    result = RuleResult(
+                        score=0, verdict="error",
+                        details={"error": str(e)},
+                        recommendation=f"La regla '{rule_def['name']}' falló durante la ejecución.",
+                    )
+
+                # Subtractive contract: a rule can only *subtract*. Whatever a
+                # rule returns on a pass (historically +5/+3/+1 "credibility"
+                # bonuses), the score it contributes — and the score shown in
+                # the UI — is clamped to <= 0. Passing a rule means "no
+                # deduction", never a bonus. The verdict/details are untouched.
+                result = replace(result, score=min(0.0, float(result.score)))
+
+                results.append(result)
+                named_results[rule_def["name"]] = result
+
+                completed_steps += 1
+                job.progress(int((completed_steps / total_steps) * 100))
+
+            total_score = self._aggregate_score(rules_defs, results)
+            base_verdict = self._determine_verdict(total_score)
+            verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
+            evaluations.append((verdict, total_score, gate_reasons, results))
+
+        # Worse verdict wins across contexts; on a tie, keep the first
+        # (the unwrapped/inner message — the one ``contexts_to_evaluate``
+        # is ordered by, and the one every other persisted field
+        # describes) rather than the wrapper.
+        chosen = evaluations[0]
+        for evaluation in evaluations[1:]:
+            if _VERDICT_SEVERITY[evaluation[0]] > _VERDICT_SEVERITY[chosen[0]]:
+                chosen = evaluation
+        return chosen
 
     @staticmethod
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
@@ -1201,10 +1236,24 @@ class IrisManager(TaskTrackingMixin):
                 fixed += 1
         return fixed
 
-    def _fail_analysis(self, analysis_id: int) -> None:
-        """Mark an analysis as ``failed`` with a finished timestamp."""
+    def _fail_analysis(self, analysis_id: int, failure: Optional[AnalysisFailure] = None) -> None:
+        """Deja el análisis en estado terminal ``failed`` con su motivo.
+
+        ``failure`` es opcional solo para no romper a un llamador que ya no
+        tenga la excepción a mano; en la práctica todos los caminos de
+        ``_run_analysis`` la traen, porque un ``failed`` sin motivo es
+        justamente lo que `B03` venía a quitar de en medio.
+
+        No se propaga ninguna excepción desde aquí: esto es el último
+        recurso de la tarea, y un fallo escribiendo el fallo solo puede
+        empeorar las cosas.
+        """
+        fields: Dict[str, Any] = {"status": "failed", "finished_at": utcnow_naive()}
+        if failure is not None:
+            fields["failure_code"] = failure.code
+            fields["failure_reason"] = failure.reason
         try:
-            self._update_analysis(analysis_id, status="failed", finished_at=utcnow_naive())
+            self._update_analysis(analysis_id, **fields)
         except Exception as e:
             logger.error(f"Failed to mark analysis {analysis_id} as failed: {e}", exc_info=True)
 

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -37,6 +37,14 @@ class IrisAnalysis(Base):
         gate_reasons: List of human-readable reasons for the
                  high-confidence gates that fired (empty when the verdict
                  comes purely from the numeric score).
+        failure_code: Why a ``failed`` analysis failed — "invalid_input"
+                 (the submitted text is not an analysable message) or
+                 "internal_error" (the pipeline broke). NULL for every
+                 non-failed analysis. See ``services/failures.py``.
+        failure_reason: Human-readable, **non-sensitive** companion to
+                 ``failure_code``. Never contains the raw email: an
+                 internal error collapses to a generic message and only
+                 the server log keeps the traceback.
         ai_summary: AI-generated executive narrative (IA1) — dict with
                  executive_summary/attacker_intent/recommendations/
                  confidence, or None until generated (or if generation
@@ -66,6 +74,8 @@ class IrisAnalysis(Base):
     total_score = Column(Float, nullable=True)
     verdict = Column(String(20), nullable=True)
     gate_reasons = Column(JSONB, nullable=True)
+    failure_code = Column(String(32), nullable=True)
+    failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
     started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     finished_at = Column(DateTime, nullable=True)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -85,12 +85,20 @@ class AnalyzeResponseSchema(Schema):
 
 
 class AnalysisStatusResponseSchema(Schema):
-    """Current lifecycle status and optional progress of an analysis."""
+    """Current lifecycle status and optional progress of an analysis.
+
+    ``failureCode``/``failureReason`` solo viajan cuando ``status`` es
+    ``failed``. Es aquí donde se consultan, y no en el informe completo,
+    porque ``GET /iris/results/<id>`` exige un análisis ``finished``: un
+    análisis que murió no tiene informe que devolver, solo un motivo.
+    """
     analysisId = fields.Integer()
     status = fields.String()
     progress = fields.Integer(load_default=None)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
+    failureCode = fields.String(load_default=None, allow_none=True)
+    failureReason = fields.String(load_default=None, allow_none=True)
 
 
 class RuleResultSchema(Schema):
@@ -135,6 +143,8 @@ class AnalysisDetailResponseSchema(Schema):
     wrapperSubject = fields.String(load_default=None, allow_none=True)
     startedAt = fields.String(load_default=None)
     finishedAt = fields.String(load_default=None)
+    failureCode = fields.String(load_default=None, allow_none=True)
+    failureReason = fields.String(load_default=None, allow_none=True)
     user = fields.String()
     rules = fields.List(fields.Nested(RuleResultSchema))
     recommendations = fields.List(fields.String())
@@ -145,6 +155,7 @@ class AnalysisListItemSchema(Schema):
     analysisId = fields.Integer()
     title = fields.String(load_default=None)
     status = fields.String()
+    failureCode = fields.String(load_default=None, allow_none=True)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     startedAt = fields.String(load_default=None)

--- a/API/src/modules/features/iris/services/failures.py
+++ b/API/src/modules/features/iris/services/failures.py
@@ -1,0 +1,71 @@
+"""
+Clasificación de fallos terminales de un análisis de Iris.
+
+Un análisis puede morir por dos motivos muy distintos, y confundirlos hace
+inútil el estado terminal: o el usuario mandó algo que no es un correo
+analizable (culpa suya, accionable), o el pipeline se rompió por dentro
+(culpa nuestra, no accionable por el usuario). ``classify_failure`` traduce
+la excepción que aborta ``IrisManager._run_analysis`` en ese par
+``(código, razón)``.
+
+La razón es **texto técnico no sensible**: nunca el ``raw_input`` ni ningún
+fragmento del correo. El motivo es que se persiste en ``IrisAnalysis`` y se
+devuelve por API a quien consulte el estado, mientras que el cuerpo del
+mensaje analizado puede contener datos personales o credenciales — el propio
+informe ya lo trata como material sensible (ver la nota de consentimiento del
+PDF en ``services/reports.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..exceptions import IrisInvalidInputError
+
+
+#: El usuario mandó algo que no es un correo analizable.
+FAILURE_INVALID_INPUT = "invalid_input"
+
+#: El pipeline se rompió por dentro (parser, regla, persistencia).
+FAILURE_INTERNAL_ERROR = "internal_error"
+
+# Tope del mensaje persistido: `failure_reason` es una columna Text, pero un
+# traceback repr-eado de una librería de terceros puede ser enorme y no aporta
+# nada más allá de la primera línea.
+_MAX_REASON_LENGTH = 500
+
+_INTERNAL_REASON = (
+    "El análisis falló por un error interno del motor. El equipo puede "
+    "consultar el detalle en los registros del servidor."
+)
+
+
+@dataclass(frozen=True)
+class AnalysisFailure:
+    """Motivo terminal de un análisis fallido, listo para persistir.
+
+    Attributes:
+        code: ``invalid_input`` o ``internal_error``.
+        reason: Mensaje legible y no sensible, apto para devolver por API.
+    """
+
+    code: str
+    reason: str
+
+
+def classify_failure(error: BaseException) -> AnalysisFailure:
+    """Traduce la excepción que abortó un análisis en un motivo persistible.
+
+    ``IrisInvalidInputError`` es la única excepción cuyo mensaje se propaga
+    tal cual: lo construye este módulo a partir de un recuento de cabeceras,
+    nunca del contenido del correo. Cualquier otra excepción —incluido un
+    parser roto, que es el caso que motiva `B03`— se colapsa en un mensaje
+    genérico: el ``str(error)`` de una librería de terceros puede arrastrar
+    el fragmento de entrada que la hizo reventar.
+    """
+    if isinstance(error, IrisInvalidInputError):
+        return AnalysisFailure(
+            code=FAILURE_INVALID_INPUT,
+            reason=str(error)[:_MAX_REASON_LENGTH],
+        )
+    return AnalysisFailure(code=FAILURE_INTERNAL_ERROR, reason=_INTERNAL_REASON)

--- a/API/tests/integration/test_iris_analysis_failures.py
+++ b/API/tests/integration/test_iris_analysis_failures.py
@@ -1,0 +1,155 @@
+"""B03: un análisis que se rompe acaba en un estado terminal con motivo.
+
+Antes, el parseo y la validación del mensaje vivían **fuera** de todo bloque
+``try`` de ``IrisManager._run_analysis``. Una excepción ahí —un parser que
+revienta con un ``.eml`` raro, por ejemplo— dejaba la fila en ``running``
+para siempre: RQ marcaba el job como fallido, pero nadie escribía en la base
+de datos y el usuario veía un análisis que no terminaba nunca.
+
+Estos tests recorren el mismo camino que el worker (``_run_analysis`` a pelo,
+que fuera de RQ funciona igual porque ``job_context()`` es un no-op sin job) y
+comprueban las tres cosas que el issue pide: estado terminal, ``finishedAt``
+presente y una razón consultable que no filtre el correo original.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.failures import (
+    FAILURE_INTERNAL_ERROR,
+    FAILURE_INVALID_INPUT,
+)
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+
+# Un correo con datos que no deben acabar nunca en la respuesta de la API.
+_SENSITIVE_RAW = (
+    "From: nomina@empresa.example\r\n"
+    "To: victima@empresa.example\r\n"
+    "Subject: Cambio de cuenta bancaria\r\n"
+    "X-Secreto: ES91-2100-0418-4502-0005-1332\r\n"
+    "\r\n"
+    "Transfiere la nómina a la nueva cuenta.\r\n"
+)
+
+
+def _make_analysis(app, user_id: int, raw: str = _SENSITIVE_RAW) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def test_broken_parser_leaves_a_terminal_state(app, regular_user):
+    """El caso literal del issue: ``parse_raw_message`` revienta."""
+    analysis_id = _make_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod, "parse_raw_message",
+                               side_effect=RuntimeError("boom en el parser")):
+            IrisManager()._run_analysis(analysis_id, _SENSITIVE_RAW)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "failed"
+    assert analysis.finished_at is not None
+    assert analysis.failure_code == FAILURE_INTERNAL_ERROR
+
+
+def test_broken_parser_reason_does_not_leak_the_raw_email(app, regular_user):
+    """Un ``str(exception)`` de terceros puede arrastrar el fragmento de
+    entrada que lo hizo fallar; por eso un error interno se colapsa en un
+    mensaje genérico en lugar de propagarse."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    leaking_error = RuntimeError(f"no pude parsear: {_SENSITIVE_RAW}")
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod, "parse_raw_message", side_effect=leaking_error):
+            IrisManager()._run_analysis(analysis_id, _SENSITIVE_RAW)
+
+    reason = _reload(app, analysis_id).failure_reason
+    assert reason
+    assert "ES91-2100-0418-4502-0005-1332" not in reason
+    assert "victima@empresa.example" not in reason
+
+
+def test_unparseable_input_is_invalid_not_internal(app, regular_user):
+    """Un texto que no es un correo es culpa del que lo manda, y el motivo
+    debe decírselo: ``invalid_input``, no un error interno opaco."""
+    analysis_id = _make_analysis(app, regular_user.id, raw="esto no es un correo")
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, "esto no es un correo")
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "failed"
+    assert analysis.finished_at is not None
+    assert analysis.failure_code == FAILURE_INVALID_INPUT
+    assert "cabeceras" in analysis.failure_reason
+
+
+class _NoTaskQueue:
+    """Doble mínimo de TaskQueue: el job ya no existe.
+
+    ``GET /iris/status`` consulta primero la cola (ruta rápida para tareas en
+    curso) y solo cae a la base de datos si no hay tarea viva. Sin este doble
+    la llamada saldría a Redis, que la suite tiene deshabilitado a propósito.
+    """
+
+    def get_task_by_external_id(self, external_id, category=None):
+        return None
+
+
+def test_status_endpoint_exposes_the_reason(client, app, regular_user, auth_headers):
+    """La razón tiene que ser consultable: ``GET /iris/results/<id>`` exige un
+    análisis ``finished``, así que el sitio donde se lee es ``/iris/status``."""
+    analysis_id = _make_analysis(app, regular_user.id, raw="esto tampoco es un correo")
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, "esto tampoco es un correo")
+
+    with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoTaskQueue()):
+        response = client.get(f"/iris/status?id={analysis_id}",
+                              headers=auth_headers(regular_user))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "failed"
+    assert body["failureCode"] == FAILURE_INVALID_INPUT
+    assert body["failureReason"]
+
+
+def test_successful_analysis_carries_no_failure_reason(app, regular_user):
+    """Un análisis que termina bien no debe arrastrar un motivo de fallo."""
+    raw = (
+        "From: alguien@example.com\r\n"
+        "To: destino@example.com\r\n"
+        "Subject: Hola\r\n"
+        "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "\r\n"
+        "Cuerpo.\r\n"
+    )
+    analysis_id = _make_analysis(app, regular_user.id, raw=raw)
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, raw)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "finished"
+    assert analysis.failure_code is None
+    assert analysis.failure_reason is None

--- a/API/tests/unit/test_iris_failures.py
+++ b/API/tests/unit/test_iris_failures.py
@@ -1,0 +1,52 @@
+"""B03: clasificación del motivo por el que un análisis de Iris muere.
+
+Un ``failed`` sin motivo no es accionable: quien lo mira no sabe si el
+problema era su fichero o el motor. ``classify_failure`` es la costura que
+separa esos dos casos, y estos tests fijan la parte que importa de verdad —
+que el mensaje persistido nunca arrastre contenido del correo analizado.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.exceptions import IrisInvalidInputError
+from src.modules.features.iris.services.failures import (
+    FAILURE_INTERNAL_ERROR,
+    FAILURE_INVALID_INPUT,
+    classify_failure,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_invalid_input_keeps_its_own_message():
+    """El mensaje de ``IrisInvalidInputError`` lo redacta el propio módulo a
+    partir de un recuento de cabeceras, así que puede viajar tal cual."""
+    failure = classify_failure(
+        IrisInvalidInputError("Tras parsear se obtuvieron 0 cabeceras (mínimo: 2).")
+    )
+
+    assert failure.code == FAILURE_INVALID_INPUT
+    assert "0 cabeceras" in failure.reason
+
+
+def test_unexpected_error_never_leaks_the_exception_text():
+    """El caso que motiva B03: un parser que revienta y arrastra en su
+    ``str()`` el fragmento de entrada que no supo digerir."""
+    leaked = "b'From: victima@banco.example\\r\\nAuthorization: Bearer s3cr3t'"
+    failure = classify_failure(ValueError(f"cannot decode {leaked}"))
+
+    assert failure.code == FAILURE_INTERNAL_ERROR
+    assert "s3cr3t" not in failure.reason
+    assert "victima@banco.example" not in failure.reason
+    assert failure.reason  # hay algo que enseñar, no una cadena vacía
+
+
+def test_reason_is_bounded():
+    """Un traceback repr-eado de una librería de terceros puede ser enorme y
+    no aporta nada más allá de la primera línea; la columna es Text, pero la
+    respuesta de la API no debería serlo."""
+    failure = classify_failure(IrisInvalidInputError("x" * 5000))
+
+    assert len(failure.reason) <= 500


### PR DESCRIPTION
## Resumen

Un análisis de Iris que se rompía a mitad podía quedarse **en `running` para siempre**. Este PR cierra esa ventana: cualquier excepción del pipeline deja ahora un estado terminal con un motivo que se puede consultar por API.

Cierra #207.

## El problema, en llano

Cuando alguien envía un correo a Iris, el trabajo real no ocurre en la petición HTTP: se encola una tarea de fondo (un *job* de RQ, el sistema de colas del proyecto) que la ejecuta un proceso aparte, el *worker*. Ese worker es quien va escribiendo en la fila de base de datos el estado del análisis: `pending` → `running` → `finished`.

En `IrisManager._run_analysis()` había tres bloques `try` que, ante un fallo, llamaban a `_fail_analysis()` para dejar la fila en `failed`. Pero entre el primero y el segundo quedaba un hueco sin proteger, y justo ahí vivían las dos operaciones más frágiles de todo el proceso:

```python
context = parse_raw_message(raw_input)          # convertir el texto en un correo
self._validate_headers_parsed(context.headers)  # ¿tiene cabeceras suficientes?
```

Si cualquiera de las dos lanzaba una excepción, esta se propagaba hasta RQ. **RQ marca su propio job como fallido, pero RQ no sabe nada de la tabla `IrisAnalysis`.** Nadie escribía en la base de datos, así que la fila se quedaba en `running` indefinidamente: el usuario veía un análisis eternamente "en curso" que nunca iba a terminar, sin ningún error que le explicara nada.

El parseo es exactamente el sitio donde esto pasa en la práctica: recibe texto arbitrario subido por un usuario y lo pasa por la librería `email` de la biblioteca estándar, con adjuntos, codificaciones raras y estructuras MIME anidadas.

## Qué cambia

**1. Un único manejador de ciclo de vida.** Parseo, validación, evaluación de reglas y persistencia comparten ahora el mismo `try`. Cualquier excepción de esa ventana acaba en `_fail_analysis()`, siempre con `finished_at` y siempre con un motivo.

Una salida no es un fallo y hay que distinguirla: la **cancelación**. Cuando el usuario cancela, el bucle de reglas se corta a mitad, pero eso ya dejó su propio estado terminal (`cancelled`) por otra vía. Por eso `_evaluate_contexts()` devuelve `None` en ese caso y el manejador sale sin tocar nada, en lugar de pisar el `cancelled` con un `failed`.

**2. Un servicio nuevo, `services/failures.py`.** El issue distingue entre entrada inválida y error interno, y esa distinción tiene una regla propia que merece sus propios tests, así que no vive en el manager:

- `IrisInvalidInputError` → código `invalid_input`, y **su mensaje se propaga tal cual**. Se puede, porque ese mensaje lo redacta el propio Iris a partir de un recuento de cabeceras ("se obtuvieron 0 cabeceras, mínimo 2"); no contiene nada del correo.
- Cualquier otra excepción → código `internal_error` y **un mensaje genérico**. Aquí no se puede propagar el original: el `str()` de una excepción de una librería de terceros suele incluir el trozo de entrada que la hizo reventar, y ese trozo es el correo del usuario. El detalle completo se queda en el log del servidor, que es donde debe estar.

Este es el punto del criterio de cierre del issue —"una razón consultable **sin filtrar el raw email**"— y tiene un test dedicado que mete un IBAN y una dirección de correo en el mensaje de la excepción y comprueba que ninguno de los dos llega a la base de datos.

**3. Dos columnas nuevas y su migración.** `failure_code` (32 caracteres) y `failure_reason` (texto). Son NULL para todo análisis que no haya fallado, así que la migración solo añade columnas: no hay relleno de filas existentes ni riesgo sobre los datos ya guardados. La bajada las elimina.

**4. El motivo se consulta en `GET /iris/status`**, no en el informe completo. Puede parecer el sitio raro, pero es el único posible: `GET /iris/results/<id>` lanza `IrisAnalysisNotReadyError` si el análisis no está `finished`, y un análisis que murió nunca lo estará. El listado paginado lleva además `failureCode` para distinguir de un vistazo un fallo del usuario de uno del motor.

**5. `_evaluate_contexts()` sale del método.** Al envolver `_run_analysis()` en un `try`, el bucle de reglas —que es la parte larga— habría quedado dentro y habría escondido qué se está protegiendo exactamente. Es un movimiento de código sin cambio de comportamiento, con una excepción que sí lo mejora: antes se llamaba a `iris_rules.get_rules()` dos veces, una para evaluar y otra para persistir. Esos dos recorridos se emparejan por posición con un `zip`, así que dos lecturas del registro podían desalinearse si alguien registrara una regla entremedias. Ahora se lee una sola vez.

## Validación

- `tests/unit/test_iris_failures.py` (nuevo) — la clasificación: mensaje propio para entrada inválida, mensaje genérico para error interno, y el test de no-filtración.
- `tests/integration/test_iris_analysis_failures.py` (nuevo) — recorre `_run_analysis()` igual que lo haría el worker (fuera de RQ funciona igual, porque `job_context()` es un no-op cuando no hay job): parser roto con `monkeypatch`, entrada que no es un correo, lectura del motivo por HTTP y comprobación de que un análisis correcto no arrastra ningún motivo de fallo.
- Suite completa en verde. `pylint` sobre los ficheros tocados: 8.08 → 8.16.
- Grafo de Alembic verificado: 48 revisiones, un solo head, sin IDs duplicados.

## Notas

- **Sobre el ID de la migración:** el primer intento usó `a1b2c3d4e5f6` siguiendo el patrón de nombres a mano del repositorio, y **ese ID ya estaba cogido** por `a1b2c3d4e5f6_add_password_change_detection.py`. La revisión final (`b46e50206411`) es aleatoria y se comprobó contra las 47 existentes antes de escribirla.
- El issue habla de estados `failed`/`invalid` "definidos". Aquí ambos casos terminan en `status="failed"` y se distinguen por `failure_code`, en lugar de añadir un valor nuevo al enum de estados: `invalid` como estado propio obligaría a tocar los filtros del listado, la SPA y los tests de todo el ciclo de vida, para no aportar nada que `failure_code` no diga ya.
- El README no se toca en este PR. Los cambios de contrato de toda la fase 0 van juntos en un único commit al final, según la regla de `CLAUDE.md`.
- `_fail_analysis()` acepta el motivo como argumento opcional. Todos los caminos actuales lo aportan; queda opcional solo para no obligar a un llamador futuro que no tenga la excepción a mano.
