### PR TITLE
fix(iris): reconciliación que no se come análisis en ejecución (B04)

### DIFF
--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -39,7 +39,12 @@ from ..repositories import IrisAnalysisRepository, IrisRuleResultRepository
 from ..services.rules import iris_rules, RuleResult
 from ..services.text import extract_domain, is_free_provider, url_host
 from ..services import parse_raw_message
-from ..services.failures import AnalysisFailure, classify_failure
+from ..services.failures import (
+    FAILURE_WORKER_LOST,
+    WORKER_LOST_REASON,
+    AnalysisFailure,
+    classify_failure,
+)
 from ..services.parsers import build_path, parse_received_line
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
@@ -1218,19 +1223,35 @@ class IrisManager(TaskTrackingMixin):
         tarea viva en TaskQueue que lo actualice tras reiniciar, y el registro
         se queda así para siempre. Se llama una vez al arrancar la API.
 
+        `B04`: antes se conservaba el análisis **solo** si su tarea estaba
+        exactamente en ``pending``. Un job ``running`` puede estar avanzando en
+        otro proceso —los workers son procesos aparte, y reiniciar la API no
+        los para—, así que ese criterio marcaba como fallidos análisis que
+        estaban perfectamente vivos: el usuario veía `failed` mientras el
+        worker seguía trabajando, y al rato el worker escribía `finished`
+        encima de esa misma fila. La pregunta correcta no es "¿en qué estado
+        está el job?" sino "¿queda alguien que vaya a terminarlo?", y esa la
+        responde ``TaskQueue.is_recoverable()``, que para un job en ejecución
+        comprueba además si su worker sigue vivo de verdad.
+
         Returns:
             Número de análisis marcados como failed.
         """
         task_queue = TaskQueue.get_instance()
+        # Una instancia para componer los external_id con el prefijo canónico
+        # (``EXTERNAL_ID_PREFIX``) en vez de repetir el formato a mano; comparte
+        # la cola que ya se acaba de resolver, así que no cuesta nada.
+        manager = cls(task_queue=task_queue)
         fixed = 0
         with UnitOfWork() as uow:
             repo = IrisAnalysisRepository(uow)
             for analysis in repo.get_active_analyses():
-                external_id = f"{cls.EXTERNAL_ID_PREFIX}{analysis.id}"
-                task = task_queue.get_task_by_external_id(external_id, cls.TASK_CATEGORY)
-                if task is not None and str(task.status) == "pending":
+                external_id = manager.external_id_for(analysis.id)
+                if task_queue.is_recoverable(external_id, cls.TASK_CATEGORY):
                     continue
                 analysis.status = "failed"
+                analysis.failure_code = FAILURE_WORKER_LOST
+                analysis.failure_reason = WORKER_LOST_REASON
                 analysis.finished_at = utcnow_naive()
                 repo.update(analysis)
                 fixed += 1

--- a/API/src/modules/features/iris/services/failures.py
+++ b/API/src/modules/features/iris/services/failures.py
@@ -29,6 +29,19 @@ FAILURE_INVALID_INPUT = "invalid_input"
 #: El pipeline se rompió por dentro (parser, regla, persistencia).
 FAILURE_INTERNAL_ERROR = "internal_error"
 
+#: El proceso que ejecutaba el análisis desapareció sin dejar resultado.
+#: No es un error del motor —nunca llegó a fallar nada— sino la constatación,
+#: al arrancar, de que ya no queda nadie que vaya a terminar ese trabajo.
+FAILURE_WORKER_LOST = "worker_lost"
+
+#: Razón asociada a ``FAILURE_WORKER_LOST``. Vive aquí, y no en el manager,
+#: porque es el mismo tipo de dato que produce ``classify_failure``: texto
+#: legible, no sensible y persistible.
+WORKER_LOST_REASON = (
+    "El proceso que ejecutaba este análisis se detuvo antes de terminarlo. "
+    "Vuelve a lanzarlo para obtener un resultado."
+)
+
 # Tope del mensaje persistido: `failure_reason` es una columna Text, pero un
 # traceback repr-eado de una librería de terceros puede ser enorme y no aporta
 # nada más allá de la primera línea.

--- a/API/src/modules/system/taskqueue/queue.py
+++ b/API/src/modules/system/taskqueue/queue.py
@@ -270,6 +270,20 @@ class ITaskQueue(Protocol):
         """
         ...
 
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        """¿Queda alguien que vaya a terminar el trabajo de este external_id?
+
+        La usan las reconciliaciones de arranque para no marcar como huérfano
+        un trabajo que sigue vivo en otro proceso. Un job en cola es
+        recuperable; uno en ejecución lo es solo si su worker sigue vivo; uno
+        terminado o inexistente, no.
+
+        Está en el contrato —y no solo en la implementación— porque un doble de
+        tests que la olvide haría que la reconciliación se comiera trabajo
+        vivo, que es justo el fallo que esta operación existe para evitar.
+        """
+        ...
+
     def update_progress(self, task_id: str, progress: int) -> None:
         """Actualiza el progreso (0-100) de un job en ejecución.
 
@@ -568,6 +582,62 @@ class TaskQueue:
             )
             return None
         return task
+
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        """¿Queda alguien que vaya a terminar el trabajo de *external_id*?
+
+        La usa la reconciliación de arranque de cada módulo para decidir si un
+        registro que quedó en pending/running está realmente huérfano. La
+        pregunta no la responde el estado del job por sí solo: un job
+        ``started`` puede estar avanzando en otro proceso ahora mismo, o
+        pertenecer a un worker que murió de un ``kill -9`` y no va a volver.
+
+        Estado por estado:
+
+        - **Sin job** (no hay mapeo, o el historial de RQ ya lo purgó por TTL):
+          no recuperable. Nadie va a tocar ese registro nunca más.
+        - **PENDING** (``queued``/``scheduled``/``deferred``): recuperable. El
+          job sigue en la cola y el primer worker libre lo tomará.
+        - **RUNNING** (``started``): recuperable **solo si su worker sigue
+          vivo**. Se comprueba con la misma verificación de PID que usa
+          ``cancel()``: la clave ``rq:worker:<name>`` sobrevive con TTL
+          completo a una muerte abrupta, así que su mera existencia no prueba
+          nada.
+        - **Terminal** (``finished``/``failed``/``stopped``): no recuperable.
+          El job acabó; si el registro sigue activo es porque el proceso murió
+          entre el trabajo y su escritura final.
+
+        Si Redis no responde se devuelve ``True``. Es deliberado y conservador:
+        sin poder mirar, no hay prueba de que el trabajo esté perdido, y el
+        precio de equivocarse es asimétrico — un huérfano que sobrevive un
+        arranque más se reconcilia en el siguiente, mientras que marcar
+        ``failed`` un trabajo vivo se lo enseña al usuario como fallido justo
+        antes de que el worker escriba su resultado encima.
+        """
+        try:
+            job_id = self._external.get(external_id)
+            if job_id is None:
+                return False
+
+            job = self._try_fetch_job(job_id)
+            if job is None:
+                return False
+
+            task = Task.from_rq_job(job)
+            if category is not None and task.category != category:
+                return False
+
+            if task.status is TaskStatus.PENDING:
+                return True
+            if task.status is TaskStatus.RUNNING:
+                return self._worker_alive(job.worker_name)
+            return False
+        except Exception as exc:
+            logger.warning(
+                "is_recoverable: no se pudo consultar %s (%s); se asume recuperable",
+                external_id, exc,
+            )
+            return True
 
     def get_running(self, category: Optional[str] = None) -> List[dict]:
         all_job_ids = []

--- a/API/tests/integration/test_iris_reconciliation.py
+++ b/API/tests/integration/test_iris_reconciliation.py
@@ -1,9 +1,16 @@
-"""C1: reconciliación de análisis Iris huérfanos tras un apagado abrupto.
+"""C1/B04: reconciliación de análisis Iris huérfanos tras un apagado abrupto.
 
 Espejo de la reconciliación que ya existía para Themis (ScanManager.
 reconcile_orphaned_scans) — sin esto, un análisis que queda en pending/running
 cuando el proceso muere se queda así para siempre, porque no hay ninguna tarea
 viva en TaskQueue que lo actualice tras reiniciar.
+
+`B04` cambió el criterio. Antes se conservaba el análisis solo si su tarea
+estaba exactamente en ``pending``, y eso se comía trabajo vivo: los workers son
+procesos aparte, reiniciar la API no los para, y un job ``running`` puede estar
+avanzando ahora mismo en otro proceso. La pregunta correcta no es "¿en qué
+estado está el job?" sino "¿queda alguien que vaya a terminarlo?", que es lo que
+responde ``TaskQueue.is_recoverable()``.
 """
 
 from __future__ import annotations
@@ -19,18 +26,34 @@ from src.modules.system.taskqueue import Task, TaskStatus
 import src.modules.features.iris.managers.analysis as managers_mod
 from src.modules.features.iris.model import IrisAnalysis
 from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.failures import FAILURE_WORKER_LOST
 
 pytestmark = pytest.mark.integration
 
 
 class _FakeQueue:
-    """Cola fake: devuelve lo que el test necesite por external_id."""
+    """Cola fake que responde lo que el test necesite por external_id.
 
-    def __init__(self, tasks_by_external_id: dict[str, Optional[Task]]):
+    ``recoverable`` modela la respuesta de ``is_recoverable()``, que en la
+    implementación real combina el estado del job con la comprobación de si el
+    worker que lo tomó sigue vivo. Aquí se declara directamente: lo que estos
+    tests fijan es qué hace la reconciliación con esa respuesta, no cómo la
+    calcula la cola (eso vive en ``tests/unit/test_taskqueue.py``).
+    """
+
+    def __init__(self, tasks_by_external_id: dict[str, Optional[Task]],
+                 recoverable: Optional[dict[str, bool]] = None):
         self._tasks = tasks_by_external_id
+        self._recoverable = recoverable or {}
 
     def get_task_by_external_id(self, external_id: str, category: Optional[str] = None):
         return self._tasks.get(external_id)
+
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        if external_id in self._recoverable:
+            return self._recoverable[external_id]
+        task = self._tasks.get(external_id)
+        return task is not None and task.status is TaskStatus.PENDING
 
     def submit(self, func: Callable, **kwargs): raise NotImplementedError
     def cancel(self, task_id: str) -> bool: return True
@@ -48,39 +71,112 @@ def _make_analysis(app, user_id, status="running"):
             return analysis.id
 
 
-def test_reconcile_marks_orphan_without_any_task_as_failed(app, regular_user):
-    analysis_id = _make_analysis(app, regular_user.id, status="running")
-    queue = _FakeQueue({})  # sin tarea en TaskQueue -> huérfano
-
+def _reconcile(app, queue) -> int:
     with app.app_context():
         with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 1
+            return managers_mod.IrisManager.reconcile_orphaned_analyses()
+
+
+def _reload(app, analysis_id) -> IrisAnalysis:
+    with app.app_context():
         with UnitOfWork() as uow:
-            assert IrisAnalysisRepository(uow).get_by_id(analysis_id).status == "failed"
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def _task(external_id: str, status: TaskStatus) -> Task:
+    return Task(id="job1", name="job1", category="iris.analyze",
+                external_id=external_id, status=status)
+
+
+def test_reconcile_marks_orphan_without_any_task_as_failed(app, regular_user):
+    """Sin tarea en TaskQueue no hay nadie que vaya a terminar el análisis."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    assert _reconcile(app, _FakeQueue({})) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_records_why_the_analysis_was_orphaned(app, regular_user):
+    """Un `failed` sin explicación no le dice nada al usuario: aquí la causa no
+    es que el motor fallara, sino que el proceso que lo ejecutaba desapareció."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    _reconcile(app, _FakeQueue({}))
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.failure_code == FAILURE_WORKER_LOST
+    assert analysis.failure_reason
+    assert analysis.finished_at is not None
 
 
 def test_reconcile_leaves_still_queued_analysis_alone(app, regular_user):
+    """Un job en cola lo tomará el primer worker libre: no está huérfano."""
     analysis_id = _make_analysis(app, regular_user.id, status="pending")
     external_id = f"iris-analysis:{analysis_id}"
-    queue = _FakeQueue({external_id: Task(
-        id="job1", name="job1", category="iris.analyze",
-        external_id=external_id, status=TaskStatus.PENDING,
-    )})
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.PENDING)})
 
-    with app.app_context():
-        with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 0
-        with UnitOfWork() as uow:
-            assert IrisAnalysisRepository(uow).get_by_id(analysis_id).status == "pending"
+    assert _reconcile(app, queue) == 0
+    assert _reload(app, analysis_id).status == "pending"
+
+
+def test_reconcile_leaves_a_running_analysis_alone(app, regular_user):
+    """El caso que motiva B04.
+
+    El worker está analizando ahora mismo en otro proceso. Con el criterio
+    viejo —conservar solo si el estado es exactamente ``pending``— este
+    análisis se marcaba ``failed``, el usuario lo veía fallido, y poco después
+    el worker escribía ``finished`` encima de esa misma fila.
+    """
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: True},  # su worker sigue vivo
+    )
+
+    assert _reconcile(app, queue) == 0
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "running"
+    assert analysis.finished_at is None
+
+
+def test_reconcile_recovers_a_running_analysis_whose_worker_died(app, regular_user):
+    """Mismo estado ``running``, decisión contraria: si el worker que tomó el
+    job ya no existe, nadie va a leer su señal ni a escribir su resultado."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: False},  # kill -9 al worker
+    )
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_recovers_an_analysis_whose_job_expired(app, regular_user):
+    """RQ purga su historial por TTL: el job existió, pero ya no está y su
+    resultado nunca llegó a la fila."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue({external_id: None}, recoverable={external_id: False})
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_recovers_an_analysis_whose_job_already_failed(app, regular_user):
+    """Un job en estado terminal no va a volver a tocar la fila: si el análisis
+    sigue activo es porque el proceso murió entre el trabajo y su escritura."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.FAILED)})
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
 
 
 def test_reconcile_ignores_already_finished_analyses(app, regular_user):
     _make_analysis(app, regular_user.id, status="finished")
-    queue = _FakeQueue({})
 
-    with app.app_context():
-        with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 0
+    assert _reconcile(app, _FakeQueue({})) == 0

--- a/API/tests/unit/test_taskqueue.py
+++ b/API/tests/unit/test_taskqueue.py
@@ -69,6 +69,11 @@ class FakeTaskQueue:
             return None
         return task
 
+    def is_recoverable(self, external_id: str,
+                       category: Optional[str] = None) -> bool:
+        task = self.get_task_by_external_id(external_id, category)
+        return task is not None and task.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
+
     def update_progress(self, task_id: str, progress: int) -> None:
         pass
 

--- a/API/tests/unit/test_taskqueue_recoverable.py
+++ b/API/tests/unit/test_taskqueue_recoverable.py
@@ -1,0 +1,128 @@
+"""B04: ``TaskQueue.is_recoverable()`` — ¿queda alguien que termine este trabajo?
+
+Las reconciliaciones de arranque necesitan distinguir un trabajo abandonado de
+uno que sigue vivo en otro proceso. Mirar solo el estado del job no basta: un
+job ``started`` puede estar avanzando ahora mismo, o pertenecer a un worker que
+murió de un ``kill -9`` y no va a volver. Estos tests fijan esa tabla de
+decisión sobre la implementación real, con Redis y RQ sustituidos por dobles.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.system.taskqueue.queue import TaskQueue
+
+pytestmark = pytest.mark.unit
+
+_EXTERNAL_ID = "iris-analysis:42"
+_CATEGORY = "iris.analyze"
+
+
+class _ExternalIdStore:
+    """Doble del mapeo external_id → job_id que vive en Redis."""
+
+    def __init__(self, mapping: dict[str, str]):
+        self._mapping = mapping
+
+    def get(self, external_id: str):
+        return self._mapping.get(external_id)
+
+
+def _queue(job_id: str | None = "job-1") -> TaskQueue:
+    """Instancia de TaskQueue sin pasar por ``__init__``.
+
+    El constructor real abre la conexión a Redis; aquí solo se necesitan las
+    tres costuras que ``is_recoverable`` consulta, y cada test las sustituye.
+    """
+    queue = TaskQueue.__new__(TaskQueue)
+    queue._external = _ExternalIdStore({_EXTERNAL_ID: job_id} if job_id else {})
+    return queue
+
+
+def _rq_job(status: str, worker_name: str | None = "worker-1"):
+    """Doble de un ``rq.job.Job`` con lo justo que lee ``Task.from_rq_job``."""
+    job = mock.MagicMock()
+    job.id = "job-1"
+    job.description = "Analysis-42"
+    job.meta = {"category": _CATEGORY, "external_id": _EXTERNAL_ID}
+    job.get_status.return_value = status
+    job.created_at = None
+    job.started_at = None
+    job.ended_at = None
+    job.exc_info = None
+    job.worker_name = worker_name
+    return job
+
+
+def test_no_mapping_means_nobody_will_finish_it():
+    queue = _queue(job_id=None)
+
+    assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_expired_job_is_not_recoverable():
+    """RQ purga su historial por TTL: el mapeo sigue, el job ya no."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=None):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_queued_job_is_recoverable():
+    """Sigue en la cola; el primer worker libre lo tomará."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("queued")):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True
+
+
+def test_started_job_with_a_live_worker_is_recoverable():
+    """El caso que motiva B04: está corriendo, no hay que tocarlo."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=True):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True
+
+
+def test_started_job_whose_worker_died_is_not_recoverable():
+    """La clave ``rq:worker:<name>`` sobrevive con TTL completo a un ``kill -9``,
+    así que "el job dice started" no prueba que alguien lo esté ejecutando."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=False):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+@pytest.mark.parametrize("rq_status", ["finished", "failed", "stopped"])
+def test_terminal_jobs_are_not_recoverable(rq_status):
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job(rq_status)):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_category_mismatch_is_not_recoverable():
+    """Un external_id reutilizado por otro módulo no responde por este trabajo."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=True):
+        assert queue.is_recoverable(_EXTERNAL_ID, "themis.scan") is False
+
+
+def test_redis_failure_assumes_recoverable():
+    """Conservador a propósito: sin poder mirar no hay prueba de que el trabajo
+    esté perdido, y el precio de equivocarse es asimétrico — un huérfano que
+    sobrevive un arranque se reconcilia en el siguiente, pero marcar `failed`
+    un trabajo vivo se lo enseña al usuario como fallido justo antes de que el
+    worker escriba su resultado encima."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job",
+                           side_effect=ConnectionError("Redis caído")):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True


### PR DESCRIPTION
## Resumen

La reconciliación de arranque de Iris marcaba como fallidos análisis que seguían ejecutándose. Este PR sustituye su criterio por uno que pregunta lo correcto, apoyado en una operación nueva de la cola de tareas.

Cierra #208.

## El problema, en llano

Cuando la API arranca, ejecuta una *reconciliación*: recorre los análisis que quedaron en `pending` o `running` y decide si alguno se quedó colgado porque el proceso murió a mitad. Es necesaria — sin ella, un apagado abrupto deja filas en `running` para siempre.

El criterio era este:

```python
task = task_queue.get_task_by_external_id(external_id, cls.TASK_CATEGORY)
if task is not None and str(task.status) == "pending":
    continue          # se conserva
analysis.status = "failed"
```

Es decir: **se conservaba solo si la tarea estaba exactamente en `pending`**. Todo lo demás, `running` incluido, iba a `failed`.

Eso es demasiado agresivo, y el motivo es que **los workers son procesos aparte**. Reiniciar la API no los detiene: un job en estado `running` puede estar analizando ahora mismo en otro proceso que nunca se enteró del reinicio. Con este criterio, la reconciliación lo marcaba como fallido, el usuario lo veía fallido en su panel, y minutos después el worker terminaba y escribía `finished` encima de esa misma fila. Dos estados contradictorios para el mismo análisis con minutos de diferencia, y ninguna forma de que el usuario supiera cuál creerse.

## Por qué no bastaba con añadir `running` a la lista

Porque `running` tampoco prueba nada por sí solo. RQ mantiene en Redis una clave `rq:worker:<nombre>` por cada worker registrado, y esa clave **sobrevive con su TTL completo aunque el proceso muera de golpe** (un `kill -9` no pasa por el apagado ordenado que la borraría). Así que un job puede quedarse marcado como `started` para siempre sin que nadie lo esté ejecutando: exactamente el huérfano que la reconciliación existe para rescatar.

La pregunta correcta no es "¿en qué estado está el job?" sino **"¿queda alguien que vaya a terminar este trabajo?"**.

## Qué cambia

**1. `TaskQueue.is_recoverable(external_id, category)`** — nueva, en `system/taskqueue/queue.py`. Responde esa pregunta:

| Situación | ¿Recuperable? | Por qué |
|---|---|---|
| No hay mapeo, o RQ ya purgó el job por TTL | **No** | Nadie va a tocar ese registro nunca más |
| `queued` / `scheduled` / `deferred` | **Sí** | Sigue en la cola; el primer worker libre lo tomará |
| `started` con su worker vivo | **Sí** | Está avanzando ahora mismo en otro proceso |
| `started` con su worker muerto | **No** | Nadie leerá su señal ni escribirá su resultado |
| `finished` / `failed` / `stopped` | **No** | El job acabó; si el registro sigue activo es que el proceso murió entre el trabajo y su escritura final |

La distinción entre las dos filas de `started` es la que necesita comprobar el worker de verdad, y para eso reutiliza `_worker_alive()`, que ya existía y que `cancel()` usa desde hace tiempo: si el worker corre en este mismo host, comprueba que su **PID siga existiendo**, en vez de fiarse de la clave de Redis.

**Ante un fallo de Redis devuelve `True`.** Es deliberado y conservador: sin poder mirar no hay prueba de que el trabajo esté perdido, y el precio de equivocarse es asimétrico. Un huérfano que sobrevive un arranque se reconcilia en el siguiente; marcar `failed` un trabajo vivo se lo enseña al usuario como fallido justo antes de que el worker escriba su resultado encima.

**2. Va al contrato `ITaskQueue`, no solo a la implementación.** `ITaskQueue` es el `Protocol` que describe qué puede hacer una cola, y los tests inyectan dobles que lo cumplen. Se declara ahí porque un doble que olvide `is_recoverable` haría que la reconciliación se comiera trabajo vivo — justo el fallo que esta operación existe para evitar. El test de conformidad `test_fake_queue_satisfies_interface` lo hace cumplir automáticamente, y de hecho ya obligó a completar `FakeTaskQueue` en este mismo PR.

**3. Un código de fallo propio para el huérfano.** Un análisis que se reconcilia se marca `worker_lost`, no `internal_error`. No es que el motor fallara — nunca llegó a fallar nada; es que el proceso que lo ejecutaba desapareció. Lo accionable para el usuario es simplemente volver a lanzarlo, y el mensaje que se persiste se lo dice. Aprovecha las columnas que añadió #207.

**4. El `external_id` deja de componerse a mano.** Pasa a construirse con `external_id_for()`, que es la regla del proyecto (`CLAUDE.md`: el prefijo lo declara el manager en `EXTERNAL_ID_PREFIX` y el mixin lo compone).

## Validación

- `tests/unit/test_taskqueue_recoverable.py` (nuevo) — la tabla de decisión completa sobre la implementación **real**, con Redis y RQ sustituidos por dobles: sin mapeo, job expirado, en cola, en ejecución con worker vivo, en ejecución con worker muerto, los tres estados terminales, categoría que no coincide y caída de Redis.
- `tests/integration/test_iris_reconciliation.py` (ampliado de 3 a 9 tests) — los dos casos que pide el criterio de cierre del issue: **una tarea `running` durante la reconciliación no se toca**, y **un job expirado sí se recupera**. Más worker muerto, job en estado terminal, y que el motivo del huérfano quede registrado.
- Suite completa en verde (1 927 tests).
- Sin migración: este PR no toca el esquema.

## Notas

- **Themis tiene el mismo defecto**, literal, en `ScanManager.reconcile_orphaned_scans()` (`scan.py:437`). Queda fuera del alcance de este issue, que es específico de Iris, así que está abierto como #346 — con `is_recoverable()` ya disponible, la corrección allí es sustituir la comprobación de estado por la llamada.
- La reconciliación sigue sin distinguir "job perdido" de "job cuyo TTL expiró": ambos son igual de no-recuperables y acaban en el mismo sitio. Modelarlos aparte solo tendría sentido si se quisiera dar mensajes distintos, y hoy no aporta nada al usuario.
