### PR TITLE
feat(iris): modo degradado visible en vez de fail-open silencioso (B05)

### DIFF
--- a/API/alembic/versions/c93b8545601b_add_iris_analysis_quality.py
+++ b/API/alembic/versions/c93b8545601b_add_iris_analysis_quality.py
@@ -1,0 +1,60 @@
+"""Calidad del análisis de Iris y catálogo de reglas que lo produjo (#209)
+
+Revision ID: c93b8545601b
+Revises: b46e50206411
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c93b8545601b'
+down_revision: Union[str, Sequence[str], None] = 'b46e50206411'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Una regla que reventaba se convertía en una fila más de ``IrisRuleResult``
+    con veredicto ``error`` y ahí se acababa: el análisis podía presentarse
+    como limpio sin ninguna advertencia, aunque la regla que faltó fuera la
+    que decide si el mensaje está autenticado.
+
+    ``analysis_quality`` distingue un análisis completo de uno degradado,
+    ``failed_rules`` guarda cuáles no llegaron a ejecutarse (nombre, familia y
+    categoría), y ``detector_version`` marca con qué catálogo de reglas se
+    produjo el resultado, para que un informe guardado siga siendo
+    interpretable cuando el catálogo cambie.
+
+    Las tres son NULL para los análisis ya existentes. No se rellenan: no hay
+    forma de saber a posteriori si una regla falló en un análisis de hace tres
+    meses, y un ``complete`` inventado sería peor que un NULL honesto — la
+    lectura correcta de NULL es "de este análisis no se registró la calidad",
+    no "fue completo".
+
+    El esquema de campos es el que comparten `B05` y `M02` (confianza e
+    incertidumbre en el veredicto): `M02` añadirá sus propias columnas de
+    confianza, pero reutiliza este ``analysis_quality`` en vez de definir un
+    segundo indicador paralelo.
+    """
+    op.add_column("IrisAnalysis", sa.Column("analysis_quality", sa.String(length=16), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("failed_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("detector_version", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde el registro de qué análisis fueron degradados y con qué catálogo
+    se produjeron; los veredictos ya calculados no cambian.
+    """
+    op.drop_column("IrisAnalysis", "detector_version")
+    op.drop_column("IrisAnalysis", "failed_rules")
+    op.drop_column("IrisAnalysis", "analysis_quality")

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -46,6 +46,7 @@ from ..services.failures import (
     classify_failure,
 )
 from ..services.parsers import build_path, parse_received_line
+from ..services.quality import AnalysisQuality, assess_quality, cap_verdict, detector_version
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
 
@@ -288,6 +289,9 @@ class IrisManager(TaskTrackingMixin):
             "wrapperSubject": context.wrapper_subject or None,
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
+            "analysisQuality": analysis.analysis_quality,
+            "failedRules": analysis.failed_rules or [],
+            "detectorVersion": analysis.detector_version,
             "failureCode": analysis.failure_code,
             "failureReason": analysis.failure_reason,
             "user": username,
@@ -575,6 +579,7 @@ class IrisManager(TaskTrackingMixin):
                 "title": analysis_record.title,
                 "status": analysis_record.status,
                 "failureCode": analysis_record.failure_code,
+                "analysisQuality": analysis_record.analysis_quality,
                 "totalScore": analysis_record.total_score,
                 "verdict": analysis_record.verdict,
                 "startedAt": isoformat_utc(analysis_record.started_at), # type: ignore
@@ -706,10 +711,11 @@ class IrisManager(TaskTrackingMixin):
                 chosen = self._evaluate_contexts(analysis_id, context, job, rules_defs)
                 if chosen is None:
                     return  # cancelado: no es un fallo, no hay nada que persistir
-                verdict, total_score, gate_reasons, results = chosen
+                verdict, total_score, gate_reasons, results, quality = chosen
 
                 self._persist_analysis_results(analysis_id, rules_defs, results,
-                                               verdict, total_score, gate_reasons)
+                                               verdict, total_score, gate_reasons,
+                                               quality, detector_version(rules_defs))
             except Exception as e:
                 logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
                 self._fail_analysis(analysis_id, classify_failure(e))
@@ -721,7 +727,7 @@ class IrisManager(TaskTrackingMixin):
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
 
     def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
-                           ) -> Optional[tuple[str, float, list[str], List[RuleResult]]]:
+                           ) -> Optional[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]]:
         """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
 
         Extraído de :meth:`_run_analysis` al envolver esa función en un único
@@ -730,8 +736,8 @@ class IrisManager(TaskTrackingMixin):
         protegiendo exactamente.
 
         Returns:
-            La tupla ``(verdict, total_score, gate_reasons, results)`` de la
-            evaluación ganadora, o ``None`` si la tarea fue cancelada a mitad
+            La tupla ``(verdict, total_score, gate_reasons, results, quality)``
+            de la evaluación ganadora, o ``None`` si fue cancelada a mitad
             (que no es un fallo: no se persiste nada y la cancelación ya dejó
             su propio estado terminal).
         """
@@ -750,7 +756,7 @@ class IrisManager(TaskTrackingMixin):
         total_steps = len(rules_defs) * len(contexts_to_evaluate)
         completed_steps = 0
 
-        evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
+        evaluations: List[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]] = []
         for evaluated_context in contexts_to_evaluate:
             results: List[RuleResult] = []
             named_results: Dict[str, RuleResult] = {}
@@ -788,7 +794,16 @@ class IrisManager(TaskTrackingMixin):
             total_score = self._aggregate_score(rules_defs, results)
             base_verdict = self._determine_verdict(total_score)
             verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
-            evaluations.append((verdict, total_score, gate_reasons, results))
+
+            # B05: una regla que revienta no aborta el análisis, pero tampoco
+            # puede desaparecer sin dejar rastro. La política conservadora se
+            # aplica aquí, junto al resto de gates, para que la degradación se
+            # lea entre los demás motivos del veredicto y no en un rincón
+            # aparte de la interfaz.
+            quality = assess_quality(rules_defs, results)
+            verdict, quality_reasons = cap_verdict(verdict, quality)
+            evaluations.append((verdict, total_score, gate_reasons + quality_reasons,
+                                results, quality))
 
         # Worse verdict wins across contexts; on a tie, keep the first
         # (the unwrapped/inner message — the one ``contexts_to_evaluate``
@@ -802,7 +817,8 @@ class IrisManager(TaskTrackingMixin):
 
     @staticmethod
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
-                                   verdict: str, total_score: float, gate_reasons: list[str]) -> None:
+                                   verdict: str, total_score: float, gate_reasons: list[str],
+                                   quality: AnalysisQuality, detector: str) -> None:
         """Persist every rule row and the final analysis state in one transaction.
 
         Previously each rule opened (and committed) its own
@@ -834,6 +850,9 @@ class IrisManager(TaskTrackingMixin):
             analysis.total_score = total_score
             analysis.verdict = verdict
             analysis.gate_reasons = gate_reasons
+            analysis.analysis_quality = quality.quality
+            analysis.failed_rules = quality.failed_rules or None
+            analysis.detector_version = detector
             analysis.finished_at = utcnow_naive()
             analysis_repo.update(analysis)
 

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -37,6 +37,16 @@ class IrisAnalysis(Base):
         gate_reasons: List of human-readable reasons for the
                  high-confidence gates that fired (empty when the verdict
                  comes purely from the numeric score).
+        analysis_quality: "complete" cuando todas las reglas se ejecutaron,
+                 "degraded" cuando alguna no llegó a hacerlo. Un análisis
+                 degradado no puede presentarse como limpio sin contexto —
+                 ver ``services/quality.py``.
+        failed_rules: Reglas que no se pudieron **ejecutar** (una excepción,
+                 no un hallazgo), con su nombre, familia y categoría. NULL
+                 cuando el análisis fue completo.
+        detector_version: Marca del catálogo de reglas que produjo el
+                 resultado (``iris-rules:<n>:<hash>``). Sin ella, un informe
+                 guardado deja de ser interpretable cuando el catálogo cambia.
         failure_code: Why a ``failed`` analysis failed — "invalid_input"
                  (the submitted text is not an analysable message) or
                  "internal_error" (the pipeline broke). NULL for every
@@ -74,6 +84,9 @@ class IrisAnalysis(Base):
     total_score = Column(Float, nullable=True)
     verdict = Column(String(20), nullable=True)
     gate_reasons = Column(JSONB, nullable=True)
+    analysis_quality = Column(String(16), nullable=True)
+    failed_rules = Column(JSONB, nullable=True)
+    detector_version = Column(String(64), nullable=True)
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -127,6 +127,18 @@ class AiSummarySchema(Schema):
     confidence = fields.String()
 
 
+class FailedRuleSchema(Schema):
+    """Regla que no se pudo **ejecutar** durante un análisis (B05).
+
+    No confundir con una regla que detectó algo: esas van en ``rules`` con su
+    puntuación negativa. Estas son las que lanzaron una excepción, así que su
+    parte del mensaje se quedó sin inspeccionar.
+    """
+    name = fields.String()
+    family = fields.String(load_default=None, allow_none=True)
+    category = fields.String(load_default=None, allow_none=True)
+
+
 class AnalysisDetailResponseSchema(Schema):
     """Full analysis report: headers, per-rule results, verdict."""
     analysisId = fields.Integer()
@@ -136,6 +148,9 @@ class AnalysisDetailResponseSchema(Schema):
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     gateReasons = fields.List(fields.String(), load_default=None)
+    analysisQuality = fields.String(load_default=None, allow_none=True)
+    failedRules = fields.List(fields.Nested(FailedRuleSchema), load_default=None)
+    detectorVersion = fields.String(load_default=None, allow_none=True)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)
     unwrappedFromForward = fields.Boolean(load_default=False)
@@ -156,6 +171,7 @@ class AnalysisListItemSchema(Schema):
     title = fields.String(load_default=None)
     status = fields.String()
     failureCode = fields.String(load_default=None, allow_none=True)
+    analysisQuality = fields.String(load_default=None, allow_none=True)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     startedAt = fields.String(load_default=None)

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -59,6 +59,33 @@ class IrisAIWriter:
     def _build_prompts(self) -> dict:
         return CR.iris_config().prompts.get("summary", {})
 
+    @staticmethod
+    def _degradation_note(report: Dict[str, Any]) -> str:
+        """Aviso que se añade al prompt cuando el análisis fue degradado (B05).
+
+        Va anexado al final del prompt en vez de como marcador de la plantilla
+        porque las plantillas viven en ``SecOpsConfig.json``: un marcador nuevo
+        obligaría a editar la configuración desplegada para que este aviso
+        apareciera, y un despliegue con la plantilla vieja se quedaría
+        silenciosamente sin él — justo el fallo silencioso que B05 corrige.
+
+        Sin esto, el modelo redacta un resumen ejecutivo seguro sobre un
+        análisis que no lo es: no tiene forma de saber que faltan reglas,
+        porque lo único que recibe son las que sí se ejecutaron.
+        """
+        if report.get("analysisQuality") != "degraded":
+            return ""
+        names = ", ".join(
+            rule.get("name", "?") for rule in (report.get("failedRules") or [])
+        ) or "desconocidas"
+        return (
+            "\n\nAVISO IMPORTANTE: este análisis está DEGRADADO. No se pudieron "
+            f"ejecutar estas reglas: {names}. La parte del mensaje que les "
+            "correspondía no se ha inspeccionado. Dilo explícitamente en el "
+            "resumen y no afirmes que el mensaje es seguro basándote en la "
+            "ausencia de hallazgos."
+        )
+
     def _build_user_prompt(self, report: Dict[str, Any]) -> str:
         failed_rules = [
             {
@@ -72,13 +99,14 @@ class IrisAIWriter:
         ]
 
         template = self._build_prompts().get("userTemplate", "")
-        return (
+        prompt = (
             template
             .replace("{{verdict}}", str(report.get("verdict") or "Suspicious"))
             .replace("{{score}}", str(report.get("totalScore")))
             .replace("{{gate_reasons_json}}", json.dumps(report.get("gateReasons") or [], ensure_ascii=False))
             .replace("{{failed_rules_json}}", json.dumps(failed_rules, indent=2, ensure_ascii=False))
         )
+        return prompt + self._degradation_note(report)
 
     def generate(self, report: Dict[str, Any]) -> dict:
         """Generate the AI narrative for a finished analysis report dict.

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -1,0 +1,151 @@
+"""
+Calidad de un análisis: qué se pudo inspeccionar de verdad y qué no.
+
+Una regla que revienta no aborta el análisis —eso sería peor: un solo fallo
+tiraría un informe entero por 47 reglas que sí funcionaron—, pero tampoco
+puede desaparecer sin dejar rastro. Hasta `B05`, una excepción de regla se
+convertía en un ``RuleResult(score=0, verdict="error")`` y ahí se acababa
+todo: el análisis podía terminar como ``Legitimate`` sin ninguna advertencia,
+aunque la regla que faltó fuera la que decide si el mensaje está autenticado.
+
+Este módulo produce las tres cosas que hacen visible esa diferencia:
+
+- ``analysis_quality``: ``complete`` o ``degraded``.
+- ``failed_rules``: qué reglas no se pudieron ejecutar (el nombre es el que
+  fija el issue; léase "reglas que fallaron **al ejecutarse**", no "reglas
+  que detectaron algo malo" — esas son las que puntúan negativo).
+- ``detector_version``: qué catálogo de reglas produjo el resultado, para que
+  un informe guardado siga siendo interpretable cuando el catálogo cambie.
+
+Y la política conservadora que las acompaña, que depende de **qué familia** de
+regla se perdió (ver ``DEGRADING_FAMILIES``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+#: Valor de ``verdict`` con el que el motor marca una regla que lanzó una
+#: excepción, en lugar de devolver un resultado (ver ``_evaluate_contexts``).
+RULE_ERROR_VERDICT = "error"
+
+QUALITY_COMPLETE = "complete"
+QUALITY_DEGRADED = "degraded"
+
+#: Familias cuya ausencia impide presentar el mensaje como limpio.
+#:
+#: No todas las reglas pesan igual cuando faltan. El catálogo tiene ocho
+#: familias, y las de contenido, enlaces, identidad, camino de respuesta y
+#: cadena Received son muchas y cada una individualmente pequeña: perder una
+#: degrada la confianza, pero las demás siguen mirando el mismo mensaje desde
+#: ángulos parecidos.
+#:
+#: ``auth`` y ``attachment`` no funcionan así. Son las dos únicas familias que
+#: responden a una pregunta que ninguna otra regla responde —«¿es quien dice
+#: ser?» y «¿lo que trae dentro es peligroso?»— y ahí el silencio no es un
+#: dato menos: es no haber mirado. Un mensaje cuyo bloque de autenticación no
+#: se pudo evaluar no puede presentarse como legítimo por el hecho de que el
+#: resto de reglas no encontrara nada.
+DEGRADING_FAMILIES = frozenset({"auth", "attachment"})
+
+
+@dataclass(frozen=True)
+class AnalysisQuality:
+    """Veredicto sobre el propio análisis, no sobre el correo.
+
+    Attributes:
+        quality: ``complete`` si se ejecutaron todas las reglas,
+            ``degraded`` si alguna no llegó a ejecutarse.
+        failed_rules: Una entrada por regla que no se pudo ejecutar, con su
+            nombre, familia y categoría. Serializable a JSONB tal cual.
+        blocks_clean_verdict: True si alguna de las reglas perdidas pertenece
+            a una familia de ``DEGRADING_FAMILIES``, es decir, si el análisis
+            no puede presentarse como limpio.
+    """
+
+    quality: str
+    failed_rules: List[Dict[str, Any]] = field(default_factory=list)
+    blocks_clean_verdict: bool = False
+
+    @property
+    def is_degraded(self) -> bool:
+        return self.quality == QUALITY_DEGRADED
+
+
+def assess_quality(rules_defs: List[dict], results: List[Any]) -> AnalysisQuality:
+    """Compara el catálogo ejecutado con sus resultados y resume qué faltó.
+
+    ``rules_defs`` y ``results`` se emparejan **por posición**: es el mismo
+    contrato que usa ``_persist_analysis_results`` para guardar las filas de
+    ``IrisRuleResult``, y por eso el motor lee el registro de reglas una sola
+    vez por análisis.
+    """
+    failed_rules = [
+        {
+            "name": rule_def["name"],
+            "family": rule_def.get("family") or None,
+            "category": rule_def.get("category") or None,
+        }
+        for rule_def, result in zip(rules_defs, results)
+        if getattr(result, "verdict", None) == RULE_ERROR_VERDICT
+    ]
+
+    if not failed_rules:
+        return AnalysisQuality(quality=QUALITY_COMPLETE)
+
+    blocks = any(rule["family"] in DEGRADING_FAMILIES for rule in failed_rules)
+    return AnalysisQuality(
+        quality=QUALITY_DEGRADED,
+        failed_rules=failed_rules,
+        blocks_clean_verdict=blocks,
+    )
+
+
+def detector_version(rules_defs: List[dict]) -> str:
+    """Identifica el catálogo de reglas que produjo un resultado.
+
+    Un informe guardado hace tres meses se leyó con un catálogo que ya no es
+    el actual, y sin esta marca no hay forma de saber cuál. Se compone del
+    número de reglas y de un resumen del conjunto **ordenado** de sus nombres:
+    ordenado a propósito, para que reordenar el registro no cambie la marca,
+    pero añadir, quitar o renombrar una regla sí lo haga.
+
+    Cabe de sobra en los 64 caracteres de la columna (``iris-rules:48:`` más
+    12 hexadecimales).
+    """
+    names = sorted(rule_def["name"] for rule_def in rules_defs)
+    digest = hashlib.sha256("\n".join(names).encode("utf-8")).hexdigest()[:12]
+    return f"iris-rules:{len(names)}:{digest}"
+
+
+def cap_verdict(verdict: str, quality: AnalysisQuality) -> tuple[str, List[str]]:
+    """Aplica la política conservadora del análisis degradado.
+
+    Devuelve el veredicto ya ajustado y las razones a añadir a
+    ``gate_reasons`` — la misma lista que ya explica por qué un veredicto es
+    el que es, para que la degradación se lea junto al resto de motivos en
+    lugar de en un rincón aparte de la interfaz.
+
+    La única corrección es impedir el ``Legitimate``: un análisis degradado
+    puede seguir siendo ``Suspicious`` o ``Phishing`` sin problema —esos
+    veredictos ya avisan— pero no puede decir "limpio" sobre un mensaje cuya
+    autenticación o cuyos adjuntos nunca llegó a mirar. Nunca **mejora** un
+    veredicto, igual que los gates existentes.
+    """
+    if not quality.is_degraded:
+        return verdict, []
+
+    lost = ", ".join(rule["name"] for rule in quality.failed_rules)
+    reasons = [f"Análisis degradado: no se pudieron ejecutar estas reglas ({lost})."]
+
+    if quality.blocks_clean_verdict and verdict == "Legitimate":
+        reasons.append(
+            "El veredicto no puede ser Legítimo: falló alguna regla de "
+            "autenticación o de adjuntos, así que el mensaje no llegó a "
+            "inspeccionarse por completo. Revisión manual recomendada."
+        )
+        return "Suspicious", reasons
+
+    return verdict, reasons

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -452,6 +452,43 @@ class IrisPDFCreator:
 
         elements.append(Spacer(1, 0.22 * inch))
 
+    def append_quality_warning(self, elements: list, theme: IrisReportTheme) -> None:
+        """Aviso de análisis degradado (B05), justo debajo del veredicto.
+
+        Va aquí y no entre las señales de más abajo porque contradice
+        parcialmente lo que el lector acaba de leer: el veredicto grande de la
+        portada se calculó sin una parte del examen, y quien imprima el
+        informe tiene que verlo antes de actuar sobre él.
+        """
+        failed_rules = self.report.get("failedRules") or []
+        if self.report.get("analysisQuality") != "degraded" and not failed_rules:
+            return
+
+        names = ", ".join(rule.get("name", "?") for rule in failed_rules) or "desconocidas"
+        warning_style = ParagraphStyle(
+            "IrisQualityWarning", parent=theme.body,
+            textColor=colors.HexColor("#7a4100"),
+        )
+        text = (
+            f"<b>Análisis incompleto.</b> No se pudieron ejecutar estas reglas: "
+            f"{_esc(names)}. La parte del mensaje que les correspondía no se ha "
+            "inspeccionado, así que este informe describe menos de lo que "
+            "describiría un análisis completo."
+        )
+
+        card = Table([[Paragraph(text, warning_style)]], colWidths=[6.4 * inch])
+        card.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), colors.HexColor("#FFF4E5")),
+            ("LINEBEFORE", (0, 0), (0, -1), 3, colors.HexColor("#f57c00")),
+            ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor("#FFD8A8")),
+            ("LEFTPADDING", (0, 0), (-1, -1), 14),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 14),
+            ("TOPPADDING", (0, 0), (-1, -1), 10),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+        ]))
+        elements.append(card)
+        elements.append(Spacer(1, 0.22 * inch))
+
     def append_gate_reasons(self, elements: list, theme: IrisReportTheme) -> None:
         """Señales de alta confianza que fijaron el veredicto (S1).
 
@@ -697,6 +734,7 @@ class IrisPDFCreator:
 
         self.append_cover_page(elements, theme)
         self.append_verdict_hero(elements, theme)
+        self.append_quality_warning(elements, theme)
         self.append_email_preview(elements, theme)
         self.append_gate_reasons(elements, theme)
         self.append_rules(elements, theme)

--- a/API/tests/integration/test_iris_degraded_analysis.py
+++ b/API/tests/integration/test_iris_degraded_analysis.py
@@ -1,0 +1,156 @@
+"""B05: una regla rota no puede pasar inadvertida en el informe.
+
+El criterio de cierre del issue pide las tres familias de regla fallida —
+autenticación, adjuntos y contenido— con comportamiento conservador. Estos
+tests las recorren de punta a punta: rompen una regla real del catálogo,
+ejecutan el análisis como lo haría el worker y comprueban qué acaba
+persistido y qué se devuelve por API.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.quality import QUALITY_COMPLETE, QUALITY_DEGRADED
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+
+# Un correo sin ninguna señal de phishing: sin romper nada sale Legitimate,
+# que es justo el veredicto que la degradación tiene que poder impedir.
+_CLEAN_RAW = (
+    "From: equipo@example.com\r\n"
+    "To: destinatario@example.com\r\n"
+    "Subject: Acta de la reunión\r\n"
+    "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+    "Message-ID: <abc123@example.com>\r\n"
+    "\r\n"
+    "Adjunto el acta de ayer.\r\n"
+)
+
+
+def _make_analysis(app, user_id: int) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=_CLEAN_RAW, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def _run_with_broken_rule(app, analysis_id: int, rule_name: str | None) -> None:
+    """Ejecuta el análisis rompiendo una regla concreta del catálogo real.
+
+    Se parchea la función de la regla, no el registro entero: así el resto del
+    catálogo se ejecuta de verdad y el test comprueba el comportamiento en un
+    análisis completo, no en un laboratorio de una sola regla.
+    """
+    original_rules = iris_rules.get_rules()
+    patched = []
+    for rule_def in original_rules:
+        if rule_name is not None and rule_def["name"] == rule_name:
+            broken = dict(rule_def)
+            broken["func"] = mock.Mock(side_effect=RuntimeError("regla rota"))
+            patched.append(broken)
+        else:
+            patched.append(rule_def)
+
+    with app.app_context():
+        with mock.patch.object(iris_rules, "get_rules", return_value=patched):
+            IrisManager()._run_analysis(analysis_id, _CLEAN_RAW)
+
+
+def _rule_name_in_family(family: str) -> str:
+    for rule_def in iris_rules.get_rules():
+        if rule_def.get("family") == family:
+            return rule_def["name"]
+    raise AssertionError(f"el catálogo no tiene ninguna regla de familia {family!r}")
+
+
+def test_a_clean_message_is_legitimate_and_complete(app, regular_user):
+    """Punto de partida: sin romper nada, este correo sale limpio. Sin esto,
+    los tests de abajo no probarían nada — un Suspicious podría venir del
+    propio mensaje en vez de la degradación."""
+    analysis_id = _make_analysis(app, regular_user.id)
+
+    _run_with_broken_rule(app, analysis_id, None)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "finished"
+    assert analysis.verdict == "Legitimate"
+    assert analysis.analysis_quality == QUALITY_COMPLETE
+    assert analysis.failed_rules is None
+    assert analysis.detector_version
+
+
+def test_a_broken_auth_rule_blocks_the_clean_verdict(app, regular_user):
+    """Si la regla que decide si el mensaje está autenticado no se ejecutó,
+    presentarlo como limpio es afirmar algo que nadie comprobó."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("auth")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Suspicious"
+    assert [rule["name"] for rule in analysis.failed_rules] == [broken]
+    assert any("no puede ser Legítimo" in reason for reason in analysis.gate_reasons)
+
+
+def test_a_broken_attachment_rule_blocks_the_clean_verdict(app, regular_user):
+    """Mismo razonamiento: nadie miró lo que el mensaje trae dentro."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("attachment")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Suspicious"
+
+
+def test_a_broken_content_rule_degrades_but_keeps_the_verdict(app, regular_user):
+    """Las reglas de contenido son muchas y solapadas: perder una degrada la
+    confianza, pero no ciega el análisis del mismo modo."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("content")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Legitimate"
+    assert [rule["name"] for rule in analysis.failed_rules] == [broken]
+    # El aviso sí aparece, aunque el veredicto no cambie.
+    assert any("Análisis degradado" in reason for reason in analysis.gate_reasons)
+
+
+def test_the_report_exposes_the_degradation(client, app, regular_user, auth_headers):
+    """El frontend y el PDF leen esto: si no viaja por API, no hay forma de
+    enseñar la degradación en ningún sitio."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("auth")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    response = client.get(f"/iris/results/{analysis_id}",
+                          headers=auth_headers(regular_user))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["analysisQuality"] == QUALITY_DEGRADED
+    assert [rule["name"] for rule in body["failedRules"]] == [broken]
+    assert body["detectorVersion"].startswith("iris-rules:")

--- a/API/tests/unit/test_iris_quality.py
+++ b/API/tests/unit/test_iris_quality.py
@@ -1,0 +1,143 @@
+"""B05: calidad del análisis — qué se inspeccionó de verdad y qué no.
+
+Una regla que revienta se convertía en un ``RuleResult(verdict="error")`` y
+ahí se acababa todo: el análisis podía terminar como ``Legitimate`` sin
+ninguna advertencia, aunque la regla que faltó fuera la que decide si el
+mensaje está autenticado. Estos tests fijan la política conservadora que lo
+sustituye, que depende de **qué familia** de regla se perdió.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.services.quality import (
+    QUALITY_COMPLETE,
+    QUALITY_DEGRADED,
+    assess_quality,
+    cap_verdict,
+    detector_version,
+)
+from src.modules.features.iris.services.rules import RuleResult
+
+pytestmark = pytest.mark.unit
+
+
+def _rule(name: str, family: str = "", category: str = "header_analysis") -> dict:
+    return {"name": name, "family": family, "category": category}
+
+
+def _ok(score: float = 0.0) -> RuleResult:
+    return RuleResult(score=score, verdict="pass")
+
+
+def _errored() -> RuleResult:
+    """Lo que el motor pone cuando una regla lanza una excepción."""
+    return RuleResult(score=0, verdict="error", details={"error": "boom"})
+
+
+# ---------------------------------------------------------------------------
+# assess_quality
+# ---------------------------------------------------------------------------
+
+def test_all_rules_executed_is_complete():
+    rules = [_rule("SPF", "auth"), _rule("Body Links", "links")]
+    quality = assess_quality(rules, [_ok(), _ok()])
+
+    assert quality.quality == QUALITY_COMPLETE
+    assert quality.failed_rules == []
+    assert quality.blocks_clean_verdict is False
+
+
+def test_a_broken_rule_degrades_and_is_recorded():
+    rules = [_rule("SPF", "auth"), _rule("Body Links", "links")]
+    quality = assess_quality(rules, [_ok(), _errored()])
+
+    assert quality.quality == QUALITY_DEGRADED
+    assert quality.failed_rules == [
+        {"name": "Body Links", "family": "links", "category": "header_analysis"}
+    ]
+
+
+def test_a_rule_that_merely_found_something_is_not_a_failure():
+    """La distinción que da nombre al campo: una regla que puntúa negativo
+    hizo su trabajo. Solo cuenta como fallida la que no llegó a ejecutarse."""
+    rules = [_rule("SPF", "auth")]
+    quality = assess_quality(rules, [RuleResult(score=-12, verdict="fail")])
+
+    assert quality.quality == QUALITY_COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Política por familia
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("family", ["auth", "attachment"])
+def test_losing_auth_or_attachment_blocks_a_clean_verdict(family):
+    """Son las dos familias que responden a una pregunta que ninguna otra
+    responde: si faltan, el silencio no es un dato — es no haber mirado."""
+    rules = [_rule("Regla", family)]
+    quality = assess_quality(rules, [_errored()])
+
+    verdict, reasons = cap_verdict("Legitimate", quality)
+
+    assert quality.blocks_clean_verdict is True
+    assert verdict == "Suspicious"
+    assert any("no puede ser Legítimo" in reason for reason in reasons)
+
+
+def test_losing_a_content_rule_degrades_without_changing_the_verdict():
+    """Las familias de contenido son muchas y cada una individualmente
+    pequeña: perder una degrada la confianza, pero las demás siguen mirando
+    el mismo mensaje desde ángulos parecidos."""
+    rules = [_rule("Alarming Keywords", "content")]
+    quality = assess_quality(rules, [_errored()])
+
+    verdict, reasons = cap_verdict("Legitimate", quality)
+
+    assert quality.is_degraded
+    assert quality.blocks_clean_verdict is False
+    assert verdict == "Legitimate"
+    assert reasons  # pero el aviso de degradación sí aparece
+
+
+def test_cap_never_improves_a_verdict():
+    """Mismo contrato que los gates existentes: solo pueden empeorar."""
+    rules = [_rule("SPF", "auth")]
+    quality = assess_quality(rules, [_errored()])
+
+    assert cap_verdict("Phishing", quality)[0] == "Phishing"
+    assert cap_verdict("Suspicious", quality)[0] == "Suspicious"
+
+
+def test_complete_analysis_adds_no_reasons():
+    quality = assess_quality([_rule("SPF", "auth")], [_ok()])
+
+    assert cap_verdict("Legitimate", quality) == ("Legitimate", [])
+
+
+# ---------------------------------------------------------------------------
+# detector_version
+# ---------------------------------------------------------------------------
+
+def test_detector_version_is_stable_across_ordering():
+    """Reordenar el registro no cambia el catálogo, así que no debe cambiar
+    la marca; si lo hiciera, dos informes idénticos parecerían distintos."""
+    a = [_rule("SPF"), _rule("DKIM"), _rule("DMARC")]
+    b = [_rule("DMARC"), _rule("SPF"), _rule("DKIM")]
+
+    assert detector_version(a) == detector_version(b)
+
+
+def test_detector_version_changes_when_the_catalogue_changes():
+    base = [_rule("SPF"), _rule("DKIM")]
+
+    assert detector_version(base) != detector_version(base + [_rule("ARC Chain")])
+    assert detector_version(base) != detector_version([_rule("SPF"), _rule("DKIM v2")])
+
+
+def test_detector_version_fits_the_column():
+    """La columna son 64 caracteres; con 48 reglas debe caber de sobra."""
+    rules = [_rule(f"Regla número {i} con nombre largo") for i in range(200)]
+
+    assert len(detector_version(rules)) <= 64

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -87,6 +87,25 @@
       <!-- Score + Verdict hero -->
       <IrisVerdictHero :score="reportData.totalScore" :verdict="reportData.verdict" />
 
+      <!-- Análisis degradado (B05): alguna regla no llegó a ejecutarse, así que
+           una parte del mensaje no se ha inspeccionado. Va inmediatamente
+           debajo del veredicto porque lo matiza: quien lea el número grande
+           tiene que saber que se calculó sin parte del examen. -->
+      <div v-if="isDegraded" class="rv-degraded">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="degraded-icon"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <div class="degraded-body">
+          <strong class="degraded-title">Análisis incompleto</strong>
+          <p class="degraded-text">
+            No se pudieron ejecutar {{ failedRuleNames.length }}
+            {{ failedRuleNames.length === 1 ? 'regla' : 'reglas' }}, así que la parte
+            del mensaje que les correspondía no se ha inspeccionado.
+          </p>
+          <p v-if="failedRuleNames.length" class="degraded-rules">
+            {{ failedRuleNames.join(' · ') }}
+          </p>
+        </div>
+      </div>
+
       <!-- Gate reasons: señales de alta confianza que fijaron el veredicto -->
       <div v-if="reportData.gateReasons && reportData.gateReasons.length" class="rv-gates">
         <h3 class="section-title">Por qué este veredicto</h3>
@@ -305,6 +324,17 @@ const rulesWithIndex = computed(() =>
   (props.reportData?.rules ?? []).map((rule, i) => ({ rule, i }))
 )
 const flaggedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict !== 'pass'))
+
+// Análisis degradado (B05): alguna regla lanzó una excepción y no llegó a
+// ejecutarse. No es lo mismo que una regla que encontró algo malo —esas
+// aparecen en flaggedRules con su puntuación— sino una parte del mensaje que
+// nadie miró, y por eso el aviso va arriba y no entre los hallazgos.
+const failedRuleNames = computed(() =>
+  (props.reportData?.failedRules ?? []).map(rule => rule.name).filter(Boolean)
+)
+const isDegraded = computed(() =>
+  props.reportData?.analysisQuality === 'degraded' || failedRuleNames.value.length > 0
+)
 const passedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict === 'pass'))
 const passedRulesOpen = ref(false)
 
@@ -789,6 +819,48 @@ watch(
 }
 
 /* Gate reasons (por qué este veredicto) */
+.rv-degraded {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--warn) 10%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 40%, var(--border));
+  color: var(--text);
+}
+
+.degraded-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  color: var(--warn);
+}
+
+.degraded-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.degraded-title {
+  font-size: var(--fs-md);
+}
+
+.degraded-text {
+  margin: 0;
+  font-size: var(--fs-md);
+  line-height: 1.6;
+}
+
+.degraded-rules {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
 .rv-gates {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Resumen

Una regla de Iris que revienta dejaba de existir para el informe. Este PR hace visible esa pérdida y le pone una política conservadora que depende de qué se perdió exactamente.

Cierra #209.

## El problema, en llano

Iris analiza un correo pasándolo por un catálogo de 48 reglas independientes: unas miran la autenticación (SPF, DKIM, DMARC…), otras los adjuntos, otras el texto, los enlaces, la cadena de servidores por los que pasó, etc. Cada una devuelve una puntuación, y la suma decide el veredicto: `Legitimate`, `Suspicious` o `Phishing`.

Si una regla lanza una excepción, el motor **no aborta el análisis**. Y hace bien: un solo fallo no debería tirar un informe entero por el que 47 reglas sí funcionaron. Lo que hacía era convertir la excepción en un resultado neutro:

```python
except Exception as e:
    logger.error(f"Rule '{rule_def['name']}' failed ...")
    result = RuleResult(score=0, verdict="error", ...)
```

El problema es lo que pasa después: **ahí se acababa todo**. Esa fila quedaba como una más entre las otras cuarenta y siete, sin contador de reglas fallidas ni bandera de calidad. Y como el modelo de puntuación es *sustractivo* —un análisis parte de 100 y las reglas solo pueden restar—, una regla que no se ejecuta resta cero, que es exactamente lo mismo que resta una regla que se ejecutó y no encontró nada.

El resultado: si la regla que revienta es la de autenticación, Iris presenta como **limpio** un mensaje cuya autenticación nunca llegó a comprobar. El usuario ve un veredicto verde y no tiene forma de saber que se calculó a ciegas.

## Qué cambia

### 1. Tres campos nuevos, en un servicio propio

`services/quality.py` responde a "¿qué se inspeccionó de verdad?" y produce:

- **`analysis_quality`** — `complete` o `degraded`.
- **`failed_rules`** — qué reglas no llegaron a ejecutarse, con nombre, familia y categoría.
- **`detector_version`** — qué catálogo produjo el resultado.

Sobre el nombre de `failed_rules`, que es el que fija el issue: **significa "reglas que fallaron al ejecutarse", no "reglas que detectaron algo malo"**. Las segundas ya viajan en `rules` con su puntuación negativa. Los dos sentidos conviven en el módulo (el prompt de IA usa `failed_rules` para el otro), así que el schema y los docstrings lo dicen explícitamente y hay un test dedicado a la distinción.

`detector_version` se compone del número de reglas y de un resumen del conjunto **ordenado** de sus nombres — `iris-rules:48:a3f9c1b20e4d`. Ordenado a propósito: reordenar el registro no cambia el catálogo, así que no debe cambiar la marca, pero añadir, quitar o renombrar una regla sí. Sin ella, un informe guardado hace tres meses deja de ser interpretable en cuanto el catálogo cambia.

### 2. La política es por familia, no por umbral

Aquí está la decisión de diseño del PR, y es la parte que el issue deja abierta ("definir si baja el techo, impide `Legitimate` o requiere revisión **según la familia de la regla**").

El catálogo tiene ocho familias. **No todas pesan igual cuando faltan.**

Las de contenido, enlaces, identidad, camino de respuesta y cadena Received son numerosas y cada una individualmente pequeña, y miran el mismo mensaje desde ángulos que se solapan. Perder una degrada la confianza, pero las otras siguen ahí.

`auth` y `attachment` no funcionan así. Son las dos únicas familias que responden a una pregunta que **ninguna otra regla responde**: "¿es quien dice ser?" y "¿lo que trae dentro es peligroso?". Ahí el silencio no es un dato menos — es no haber mirado.

De modo que:

| Familia perdida | Efecto |
|---|---|
| `auth` o `attachment` | El análisis **no puede** quedar en `Legitimate`; baja a `Suspicious` con una razón que lo explica y pide revisión manual |
| Cualquier otra | Se marca `degraded` y se avisa, pero el veredicto no cambia |

En ambos casos se añade una razón a `gate_reasons`, que es la lista que ya explica por qué un veredicto es el que es. Se reutiliza a propósito: la degradación se lee **entre** los demás motivos, no en un rincón aparte de la interfaz.

Y como los gates que ya existían, `cap_verdict()` **solo puede empeorar** un veredicto, nunca mejorarlo. Un análisis degradado que salió `Phishing` sigue siendo `Phishing`.

### 3. Los tres consumidores del informe se enteran

Antes, PDF, resumen de IA y panel web daban por bueno lo que recibían.

- **PDF**: banda de aviso justo debajo del veredicto de portada.
- **Panel web** (`IrisReportViewer.vue`): mismo aviso, mismo sitio, con la lista de reglas perdidas.
- **Resumen de IA**: el modelo redactaba un resumen ejecutivo seguro sobre un análisis que no lo era, porque lo único que recibía eran las reglas que sí se ejecutaron. Ahora el prompt lleva un aviso explícito.

Sobre el aviso de IA: va **anexado al final del prompt**, no como marcador de la plantilla. Las plantillas viven en `SecOpsConfig.json`, así que un marcador nuevo obligaría a editar la configuración ya desplegada para que el aviso apareciera — y un despliegue con la plantilla vieja se quedaría sin él sin que nadie se enterara. Que es exactamente el tipo de fallo silencioso que este issue viene a corregir.

### 4. Migración

Tres columnas nuevas, todas NULL para los análisis existentes. **No se rellenan a posteriori**: no hay forma de saber si una regla falló en un análisis de hace tres meses, y un `complete` inventado sería peor que un NULL honesto. La lectura correcta de NULL aquí es "de este análisis no se registró la calidad", no "fue completo".

El esquema de campos es el que el issue pide compartir con `M02` (confianza e incertidumbre en el veredicto): `M02` añadirá sus propias columnas de confianza pero reutilizará este `analysis_quality` en lugar de definir un segundo indicador paralelo.

## Validación

- `tests/unit/test_iris_quality.py` (nuevo, 11 tests) — la política familia por familia, la distinción entre "regla rota" y "regla que encontró algo", que el cap nunca mejora un veredicto, y las propiedades de `detector_version` (estable ante reordenación, sensible al catálogo, cabe en la columna).
- `tests/integration/test_iris_degraded_analysis.py` (nuevo, 5 tests) — las tres familias que pide el criterio de cierre, rompiendo una regla **real** del catálogo y dejando que las otras 47 se ejecuten de verdad. Incluye un test de línea base que comprueba que el correo de prueba sale `Legitimate` sin romper nada: sin él, un `Suspicious` podría venir del propio mensaje en vez de la degradación, y los otros tests no probarían nada.
- Suite completa en verde. Build del SPA correcto.
- Grafo de Alembic verificado: 49 revisiones, un solo head, sin IDs duplicados.

## Notas

- El issue menciona 48 reglas registradas frente a las 46 del documento original. El conteo exacto ya no está clavado en ningún sitio: `detector_version` lo deriva del registro en tiempo de ejecución, así que no puede quedarse desactualizado.
- No hay test del PDF degradado más allá de que el informe lleve los campos: la suite de `test_iris_reports.py` comprueba estructura, y la banda es presentación. El dato que la alimenta sí está cubierto de punta a punta.
- El README no se toca aquí; los cambios de contrato de toda la fase 0 van juntos en un commit al final.
