### PR TITLE
fix(iris): nombre de PDF único por documento y escritura atómica (B11)

### DIFF
--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -488,7 +488,11 @@ def download_document(document_id: int):
         document.filename,
         mimetype="application/pdf",
         as_attachment=True,
-        download_name=f"iris_analysis_{document.analysis_id}.pdf",
+        # B11: el nombre descargable identifica el documento, no solo el
+        # análisis. Dos informes del mismo análisis llegaban al navegador con
+        # el mismo nombre y el segundo sobrescribía al primero en la carpeta
+        # de descargas.
+        download_name=f"iris_analysis_{document.analysis_id}_{document.id}.pdf",
     )
 
 

--- a/API/src/modules/features/iris/managers/reports.py
+++ b/API/src/modules/features/iris/managers/reports.py
@@ -116,7 +116,8 @@ class IrisReportManager(DocumentManager):
             if analysis is not None:
                 context = parse_raw_message(analysis.raw_headers or "")
                 path = {"analysisId": analysis_id, **build_path(context.received_headers)}
-            return IrisPDFCreator(report=report, path=path).print_pdf()
+            return IrisPDFCreator(report=report, path=path,
+                                  document_id=document_id).print_pdf()
 
         run_report_generation(
             document_id=document_id,

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import logging
+import uuid
 from datetime import datetime
 from email.utils import parseaddr
 from typing import Any, Dict, Optional
@@ -224,9 +225,11 @@ class IrisPDFCreator:
     direct database access.
     """
 
-    def __init__(self, report: Dict[str, Any], path: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, report: Dict[str, Any], path: Optional[Dict[str, Any]] = None,
+                 document_id: Optional[int] = None) -> None:
         self.report = report
         self.path = path or {}
+        self.document_id = document_id
         self.directory = CR.get_directory_of(CR.DirectoryType.OUTPUT_IRIS)
 
     def _set_pdf_metadata(self, document) -> None:
@@ -716,15 +719,40 @@ class IrisPDFCreator:
         elements.append(Spacer(1, 0.2 * inch))
         elements.append(Paragraph(f"Informe generado automáticamente | {timestamp}", theme.footer))
 
+    def _output_path(self) -> str:
+        """Ruta del PDF, única por **documento** y no por análisis (B11).
+
+        El modelo permite N ``IrisDocument`` por análisis, pero el nombre solo
+        dependía del ``analysis_id``, así que todos escribían el mismo fichero:
+        dos generaciones a la vez se pisaban, y borrar un documento destruía el
+        PDF del otro (``delete_document_with_file`` borra por ``filename``, que
+        era el mismo para ambos).
+
+        Cuando no hay ``document_id`` —ningún camino de la aplicación llega
+        así hoy; queda para que la clase siga siendo usable a pelo— se cae a un
+        sufijo aleatorio, que no colisiona aunque tampoco sea reproducible.
+        """
+        analysis_id = self.report.get("analysisId")
+        suffix = self.document_id if self.document_id is not None else uuid.uuid4().hex
+        return os.path.join(self.directory, f"{analysis_id}_{suffix}_Iris.pdf")
+
     def print_pdf(self) -> str:
-        """Generate the complete PDF report and return its file path."""
+        """Generate the complete PDF report and return its file path.
+
+        Se escribe en un temporal del mismo directorio y se mueve con
+        ``os.replace()``, que es atómico dentro de un mismo sistema de
+        ficheros. Sin eso, un lector que descargue el informe mientras se
+        regenera recibe un PDF a medio escribir: ``document.status`` pasa a
+        ``done`` una sola vez, pero el fichero al que apunta se reescribe en
+        sitio en cada regeneración.
+        """
         os.makedirs(self.directory, exist_ok=True)
 
-        analysis_id = self.report.get("analysisId")
-        filename = os.path.join(self.directory, f"{analysis_id}_Iris.pdf")
+        filename = self._output_path()
+        temporary = f"{filename}.{uuid.uuid4().hex}.tmp"
 
         document = SimpleDocTemplate(
-            filename, pagesize=A4,
+            temporary, pagesize=A4,
             rightMargin=36, leftMargin=36, topMargin=60, bottomMargin=40,
         )
 
@@ -745,6 +773,17 @@ class IrisPDFCreator:
         self.append_footer(elements, theme)
 
         self._set_pdf_metadata(document)
-        document.build(elements, onFirstPage=self._on_page, onLaterPages=self._on_page)
+        try:
+            document.build(elements, onFirstPage=self._on_page, onLaterPages=self._on_page)
+            os.replace(temporary, filename)
+        except Exception:
+            # Un temporal huérfano no lo limpia nadie: el nombre lleva un UUID,
+            # así que ni siquiera lo pisaría el siguiente intento.
+            if os.path.exists(temporary):
+                try:
+                    os.remove(temporary)
+                except OSError:
+                    logger.warning("No se pudo borrar el temporal %s", temporary)
+            raise
 
         return filename

--- a/API/tests/integration/test_iris_documents.py
+++ b/API/tests/integration/test_iris_documents.py
@@ -196,3 +196,49 @@ def test_delete_document(client, app, root_user, root_headers, fake_queue):
 
     after = client.get(f"/iris/document-status?documentId={doc_id}", headers=root_headers)
     assert after.status_code == 404
+
+
+# --------------------------------------------------------------- B11: PDFs independientes
+
+def test_two_documents_of_the_same_analysis_are_independent(client, app, root_user,
+                                                            root_headers, fake_queue):
+    """B11 de punta a punta.
+
+    El modelo permite N ``IrisDocument`` por análisis (relación ``documents``
+    con ``cascade="all, delete-orphan"``), pero el PDF se llamaba
+    ``<analysis_id>_Iris.pdf`` para todos: el segundo informe pisaba el fichero
+    del primero, y borrar cualquiera de los dos dejaba al otro apuntando a una
+    ruta que ya no existía.
+    """
+    import os
+    from src.modules.features.iris.repositories import IrisReportRepository
+    from src.modules.infrastructure import UnitOfWork
+
+    analysis_id = _seed_analysis(app, root_user.id)
+
+    first = client.post(f"/iris/results/{analysis_id}/document", headers=root_headers)
+    second = client.post(f"/iris/results/{analysis_id}/document", headers=root_headers)
+    assert first.status_code == 202 and second.status_code == 202
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            documents = IrisReportRepository(uow).get_documents_by_parent(analysis_id)
+            assert len(documents) == 2
+            paths = {document.filename for document in documents}
+            assert len(paths) == 2, "los dos informes escribieron el mismo fichero"
+            assert all(os.path.exists(path) for path in paths)
+
+    # Ambos se descargan, y cada uno con su propio nombre.
+    ids = sorted(document["documentId"] for document in
+                 client.get(f"/iris/results/{analysis_id}/documents",
+                            headers=root_headers).get_json()["documents"])
+    for document_id in ids:
+        download = client.get(f"/iris/document/{document_id}/download", headers=root_headers)
+        assert download.status_code == 200
+        assert f"_{document_id}.pdf" in download.headers["Content-Disposition"]
+
+    # Y borrar uno no destruye el fichero del otro.
+    assert client.delete(f"/iris/document/{ids[0]}", headers=root_headers).status_code == 200
+    survivor = client.get(f"/iris/document/{ids[1]}/download", headers=root_headers)
+    assert survivor.status_code == 200
+    assert len(survivor.data) > 0

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -49,11 +49,74 @@ def _sample_report(**overrides):
 
 
 def test_print_pdf_creates_a_file():
-    creator = IrisPDFCreator(report=_sample_report())
+    creator = IrisPDFCreator(report=_sample_report(), document_id=7)
     path = creator.print_pdf()
     assert os.path.exists(path)
     assert os.path.getsize(path) > 0
-    assert path.endswith("42_Iris.pdf")
+    assert path.endswith("42_7_Iris.pdf")
+
+
+def test_two_documents_of_the_same_analysis_do_not_collide():
+    """B11: el modelo permite N documentos por análisis, pero el nombre del
+    fichero solo dependía del análisis, así que todos escribían el mismo PDF."""
+    first = IrisPDFCreator(report=_sample_report(), document_id=1).print_pdf()
+    second = IrisPDFCreator(report=_sample_report(), document_id=2).print_pdf()
+
+    assert first != second
+    assert os.path.exists(first) and os.path.exists(second)
+
+
+def test_deleting_one_document_leaves_the_other_intact():
+    """El caso que hacía daño de verdad: ``delete_document_with_file`` borra
+    por ``filename``, que era el mismo para los dos documentos."""
+    first = IrisPDFCreator(report=_sample_report(), document_id=1).print_pdf()
+    second = IrisPDFCreator(report=_sample_report(), document_id=2).print_pdf()
+
+    os.remove(first)
+
+    assert not os.path.exists(first)
+    assert os.path.exists(second)
+    assert os.path.getsize(second) > 0
+
+
+def test_without_a_document_id_the_name_is_still_unique():
+    """Ningún camino de la aplicación llega así, pero la clase sigue siendo
+    usable a pelo y no debe reintroducir la colisión por la puerta de atrás."""
+    first = IrisPDFCreator(report=_sample_report()).print_pdf()
+    second = IrisPDFCreator(report=_sample_report()).print_pdf()
+
+    assert first != second
+    assert os.path.exists(first) and os.path.exists(second)
+
+
+def test_no_temporary_file_survives_a_successful_render(tmp_path):
+    """El PDF se escribe en un temporal y se mueve con ``os.replace()``; si el
+    temporal sobreviviera, cada informe dejaría basura en el directorio."""
+    path = IrisPDFCreator(report=_sample_report(), document_id=3).print_pdf()
+
+    leftovers = [name for name in os.listdir(os.path.dirname(path)) if name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_a_failed_render_leaves_neither_temporary_nor_output(tmp_path, monkeypatch):
+    """Un fallo a mitad no debe dejar un PDF truncado en la ruta final: el
+    lector que lo descargue recibiría un fichero corrupto sin saberlo."""
+    import src.modules.features.iris.services.reports as reports_mod
+
+    creator = IrisPDFCreator(report=_sample_report(), document_id=4)
+    expected = creator._output_path()
+
+    monkeypatch.setattr(
+        reports_mod.SimpleDocTemplate, "build",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError):
+        creator.print_pdf()
+
+    assert not os.path.exists(expected)
+    leftovers = [name for name in os.listdir(str(tmp_path)) if name.endswith(".tmp")]
+    assert leftovers == []
 
 
 def test_print_pdf_without_path_data_does_not_fail():


### PR DESCRIPTION
## Resumen

Todos los informes PDF de un mismo análisis de Iris escribían **el mismo fichero**. Este PR les da un nombre por documento y hace la escritura atómica.

Cierra #210.

## El problema, en llano

Cuando un usuario pide el informe de un análisis, Iris crea una fila `IrisDocument` y encola la generación del PDF. El modelo permite **varios documentos por análisis** — la relación es `documents` con `cascade="all, delete-orphan"`, y no hay nada que impida pedir el informe dos veces (regenerarlo tras editar algo, o simplemente dos clics).

Pero el nombre del fichero no lo sabía:

```python
filename = os.path.join(self.directory, f"{analysis_id}_Iris.pdf")
```

Depende **solo** del análisis. Así que N documentos del mismo análisis apuntaban todos a la misma ruta en disco, con dos consecuencias:

1. **Dos generaciones se pisan.** La segunda reescribe el fichero de la primera. Y como no había fichero temporal ni movimiento atómico, la reescritura ocurría *en sitio*: quien estuviera descargando el informe justo en ese momento recibía un PDF a medio escribir. El estado del documento decía `done` — porque lo era, para el primero — mientras sus bytes cambiaban debajo.

2. **Borrar un documento destruye el PDF del otro.** Esta es la que hace daño de verdad. `delete_document_with_file()` (el helper compartido con Themis) borra el fichero por `document.filename`; si dos filas comparten ese valor, eliminar una deja a la otra apuntando a una ruta que ya no existe. El usuario ve el informe listado, pulsa descargar, y recibe un 400 «documento no disponible» sin haber hecho nada malo.

## Qué cambia

**1. El nombre lleva el `document_id`:** `<analysis_id>_<document_id>_Iris.pdf`. Conserva el `analysis_id` delante porque sigue siendo útil para localizar a ojo los informes de un análisis en el directorio de salida.

`IrisPDFCreator` recibe ahora `document_id`, que le pasa `IrisReportManager._generate_pdf_async()` — ya lo tenía a mano, era el argumento del propio job. Si no se le pasa (ningún camino de la aplicación llega así hoy; queda para que la clase siga siendo usable a pelo desde un script o un test) cae a un sufijo aleatorio: no reproducible, pero tampoco colisiona, que es lo que importa aquí.

**2. Escritura atómica.** El PDF se genera en `<ruta_final>.<uuid>.tmp`, en el mismo directorio, y se mueve con `os.replace()` — atómico dentro de un mismo sistema de ficheros. Un lector nunca ve un fichero a medias: o está el anterior completo, o está el nuevo completo.

Si la generación falla a mitad, el temporal se borra y **no se toca la ruta final**. Antes, un fallo dejaba un PDF truncado en el sitio bueno. El temporal lleva UUID a propósito: si quedara huérfano por un `kill` del proceso, no lo pisaría el siguiente intento, así que borrarlo explícitamente en el camino de error es lo único que evita acumular basura.

**3. El nombre descargable identifica el documento.** Era `iris_analysis_<analysis_id>.pdf` para todos, así que dos informes del mismo análisis llegaban al navegador con el mismo nombre y el segundo sobrescribía al primero en la carpeta de descargas del usuario. Ahora incluye el id del documento.

## Validación

- `tests/unit/test_iris_reports.py` (ampliado) — dos documentos del mismo análisis no colisionan; borrar uno deja el otro intacto; sin `document_id` el nombre sigue siendo único; un render correcto no deja temporales; un render fallido no deja ni temporal ni salida.
- `tests/integration/test_iris_documents.py` (nuevo test) — el ciclo entero por HTTP: se generan dos informes del mismo análisis, se comprueba que las dos filas tienen rutas distintas y ambos ficheros existen, se descargan los dos con su propio `Content-Disposition`, se borra uno y **el otro sigue descargándose con contenido**.
- Suite completa en verde.

## Notas

- Sin migración: los `filename` ya guardados siguen siendo válidos y se siguen sirviendo tal cual. Los informes históricos de un mismo análisis que ya se pisaron entre sí no se pueden recuperar — el fichero perdido no está en ninguna parte —, pero tampoco empeoran: el que quedó vivo sigue funcionando, y a partir de ahora no vuelve a ocurrir.
- No se toca el helper compartido `delete_document_with_file()`. El defecto no estaba ahí: borrar el fichero de un documento es lo correcto, lo que estaba mal era que dos documentos distintos tuvieran el mismo fichero.
- El README no se toca aquí; los cambios de contrato de la fase 0 van juntos en un commit al final.
