### PR TITLE
fix(iris): sync_cursor a Text para el deltaLink de Graph (B12)

### DIFF
--- a/API/alembic/versions/dd19efde1d08_alter_iris_sync_cursor_to_text.py
+++ b/API/alembic/versions/dd19efde1d08_alter_iris_sync_cursor_to_text.py
@@ -1,0 +1,63 @@
+"""sync_cursor de Iris a Text: el deltaLink de Graph no cabe en 255 (#211)
+
+Revision ID: dd19efde1d08
+Revises: c93b8545601b
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'dd19efde1d08'
+down_revision: Union[str, Sequence[str], None] = 'c93b8545601b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    ``sync_cursor`` guarda el marcador de hasta dónde ha llegado la ingesta de
+    un buzón conectado. Para Gmail es un ``historyId`` corto, pero para
+    Microsoft Graph es un ``@odata.deltaLink``: una URL completa con un token
+    de estado opaco dentro, que rebasa con holgura los 255 caracteres.
+
+    El propio docstring del modelo ya decía que el valor es opaco —es decir,
+    que no debe interpretarse ni recortarse—, pero la columna lo acotaba. Un
+    truncado silencioso rompe la sincronización incremental: el cursor
+    guardado deja de ser válido, Graph responde 410 y la conexión vuelve a
+    hacer bootstrap, perdiendo el punto en el que iba.
+
+    ``Text`` no tiene límite práctico en PostgreSQL y no cuesta nada frente a
+    ``varchar``: internamente son el mismo tipo, solo cambia la comprobación
+    de longitud. La conversión ensancha la columna, así que ningún valor
+    existente se pierde.
+    """
+    op.alter_column(
+        "IrisMailboxConnection", "sync_cursor",
+        existing_type=sa.String(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Estrecha la columna de vuelta a 255. **Cualquier cursor más largo que eso
+    hace fallar la bajada**, que es el comportamiento correcto: truncarlo en
+    silencio dejaría conexiones con un marcador inválido que solo se
+    manifestaría en la siguiente sincronización. Si hiciera falta bajar de
+    verdad, lo seguro es poner a NULL los cursores largos primero — la
+    conexión rehará el bootstrap, que es lento pero no pierde correo.
+    """
+    op.alter_column(
+        "IrisMailboxConnection", "sync_cursor",
+        existing_type=sa.Text(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -151,7 +151,10 @@ class IrisMailboxConnection(Base):
                  until the first bootstrap sync runs (see
                  ``services/mailbox`` connectors: the first sync never
                  backfills historical mail, it only captures the starting
-                 cursor).
+                 cursor). Es ``Text`` y no ``String(n)`` a propósito: el
+                 ``@odata.deltaLink`` de Graph es una URL completa con un
+                 token de estado dentro y rebasa los 255 caracteres. Opaco
+                 significa opaco — no se interpreta, no se recorta.
         status: "active" | "reauth_required" | "revoked" | "paused".
         ingested_today / ingested_reset_date: Per-connection daily ingest
                  counter enforcing ``iris.maxIngestedPerDay`` — reset when
@@ -178,7 +181,7 @@ class IrisMailboxConnection(Base):
 
     folder = Column(String(255), nullable=True)
     full_message_mode = Column(Boolean, nullable=False, default=False)
-    sync_cursor = Column(String(255), nullable=True)
+    sync_cursor = Column(Text, nullable=True)
 
     status = Column(String(20), nullable=False, default="active")
     ingested_today = Column(Integer, nullable=False, default=0)

--- a/API/tests/integration/test_iris_mailbox_model.py
+++ b/API/tests/integration/test_iris_mailbox_model.py
@@ -100,3 +100,51 @@ def test_analysis_source_message_uid_unique_per_connection(app, regular_user):
             repo = IrisAnalysisRepository(uow)
             repo.save(IrisAnalysis(raw_headers="From: a@b.com", user_id=regular_user.id))
             repo.save(IrisAnalysis(raw_headers="From: c@d.com", user_id=regular_user.id))
+
+
+# --------------------------------------------------------------- B12: cursor opaco
+
+def test_sync_cursor_column_has_no_length_limit():
+    """B12: la columna era ``String(255)``, pero el ``@odata.deltaLink`` de
+    Microsoft Graph es una URL con un token de estado dentro que la rebasa.
+
+    Esta comprobación mira el **tipo declarado**, no un round-trip, a
+    propósito: la suite corre sobre SQLite, que ignora la longitud de un
+    ``VARCHAR`` y por tanto guardaría feliz un cursor de 900 caracteres
+    incluso con la columna acotada. En PostgreSQL, que es donde corre de
+    verdad, ese INSERT falla. El tipo es lo único que distingue las dos cosas
+    desde aquí.
+    """
+    column_type = IrisMailboxConnection.__table__.c.sync_cursor.type
+
+    assert not getattr(column_type, "length", None), (
+        "sync_cursor volvió a tener un límite de longitud; un deltaLink de "
+        "Graph no cabe y la sincronización incremental se rompe en silencio"
+    )
+
+
+def test_a_long_opaque_cursor_survives_a_round_trip(app, regular_user):
+    """Complemento del anterior: el valor vuelve **exactamente** igual.
+
+    Aunque SQLite no valide la longitud, este test protege contra cualquier
+    recorte o normalización que alguien introdujera en el camino de guardado —
+    el cursor es opaco y un solo carácter de diferencia lo invalida.
+    """
+    cursor = (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + "Ag0AAA" + "Z" * 1200
+    )
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = IrisMailboxConnectionRepository(uow)
+            connection = _make_connection(regular_user.id, "cursor@outlook.com")
+            connection.provider = "microsoft"
+            connection.sync_cursor = cursor
+            repo.save(connection)
+            connection_id = connection.id
+
+        with UnitOfWork() as uow:
+            fetched = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert fetched.sync_cursor == cursor
+            assert len(fetched.sync_cursor) > 255

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -225,6 +225,72 @@ def test_graph_list_new_with_cursor_caches_headers_from_delta_response():
     assert raw == "From: a@b.com\r\n"
 
 
+# B12: el deltaLink de Graph es un token opaco que puede rebasar los 255
+# caracteres que la columna `sync_cursor` permitía. Estos tests fijan que el
+# conector lo devuelve intacto — cualquier recorte lo invalida, y un cursor
+# inválido tira la sincronización incremental al bootstrap.
+
+def _long_delta_link(length: int = 900) -> str:
+    """Un deltaLink realista: URL de Graph más un token de estado largo.
+
+    Los deltaLink reales llevan dentro un `$deltatoken` codificado cuyo tamaño
+    depende del estado de la carpeta; 900 caracteres está dentro de lo que
+    devuelve un buzón con actividad, y en todo caso lo que importa aquí es que
+    pase de 255.
+    """
+    return (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + ("Ag0AAA" + "X" * length)
+    )
+
+
+def test_graph_bootstrap_preserves_a_delta_link_longer_than_255_chars():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    delta_link = _long_delta_link()
+    assert len(delta_link) > 255
+
+    page = _response({"value": [], "@odata.deltaLink": delta_link})
+    with mock.patch("requests.get", return_value=page):
+        _refs, cursor = connector.list_new("access-token", cursor=None)
+
+    assert cursor == delta_link
+
+
+def test_graph_incremental_sync_preserves_a_long_delta_link_exactly():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    previous = _long_delta_link(600)
+    next_link = _long_delta_link(950)
+
+    page = _response({"value": [{"id": "msg-1"}], "@odata.deltaLink": next_link})
+    with mock.patch("requests.get", return_value=page) as get:
+        refs, cursor = connector.list_new("access-token", cursor=previous)
+
+    # El cursor anterior se usa como URL tal cual, sin reconstruirlo.
+    assert get.call_args.args[0] == previous
+    assert len(refs) == 1
+    assert cursor == next_link
+    assert len(cursor) > 255
+
+
+def test_graph_expired_cursor_rebootstraps_instead_of_failing():
+    """410 Gone: el deltaLink cayó fuera de la ventana de retención de Graph.
+
+    La única salida es volver a capturar un cursor desde cero. No se pierde
+    correo local: el bootstrap no hace backfill, solo marca el punto de
+    partida, y los análisis ya ingeridos siguen donde estaban.
+    """
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    fresh = _long_delta_link(400)
+
+    gone = _response(status_code=410)
+    bootstrap = _response({"value": [], "@odata.deltaLink": fresh})
+    with mock.patch("requests.get", side_effect=[gone, bootstrap]):
+        refs, cursor = connector.list_new("access-token", cursor=_long_delta_link(300))
+
+    assert refs == []
+    assert cursor == fresh
+
+
 def test_graph_fetch_raw_returns_response_text_directly():
     connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
     resp = _response(text="From: a@b.com\r\nSubject: Hi\r\n\r\nBody")


### PR DESCRIPTION
## Resumen

`IrisMailboxConnection.sync_cursor` era `String(255)`, pero el cursor que devuelve Microsoft Graph no cabe ahí. Este PR lo pasa a `Text` y fija con tests que el conector lo devuelve intacto.

Cierra #211.

## El problema, en llano

Cuando un usuario conecta su buzón a Iris, la ingesta no relee el buzón entero cada vez: guarda un **cursor**, un marcador de hasta dónde llegó la última sincronización, y en la siguiente pide solo lo posterior a ese punto.

Ese cursor es **opaco**: lo emite el proveedor, y el cliente no debe interpretarlo, ni parsearlo, ni recortarlo — solo devolverlo tal cual. El propio docstring del modelo ya lo decía así (*"Opaque provider cursor (Gmail historyId / Graph deltaLink)"*).

El problema es que los dos proveedores emiten cosas de tamaños muy distintos:

- **Gmail** devuelve un `historyId`: un número. Ocupa una docena de caracteres.
- **Microsoft Graph** devuelve un `@odata.deltaLink`: una URL completa con un `$deltatoken` codificado dentro, cuyo tamaño depende del estado de la carpeta. Pasa de 255 caracteres con normalidad.

Y la columna era `String(255)`.

## Qué pasa cuando no cabe

Depende del motor, y ninguna de las dos opciones es buena:

- En **PostgreSQL** (producción) el `INSERT` falla directamente: la sincronización revienta con un error de base de datos.
- En cualquier motor que trunque en silencio, es peor: el cursor guardado queda a medias, deja de ser un token válido, Graph responde **410 Gone** en la siguiente sincronización y la conexión rehace el bootstrap desde cero. No se pierde correo —el bootstrap no hace backfill, solo recaptura el punto de partida— pero la sincronización incremental deja de funcionar de facto, se repite en cada ciclo, y nadie se entera: en el log solo aparece un `Graph delta cursor expirado, re-bootstrapping` que parece rutina.

## Qué cambia

**La columna pasa a `Text`.** En PostgreSQL `text` y `varchar(n)` son internamente el mismo tipo; lo único que cambia es la comprobación de longitud. No hay coste de almacenamiento ni de rendimiento por quitarla, y el límite no aportaba nada: un valor opaco no tiene una longitud "correcta" que validar.

La bajada de la migración estrecha la columna de vuelta y **falla si existe algún cursor más largo de 255**. Es deliberado: truncarlos en silencio dejaría conexiones con un marcador inválido que solo se notaría en la siguiente sincronización. Si hiciera falta bajar de verdad, lo seguro es poner esos cursores a NULL primero — la conexión rehace el bootstrap, que es lento pero honesto.

**El manejo de `410 Gone` ya existía** y no se toca (`microsoft.py:122`). El issue lo pedía como parte del alcance, pero al verificarlo contra el código estaba implementado: un 410 vuelve a llamar a `list_new(cursor=None)`. Lo que faltaba era la columna. Se le añade test, que es lo que no tenía.

## Validación

- `tests/unit/test_iris_mailbox_connectors.py` (3 tests nuevos) — un deltaLink de más de 255 caracteres se devuelve **exacto** en el bootstrap y en la sincronización incremental; el cursor previo se usa como URL tal cual, sin reconstruirlo; y un 410 rehace el bootstrap en vez de fallar.
- `tests/integration/test_iris_mailbox_model.py` (2 tests nuevos) — uno comprueba que la columna **no tiene límite de longitud declarado**, y otro que un cursor de 1 200 caracteres sobrevive un round-trip completo.

  La distinción entre esos dos importa: la suite corre sobre SQLite, que **ignora la longitud de un `VARCHAR`**. Un test que solo guardara y releyera un cursor largo pasaría igual de bien con la columna acotada, así que no probaría nada de lo que este PR arregla. Por eso el que de verdad protege es el que mira el tipo declarado; el round-trip cubre lo otro, que nadie meta un recorte en el camino de guardado.
- Tests de Iris (unitarios e integración) en verde.
- Grafo de Alembic verificado: 50 revisiones, un solo head, sin IDs duplicados.

## Notas

- Es prerequisito de facto de `F14` (ingesta event-driven), que va a manejar más cursores y más largos.
- Gmail no se ve afectado: su `historyId` cabía de sobra y sigue cabiendo.
- El README no se toca aquí; los cambios de contrato de la fase 0 van juntos en un commit al final.
