### PR TITLE
feat(iris): límite de tamaño alineado vía GET /iris/capabilities (B13)

### DIFF
--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -3,6 +3,7 @@ Iris REST API endpoints for email header analysis.
 
 Provides:
 - POST /iris/analyze         — submit headers for analysis
+- GET  /iris/capabilities     — server-side limits the UI must honour
 - GET  /iris/status?id=...   — check analysis status/progress
 - GET  /iris/results         — list all analyses for the current user
 - GET  /iris/results/{id}    — full analysis report
@@ -40,6 +41,7 @@ from .exceptions import (
 )
 from .schemas import (
     AnalysisIdQuerySchema,
+    IrisCapabilitiesResponseSchema,
     AnalyzeRequestSchema,
     AnalyzeResponseSchema,
     AnalysisStatusResponseSchema,
@@ -110,6 +112,19 @@ def analyze_headers(data):
         "analysisId": analysis_id,
         "status": "pending",
     }
+
+
+@iris_blp.get("/capabilities")
+@iris_blp.response(200, IrisCapabilitiesResponseSchema, description="Iris limits and analysis modes")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(logger=logger)
+def get_capabilities():
+    """Limites y modos de analisis que aplica el servidor"""
+    return IrisManager.get_capabilities()
 
 
 @iris_blp.get("/status")

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -195,6 +195,33 @@ class IrisManager(TaskTrackingMixin):
         """
         return build_repository(IrisAnalysisRepository).get_by_id(analysis_id)
 
+    @staticmethod
+    def get_capabilities() -> Dict[str, Any]:
+        """Límites y modos de análisis que la interfaz necesita conocer (B13).
+
+        El backend rechazaba mensajes por encima de un tamaño que la UI no
+        tenía forma de saber: el usuario elegía un fichero que la interfaz
+        daba por bueno, esperaba a que se cargara entero en memoria y recibía
+        un rechazo del API al enviarlo. Cualquier constante duplicada en el
+        frontend deriva antes o después —de hecho ya había derivado a 2×—, así
+        que el límite se publica en lugar de replicarse.
+
+        Se lee de la configuración en cada llamada, no se hornea al importar
+        el módulo, para que un cambio vía ``PUT /system`` surta efecto sin
+        reiniciar (mismo patrón que ``AnalyzeRequestSchema.validate_max_size``,
+        que es la validación que este endpoint describe).
+        """
+        config = CR.iris_config()
+        return {
+            "maxMessageBytes": config.max_message_bytes,
+            "minHeaders": config.min_headers,
+            "analysisModes": ["headers", "message"],
+            "verdictThresholds": {
+                "legitimate": config.legitimate_threshold,
+                "suspicious": config.suspicious_threshold,
+            },
+        }
+
     def get_analysis_status(self, analysis_id: int) -> Optional[str]:
         """Return the current lifecycle status string of an analysis.
 

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -50,6 +50,24 @@ class AnalyzeRequestSchema(Schema):
                 )
 
 
+class IrisCapabilitiesResponseSchema(Schema):
+    """Límites y modos que la interfaz necesita para decidir igual que el API.
+
+    Existe para que el frontend no tenga que replicar constantes del backend:
+    una copia en el navegador deriva en cuanto alguien cambia la config del
+    servidor, y el usuario se lleva el rechazo después de haber cargado el
+    fichero entero en memoria.
+
+    ``verdictThresholds`` viaja ya en la respuesta del listado; se repite aquí
+    para que una vista que aún no ha listado nada pueda pintar la escala de
+    riesgo sin pedir primero una página de resultados.
+    """
+    maxMessageBytes = fields.Integer()
+    minHeaders = fields.Integer()
+    analysisModes = fields.List(fields.String())
+    verdictThresholds = fields.Nested(lambda: VerdictThresholdsSchema())
+
+
 class AnalysisIdQuerySchema(Schema):
     """Query parameter for ``GET /iris/status`` — supplied as ``?id=...``."""
     id = fields.Integer(required=True)

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -1,8 +1,36 @@
 """Tests de integración del módulo Iris (análisis de cabeceras)."""
 
+from typing import Callable, Optional
+from unittest import mock
+
 import pytest
 
+from src.modules.system.taskqueue import Task, TaskStatus
+
 pytestmark = pytest.mark.integration
+
+
+class _NoopQueue:
+    """Cola que acepta el encolado y no ejecuta nada.
+
+    Los tests de aceptación de tamaño solo miran si la validación del schema
+    deja pasar la petición; ejecutar el análisis de verdad no aporta nada y
+    saldría a Redis, que la suite tiene deshabilitado.
+    """
+
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        return Task(id=name or "job", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
 
 
 def test_analyze_requires_authentication(client):
@@ -37,4 +65,88 @@ def test_analyze_rejects_request_without_headers_or_message(client, root_headers
     # Fase 2: 'headers' ya no es obligatorio si se envía 'message', pero al
     # menos uno de los dos debe estar presente (validado en el schema).
     resp = client.post("/iris/analyze", headers=root_headers, json={"title": "x"})
+    assert resp.status_code == 422
+
+
+# --------------------------------------------------------------- B13: capacidades
+
+def test_capabilities_requires_authentication(client):
+    assert client.get("/iris/capabilities").status_code == 401
+
+
+def test_capabilities_requires_read_attribute(client, stripped_user, auth_headers):
+    resp = client.get("/iris/capabilities", headers=auth_headers(stripped_user))
+    assert resp.status_code == 403
+
+
+def test_capabilities_publishes_the_limit_the_api_actually_enforces(client, regular_user,
+                                                                   auth_headers):
+    """B13: el frontend tenía su propio tope, y había derivado a 2× del real.
+
+    La única defensa contra que vuelva a derivar es que el número que publica
+    este endpoint sea el mismo que aplica la validación, leído del mismo sitio.
+    """
+    import src.modules.system.config_reading as CR
+
+    resp = client.get("/iris/capabilities", headers=auth_headers(regular_user))
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["maxMessageBytes"] == CR.iris_config().max_message_bytes
+    assert body["minHeaders"] == CR.iris_config().min_headers
+    assert set(body["analysisModes"]) == {"headers", "message"}
+
+
+def test_a_message_at_the_published_limit_is_accepted(client, regular_user, auth_headers,
+                                                      monkeypatch):
+    """Misma entrada, misma decisión: justo en el límite el API acepta."""
+    import src.modules.features.iris.schemas as schemas_mod
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    class _Limited:
+        max_message_bytes = 2048
+        min_headers = 2
+        legitimate_threshold = 80
+        suspicious_threshold = 55
+
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+
+    limit = client.get("/iris/capabilities",
+                       headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]
+
+    prefix = "From: a@b.com\r\nSubject: "
+    headers_block = prefix + "x" * (limit - len(prefix))
+    assert len(headers_block.encode("utf-8")) == limit
+
+    with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+        resp = client.post("/iris/analyze", headers=auth_headers(regular_user),
+                           json={"headers": headers_block})
+
+    assert resp.status_code != 422, resp.get_json()
+
+
+def test_a_message_over_the_published_limit_is_rejected(client, regular_user, auth_headers,
+                                                        monkeypatch):
+    """Y un byte por encima lo rechaza, que es la otra mitad del contrato: si
+    la UI corta por este número, no puede recibir sorpresas a ninguno de los
+    dos lados."""
+    import src.modules.features.iris.schemas as schemas_mod
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    class _Limited:
+        max_message_bytes = 2048
+        min_headers = 2
+        legitimate_threshold = 80
+        suspicious_threshold = 55
+
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+
+    limit = client.get("/iris/capabilities",
+                       headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]
+
+    resp = client.post("/iris/analyze", headers=auth_headers(regular_user),
+                       json={"headers": "From: a@b.com\r\nSubject: " + "x" * limit})
+
     assert resp.status_code == 422

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,7 +12,8 @@
     "test:polling": "node test/usePolling.test.mjs",
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
-    "test:logs": "node test/logTransport.test.mjs"
+    "test:logs": "node test/logTransport.test.mjs",
+    "test:iris": "node test/iris.intake.test.mjs"
   },
   "dependencies": {
     "hash-wasm": "^4.12.0",

--- a/web/app/src/components/iris/intake.js
+++ b/web/app/src/components/iris/intake.js
@@ -1,0 +1,84 @@
+/**
+ * Decisiones de admisión de un fichero arrastrado a Iris.
+ *
+ * Vive fuera de `IrisView.vue` por dos motivos. El primero es poder probarlo:
+ * son funciones puras sin DOM, igual que `components/hygeia/format.js`, así
+ * que corren con `node` a secas (ver `test/iris.intake.test.mjs`).
+ *
+ * El segundo es el que motiva B13. El tope de tamaño estaba escrito a mano en
+ * la vista (`20 * 1024 * 1024`) mientras el backend aplicaba otro
+ * (`iris.maxMessageBytes`, 10 MiB): el usuario elegía un fichero que la
+ * interfaz daba por bueno, esperaba a que se cargara entero en memoria y
+ * recibía un rechazo del API. Una constante duplicada en el navegador deriva
+ * en cuanto alguien cambia la configuración del servidor —y ya había
+ * derivado, al doble—, así que el límite se pide a `GET /iris/capabilities` y
+ * aquí solo queda cómo aplicarlo.
+ */
+
+/** Tope de emergencia si `/iris/capabilities` no ha respondido todavía.
+ *
+ *  Coincide con el default de `IrisConfig.max_message_bytes`. No es la fuente
+ *  de verdad —el servidor lo es— sino lo que evita que la vista quede
+ *  inutilizable mientras la petición está en vuelo o si falla. Ante la duda,
+ *  es preferible pecar por defecto: un fichero rechazado de más se puede
+ *  reintentar, uno aceptado de más se rechaza igualmente al enviarlo, pero
+ *  después de habérselo comido entero.
+ */
+export const FALLBACK_MAX_MESSAGE_BYTES = 10 * 1024 * 1024
+
+/** ¿Es un `.eml`? Se acepta por extensión o por tipo MIME: los navegadores no
+ *  siempre rellenan `file.type` para ficheros arrastrados desde el disco. */
+export function isEmlFile(file) {
+  if (!file) return false
+  return /\.eml$/i.test(file.name ?? '') || file.type === 'message/rfc822'
+}
+
+/** Tope efectivo a partir de la respuesta de capacidades del servidor.
+ *
+ *  Solo acepta enteros positivos: un `null`, un `0` o un valor no numérico
+ *  significan "el servidor no me lo ha dicho", no "no hay límite" — tratarlos
+ *  como cero rechazaría absolutamente todo.
+ */
+export function resolveMaxMessageBytes(capabilities) {
+  const declared = capabilities?.maxMessageBytes
+  if (typeof declared === 'number' && Number.isFinite(declared) && declared > 0) {
+    return Math.floor(declared)
+  }
+  return FALLBACK_MAX_MESSAGE_BYTES
+}
+
+/**
+ * Decide qué hacer con un fichero antes de leerlo.
+ *
+ * Devuelve `{ accepted, reason, headersOnly }`:
+ *
+ * - `accepted: false` — no es un `.eml`; no hay nada que leer.
+ * - `headersOnly: true` — es un `.eml` pero pasa del tope, así que solo se
+ *   enviarán las cabeceras extraídas. No es un rechazo: un correo enorme casi
+ *   siempre lo es por sus adjuntos, y sus cabeceras siguen siendo analizables.
+ * - `headersOnly: false` — cabe entero y se manda completo, para que las
+ *   reglas de contenido (cuerpo, enlaces, adjuntos) puedan aplicarse.
+ */
+export function classifyIntake(file, capabilities) {
+  if (!isEmlFile(file)) {
+    return { accepted: false, reason: 'not-eml', headersOnly: false, limit: null }
+  }
+
+  const limit = resolveMaxMessageBytes(capabilities)
+  const headersOnly = (file.size ?? 0) > limit
+
+  return {
+    accepted: true,
+    reason: headersOnly ? 'too-big' : 'ok',
+    headersOnly,
+    limit,
+  }
+}
+
+/** Tamaño legible para el aviso que ve el usuario ("10 MB"). */
+export function formatByteLimit(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return ''
+  const megabytes = bytes / (1024 * 1024)
+  const rounded = megabytes >= 10 ? Math.round(megabytes) : Math.round(megabytes * 10) / 10
+  return `${rounded} MB`
+}

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -27,6 +27,14 @@ export const useIrisStore = defineStore('iris', () => {
   // hardcodee. Los valores por defecto solo se usan hasta el primer fetch.
   const thresholds = reactive({ legitimate: 80, suspicious: 55 })
 
+  // B13: límites que aplica el servidor (`GET /iris/capabilities`). La vista
+  // los necesita para decidir igual que el API en vez de replicar constantes:
+  // el tope de tamaño estaba escrito a mano allí y había derivado al doble
+  // del real, así que el usuario cargaba en memoria ficheros que el backend
+  // iba a rechazar. Se pide una vez y se cachea; si falla, `intake.js` cae a
+  // su respaldo y la interfaz sigue siendo usable.
+  const capabilities = ref(null)
+
   const currentId = ref(null)
   const currentReport = reactive({ loading: false, data: null })
   const currentStatus = reactive({ polling: false, status: null, progress: null })
@@ -48,6 +56,19 @@ export const useIrisStore = defineStore('iris', () => {
   // "message" para que el backend analice cuerpo, enlaces y adjuntos
   // reales; "headers" se mantiene como respaldo cuando solo se pegaron
   // cabeceras a mano.
+  async function fetchCapabilities() {
+    if (capabilities.value) return capabilities.value
+    try {
+      capabilities.value = await apiFetch('/iris/capabilities')
+    } catch {
+      // Silencioso a propósito: no poder leer los límites no impide analizar
+      // nada, solo hace que la interfaz use su respaldo. Un toast de error
+      // aquí sería ruido por algo que el usuario no puede arreglar.
+      capabilities.value = null
+    }
+    return capabilities.value
+  }
+
   async function submitAnalysis({ headers, message, title } = {}) {
     submitting.value = true
     try {
@@ -553,6 +574,7 @@ export const useIrisStore = defineStore('iris', () => {
     submitting.value = false
     totalCount.value = 0
     Object.assign(thresholds, { legitimate: 80, suspicious: 55 })
+    capabilities.value = null
 
     archive.items = []
     archive.total = 0
@@ -578,6 +600,7 @@ export const useIrisStore = defineStore('iris', () => {
   return {
     BENCH_SIZE,
     analyses, loading, listError, submitting, totalCount, thresholds,
+    capabilities, fetchCapabilities,
     currentId, currentReport, currentStatus, aiSummaryLoading,
     documents, documentsLoading,
     archive, archiveHasFilters,

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -99,6 +99,7 @@ import IrisForm from '@/components/iris/IrisForm.vue'
 import { useIrisStore } from '@/stores/irisStore'
 import { useToastStore } from '@/stores/toastStore'
 import { parseEml } from '@/composables/useEml'
+import { classifyIntake, formatByteLimit } from '@/components/iris/intake.js'
 
 const store = useIrisStore()
 const toast = useToastStore()
@@ -109,9 +110,13 @@ const archiveOpen = ref(false)
 const prefill = ref(null)
 
 // Fase 2: enviamos el .eml completo (cuerpo, enlaces, adjuntos) para que las
-// reglas de contenido puedan analizarlo. Tope generoso para correos con
-// adjuntos grandes en base64, evitando cargar archivos descomunales.
-const MESSAGE_READ_LIMIT = 20 * 1024 * 1024
+// reglas de contenido puedan analizarlo.
+//
+// B13: el tope ya no se escribe aquí. Era `20 * 1024 * 1024` mientras el
+// backend aplicaba 10 MiB, así que la vista aceptaba ficheros que el API iba
+// a rechazar — después de haberlos leído enteros en memoria. Ahora sale de
+// `GET /iris/capabilities` y la decisión vive en `intake.js`, que es puro y
+// está cubierto por `npm run test:iris`.
 
 // --- Intake por arrastre ---
 // dragDepth cuenta enter/leave para no parpadear sobre los hijos; rejecting
@@ -158,16 +163,17 @@ async function onDrop(e) {
   const file = e.dataTransfer?.files?.[0]
   if (!file) return
 
-  const isEml = /\.eml$/i.test(file.name) || file.type === 'message/rfc822'
-  if (!isEml) {
+  const capabilities = await store.fetchCapabilities()
+  const intake = classifyIntake(file, capabilities)
+  if (!intake.accepted) {
     flashReject()
     toast.show('Solo se aceptan archivos .eml', 'error')
     return
   }
 
   try {
-    const tooBig = file.size > MESSAGE_READ_LIMIT
-    const text = await (tooBig ? file.slice(0, MESSAGE_READ_LIMIT) : file).text()
+    const tooBig = intake.headersOnly
+    const text = await (tooBig ? file.slice(0, intake.limit) : file).text()
     const { rawHeaders, subject } = parseEml(text)
     if (!rawHeaders) {
       flashReject()
@@ -185,7 +191,12 @@ async function onDrop(e) {
     }
     if (store.currentId || store.currentReport.data) store.selectAnalysis(null)
     if (tooBig) {
-      toast.show('Archivo muy grande: solo se cargaron las cabeceras.', 'info')
+      const readable = formatByteLimit(intake.limit)
+      toast.show(
+        `El archivo supera el máximo que admite el servidor${readable ? ` (${readable})` : ''}: `
+        + 'solo se analizarán las cabeceras.',
+        'info',
+      )
     } else {
       toast.show('Correo cargado.', 'success')
     }
@@ -214,6 +225,10 @@ onBeforeUnmount(() => {
 
 onMounted(async () => {
   window.addEventListener('keydown', handleGlobalShortcut)
+  // Los limites del servidor se piden al entrar, no al soltar un fichero: asi
+  // el arrastre decide con el valor real desde el primer intento en vez de
+  // caer al respaldo mientras la peticion esta en vuelo.
+  store.fetchCapabilities()
   await store.fetchResults()
   const last = store.analyses[0]
   if (last && (last.status === 'running' || last.status === 'pending')) {

--- a/web/app/test/iris.intake.test.mjs
+++ b/web/app/test/iris.intake.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Test de la admisión de ficheros de Iris (`components/iris/intake.js`).
+ *
+ * B13: la vista tenía su propio tope de tamaño (20 MiB) mientras el backend
+ * aplicaba otro (10 MiB). El usuario elegía un fichero que la interfaz daba
+ * por bueno, esperaba a que se cargara entero en memoria y recibía un rechazo
+ * del API. Estos tests fijan que la decisión sale del límite que publica el
+ * servidor y no de una constante escrita a mano.
+ *
+ * Funciones puras sin DOM, así que se ejecutan con `node` a secas — mismo
+ * precedente que los tests de Acheron y Hygeia, sin introducir un framework:
+ *
+ *   node web/app/test/iris.intake.test.mjs
+ */
+
+import {
+  FALLBACK_MAX_MESSAGE_BYTES,
+  classifyIntake,
+  formatByteLimit,
+  isEmlFile,
+  resolveMaxMessageBytes,
+} from '../src/components/iris/intake.js'
+
+let passed = 0
+let failed = 0
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  ✓ ${name}`) }
+  else { failed++; console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`) }
+}
+
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  check(name, a === e, `esperado ${e}, obtenido ${a}`)
+}
+
+const MB = 1024 * 1024
+const file = (name, size, type = '') => ({ name, size, type })
+
+console.log('\nisEmlFile')
+check('acepta por extensión', isEmlFile(file('correo.eml', 10)))
+check('acepta en mayúsculas', isEmlFile(file('CORREO.EML', 10)))
+check('acepta por tipo MIME sin extensión', isEmlFile(file('adjunto', 10, 'message/rfc822')))
+check('rechaza un PDF', !isEmlFile(file('informe.pdf', 10)))
+check('rechaza la ausencia de fichero', !isEmlFile(null))
+
+console.log('\nresolveMaxMessageBytes')
+eq('usa el límite que publica el servidor', resolveMaxMessageBytes({ maxMessageBytes: 5 * MB }), 5 * MB)
+eq('sin capacidades cae al respaldo', resolveMaxMessageBytes(null), FALLBACK_MAX_MESSAGE_BYTES)
+eq('sin el campo cae al respaldo', resolveMaxMessageBytes({}), FALLBACK_MAX_MESSAGE_BYTES)
+// Un 0 o un null significan "el servidor no me lo ha dicho", no "no hay
+// límite": tratarlos como cero rechazaría absolutamente todo.
+eq('un cero no es un límite', resolveMaxMessageBytes({ maxMessageBytes: 0 }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('un null no es un límite', resolveMaxMessageBytes({ maxMessageBytes: null }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('una cadena no es un límite', resolveMaxMessageBytes({ maxMessageBytes: '5000' }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('el respaldo coincide con el default del backend', FALLBACK_MAX_MESSAGE_BYTES, 10 * MB)
+
+console.log('\nclassifyIntake — el límite lo manda el servidor')
+const capabilities = { maxMessageBytes: 10 * MB }
+
+eq('un .eml pequeño se manda entero',
+  classifyIntake(file('a.eml', 2 * MB), capabilities),
+  { accepted: true, reason: 'ok', headersOnly: false, limit: 10 * MB })
+
+eq('justo en el límite todavía cabe entero',
+  classifyIntake(file('a.eml', 10 * MB), capabilities),
+  { accepted: true, reason: 'ok', headersOnly: false, limit: 10 * MB })
+
+eq('un byte por encima pasa a solo cabeceras',
+  classifyIntake(file('a.eml', 10 * MB + 1), capabilities),
+  { accepted: true, reason: 'too-big', headersOnly: true, limit: 10 * MB })
+
+// El caso que motiva el issue: 15 MiB caía en la franja entre el tope viejo
+// del frontend (20 MiB) y el real del backend (10 MiB). La interfaz lo daba
+// por bueno y el API lo rechazaba después.
+eq('los 15 MiB de la franja discordante ya no se mandan enteros',
+  classifyIntake(file('a.eml', 15 * MB), capabilities),
+  { accepted: true, reason: 'too-big', headersOnly: true, limit: 10 * MB })
+
+eq('un fichero que no es .eml no se lee siquiera',
+  classifyIntake(file('informe.pdf', 1), capabilities),
+  { accepted: false, reason: 'not-eml', headersOnly: false, limit: null })
+
+console.log('\nclassifyIntake — sigue la configuración del servidor')
+// Si alguien sube el tope por PUT /system, la interfaz debe seguirlo sin que
+// haya que tocar el código del navegador. Es la propiedad que la constante
+// escrita a mano no podía tener.
+eq('un tope mayor deja pasar enteros ficheros antes truncados',
+  classifyIntake(file('a.eml', 15 * MB), { maxMessageBytes: 20 * MB }).headersOnly,
+  false)
+eq('un tope menor los trunca antes',
+  classifyIntake(file('a.eml', 6 * MB), { maxMessageBytes: 5 * MB }).headersOnly,
+  true)
+
+console.log('\nformatByteLimit')
+eq('10 MB', formatByteLimit(10 * MB), '10 MB')
+eq('20 MB', formatByteLimit(20 * MB), '20 MB')
+eq('decimal por debajo de 10', formatByteLimit(2.5 * MB), '2.5 MB')
+eq('sin límite no hay texto', formatByteLimit(0), '')
+
+console.log(`\n${passed} pasados, ${failed} fallidos`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Resumen

La interfaz de Iris aceptaba ficheros que el API iba a rechazar, porque cada lado tenía su propio límite de tamaño escrito a mano. Este PR publica el límite real del servidor y hace que la UI decida con él.

Cierra #212.

## El problema, en llano

Iris acepta dos formas de enviar un correo: pegar solo las cabeceras, o soltar un `.eml` completo (que permite analizar cuerpo, enlaces y adjuntos). El `.eml` completo tiene un tope, porque entra entero en una columna de texto y se vuelve a parsear —decodificación base64 incluida— en cada lectura posterior del informe.

El tope estaba escrito **dos veces**, y no coincidían:

- **Backend**: `AnalyzeRequestSchema.validate_max_size()` lee `iris.maxMessageBytes` de la configuración → **10 MiB**.
- **Frontend**: `IrisView.vue` tenía `const MESSAGE_READ_LIMIT = 20 * 1024 * 1024` → **20 MiB**.

Exactamente el doble. Para cualquier `.eml` entre 10 y 20 MiB, la secuencia era: el usuario arrastra el fichero, la interfaz lo da por bueno, **lo lee entero en memoria** (que es la parte cara), lo envía, y el API responde 422. El usuario paga la espera completa para recibir un rechazo.

No es que el frontend estuviera "mal" y el backend "bien": es que **una constante duplicada en el navegador no puede seguir a la configuración del servidor**. Ese límite es editable desde ConfigView, así que la copia del navegador quedaría desactualizada a la primera que alguien lo tocara — aquí ya había derivado sola.

## Qué cambia

### Backend: `GET /iris/capabilities`

Un endpoint que publica lo que el servidor aplica, en vez de obligar al navegador a adivinarlo:

```json
{
  "maxMessageBytes": 10485760,
  "minHeaders": 2,
  "analysisModes": ["headers", "message"],
  "verdictThresholds": { "legitimate": 80, "suspicious": 55 }
}
```

- `minHeaders` está por el mismo motivo que el tamaño: es otra validación del backend que la UI no podía ver.
- `verdictThresholds` ya viajaba en la respuesta del listado. Se repite aquí para que una vista que aún no ha listado nada pueda pintar la escala de riesgo sin pedir antes una página de resultados.
- Requiere `IRIS_READ`, como el resto de lecturas de Iris. No es información pública: describe la configuración del despliegue.

El valor se lee de la configuración **en cada llamada**, no se hornea al importar el módulo, para que un cambio vía `PUT /system` surta efecto sin reiniciar. Es el mismo patrón que usa la validación que este endpoint describe — importa que ambos se comporten igual, o volverían a divergir por otro camino.

### Frontend: la decisión sale del `.vue` a un módulo puro

`web/app/src/components/iris/intake.js` (nuevo) contiene `classifyIntake(file, capabilities)` y sus ayudas. Es puro y sin DOM, con el mismo precedente que `components/hygeia/format.js`.

Esto no es aseo: **la lógica que estaba dentro del `.vue` no se podía probar**. Los tests de la SPA corren con `node` a secas, sin framework de componentes, así que cualquier decisión enterrada en un manejador de eventos de un componente se queda sin cobertura por construcción.

`IrisView.vue` pide las capacidades **al entrar en la vista**, no al soltar un fichero, para que el primer arrastre ya decida con el valor real en vez de caer al respaldo mientras la petición está en vuelo.

Si `/iris/capabilities` falla, `intake.js` usa un respaldo que coincide con el default del backend (10 MiB) y **no se muestra ningún error**: no poder leer los límites no impide analizar nada, y un toast por algo que el usuario no puede arreglar es solo ruido.

Un detalle del respaldo que sí merece atención: `resolveMaxMessageBytes` solo acepta enteros positivos. Un `0`, un `null` o una cadena significan *"el servidor no me lo ha dicho"*, no *"el límite es cero"* — tratarlos como cero rechazaría absolutamente todo. Tiene sus tres tests.

El aviso al usuario también mejora: antes decía "Archivo muy grande" sin más; ahora nombra el máximo real ("El archivo supera el máximo que admite el servidor (10 MB)").

### `npm run test:iris`

Suite nueva en `package.json`, siguiendo el patrón de las seis existentes.

## Validación

- `web/app/test/iris.intake.test.mjs` (nuevo, 23 comprobaciones) — detección de `.eml` por extensión y por MIME; el límite sale de las capacidades; los tres casos de valor inválido caen al respaldo; comportamiento justo en el límite y un byte por encima; **el caso concreto del issue** (un fichero de 15 MiB, que caía en la franja entre el tope viejo del frontend y el real del backend, ya no se manda entero); y que subir o bajar el tope en el servidor cambia la decisión sin tocar código del navegador — que es la propiedad que la constante escrita a mano no podía tener.
- `API/tests/integration/test_iris.py` (5 tests nuevos) — el endpoint pide autenticación y `IRIS_READ`; **el número publicado es el mismo que aplica la validación**, leído del mismo sitio; un mensaje justo en el límite se acepta y uno por encima se rechaza. Esas dos últimas son las dos mitades del contrato: si la UI corta por este número, no puede llevarse sorpresas por ninguno de los dos lados.
- Tests de Iris (unitarios e integración) y de contrato (`test_caddy_api_routes`, `test_config_view_paths`) en verde. Build del SPA correcto.

## Notas

- **El endpoint nuevo no obliga a tocar `web/Caddyfile`**: el matcher `@api` enruta por prefijo `/iris`, que ya existe. `test_caddy_api_routes.py` lo confirma.
- El schema se comparte con `M07` (modo mensaje completo visible y coherente), que añadirá sobre esta misma respuesta la cobertura por modo y el aviso de datos sensibles. Aquí se ha dejado solo lo que está respaldado por el código de hoy — `analysisModes` lista los dos modos que `AnalyzeRequestSchema` acepta realmente — en vez de adelantar campos que `M07` todavía tiene que definir.
- Sin migración: este PR no toca el esquema.
- El README no se toca aquí; los cambios de contrato de la fase 0 (este endpoint incluido) van juntos en un commit al final.
