### PR TITLE
fix(iris): frontera de confianza real para Authentication-Results y ARC (B06)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1108,6 +1108,7 @@
           "application/java-archive",
           "application/octet-stream"
         ],
+        "trusted_authserv_ids": [],
         "suspicious_tlds": [
           ".tk",
           ".ml",

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -956,8 +956,16 @@ class IrisManager(TaskTrackingMixin):
         # what those three signals are suppressed for below. "cv=fail"
         # (the chain itself declares a prior hop broken) is its own gate,
         # see D7 in ROADMAP.md.
+        #
+        # B06: la supresión exige además que la cadena la haya validado un
+        # verificador de confianza (`details["verified"]`). Un `cv=pass` a
+        # secas es una afirmación del propio mensaje sobre sí mismo, y como
+        # Iris no verifica firmas, bastaba escribirlo para desactivar los tres
+        # gates que cazan suplantación. Un ARC sin confirmar sigue viajando en
+        # el informe como contexto; lo que ya no hace es dar permisos.
         arc = res("ARC Chain")
-        arc_pass = arc is not None and arc.verdict == "pass"
+        arc_pass = (arc is not None and arc.verdict == "pass"
+                    and bool(arc.details.get("verified")))
         arc_fail = arc is not None and arc.verdict == "fail"
 
         spf_fail = verdict_is("SPF", "fail", "hardfail") and not arc_pass

--- a/API/src/modules/features/iris/services/auth_trust.py
+++ b/API/src/modules/features/iris/services/auth_trust.py
@@ -1,0 +1,231 @@
+"""
+Frontera de confianza de la cadena ``Received`` de un mensaje.
+
+El problema que resuelve este módulo es que **una parte de las cabeceras de un
+correo las escribe el atacante**. Los MTA *anteponen* su ``Received``, así que
+la cadena se lee de arriba abajo desde el último salto (el servidor del
+destinatario) hasta el origen. Los saltos de abajo los aportó quien envió el
+mensaje, y puede inventárselos: nada le impide fabricar tres ``Received``
+falsos que describan un recorrido que nunca ocurrió.
+
+Eso importa porque ``Authentication-Results`` —la cabecera donde un servidor
+apunta el resultado de SPF, DKIM y DMARC— **también la puede escribir el
+remitente**. Iris ya comprobaba que el ``authserv-id`` que la firma apareciera
+como host ``by`` de algún salto de la cadena, pero aceptaba *cualquier* salto,
+incluidos los de abajo. Un atacante que inyecte a la vez su propio ``Received``
+(``by: mx.suservidor.example``) y su propio ``Authentication-Results``
+(``mx.suservidor.example; spf=pass; dkim=pass; dmarc=pass``) pasaba la
+comprobación: los dos elementos que se estaban contrastando eran suyos.
+
+La frontera de confianza es el punto de la cadena por debajo del cual nada es
+verificable. Este módulo la calcula y responde a la única pregunta que las
+reglas necesitan: *¿escribió esta cabecera alguien en quien podemos confiar?*
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import src.modules.system.config_reading as CR
+
+from .parsers import parse_received_line
+from .text import registrable_domain
+
+
+#: Veredictos de :func:`assess_authserv_trust`.
+TRUST_CONFIGURED = "configured"
+"""El verificador está en la lista explícita de confianza del despliegue."""
+
+TRUST_BOUNDARY = "boundary"
+"""El verificador es la propia infraestructura receptora (por encima de la
+frontera). Es el caso normal del correo legítimo."""
+
+TRUST_BELOW_BOUNDARY = "below_boundary"
+"""El ``authserv-id`` solo aparece en saltos que el remitente pudo fabricar.
+Es el bypass que cierra `B06`: la cabecera existe y "cuadra" con la cadena,
+pero cuadra con la parte de la cadena que escribió el atacante."""
+
+TRUST_ABSENT = "absent"
+"""El ``authserv-id`` no aparece en ningún salto: la cabecera la estampó un
+servidor que nunca tocó el mensaje."""
+
+TRUST_UNKNOWN = "unknown"
+"""No hay cadena ``Received`` que contrastar. No es una acusación: sin base
+para juzgar, la regla se queda neutral."""
+
+
+def trusted_authserv_ids() -> frozenset[str]:
+    """Verificadores declarados de confianza en ``features.iris.data``.
+
+    Sirve para el despliegue que sabe qué servidor autentica su correo —el
+    gateway corporativo, el proveedor gestionado— y quiere que se acepte
+    aunque no encabece la cadena. Vacío por defecto: sin configuración, la
+    confianza se deduce de la propia cadena (ver :func:`trust_boundary`), que
+    es lo que hace que el módulo funcione en cualquier despliegue sin tocar
+    nada.
+    """
+    configured = CR.get_iris_data("trusted_authserv_ids") or []
+    return frozenset(str(entry).strip().lower() for entry in configured if str(entry).strip())
+
+
+@dataclass(frozen=True)
+class ReceivedHop:
+    """Un salto de la cadena, reducido a lo que la frontera necesita."""
+
+    position: int
+    """0 es el último salto (el servidor del destinatario), el más fiable."""
+
+    by_host: Optional[str]
+    by_domain: Optional[str]
+
+
+def parse_hops(received_headers: Sequence[str]) -> List[ReceivedHop]:
+    """Reduce la cadena a sus hosts ``by``, conservando el orden de entrega.
+
+    ``received_headers[0]`` es el salto final y ``[-1]`` el origen — el mismo
+    orden que produce ``MessageContext.received_headers`` y que consume
+    ``build_path``.
+    """
+    hops: List[ReceivedHop] = []
+    for position, line in enumerate(received_headers):
+        by_host = (parse_received_line(line).get("by") or "").strip().rstrip(".,;").lower()
+        hops.append(ReceivedHop(
+            position=position,
+            by_host=by_host or None,
+            by_domain=registrable_domain(by_host) if by_host else None,
+        ))
+    return hops
+
+
+def trust_boundary(hops: Sequence[ReceivedHop]) -> int:
+    """Cuántos saltos, contando desde el final de entrega, son fiables.
+
+    La regla es la contigüidad organizativa desde arriba: el salto 0 lo escribió
+    el servidor que entregó el mensaje —el nuestro, o el de nuestro proveedor—
+    y por tanto no lo pudo fabricar el remitente. Los saltos inmediatamente
+    siguientes que pertenecen a **la misma organización** (mismo dominio
+    registrable) son el recorrido interno de esa misma infraestructura, y
+    tampoco. En cuanto la cadena cambia de organización se ha salido del
+    perímetro receptor y ya no hay nada que garantice que lo de abajo ocurrió.
+
+    Un salto declarado de confianza en la configuración extiende la frontera
+    aunque cambie de dominio: es el caso del gateway corporativo que entrega a
+    un buzón alojado en otro proveedor.
+
+    Sin cadena, la frontera es 0 — no hay nada fiable, pero tampoco nada que
+    acusar; de eso se encarga el llamante.
+    """
+    if not hops:
+        return 0
+
+    anchor_domain = hops[0].by_domain
+    configured = trusted_authserv_ids()
+
+    boundary = 0
+    for hop in hops:
+        is_same_organisation = anchor_domain is not None and hop.by_domain == anchor_domain
+        is_configured = (hop.by_host in configured) or (hop.by_domain in configured)
+        if is_same_organisation or is_configured:
+            boundary = hop.position + 1
+            continue
+        break
+
+    # Una cadena de un solo salto sin `by` legible no ancla nada, pero el salto
+    # final sigue siendo el final: se cuenta como frontera para no tratar como
+    # forjado un mensaje cuya cadena simplemente no se pudo parsear.
+    return boundary or 1
+
+
+@dataclass(frozen=True)
+class AuthservTrust:
+    """Resultado de contrastar un ``authserv-id`` con la cadena real."""
+
+    verdict: str
+    is_trusted: bool
+    boundary: int
+    matched_position: Optional[int] = None
+    trusted_by_domains: tuple[str, ...] = ()
+    untrusted_by_domains: tuple[str, ...] = ()
+
+
+def assess_authserv_trust(authserv_id: str, received_headers: Sequence[str]) -> AuthservTrust:
+    """¿Escribió esta cabecera alguien en quien podemos confiar?
+
+    Distingue tres desenlaces que antes eran dos. Que el ``authserv-id``
+    aparezca *en algún sitio* de la cadena ya no basta: importa **dónde**.
+    Aparecer solo por debajo de la frontera (``below_boundary``) es la firma de
+    la inyección que este módulo existe para detectar, y es un caso más grave
+    que no aparecer en absoluto — quien fabrica los dos elementos a la vez para
+    que se corroboren mutuamente sabe exactamente lo que hace.
+    """
+    normalised = (authserv_id or "").strip().lower()
+    configured = trusted_authserv_ids()
+    hops = parse_hops(received_headers)
+
+    if normalised in configured or (registrable_domain(normalised) or "") in configured:
+        return AuthservTrust(verdict=TRUST_CONFIGURED, is_trusted=True,
+                             boundary=len(hops))
+
+    if not hops or all(hop.by_domain is None for hop in hops):
+        return AuthservTrust(verdict=TRUST_UNKNOWN, is_trusted=False, boundary=0)
+
+    boundary = trust_boundary(hops)
+    authserv_domain = registrable_domain(normalised)
+
+    trusted_domains = tuple(sorted({
+        hop.by_domain for hop in hops[:boundary] if hop.by_domain
+    }))
+    untrusted_domains = tuple(sorted({
+        hop.by_domain for hop in hops[boundary:] if hop.by_domain
+    }))
+
+    for hop in hops[:boundary]:
+        if hop.by_domain and hop.by_domain == authserv_domain:
+            return AuthservTrust(verdict=TRUST_BOUNDARY, is_trusted=True, boundary=boundary,
+                                 matched_position=hop.position,
+                                 trusted_by_domains=trusted_domains,
+                                 untrusted_by_domains=untrusted_domains)
+
+    for hop in hops[boundary:]:
+        if hop.by_domain and hop.by_domain == authserv_domain:
+            return AuthservTrust(verdict=TRUST_BELOW_BOUNDARY, is_trusted=False, boundary=boundary,
+                                 matched_position=hop.position,
+                                 trusted_by_domains=trusted_domains,
+                                 untrusted_by_domains=untrusted_domains)
+
+    return AuthservTrust(verdict=TRUST_ABSENT, is_trusted=False, boundary=boundary,
+                         trusted_by_domains=trusted_domains,
+                         untrusted_by_domains=untrusted_domains)
+
+
+# ``arc=pass`` dentro de un Authentication-Results: el resultado de que **el
+# servidor receptor** validara criptográficamente la cadena ARC. Es distinto de
+# ``ARC-Seal: cv=pass``, que es lo que la propia cadena dice de sí misma.
+_ARC_RESULT_RE = re.compile(r"\barc\s*=\s*pass\b", re.IGNORECASE)
+
+
+def is_arc_verified_by_trusted_hop(headers: dict, received_headers: Sequence[str]) -> bool:
+    """¿Ha validado la cadena ARC alguien en quien confiamos?
+
+    Iris no verifica firmas criptográficas —ni de DKIM, ni de ARC—, así que un
+    ``ARC-Seal: cv=pass`` es solo una afirmación del propio mensaje sobre sí
+    mismo. Cualquiera puede escribirla, incluido quien tenga interés en que su
+    correo parezca un reenvío legítimo.
+
+    Quien sí la verifica es el MTA receptor, que apunta el resultado como
+    ``arc=pass`` dentro de **su** ``Authentication-Results`` (RFC 8617 §5.2).
+    Esa afirmación sí vale, con la condición de siempre: que la cabecera la
+    haya escrito un verificador por encima de la frontera de confianza. Si no,
+    estaríamos otra vez creyéndonos algo que pudo escribir el remitente, solo
+    que con un rodeo más.
+    """
+    auth_results = (headers.get("authentication-results") or "").strip()
+    if not auth_results:
+        return False
+    if not _ARC_RESULT_RE.search(auth_results):
+        return False
+
+    authserv_id = auth_results.split(";", 1)[0].strip().lower()
+    return assess_authserv_trust(authserv_id, received_headers).is_trusted

--- a/API/src/modules/features/iris/services/rules/auth_rules.py
+++ b/API/src/modules/features/iris/services/rules/auth_rules.py
@@ -36,8 +36,14 @@ import re
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..auth_trust import (
+    TRUST_ABSENT,
+    TRUST_BELOW_BOUNDARY,
+    TRUST_UNKNOWN,
+    assess_authserv_trust,
+    is_arc_verified_by_trusted_hop,
+)
 from ..text import extract_domain, registrable_domain
-from ..parsers import parse_received_line
 
 
 def _dmarc_is_conclusive(auth_lower: str) -> bool:
@@ -389,9 +395,13 @@ _ARC_CV_RE = re.compile(r"\bcv=(\w+)", re.IGNORECASE)
 
 @iris_rules.register(
     name="ARC Chain", category="authentication",
-    description="Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated Received Chain, RFC 8617)",
+    description=(
+        "Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated "
+        "Received Chain, RFC 8617) y si la validó un verificador de confianza"
+    ),
+    needs_context=True,
 )
-def check_arc_chain(headers: dict) -> RuleResult:
+def check_arc_chain(context) -> RuleResult:
     """Evaluate the ``cv=`` (chain validation) status of an ARC seal.
 
     ARC lets a legitimate intermediary (mailing list, forwarding service)
@@ -400,11 +410,21 @@ def check_arc_chain(headers: dict) -> RuleResult:
     chain *declares* — it does not re-verify the ARC cryptographic
     signatures itself (same accepted limitation as SPF/DKIM/DMARC above).
 
+    `B06`: ``cv=pass`` por sí solo ya **no** ablanda ningún gate. Esa
+    afirmación la hace el propio mensaje sobre sí mismo, y Iris no verifica
+    firmas criptográficas, así que un atacante podía escribir un ``ARC-Seal:
+    cv=pass`` inventado y con eso suprimir los gates de SPF, DMARC y
+    alignment — precisamente los que existen para cazar suplantación. Quien sí
+    valida la cadena es el MTA receptor, que lo apunta como ``arc=pass`` en su
+    propio ``Authentication-Results``; ``details["verified"]`` recoge si esa
+    confirmación existe y viene de un verificador por encima de la frontera de
+    confianza, y es lo único que ``_extract_verdict_signals`` acepta ya como
+    permiso para ablandar.
+
     Returns:
         - ``pass`` (score +2) when ``cv=pass`` — a prior legitimate hop's
-          authentication validated correctly; consumed by
-          ``managers._extract_verdict_signals`` to soften the SPF/DMARC/
-          alignment gates for genuine forwards.
+          authentication validated correctly. Solo ablanda los gates de
+          SPF/DMARC/alignment si ``details["verified"]`` es True.
         - ``fail`` (score -8) when ``cv=fail`` — the chain itself declares
           a previous hop's authentication broken.
         - ``missing`` (score 0) when no ARC headers are present at all
@@ -413,6 +433,7 @@ def check_arc_chain(headers: dict) -> RuleResult:
           chain — genuinely uninformative, not suspicious) or any other
           value.
     """
+    headers = context.headers
     arc_seal = headers.get("arc-seal", "")
     arc_msg_sig = headers.get("arc-message-signature", "")
     arc_auth_results = headers.get("arc-authentication-results", "")
@@ -428,10 +449,16 @@ def check_arc_chain(headers: dict) -> RuleResult:
     chain_validation = match.group(1).lower() if match else None
 
     if chain_validation == "pass":
+        is_verified = is_arc_verified_by_trusted_hop(headers, context.received_headers)
         return RuleResult(
             score=2, verdict="pass",
-            details={"cv": chain_validation},
-            recommendation=None,
+            details={"cv": chain_validation, "verified": is_verified},
+            recommendation=None if is_verified else (
+                "La cadena ARC declara haberse validado correctamente (cv=pass), "
+                "pero ningún servidor de confianza lo confirma en su propia "
+                "cabecera Authentication-Results. Se toma como contexto, no como "
+                "prueba: esa declaración la puede escribir el propio remitente."
+            ),
         )
 
     if chain_validation == "fail":
@@ -492,6 +519,13 @@ def check_auth_results_provenance(context) -> RuleResult:
     hecho que el atacante SÍ controla mucho menos: la cadena Received real
     del mensaje. Si el authserv-id que reclama "pass" no aparece como host
     `by` de ningún salto, la línea es forjada.
+
+    `B06`: aparecer en la cadena tampoco basta. Los saltos de abajo los aporta
+    quien envía el mensaje, así que un atacante podía inyectar a la vez su
+    propio `Received` y su propio `Authentication-Results` y hacer que se
+    corroboraran entre sí — los dos elementos contrastados eran suyos. La
+    comprobación la hace ahora `services/auth_trust.py`, que exige que el
+    salto coincidente esté **por encima de la frontera de confianza**.
     """
     headers = context.headers
     auth_results = headers.get("authentication-results", "")
@@ -508,30 +542,44 @@ def check_auth_results_provenance(context) -> RuleResult:
         # cabecera -- fallar la autenticación no le compra nada al atacante.
         return RuleResult(score=0, verdict="neutral", details={"authserv_id": authserv_id, "statuses": statuses})
 
-    by_domains: set[str] = set()
-    for line in context.received_headers:
-        by_host = (parse_received_line(line).get("by") or "").strip().rstrip(".,;")
-        if by_host:
-            dom = registrable_domain(by_host)
-            if dom:
-                by_domains.add(dom)
+    trust = assess_authserv_trust(authserv_id, context.received_headers)
 
-    if not by_domains:
+    if trust.verdict == TRUST_UNKNOWN:
         # Sin cadena Received que verificar, no hay base para acusar de
         # forjado -- neutral, no "sospechoso por defecto".
-        return RuleResult(score=0, verdict="neutral", details={"reason": "no hay cadena Received que verificar"})
+        return RuleResult(score=0, verdict="neutral",
+                          details={"reason": "no hay cadena Received que verificar"})
 
-    authserv_reg = registrable_domain(authserv_id)
-    if authserv_reg in by_domains:
-        return RuleResult(score=0, verdict="pass", details={"authserv_id": authserv_id})
+    evidence = {
+        "authserv_id": authserv_id,
+        "statuses": statuses,
+        "trust": trust.verdict,
+        "trust_boundary": trust.boundary,
+        "trusted_by_domains": list(trust.trusted_by_domains),
+        "untrusted_by_domains": list(trust.untrusted_by_domains),
+    }
+
+    if trust.is_trusted:
+        return RuleResult(score=0, verdict="pass", details=evidence)
+
+    if trust.verdict == TRUST_BELOW_BOUNDARY:
+        return RuleResult(
+            score=CR.get_iris_scoring_weight("auth_provenance.below_boundary", -12),
+            verdict="fail",
+            details=evidence,
+            recommendation=(
+                f"La cabecera Authentication-Results declara autenticación 'pass' y está "
+                f"estampada por '{authserv_id}', que sí aparece en la cadena Received "
+                "del mensaje -- pero solo por debajo de la frontera de confianza, en la "
+                "parte de la cadena que aporta quien envía. Un remitente puede fabricar "
+                "a la vez el salto y la línea de autenticación para que se respalden "
+                "mutuamente; ninguno de los dos lo escribió un servidor verificable."
+            ),
+        )
 
     return RuleResult(
         score=CR.get_iris_scoring_weight("auth_provenance.forged", -12), verdict="fail",
-        details={
-            "authserv_id": authserv_id,
-            "statuses": statuses,
-            "received_by_domains": sorted(by_domains),
-        },
+        details=evidence,
         recommendation=(
             f"La cabecera Authentication-Results declara autenticación 'pass' pero fue "
             f"estampada por '{authserv_id}', un servidor que no aparece en ningún salto "

--- a/API/tests/unit/test_iris_auth_trust.py
+++ b/API/tests/unit/test_iris_auth_trust.py
@@ -1,0 +1,256 @@
+"""B06: frontera de confianza de la cadena ``Received``.
+
+El corpus de ataque que pide el criterio de cierre del issue: **ningún
+``Authentication-Results`` aportado por el atacante convierte por sí solo un
+mensaje en autenticado**.
+
+La idea que se prueba aquí es sencilla de enunciar y fácil de perder de vista:
+los MTA *anteponen* su ``Received``, así que la cadena va del último salto (el
+servidor del destinatario) al origen, y **los saltos de abajo los escribió
+quien envió el mensaje**. Contrastar una cabecera que aporta el remitente
+contra otra cabecera que también aporta el remitente no verifica nada.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.services.auth_trust import (
+    TRUST_ABSENT,
+    TRUST_BELOW_BOUNDARY,
+    TRUST_BOUNDARY,
+    TRUST_CONFIGURED,
+    TRUST_UNKNOWN,
+    assess_authserv_trust,
+    is_arc_verified_by_trusted_hop,
+    parse_hops,
+    trust_boundary,
+)
+from src.modules.features.iris.services.parsers import MessageContext
+from src.modules.features.iris.services.rules.auth_rules import (
+    check_auth_results_provenance,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _hop(sender: str, receiver: str, when: str = "Wed, 25 Jun 2025 10:00:00 +0000") -> str:
+    return f"from {sender} by {receiver}; {when}"
+
+
+# La cadena legítima: dos saltos internos del proveedor del destinatario y,
+# debajo, el servidor real del remitente.
+_LEGITIMATE_CHAIN = [
+    _hop("mx-in.destino.example", "mx2.destino.example"),
+    _hop("smtp.remitente.example", "mx-in.destino.example"),
+]
+
+
+# ---------------------------------------------------------------------------
+# La frontera en sí
+# ---------------------------------------------------------------------------
+
+def test_boundary_covers_the_receiving_infrastructure():
+    """Los saltos contiguos de la misma organización que entregó el mensaje
+    son recorrido interno suyo: nadie de fuera los pudo escribir."""
+    hops = parse_hops(_LEGITIMATE_CHAIN)
+
+    # Los dos saltos entregan a destino.example (mx2 y mx-in): son el recorrido
+    # interno del proveedor del destinatario, así que ninguno de los dos lo
+    # pudo escribir el remitente. El salto de origen ya queda fuera.
+    assert [hop.by_domain for hop in hops] == ["destino.example", "destino.example"]
+    assert trust_boundary(hops) == 2
+
+
+def test_boundary_extends_across_contiguous_hops_of_the_same_organisation():
+    chain = [
+        _hop("mx1.destino.example", "mx2.destino.example"),
+        _hop("gateway.destino.example", "mx1.destino.example"),
+        _hop("smtp.remitente.example", "gateway.destino.example"),
+    ]
+
+    # Los tres primeros `by` son destino.example; el cuarto salto ya no existe.
+    assert trust_boundary(parse_hops(chain)) == 3
+
+
+def test_boundary_stops_at_the_first_foreign_organisation():
+    chain = [
+        _hop("relay.tercero.example", "mx.destino.example"),
+        _hop("origen.example", "relay.tercero.example"),
+        _hop("otro.example", "mx.destino.example"),  # vuelve a "los nuestros"
+    ]
+
+    # La frontera es contigua desde arriba: que un salto de más abajo vuelva a
+    # nombrar nuestro dominio no lo hace fiable — eso es justamente lo que
+    # escribiría quien quisiera colarse.
+    assert trust_boundary(parse_hops(chain)) == 1
+
+
+# ---------------------------------------------------------------------------
+# El ataque que cierra B06
+# ---------------------------------------------------------------------------
+
+def test_injected_received_plus_auth_results_no_longer_passes():
+    """El bypass, en su forma exacta.
+
+    El atacante añade a su propio correo dos cabeceras que se respaldan
+    mutuamente: un ``Received`` que dice ``by: mx.atacante.example`` y un
+    ``Authentication-Results`` firmado por ``mx.atacante.example``. Antes, la
+    regla comprobaba que el authserv-id apareciera en *algún* salto — y
+    aparecía, porque el propio atacante lo había puesto ahí.
+    """
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx.atacante.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=[
+            _hop("mx.atacante.example", "mx2.destino.example"),   # salto real
+            _hop("origen.atacante.example", "mx.atacante.example"),  # inventado
+        ],
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "fail"
+    assert result.score < 0
+    assert result.details["trust"] == TRUST_BELOW_BOUNDARY
+
+
+def test_the_same_header_from_the_real_delivering_server_still_passes():
+    """La otra mitad: el correo legítimo no puede empezar a fallar."""
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx2.destino.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=_LEGITIMATE_CHAIN,
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "pass"
+    assert result.details["trust"] == TRUST_BOUNDARY
+
+
+def test_an_authserv_id_that_never_touched_the_message_still_fails():
+    """El caso que ya se detectaba antes de B06 sigue detectándose."""
+    context = MessageContext(
+        headers={
+            "authentication-results": "inventado.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=_LEGITIMATE_CHAIN,
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "fail"
+    assert result.details["trust"] == TRUST_ABSENT
+
+
+def test_duplicate_authentication_results_cannot_be_smuggled_below():
+    """Cabeceras duplicadas.
+
+    El dict de cabeceras conserva una sola aparición por nombre, así que el
+    atacante no gana nada duplicando ``Authentication-Results``: la que se
+    evalúa se contrasta igualmente contra la frontera, y su salto sigue
+    estando por debajo.
+    """
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx.atacante.example; spf=pass; dmarc=pass",
+        },
+        received_headers=[
+            _hop("mx.atacante.example", "mx2.destino.example"),
+            _hop("a.example", "mx.atacante.example"),
+            _hop("b.example", "mx.atacante.example"),
+        ],
+    )
+
+    assert check_auth_results_provenance(context).verdict == "fail"
+
+
+def test_no_received_chain_stays_neutral():
+    """Sin cadena que contrastar no hay base para acusar de forjado; neutral,
+    no "sospechoso por defecto" — pegar solo unas cabeceras sueltas es un uso
+    legítimo de Iris."""
+    context = MessageContext(
+        headers={"authentication-results": "cualquiera.example; spf=pass"},
+        received_headers=[],
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "neutral"
+    assert result.score == 0
+    assert assess_authserv_trust("cualquiera.example", []).verdict == TRUST_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Lista explícita de verificadores de confianza
+# ---------------------------------------------------------------------------
+
+def test_a_configured_verifier_is_trusted_wherever_it_appears(monkeypatch):
+    """Para el despliegue que sabe qué servidor autentica su correo — un
+    gateway corporativo que entrega a un buzón alojado en otro proveedor y
+    que, por tanto, no encabeza la cadena."""
+    import src.modules.features.iris.services.auth_trust as auth_trust
+
+    monkeypatch.setattr(auth_trust.CR, "get_iris_data",
+                        lambda key: ["gateway.corporativo.example"] if key == "trusted_authserv_ids" else None)
+
+    trust = assess_authserv_trust("gateway.corporativo.example", _LEGITIMATE_CHAIN)
+
+    assert trust.verdict == TRUST_CONFIGURED
+    assert trust.is_trusted is True
+
+
+def test_without_configuration_trust_comes_from_the_chain_alone():
+    """El dataset está vacío por defecto: el módulo tiene que funcionar en
+    cualquier despliegue sin que nadie configure nada."""
+    trust = assess_authserv_trust("mx2.destino.example", _LEGITIMATE_CHAIN)
+
+    assert trust.is_trusted is True
+    assert trust.verdict == TRUST_BOUNDARY
+
+
+# ---------------------------------------------------------------------------
+# ARC
+# ---------------------------------------------------------------------------
+
+def test_a_forged_arc_seal_is_not_verified():
+    """``ARC-Seal: cv=pass`` es lo que el mensaje dice de sí mismo. Iris no
+    verifica firmas, así que no puede valer como prueba."""
+    headers = {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=atacante.example; s=s1; b=xyz"}
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is False
+
+
+def test_arc_is_verified_when_the_delivering_server_says_so():
+    """Quien sí valida la cadena es el MTA receptor, que lo apunta como
+    ``arc=pass`` en su propio Authentication-Results (RFC 8617 §5.2)."""
+    headers = {
+        "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=lista.example; s=s1; b=xyz",
+        "authentication-results": "mx2.destino.example; arc=pass; spf=fail; dmarc=fail",
+    }
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is True
+
+
+def test_arc_confirmation_signed_below_the_boundary_does_not_count():
+    """Y el rodeo obvio tampoco funciona: escribir uno mismo el ``arc=pass``
+    en un Authentication-Results propio es el mismo ataque con un paso más."""
+    headers = {
+        "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=atacante.example; s=s1; b=xyz",
+        "authentication-results": "mx.atacante.example; arc=pass; spf=pass; dmarc=pass",
+    }
+    chain = [
+        _hop("mx.atacante.example", "mx2.destino.example"),
+        _hop("origen.example", "mx.atacante.example"),
+    ]
+
+    assert is_arc_verified_by_trusted_hop(headers, chain) is False
+
+
+def test_arc_without_any_authentication_results_is_not_verified():
+    headers = {"arc-seal": "i=1; cv=pass; d=lista.example"}
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is False

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -128,27 +128,88 @@ def test_dmarc_missing_is_neutral():
 
 # -------------------------------------------------------------------- ARC (D7)
 
+class _ArcContext:
+    """Contexto mínimo para ``check_arc_chain``.
+
+    B06 pasó la regla a ``needs_context=True``: ya no le basta con las
+    cabeceras, necesita la cadena Received para saber si quien dice haber
+    validado la cadena ARC está por encima de la frontera de confianza.
+    """
+
+    def __init__(self, headers, received_headers=()):
+        self.headers = headers
+        self.received_headers = list(received_headers)
+
+
 def test_arc_missing_is_neutral_missing_verdict():
-    result = check_arc_chain({})
+    result = check_arc_chain(_ArcContext({}))
     assert result.verdict == "missing"
     assert result.score == 0
 
 
 def test_arc_cv_pass_is_positive():
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "pass"
     assert result.score > 0
 
 
+def test_arc_cv_pass_alone_is_not_verified():
+    """B06: `cv=pass` es lo que el mensaje dice de sí mismo.
+
+    Iris no verifica firmas criptográficas, así que esa declaración no puede
+    valer como prueba — cualquiera puede escribirla. La regla sigue
+    reportándola, pero marcada como no verificada.
+    """
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=reenviador.example; s=s1; b=xyz"}))
+    assert result.verdict == "pass"
+    assert result.details["verified"] is False
+    assert result.recommendation  # y se le explica al usuario por qué
+
+
+def test_arc_cv_pass_is_verified_when_a_trusted_hop_confirms_it():
+    """Quien sí valida la cadena es el MTA receptor, que lo apunta como
+    `arc=pass` en su propio Authentication-Results."""
+    result = check_arc_chain(_ArcContext(
+        headers={
+            "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=reenviador.example; s=s1; b=xyz",
+            "authentication-results": "mx.destino.example; arc=pass; spf=fail; dmarc=fail",
+        },
+        received_headers=["from relay.example by mx.destino.example; Mon, 1 Jan 2026 10:00:00 +0000"],
+    ))
+    assert result.verdict == "pass"
+    assert result.details["verified"] is True
+    assert result.recommendation is None
+
+
+def test_arc_confirmation_from_an_untrusted_hop_does_not_count():
+    """Un `arc=pass` firmado por un servidor que solo aparece por debajo de la
+    frontera lo pudo escribir el propio remitente: no verifica nada."""
+    result = check_arc_chain(_ArcContext(
+        headers={
+            "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=malo.example; s=s1; b=xyz",
+            "authentication-results": "mx.malo.example; arc=pass; spf=pass; dmarc=pass",
+        },
+        received_headers=[
+            "from relay.example by mx.destino.example; Mon, 1 Jan 2026 10:00:00 +0000",
+            "from origen.example by mx.malo.example; Mon, 1 Jan 2026 09:59:00 +0000",
+        ],
+    ))
+    assert result.details["verified"] is False
+
+
 def test_arc_cv_fail_is_negative():
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=fail; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=fail; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "fail"
     assert result.score < 0
 
 
 def test_arc_cv_none_is_neutral_first_hop():
     # cv=none just means "I'm the first ARC seal in the chain" -- not suspicious.
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=none; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=none; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "neutral"
     assert result.score == 0
 
@@ -418,18 +479,38 @@ def test_gating_caps_at_suspicious_on_domain_misalignment():
     assert _gated("Legitimate", named) == "Suspicious"
 
 
-def test_gating_arc_pass_softens_spf_dmarc_alignment_gates():
+def test_gating_verified_arc_pass_softens_spf_dmarc_alignment_gates():
     # D7: a legitimate forward validated by ARC (cv=pass) must not trip
     # the SPF/DMARC/alignment gates that exist to catch spoofing --
     # mailing lists/forwarders routinely break raw SPF/alignment as a
     # side effect of legitimate relaying.
+    #
+    # B06 añade la condición que faltaba: la validación tiene que venir
+    # confirmada por un verificador de confianza (`verified`), no del propio
+    # sello del mensaje.
     named = {
         "SPF": _rr("fail"),
         "DMARC": _rr("fail"),
         "Domain Alignment": _rr("fail"),
-        "ARC Chain": _rr("pass"),
+        "ARC Chain": _rr("pass", verified=True),
     }
     assert _gated("Legitimate", named) == "Legitimate"
+
+
+def test_gating_unverified_arc_pass_no_longer_softens_the_gates():
+    """B06, el bypass que se cierra.
+
+    Antes bastaba con escribir `ARC-Seal: cv=pass` en el propio correo para
+    desactivar de golpe los tres gates que cazan suplantación. Ahora un ARC sin
+    confirmar es contexto: aparece en el informe, pero no da permisos.
+    """
+    named = {
+        "SPF": _rr("fail"),
+        "DMARC": _rr("fail"),
+        "Domain Alignment": _rr("fail"),
+        "ARC Chain": _rr("pass", verified=False),
+    }
+    assert _gated("Legitimate", named) == "Suspicious"
 
 
 def test_gating_arc_fail_escalates_to_suspicious():


### PR DESCRIPTION
## Resumen

Iris se creía dos afirmaciones que puede escribir el propio atacante. Este PR introduce una **frontera de confianza** sobre la cadena `Received` y la aplica a las dos.

Cierra #219. Es el ítem de mayor riesgo de seguridad de la fase 0.

## El problema, en llano

Un correo llega con una pila de cabeceras `Received`, una por cada servidor que lo tocó. Cada servidor **antepone** la suya, así que la lista se lee de arriba abajo desde el último salto —el servidor del destinatario— hasta el origen.

Lo importante, y lo que este PR gira alrededor: **los saltos de abajo los aporta quien envía el mensaje**. Nada le impide fabricar tres `Received` inventados que describan un recorrido que nunca ocurrió. Solo los de arriba, los que añadió la infraestructura receptora, son verificables.

### Agujero 1 — `Authentication-Results` que se autoconfirma

`Authentication-Results` es la cabecera donde un servidor apunta el resultado de SPF, DKIM y DMARC. Cinco reglas de Iris la leen. Y **también la puede escribir el remitente**: nada impide que alguien añada a su propio correo una línea que diga `spf=pass; dkim=pass; dmarc=pass`.

Iris ya lo sabía y tenía una defensa: la regla *Auth Results Provenance*, que comprueba que el `authserv-id` (el servidor que firma esa línea) aparezca como host `by` de algún salto de la cadena. La idea era buena — atar la cabecera a un hecho que el atacante controla menos.

Pero aceptaba **cualquier** salto:

```python
for line in context.received_headers:      # todos, sin distinción
    by_domains.add(registrable_domain(parse_received_line(line).get("by")))
if authserv_reg in by_domains:
    return RuleResult(score=0, verdict="pass", ...)
```

Y los saltos de abajo los escribe el atacante. Así que el bypass es directo: inyectar **las dos cosas a la vez**.

```
Received: from mx.atacante.example by mx2.destino.example      ← real
Received: from origen.atacante.example by mx.atacante.example  ← inventado por el atacante
Authentication-Results: mx.atacante.example; spf=pass; dkim=pass; dmarc=pass
```

El `authserv-id` (`mx.atacante.example`) aparece en la cadena, así que la regla daba `pass`, y las cinco reglas de autenticación se creían el `spf=pass`. Los dos elementos que se estaban contrastando el uno contra el otro **eran del mismo autor**.

### Agujero 2 — ARC como salvoconducto

ARC (RFC 8617) existe para que un intermediario legítimo —una lista de correo, un reenviador— pueda preservar el resultado de autenticación original antes de que su propio reenvío lo rompa. Iris lo respeta: si `ARC-Seal` declara `cv=pass`, se suprimen los gates de SPF, DMARC y alignment, porque un reenvío legítimo los rompe como efecto colateral.

El problema es que **`cv=pass` es lo que el mensaje dice de sí mismo**, e Iris no verifica firmas criptográficas (limitación asumida y documentada, igual que con DKIM). Así que bastaba con escribir una línea:

```
ARC-Seal: i=1; a=rsa-sha256; cv=pass; d=loquesea.example; s=s1; b=xxxx
```

...para desactivar de golpe los tres gates que existen específicamente para cazar suplantación. Sin firmar nada, sin controlar ningún dominio.

## Qué cambia

### `services/auth_trust.py` (nuevo)

Calcula dónde está la frontera. La regla es la **contigüidad organizativa desde arriba**:

- El salto 0 lo escribió el servidor que entregó el mensaje. Ese no lo pudo fabricar el remitente.
- Los saltos inmediatamente siguientes que pertenecen a **la misma organización** (mismo dominio registrable) son el recorrido interno de esa misma infraestructura. Tampoco.
- En cuanto la cadena cambia de organización, se ha salido del perímetro receptor: de ahí para abajo, nada está garantizado.

La contigüidad importa: si un salto de más abajo vuelve a nombrar nuestro dominio, **no** cuenta. Eso es justamente lo que escribiría alguien que quisiera colarse, y tiene su test.

`assess_authserv_trust()` devuelve uno de cinco veredictos, y la distinción entre dos de ellos es el corazón del PR:

| Veredicto | Significado |
|---|---|
| `configured` | Está en la lista explícita del despliegue |
| `boundary` | Es la propia infraestructura receptora — el caso normal del correo legítimo |
| `below_boundary` | **Aparece, pero solo donde el remitente pudo escribirlo** |
| `absent` | No aparece en ningún salto |
| `unknown` | No hay cadena que contrastar |

`below_boundary` es nuevo, y se trata como fallo con su propio mensaje. Merece distinguirse de `absent` porque es *más* grave, no menos: quien fabrica el salto y la línea de autenticación a la vez para que se respalden mutuamente sabe exactamente lo que está haciendo.

### `trusted_authserv_ids` en la configuración

Lista explícita, **vacía por defecto**, para el despliegue que sabe qué servidor autentica su correo — el caso típico es un gateway corporativo que entrega a un buzón alojado en otro proveedor y que por tanto no encabeza la cadena.

Vacía funciona igual de bien: sin configuración, la confianza se deduce de la propia cadena. Esto es deliberado — un módulo de seguridad que solo protege si alguien lo configura no protege.

### ARC: solo cuenta si lo confirma quien puede verificarlo

Quien **sí** valida criptográficamente la cadena ARC es el MTA receptor, que apunta el resultado como `arc=pass` dentro de **su propio** `Authentication-Results` (RFC 8617 §5.2). Esa afirmación sí vale — con la condición de siempre: que la cabecera la haya escrito un verificador por encima de la frontera.

Así que ahora:

- `ARC-Seal: cv=pass` a secas → sigue reportándose, con `details["verified"] = False` y una recomendación que explica al usuario por qué no cuenta. **No suprime nada.**
- `cv=pass` + `arc=pass` en un `Authentication-Results` de confianza → `verified = True`, y ahí sí se ablandan los gates, como antes.
- El rodeo obvio —escribirse uno mismo el `arc=pass`— no funciona: es el mismo ataque con un paso más, y la misma frontera lo corta. Tiene su test.

`check_arc_chain` pasa a `needs_context=True`, porque ya no le basta con las cabeceras: necesita la cadena `Received`.

## Validación

- `tests/unit/test_iris_auth_trust.py` (nuevo, 14 tests) — el corpus de ataque del criterio de cierre: `Received` inyectado + `Authentication-Results` propio, cabeceras duplicadas, `authserv-id` que nunca tocó el mensaje, ARC falsificado y ARC confirmado desde debajo de la frontera. Más la mecánica de la frontera y el caso de la lista configurada.
- `tests/unit/test_iris_rules.py` — los cuatro tests de ARC se adaptan al contexto nuevo, y **se añaden tres**: `cv=pass` solo no está verificado, sí lo está cuando un salto de confianza lo confirma, y no lo está cuando la confirmación viene de abajo.

  El test `test_gating_arc_pass_softens_spf_dmarc_alignment_gates` cambia de nombre y de contenido, porque **codificaba exactamente el comportamiento que este PR corrige**. Se parte en dos: uno comprueba que un ARC verificado sigue ablandando los gates (el reenvío legítimo no puede empezar a fallar), y otro —nuevo— que uno sin verificar ya no lo hace.
- **`tests/unit/test_iris_fp_regression.py` en verde sin tocar nada.** Es la comprobación que más importaba: esa suite recorre correos legítimos reales, y un endurecimiento de autenticación es exactamente el tipo de cambio que los convierte en falsos positivos. Ninguno se movió.
- Tests de Iris (unitarios e integración) y de forma de configuración (`test_config_shape`, `test_config_view_paths`) en verde.

## Notas

- **Iris sigue sin verificar firmas criptográficas.** Ni DKIM, ni ARC. Este PR no cambia eso: cambia *de quién* se fía Iris cuando lee el resultado que otro apuntó. La validación DNS/criptográfica real mediante librería aislada sigue siendo trabajo de una fase posterior, como dice el propio issue.
- La clave nueva de configuración va vacía, así que el comportamiento por defecto no depende de que nadie la rellene.
- Sin migración: este PR no toca el esquema.
- El README no se toca aquí; los cambios de contrato de la fase 0 van juntos en un commit al final.
