### PR TITLE
fix(iris): cola nominal, idempotencia y reembolso del resumen de IA (B10)

### DIFF
--- a/API/alembic/versions/f1e0d1ee8820_add_iris_ai_summary_state.py
+++ b/API/alembic/versions/f1e0d1ee8820_add_iris_ai_summary_state.py
@@ -1,0 +1,61 @@
+"""Estado del resumen IA de Iris: idempotencia y trazabilidad (#220)
+
+Revision ID: f1e0d1ee8820
+Revises: dd19efde1d08
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1e0d1ee8820'
+down_revision: Union[str, Sequence[str], None] = 'dd19efde1d08'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    El resumen ejecutivo de IA solo tenía dónde guardar su resultado
+    (``ai_summary``), no su estado. Sin estado no hay forma de saber si ya hay
+    una generación en curso, así que dos peticiones seguidas consumían cuota
+    dos veces y encolaban dos trabajos para el mismo análisis.
+
+    ``ai_summary_status`` es la pieza que hace idempotente la operación: el
+    manager reclama la fila con una transición condicional, y quien pierde la
+    carrera no cobra ni encola. ``ai_summary_job_id`` permite relacionar la
+    fila con su trabajo en la cola.
+
+    ``ai_summary_model`` y ``ai_summary_prompt_version`` son trazabilidad: un
+    resumen generado hace tres meses lo escribió otro modelo con otro prompt,
+    y sin registrarlo no hay manera de saber cuál — el mismo problema que
+    ``detector_version`` resuelve para las reglas.
+
+    Todas son NULL para las filas existentes. Los resúmenes ya generados se
+    reconocen igualmente por tener ``ai_summary`` no nulo, así que no hace
+    falta rellenar nada: el manager trata "hay resumen, sin estado" como
+    terminado.
+    """
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_status", sa.String(length=16), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_job_id", sa.String(length=64), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_model", sa.String(length=64), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_prompt_version", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Los resúmenes generados se conservan (``ai_summary`` no se toca); lo que
+    se pierde es su estado y su procedencia, y con ello la idempotencia:
+    volver aquí reabre la posibilidad de encolar dos generaciones del mismo
+    análisis.
+    """
+    op.drop_column("IrisAnalysis", "ai_summary_prompt_version")
+    op.drop_column("IrisAnalysis", "ai_summary_model")
+    op.drop_column("IrisAnalysis", "ai_summary_job_id")
+    op.drop_column("IrisAnalysis", "ai_summary_status")

--- a/API/src/modules/accounts/services/quotas.py
+++ b/API/src/modules/accounts/services/quotas.py
@@ -130,6 +130,54 @@ class QuotaManager:
         else:
             self._consume_counter(entitlement, amount)
 
+    def refund(self, user_id: int, key: LimitKey, amount: int = 1) -> None:
+        """Devuelve ``amount`` usos ya apuntados de ``key``.
+
+        Existe porque ``consume()`` ocurre **antes** que el trabajo que se está
+        pagando, y tiene que ser así: cobrar después dejaría la puerta abierta
+        a lanzar N trabajos concurrentes con cupo para uno. El precio de ese
+        orden es que un trabajo que nunca llega a hacerse —el encolado lo
+        rechaza, el worker revienta— deja al usuario pagando por nada.
+
+        No es lo contrario exacto de ``consume()`` y no debe usarse como tal:
+        no resucita una fila de periodo que ya no existe (si el mes cambió
+        entre el cobro y el reembolso, el cargo pertenece al periodo anterior
+        y ya no se puede deshacer ahí), ni baja de cero. Nunca lanza: un
+        reembolso fallido no puede tumbar el camino de error que lo invocó, y
+        cobrar de más una vez es preferible a perder el error original.
+
+        Las claves de nivel (TIER) y de existencias (STOCK) no llevan
+        contador que devolver — su "consumo" es la tabla real — así que
+        reembolsarlas es un no-op.
+        """
+        try:
+            entitlement = resolve_entitlement(user_id, key)
+            if entitlement.period in (LimitPeriod.TIER, LimitPeriod.STOCK):
+                return
+            if entitlement.is_unlimited:
+                return
+
+            period_start = period_start_for(entitlement.period)
+            with UnitOfWork() as uow:
+                # Igual que el cobro: la resta va dentro del UPDATE, con el
+                # suelo en la condición, para no leer-decidir-escribir.
+                uow.session.execute(
+                    update(UsageCounter)
+                    .where(and_(
+                        UsageCounter.holder_kind == entitlement.holder_kind,
+                        UsageCounter.holder_id == entitlement.holder_id,
+                        UsageCounter.limit_key == entitlement.key.db_name,
+                        UsageCounter.period_start == period_start,
+                        UsageCounter.used >= amount,
+                    ))
+                    .values(used=UsageCounter.used - amount)
+                )
+        except Exception as exc:
+            logger.warning(
+                "No se pudo reembolsar cuota | user=%s key=%s: %s",
+                user_id, key.db_name, exc,
+            )
+
     # ------------------------------------------------------------- internos
 
     @staticmethod

--- a/API/src/modules/features/iris/__init__.py
+++ b/API/src/modules/features/iris/__init__.py
@@ -8,6 +8,7 @@ from .endpoints import iris_blp
 
 # Registro de las categorías de cola de este módulo (OCP).
 QueueRegistry.register("iris.analyze")
+QueueRegistry.register("iris.ai_summary")
 QueueRegistry.register("iris.report")
 QueueRegistry.register("iris.ingest")
 QueueRegistry.register("iris.notify")

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -53,6 +53,7 @@ from .schemas import (
     AnalysisIocsResponseSchema,
     ResultsQuerySchema,
     GenerateDocumentResponseSchema,
+    GenerateAiSummaryRequestSchema,
     GenerateAiSummaryResponseSchema,
     DocumentStatusQuerySchema,
     IrisDocumentStatusResponseSchema,
@@ -277,6 +278,7 @@ def reanalyze_analysis(analysis_id: int):
 
 
 @iris_blp.post("/results/<int:analysis_id>/ai-summary")
+@iris_blp.arguments(GenerateAiSummaryRequestSchema, location="query")
 @iris_blp.response(202, GenerateAiSummaryResponseSchema, description="AI summary generation started")
 @iris_blp.alt_response(400, schema=ErrorSchema, description="Analysis not finished")
 @iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
@@ -286,18 +288,20 @@ def reanalyze_analysis(analysis_id: int):
 @require_attributes(at_least_one=[AttributeType.IRIS_CREATE])
 @limiter.limit("20 per hour; 100 per day")
 @handle_exceptions(default_exception=IrisAnalysisNotFoundError, logger=logger)
-def generate_ai_summary(analysis_id: int):
+def generate_ai_summary(args: dict, analysis_id: int):
     """Solicitar la generacion asincrona de la narrativa ejecutiva IA (IrisAIWriter)"""
     user = get_current_user()
 
     manager = IrisManager()
-    manager.generate_ai_summary(analysis_id, user.id)
+    status = manager.generate_ai_summary(analysis_id, user.id,
+                                         regenerate=args["regenerate"])
 
     logger.info(f"AI summary solicitado para analysis {analysis_id} por usuario {user.username}")
     return {
-        "message": "Generacion de resumen ejecutivo IA iniciada",
+        "message": ("Resumen ejecutivo IA ya disponible" if status == "done"
+                    else "Generacion de resumen ejecutivo IA iniciada"),
         "analysisId": analysis_id,
-        "status": "running",
+        "status": status,
     }, 202
 
 

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -21,6 +21,8 @@ from dataclasses import replace
 from typing import Any, Dict, List, Optional
 
 import src.modules.system.config_reading as CR
+from sqlalchemy import and_, or_, update
+
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
@@ -311,6 +313,9 @@ class IrisManager(TaskTrackingMixin):
             "gateReasons": analysis.gate_reasons or [],
             "topSignals": self._top_signals(rules_data),
             "aiSummary": analysis.ai_summary,
+            "aiSummaryStatus": analysis.ai_summary_status,
+            "aiSummaryModel": analysis.ai_summary_model,
+            "aiSummaryPromptVersion": analysis.ai_summary_prompt_version,
             "unwrappedFromForward": context.unwrapped_from_forward,
             "wrapperFrom": context.wrapper_from or None,
             "wrapperSubject": context.wrapper_subject or None,
@@ -450,57 +455,171 @@ class IrisManager(TaskTrackingMixin):
             "hashes": sorted(hashes),
         }
 
-    def generate_ai_summary(self, analysis_id: int, user_id: int) -> None:
-        """Trigger async generation of the AI executive narrative (IA1).
+    AI_SUMMARY_EXTERNAL_ID_PREFIX = "iris-ai-summary:"
 
-        Fire-and-forget: submits a TaskQueue job and returns immediately.
-        The caller re-fetches ``get_analysis_results`` (``aiSummary``) to
-        see the result once ``execute_ai_summary_generation`` finishes —
-        there is no separate status to poll, matching how gate reasons
-        and top signals are already just part of the main report.
+    #: Estados desde los que se puede reclamar una generación de resumen.
+    #: ``None`` es "nunca se pidió" y ``failed`` es un reintento legítimo;
+    #: ``running`` no está porque ya hay una en curso, y ``done`` solo se
+    #: reclama con una regeneración explícita.
+    _AI_SUMMARY_CLAIMABLE = (None, "failed")
+
+    def generate_ai_summary(self, analysis_id: int, user_id: int,
+                            regenerate: bool = False) -> str:
+        """Encola la narrativa ejecutiva de IA (IA1), una sola vez.
+
+        Fire-and-forget: encola y vuelve. El llamante relee
+        ``get_analysis_results`` (``aiSummary``) para ver el resultado.
+
+        `B10`: la operación es **idempotente por análisis**. Antes consumía
+        cuota y encolaba sin mirar si ya había un resumen o un trabajo en
+        curso, así que dos peticiones seguidas —dos clics, un reintento del
+        navegador— cobraban dos veces y lanzaban dos generaciones del mismo
+        análisis. El ``external_id`` era determinista pero nadie lo consultaba.
+
+        La exclusión se apoya en una transición condicional sobre
+        ``ai_summary_status``, no en leer-decidir-escribir: bajo dos peticiones
+        simultáneas la base de datos serializa los dos UPDATE y el segundo no
+        afecta a ninguna fila. Quien pierde esa carrera no cobra cuota ni
+        encola nada.
+
+        Args:
+            regenerate: Pedir explícitamente una regeneración de un resumen
+                que ya existe. Sin esto, repetir la petición devuelve el
+                resultado que ya hay — que es lo que quiere quien hace doble
+                clic, y no lo que quiere quien busca otra redacción; el issue
+                pedía decidirlo explícitamente y esta es la decisión.
+
+        Returns:
+            ``"running"`` si esta llamada encoló el trabajo, ``"done"`` si ya
+            había resumen y no se pidió regenerar.
 
         Raises:
-            IrisAnalysisNotFoundError: If *analysis_id* does not exist or
-                does not belong to *user_id*.
-            IrisAnalysisNotReadyError: If the analysis is not ``finished``.
+            IrisAnalysisNotFoundError: si el análisis no existe o no es suyo.
+            IrisAnalysisNotReadyError: si el análisis no está ``finished``.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
         if analysis.status != "finished":
             raise IrisAnalysisNotReadyError(analysis_id, analysis.status)
 
+        # Un resumen ya generado se devuelve tal cual: no cuesta cuota, no
+        # encola y no sorprende a quien solo hizo doble clic.
+        if analysis.ai_summary is not None and not regenerate:
+            return "done"
+
+        if not self._claim_ai_summary(analysis_id, regenerate=regenerate):
+            # Otra petición se lo llevó (o ya estaba en curso). Sin cobro.
+            return "running"
+
         # La concreta y el techo agregado de IA, en ese orden, para que el 402
         # nombre lo que el usuario estaba pidiendo.
         quota_manager = QuotaManager()
-        quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
-        quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
+        try:
+            quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
+            quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
+        except Exception:
+            # Sin cupo no hay trabajo: se suelta la reserva para que el
+            # análisis no se quede en `running` para siempre y el usuario
+            # pueda reintentar cuando renueve su plan.
+            self._release_ai_summary(analysis_id)
+            raise
 
-        self._task_queue.submit(
-            func=IrisManager.execute_ai_summary_generation,
-            args=(analysis_id,),
-            name=f"AISummary-Analysis-{analysis_id}",
-            category="iris.ai_summary",
-            external_id=f"iris-ai-summary:{analysis_id}",
-        )
+        try:
+            task = self._task_queue.submit(
+                func=IrisManager.execute_ai_summary_generation,
+                args=(analysis_id, user_id),
+                name=f"AISummary-Analysis-{analysis_id}",
+                category="iris.ai_summary",
+                external_id=f"{self.AI_SUMMARY_EXTERNAL_ID_PREFIX}{analysis_id}",
+            )
+        except Exception:
+            # El encolado rechazó el trabajo: nadie lo va a ejecutar, así que
+            # ni la reserva ni el cobro tienen sentido.
+            self._release_ai_summary(analysis_id)
+            self._refund_ai_summary_quota(user_id)
+            raise
+
+        self._update_analysis(analysis_id, ai_summary_job_id=getattr(task, "id", None))
+        return "running"
 
     @staticmethod
-    def execute_ai_summary_generation(analysis_id: int) -> None:
+    def _claim_ai_summary(analysis_id: int, regenerate: bool = False) -> bool:
+        """Reclama la generación con un UPDATE condicional. True si se ganó.
+
+        La condición vive dentro del UPDATE a propósito, igual que en el
+        consumo de cuota: leer el estado, decidir en Python y escribir después
+        regala una segunda generación cada vez que dos peticiones coinciden.
+        """
+        claimable = list(IrisManager._AI_SUMMARY_CLAIMABLE)
+        if regenerate:
+            claimable.append("done")
+
+        with UnitOfWork() as uow:
+            condition = IrisAnalysis.id == analysis_id
+            if None in claimable:
+                states = [state for state in claimable if state is not None]
+                status_matches = or_(
+                    IrisAnalysis.ai_summary_status.is_(None),
+                    IrisAnalysis.ai_summary_status.in_(states),
+                )
+            else:
+                status_matches = IrisAnalysis.ai_summary_status.in_(claimable)
+
+            result = uow.session.execute(
+                update(IrisAnalysis)
+                .where(and_(condition, status_matches))
+                .values(ai_summary_status="running")
+            )
+            return bool(result.rowcount)
+
+    def _release_ai_summary(self, analysis_id: int) -> None:
+        """Deshace la reserva cuando el trabajo no va a llegar a ejecutarse."""
+        self._update_analysis(analysis_id, ai_summary_status=None, ai_summary_job_id=None)
+
+    @staticmethod
+    def _refund_ai_summary_quota(user_id: int) -> None:
+        """Devuelve los dos cargos del resumen (el concreto y el agregado)."""
+        quota_manager = QuotaManager()
+        quota_manager.refund(user_id, LimitKey.IRIS_AI_SUMMARIES)
+        quota_manager.refund(user_id, LimitKey.AI_REQUESTS)
+
+    @staticmethod
+    def execute_ai_summary_generation(analysis_id: int, user_id: Optional[int] = None) -> None:
         """Entry point submitted to the TaskQueue for background AI narrative generation.
 
         Degrades cleanly on any failure (missing/misconfigured AI backend,
         circuit breaker open, malformed model response): logs the error
         and leaves ``ai_summary`` as ``NULL`` rather than failing the
         already-finished analysis it's attached to.
+
+        `B10`: además deja el estado en terminal y, si no hubo resumen,
+        devuelve la cuota. Cobrar antes de trabajar es correcto —cobrar
+        después permitiría lanzar N generaciones concurrentes con cupo para
+        una— pero obliga a devolver el dinero cuando el trabajo no se hace.
+
+        ``user_id`` es opcional para que un trabajo ya encolado con la firma
+        anterior no reviente al ejecutarse tras el despliegue; sin él
+        simplemente no hay a quién reembolsar.
         """
         with job_context():
+            manager = IrisManager()
             try:
-                report = IrisManager().get_analysis_results(analysis_id)
+                report = manager.get_analysis_results(analysis_id)
                 summary = IrisAIWriter().generate(report)
 
-                IrisManager()._update_analysis(analysis_id, ai_summary=summary)
+                manager._update_analysis(
+                    analysis_id,
+                    ai_summary=summary,
+                    ai_summary_status="done",
+                    ai_summary_model=IrisAIWriter.model_name(),
+                    ai_summary_prompt_version=IrisAIWriter.prompt_version(),
+                )
 
                 logger.info(f"AI summary generado para analysis {analysis_id}")
             except Exception as e:
                 logger.error(f"Error generando AI summary para analysis {analysis_id}: {e}", exc_info=True)
+                manager._update_analysis(analysis_id, ai_summary_status="failed")
+                if user_id is not None:
+                    IrisManager._refund_ai_summary_quota(user_id)
 
     def cancel_analysis(self, analysis_id: int, user_id: int) -> bool:
         """Cancel a running or pending analysis.

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -59,6 +59,15 @@ class IrisAnalysis(Base):
                  executive_summary/attacker_intent/recommendations/
                  confidence, or None until generated (or if generation
                  failed/was never requested).
+        ai_summary_status: "running" | "done" | "failed", o NULL si nunca se
+                 pidió. Es lo que hace idempotente la generación: el manager
+                 reclama la fila con una transición condicional sobre esta
+                 columna, y quien pierde la carrera no cobra cuota ni encola.
+        ai_summary_job_id: Id del trabajo en la cola que lo está generando.
+        ai_summary_model / ai_summary_prompt_version: Con qué se generó. Un
+                 resumen de hace tres meses lo escribió otro modelo con otro
+                 prompt, y sin esto no hay forma de saber cuál (mismo papel
+                 que ``detector_version`` para las reglas).
         started_at: Timestamp when the analysis was created.
         finished_at: Timestamp when the analysis reached a terminal state.
         user_id: Foreign key to the owning User.
@@ -90,6 +99,10 @@ class IrisAnalysis(Base):
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
+    ai_summary_status = Column(String(16), nullable=True)
+    ai_summary_job_id = Column(String(64), nullable=True)
+    ai_summary_model = Column(String(64), nullable=True)
+    ai_summary_prompt_version = Column(String(32), nullable=True)
     started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     finished_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow_naive)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -171,6 +171,9 @@ class AnalysisDetailResponseSchema(Schema):
     detectorVersion = fields.String(load_default=None, allow_none=True)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)
+    aiSummaryStatus = fields.String(load_default=None, allow_none=True)
+    aiSummaryModel = fields.String(load_default=None, allow_none=True)
+    aiSummaryPromptVersion = fields.String(load_default=None, allow_none=True)
     unwrappedFromForward = fields.Boolean(load_default=False)
     wrapperFrom = fields.String(load_default=None, allow_none=True)
     wrapperSubject = fields.String(load_default=None, allow_none=True)
@@ -298,12 +301,28 @@ class GenerateDocumentResponseSchema(Schema):
     downloadUrl = fields.String(load_default=None)
 
 
+class GenerateAiSummaryRequestSchema(Schema):
+    """Parámetros de ``POST /iris/results/<id>/ai-summary``.
+
+    ``regenerate`` distingue las dos intenciones que antes eran una sola
+    petición indistinguible: repetirla porque el navegador reintentó o porque
+    el usuario hizo doble clic (y entonces lo correcto es devolver el resumen
+    que ya hay, sin cobrar), o pedir explícitamente otra redacción (y entonces
+    sí se genera de nuevo, y se cobra).
+    """
+    regenerate = fields.Boolean(load_default=False)
+
+
 class GenerateAiSummaryResponseSchema(Schema):
     """Response returned immediately after queuing AI summary generation (IA1).
 
     There is no separate status to poll: the caller re-fetches
     ``GET /iris/results/<id>`` (``aiSummary``) to see the result once the
     background task finishes.
+
+    ``status`` dice qué pasó de verdad con esta llamada: ``running`` si encoló
+    la generación (o si ya había una en curso) y ``done`` si el resumen ya
+    existía y se devolvió sin trabajo ni cobro.
     """
     message = fields.String()
     analysisId = fields.Integer()

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -17,6 +17,7 @@ PDF export.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from typing import Any, Dict, Optional
@@ -58,6 +59,34 @@ class IrisAIWriter:
 
     def _build_prompts(self) -> dict:
         return CR.iris_config().prompts.get("summary", {})
+
+    @staticmethod
+    def model_name() -> str:
+        """Qué backend de IA produjo el resumen.
+
+        Es el nombre de la estrategia de scribe configurada para Iris
+        (``ollama``/``openai``/``google``), que es la identidad que la
+        aplicación controla de verdad: el modelo concreto lo elige cada
+        estrategia por su cuenta y puede cambiar bajo los pies sin que aquí se
+        note.
+        """
+        return str(CR.scribe_config().strategy_for("iris"))
+
+    @classmethod
+    def prompt_version(cls) -> str:
+        """Marca del prompt con el que se generó un resumen.
+
+        Los prompts viven en ``SecOpsConfig.json`` y se pueden editar en
+        caliente, así que dos resúmenes guardados pueden venir de instrucciones
+        distintas sin que nada lo delate. Se resume el par
+        (system, userTemplate) para que cualquier edición cambie la marca —
+        mismo criterio que ``detector_version`` con el catálogo de reglas:
+        derivado, no escrito a mano, así que no puede quedarse desactualizado.
+        """
+        prompts = CR.iris_config().prompts.get("summary", {})
+        material = f"{prompts.get('system', '')}\n{prompts.get('userTemplate', '')}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+        return f"iris-summary:{digest}"
 
     @staticmethod
     def _degradation_note(report: Dict[str, Any]) -> str:

--- a/API/tests/integration/test_iris_ai_summary.py
+++ b/API/tests/integration/test_iris_ai_summary.py
@@ -1,0 +1,285 @@
+"""B10: el resumen ejecutivo de IA se pide una vez y se cobra una vez.
+
+Antes, `generate_ai_summary` consumía cuota y encolaba sin mirar si ya había
+un resumen o un trabajo en curso. Dos peticiones seguidas —dos clics, un
+reintento del navegador, dos pestañas— cobraban dos veces y lanzaban dos
+generaciones del mismo análisis. El `external_id` era determinista, así que la
+información para evitarlo estaba ahí; simplemente nadie la consultaba.
+
+Además, la cola `iris.ai_summary` no estaba registrada: los trabajos caían en
+la cola `default` en lugar de en la suya.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.system.taskqueue import QueueRegistry, Task, TaskStatus
+
+pytestmark = pytest.mark.integration
+
+
+class _RecordingQueue:
+    """Cola que apunta lo que se le encola, sin ejecutarlo."""
+
+    def __init__(self) -> None:
+        self.submitted: list[dict] = []
+
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        self.submitted.append({"name": name, "category": category,
+                               "external_id": external_id, "args": args})
+        return Task(id=f"job-{len(self.submitted)}", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
+
+
+class _RejectingQueue(_RecordingQueue):
+    def submit(self, *args, **kwargs):
+        raise RuntimeError("la cola rechazó el trabajo")
+
+
+class _CountingQuota:
+    """Doble de QuotaManager que cuenta cobros y devoluciones."""
+
+    consumed: list[str] = []
+    refunded: list[str] = []
+
+    @classmethod
+    def reset(cls):
+        cls.consumed = []
+        cls.refunded = []
+
+    def consume(self, user_id, key, amount=1):
+        type(self).consumed.append(key.db_name)
+
+    def refund(self, user_id, key, amount=1):
+        type(self).refunded.append(key.db_name)
+
+
+@pytest.fixture()
+def counting_quota(monkeypatch):
+    _CountingQuota.reset()
+    monkeypatch.setattr(analysis_mod, "QuotaManager", _CountingQuota)
+    return _CountingQuota
+
+
+def _seed_finished_analysis(app, user_id: int, ai_summary=None) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(
+                raw_headers="From: a@b.com\nSubject: Test\n",
+                user_id=user_id, status="finished",
+                total_score=-25.0, verdict="Phishing",
+                ai_summary=ai_summary,
+            )
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+# ---------------------------------------------------------------------------
+# La cola nominal
+# ---------------------------------------------------------------------------
+
+def test_the_ai_summary_queue_is_registered():
+    """Sin registrar, `QueueRegistry.resolve_queue_name` cae a `default` y el
+    trabajo acaba compartiendo cola con todo lo demás, en vez de en la suya."""
+    assert QueueRegistry.is_registered("iris.ai_summary")
+
+
+def test_the_job_is_enqueued_in_its_own_queue(app, regular_user, counting_quota):
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(queue.submitted) == 1
+    assert queue.submitted[0]["category"] == "iris.ai_summary"
+    assert queue.submitted[0]["external_id"] == f"iris-ai-summary:{analysis_id}"
+
+
+# ---------------------------------------------------------------------------
+# Idempotencia
+# ---------------------------------------------------------------------------
+
+def test_two_requests_produce_a_single_job(app, regular_user, counting_quota):
+    """El caso del issue: dos peticiones concurrentes del mismo análisis."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        manager = IrisManager(task_queue=queue)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(queue.submitted) == 1
+
+
+def test_the_second_request_does_not_consume_quota(app, regular_user, counting_quota):
+    """La otra mitad, y la que le cuesta dinero al usuario: perder la carrera
+    no puede cobrarse."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        manager = IrisManager(task_queue=queue)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+        first_charges = list(counting_quota.consumed)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+
+    assert counting_quota.consumed == first_charges
+    assert "iris.ai_summaries" in first_charges
+
+
+def test_an_existing_summary_is_returned_without_working_or_charging(app, regular_user,
+                                                                    counting_quota):
+    """Doble clic sobre un análisis que ya tiene resumen: se devuelve el que
+    hay. Es lo que quiere quien hizo doble clic, y no cuesta nada."""
+    analysis_id = _seed_finished_analysis(
+        app, regular_user.id, ai_summary={"executive_summary": "ya estaba"})
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        status = IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert status == "done"
+    assert queue.submitted == []
+    assert counting_quota.consumed == []
+
+
+def test_an_explicit_regeneration_does_work_and_charge(app, regular_user, counting_quota):
+    """Y quien sí quiere otra redacción lo pide explícitamente."""
+    analysis_id = _seed_finished_analysis(
+        app, regular_user.id, ai_summary={"executive_summary": "ya estaba"})
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        status = IrisManager(task_queue=queue).generate_ai_summary(
+            analysis_id, regular_user.id, regenerate=True)
+
+    assert status == "running"
+    assert len(queue.submitted) == 1
+    assert counting_quota.consumed
+
+
+# ---------------------------------------------------------------------------
+# Reembolso
+# ---------------------------------------------------------------------------
+
+def test_a_rejected_enqueue_refunds_the_quota(app, regular_user, counting_quota):
+    """Cobrar antes de trabajar es correcto —cobrar después dejaría lanzar N
+    generaciones con cupo para una—, pero obliga a devolver el dinero cuando
+    el trabajo no llega a hacerse."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with pytest.raises(RuntimeError):
+            IrisManager(task_queue=_RejectingQueue()).generate_ai_summary(
+                analysis_id, regular_user.id)
+
+    assert counting_quota.refunded == counting_quota.consumed
+    assert counting_quota.refunded  # y algo se cobró, no es un empate vacío
+
+
+def test_a_rejected_enqueue_leaves_the_analysis_retryable(app, regular_user, counting_quota):
+    """Si la reserva no se soltara, el análisis se quedaría en `running` para
+    siempre y el usuario no podría volver a pedirlo nunca."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with pytest.raises(RuntimeError):
+            IrisManager(task_queue=_RejectingQueue()).generate_ai_summary(
+                analysis_id, regular_user.id)
+
+    assert _reload(app, analysis_id).ai_summary_status is None
+
+    queue = _RecordingQueue()
+    with app.app_context():
+        IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+    assert len(queue.submitted) == 1
+
+
+def test_a_failed_generation_refunds_and_ends_in_a_terminal_state(app, regular_user,
+                                                                  counting_quota):
+    """El backend de IA puede estar caído o devolver basura. El análisis ya
+    terminado no se toca, pero el resumen no puede quedarse en `running` ni
+    cobrado."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        counting_quota.reset()
+
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               side_effect=RuntimeError("modelo caído")):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.ai_summary_status == "failed"
+    assert analysis.ai_summary is None
+    assert analysis.status == "finished"  # el análisis en sí no se ve afectado
+    assert counting_quota.refunded
+
+
+def test_a_failed_generation_can_be_retried(app, regular_user, counting_quota):
+    """`failed` es un estado reclamable: reintentar es legítimo."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               side_effect=RuntimeError("modelo caído")):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+        retry_queue = _RecordingQueue()
+        IrisManager(task_queue=retry_queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(retry_queue.submitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Trazabilidad
+# ---------------------------------------------------------------------------
+
+def test_a_generated_summary_records_how_it_was_made(app, regular_user, counting_quota):
+    """Un resumen de hace tres meses lo escribió otro modelo con otro prompt.
+    Sin registrarlo no hay forma de saber cuál."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               return_value={"executive_summary": "resumen"}):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.ai_summary_status == "done"
+    assert analysis.ai_summary == {"executive_summary": "resumen"}
+    assert analysis.ai_summary_model
+    assert analysis.ai_summary_prompt_version.startswith("iris-summary:")

--- a/API/tests/integration/test_quotas.py
+++ b/API/tests/integration/test_quotas.py
@@ -407,3 +407,61 @@ def test_usage_flags_a_key_over_its_limit(
     assert body["usage"]["hygeia.assets"]["used"] == 3
     # Lo ya creado sigue ahí: degradar nunca borra.
     assert len(client.get("/hygeia/assets", headers=headers).get_json()["assets"]) == 3
+
+
+# ------------------------------------------------------------------ reembolso
+
+def test_refund_gives_the_room_back(app, regular_user, set_plan_limits):
+    """B10: `consume()` ocurre antes que el trabajo que se paga, y tiene que
+    ser así — cobrar después dejaría lanzar N trabajos concurrentes con cupo
+    para uno. El precio de ese orden es que un trabajo que nunca llega a
+    hacerse deja al usuario pagando por nada."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 2})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 2
+
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 1
+        # Y el hueco devuelto se puede volver a gastar de verdad.
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+
+
+def test_refund_never_goes_below_zero(app, regular_user, set_plan_limits):
+    """Un reembolso de más regalaría cupo. La condición vive dentro del UPDATE,
+    igual que en el cobro, para no leer-decidir-escribir."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 5})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 0
+
+
+def test_refund_without_a_previous_charge_is_harmless(app, regular_user, set_plan_limits):
+    """No resucita filas ni inventa cupo: si no había contador, no hay nada
+    que devolver."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 3})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 0
+
+
+def test_refund_never_raises(app, regular_user, set_plan_limits):
+    """Se invoca desde caminos de error. Un reembolso que lanzara taparía la
+    excepción original, que es la que el usuario necesita ver."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 1})
+
+    with app.app_context():
+        # Usuario inexistente: resolver el derecho no puede prosperar.
+        QuotaManager().refund(999999, LimitKey.AI_REQUESTS)


### PR DESCRIPTION
## Resumen

El resumen ejecutivo de IA de Iris se encolaba en la cola equivocada, se podía pedir dos veces cobrando dos veces, y no devolvía la cuota cuando el trabajo no llegaba a hacerse. Este PR arregla los tres.

Cierra #220.

## Los tres problemas

### 1. La cola no estaba registrada

`API/src/modules/features/iris/__init__.py` daba de alta cuatro categorías:

```python
QueueRegistry.register("iris.analyze")
QueueRegistry.register("iris.report")
QueueRegistry.register("iris.ingest")
QueueRegistry.register("iris.notify")
```

Pero el manager encolaba en una quinta: `category="iris.ai_summary"`. Cuando `QueueRegistry` no reconoce una categoría, cae a `default`, así que los resúmenes de IA acababan en la cola compartida en lugar de en la suya. Los workers escuchan por cola, de modo que esto anula la posibilidad de dimensionar o aislar ese trabajo — y es invisible: nada falla, simplemente el trabajo no está donde debería.

### 2. Dos peticiones, dos cobros, dos trabajos

```python
quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
self._task_queue.submit(..., external_id=f"iris-ai-summary:{analysis_id}")
```

No había ninguna comprobación previa: ni de si el análisis ya tenía `ai_summary`, ni de si había un trabajo en curso. Dos clics, un reintento del navegador o dos pestañas abiertas cobraban **dos veces** al usuario y lanzaban **dos generaciones** del mismo análisis, que además compiten por escribir en la misma fila.

Lo llamativo es que la información para evitarlo ya estaba: el `external_id` es determinista (`iris-ai-summary:<id>`), precisamente para poder preguntar "¿ya hay un trabajo para este análisis?". Simplemente nadie lo preguntaba.

### 3. El cobro iba por delante y no se devolvía nunca

Cobrar **antes** de trabajar es lo correcto — cobrar después dejaría la puerta abierta a lanzar N trabajos concurrentes con cupo para uno. Pero eso obliga a devolver el dinero cuando el trabajo no se hace: si el encolado rechaza el job, o si el backend de IA está caído, el usuario ha pagado por nada y no había ninguna forma de arreglarlo.

## Qué cambia

### `QuotaManager.refund()` (nuevo, en `accounts`)

La pieza que faltaba. Deliberadamente **no** es el inverso exacto de `consume()`, y el docstring lo explica:

- **No resucita un periodo pasado.** Si el mes cambió entre el cobro y el reembolso, el cargo pertenece al periodo anterior y ya no se puede deshacer ahí.
- **No baja de cero.** La condición vive dentro del `UPDATE` con el suelo incluido, igual que el cobro: leer, decidir en Python y escribir regalaría cupo bajo concurrencia.
- **Nunca lanza.** Se invoca desde caminos de error; un reembolso que fallara taparía la excepción original, que es la que el usuario necesita ver. Un cargo de más una vez es preferible a perder el error.
- Las claves de nivel (`TIER`) y de existencias (`STOCK`) son no-op: su "consumo" es la tabla real, no un contador.

### Idempotencia por transición condicional

El estado vive ahora en `ai_summary_status`, y la exclusión se hace con un `UPDATE ... WHERE ai_summary_status IS NULL OR IN ('failed')`. Es el mismo patrón que ya usa el consumo de cuota, y por el mismo motivo: bajo dos peticiones simultáneas la base de datos serializa los dos `UPDATE` y el segundo no afecta a ninguna fila. **Quien pierde esa carrera no cobra cuota ni encola nada.**

Un `if analysis.ai_summary_status != "running"` en Python no habría servido: entre la lectura y la escritura caben las dos peticiones.

### `?regenerate=true` — la decisión que el issue pedía tomar

El issue dice explícitamente: *"Decidir explícitamente si repetir la petición implica regenerar o devolver el resultado existente."*

La decisión es **devolver el existente por defecto**, y regenerar solo si se pide. El motivo es que las dos intenciones eran indistinguibles y tienen usuarios distintos:

- Quien repite la petición sin querer (doble clic, reintento del navegador) quiere ver el resumen. Devolver el que hay es exactamente lo que espera, y no cuesta nada.
- Quien quiere otra redacción lo pide con `?regenerate=true`, paga y espera.

La respuesta lleva `status`: `"done"` si se devolvió el existente, `"running"` si se encoló trabajo. Antes decía `"running"` siempre, incluso cuando no había encolado nada.

### Reembolso en los dos caminos de fracaso

- **Encolado rechazado**: se suelta la reserva y se devuelve la cuota. Sin soltar la reserva, el análisis se quedaría en `running` para siempre y el usuario no podría volver a pedirlo nunca.
- **Generación fallida** (backend caído, respuesta ilegible): estado a `failed` —que es reclamable, así que reintentar funciona— y cuota devuelta. El análisis en sí no se toca: sigue `finished`, porque el resumen es un extra, no parte del veredicto.

### Trazabilidad

`ai_summary_model` (la estrategia de scribe configurada) y `ai_summary_prompt_version` (un resumen de los prompts, que viven en `SecOpsConfig.json` y se editan en caliente). Un resumen guardado hace tres meses lo escribió otro modelo con otras instrucciones, y sin esto no hay forma de saber cuál.

Ambos se **derivan** en tiempo de ejecución, por el mismo motivo que `detector_version` en #209: un valor escrito a mano se queda desactualizado y nadie se entera.

### Compatibilidad del trabajo en vuelo

`execute_ai_summary_generation` gana un segundo parámetro `user_id`, **opcional**. Un trabajo ya encolado con la firma anterior sobrevive al despliegue en lugar de reventar al ejecutarse; sin `user_id` simplemente no hay a quién reembolsar.

## Validación

- `tests/integration/test_iris_ai_summary.py` (nuevo, 11 tests) — la cola está registrada y el trabajo va a ella; dos peticiones producen un solo trabajo; **la segunda no consume cuota** (la que le cuesta dinero al usuario); un resumen existente se devuelve sin trabajo ni cobro; una regeneración explícita sí trabaja y cobra; un encolado rechazado devuelve la cuota **y** deja el análisis reintentable; una generación fallida acaba en estado terminal con reembolso y se puede reintentar; y un resumen generado registra con qué se hizo.
- `tests/integration/test_quotas.py` (4 tests nuevos) — el reembolso devuelve hueco realmente gastable; nunca baja de cero; sin cargo previo es inofensivo; y no lanza ni con un usuario inexistente.
- Tests de Iris, cuentas, taskqueue y forma de configuración en verde.
- Grafo de Alembic verificado: 51 revisiones, un solo head, sin IDs duplicados.

## Notas

- El reembolso de la generación fallida es una interpretación del issue, que menciona "reembolsar cuota" en el contexto de los duplicados. Se ha aplicado también aquí porque es el mismo problema: el usuario pagó por un trabajo que no se hizo.
- La migración añade cuatro columnas, todas NULL para las filas existentes. No se rellenan: los resúmenes ya generados se reconocen igualmente por tener `ai_summary` no nulo, y el manager trata "hay resumen, sin estado" como terminado.
- La lógica de cuota que el issue dice compartir con `B09` queda en `QuotaManager.refund()`, disponible para cualquier módulo — no es específica de Iris.
- El README no se toca aquí; los cambios de contrato de la fase 0 (esta categoría de cola incluida) van juntos en un commit al final.
