### PR TITLE
fix(iris): las cachés de datasets siguen a la configuración (B18)

### DIFF
--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -427,105 +427,142 @@ def _data(key: str) -> Any:
     return value if value is not None else _DEFAULTS[key]
 
 
-@lru_cache(maxsize=None)
-def _cached_set(key: str) -> frozenset[str]:
+# B18: las cachés se indexan por (versión de configuración, nombre del
+# dataset), no solo por el nombre.
+#
+# Antes la clave era el nombre a secas y eran permanentes, así que recargar la
+# configuración —``PUT /system``, o el ``reload_if_changed()`` que el worker
+# hace antes de cada job— sustituía ``_configs`` pero dejaba en pie las marcas,
+# proveedores, keywords y TLDs viejos. Un cambio guardado desde ConfigView no
+# llegaba al siguiente análisis, y el operador no tenía forma de enterarse: no
+# fallaba nada, simplemente se seguía analizando con los datos anteriores.
+#
+# Con la versión dentro de la clave, una configuración nueva no puede acertar
+# con una entrada vieja. No hace falta invalidar nada a mano —que es lo que se
+# olvida— y las entradas de generaciones pasadas quedan inalcanzables; el tope
+# de las cachés hace el resto, expulsándolas por LRU. Es el mismo criterio que
+# ``load_block`` aplica a los bloques de configuración.
+#
+# El tope da holgura para varias generaciones de los ~31 datasets a la vez, y
+# lo que pasa al desbordar es una recarga, no un error.
+_CACHE_SIZE = 256
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _cached_set(config_version: tuple, key: str) -> frozenset[str]:
     return frozenset(_data(key))
 
 
-@lru_cache(maxsize=None)
-def _cached_tuple(key: str) -> tuple[str, ...]:
+@lru_cache(maxsize=_CACHE_SIZE)
+def _cached_tuple(config_version: tuple, key: str) -> tuple[str, ...]:
     return tuple(_data(key))
+
+
+def _set_of(key: str) -> frozenset[str]:
+    return _cached_set(CR.config_version(), key)
+
+
+def _tuple_of(key: str) -> tuple[str, ...]:
+    return _cached_tuple(CR.config_version(), key)
 
 
 # --- Accessors públicos (uno por dataset) ------------------------------------
 
 def multi_level_tlds() -> frozenset[str]:
-    return _cached_set("multi_level_tlds")
+    return _set_of("multi_level_tlds")
 
 def canonical_brands() -> frozenset[str]:
-    return _cached_set("canonical_brands")
+    return _set_of("canonical_brands")
 
 def free_provider_domains() -> tuple[str, ...]:
-    return _cached_tuple("free_provider_domains")
+    return _tuple_of("free_provider_domains")
 
 def shortener_domains() -> frozenset[str]:
-    return _cached_set("shortener_domains")
+    return _set_of("shortener_domains")
 
 def dangerous_extensions() -> frozenset[str]:
-    return _cached_set("dangerous_extensions")
+    return _set_of("dangerous_extensions")
 
 def suspicious_mime_types() -> tuple[str, ...]:
-    return _cached_tuple("suspicious_mime_types")
+    return _tuple_of("suspicious_mime_types")
 
 def macro_extensions() -> frozenset[str]:
-    return _cached_set("macro_extensions")
+    return _set_of("macro_extensions")
 
 def credential_phrases() -> tuple[str, ...]:
-    return _cached_tuple("credential_phrases")
+    return _tuple_of("credential_phrases")
 
 def high_signal_keywords() -> tuple[str, ...]:
-    return _cached_tuple("high_signal_keywords")
+    return _tuple_of("high_signal_keywords")
 
 def low_signal_keywords() -> tuple[str, ...]:
-    return _cached_tuple("low_signal_keywords")
+    return _tuple_of("low_signal_keywords")
 
 def alarming_emojis() -> tuple[str, ...]:
-    return _cached_tuple("alarming_emojis")
+    return _tuple_of("alarming_emojis")
 
 def suspicious_tlds() -> frozenset[str]:
-    return _cached_set("suspicious_tlds")
+    return _set_of("suspicious_tlds")
 
 def generic_greetings() -> tuple[str, ...]:
-    return _cached_tuple("generic_greetings")
+    return _tuple_of("generic_greetings")
 
 def action_verbs() -> tuple[str, ...]:
-    return _cached_tuple("action_verbs")
+    return _tuple_of("action_verbs")
 
 def bec_phrases() -> tuple[str, ...]:
-    return _cached_tuple("bec_phrases")
+    return _tuple_of("bec_phrases")
 
 def toad_phrases() -> tuple[str, ...]:
-    return _cached_tuple("toad_phrases")
+    return _tuple_of("toad_phrases")
 
 def subdomain_action_words() -> frozenset[str]:
-    return _cached_set("subdomain_action_words")
+    return _set_of("subdomain_action_words")
 
 def esp_tracker_domains() -> frozenset[str]:
-    return _cached_set("esp_tracker_domains")
+    return _set_of("esp_tracker_domains")
 
 def esp_msgid_domains() -> frozenset[str]:
-    return _cached_set("esp_msgid_domains")
+    return _set_of("esp_msgid_domains")
 
 def redirect_params() -> frozenset[str]:
-    return _cached_set("redirect_params")
+    return _set_of("redirect_params")
 
 def undisclosed_patterns() -> tuple[str, ...]:
-    return _cached_tuple("undisclosed_patterns")
+    return _tuple_of("undisclosed_patterns")
 
 def url_phishing_keywords() -> tuple[str, ...]:
-    return _cached_tuple("url_phishing_keywords")
+    return _tuple_of("url_phishing_keywords")
 
 def multitenant_hosting_domains() -> frozenset[str]:
-    return _cached_set("multitenant_hosting_domains")
+    return _set_of("multitenant_hosting_domains")
 
 def exotic_charsets() -> tuple[str, ...]:
-    return _cached_tuple("exotic_charsets")
+    return _tuple_of("exotic_charsets")
 
 
-@lru_cache(maxsize=None)
-def homoglyph_table() -> dict[int, str]:
-    """Tabla para ``str.translate`` construida desde ``homoglyph_map``."""
+@lru_cache(maxsize=_CACHE_SIZE)
+def _homoglyph_table(config_version: tuple) -> dict[int, str]:
     mapping = {str(k): str(v) for k, v in dict(_data("homoglyph_map")).items()}
     return str.maketrans(mapping)
 
 
-@lru_cache(maxsize=None)
-def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
-    """Pares (keywords, dominios legítimos) por marca, desde ``brand_trusted_domains``."""
+def homoglyph_table() -> dict[int, str]:
+    """Tabla para ``str.translate`` construida desde ``homoglyph_map``."""
+    return _homoglyph_table(CR.config_version())
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _brand_trusted_domains(config_version: tuple) -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
     return tuple(
         (tuple(entry["keywords"]), tuple(entry["domains"]))
         for entry in _data("brand_trusted_domains")
     )
+
+
+def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
+    """Pares (keywords, dominios legítimos) por marca, desde ``brand_trusted_domains``."""
+    return _brand_trusted_domains(CR.config_version())
 
 
 # =============================================================================
@@ -541,11 +578,15 @@ def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ..
 # completa(s), en el mismo orden que el dataset (para no cambiar el
 # comportamiento de "primeros N matches" que ya consumían las reglas).
 
-@lru_cache(maxsize=None)
-def _phrase_pattern(key: str) -> re.Pattern:
+@lru_cache(maxsize=_CACHE_SIZE)
+def _compiled_phrase_pattern(config_version: tuple, key: str) -> re.Pattern:
     phrases = sorted(_data(key), key=len, reverse=True)
     alternation = "|".join(re.escape(phras) for phras in phrases)
     return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
+
+
+def _phrase_pattern(key: str) -> re.Pattern:
+    return _compiled_phrase_pattern(CR.config_version(), key)
 
 
 def phrase_matches(key: str, text: str) -> list[str]:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -97,11 +97,48 @@ def _lazy_load(func):
 # UTILIDADES
 # =============================================================================
 
+#: Contador que avanza cada vez que la configuración cargada es sustituida.
+#: Ver ``config_version``.
+_configs_generation = 0
+
+
+def config_version() -> tuple[int, int]:
+    """Identifica el árbol de configuración vigente ahora mismo.
+
+    Sirve para cachear cosas **derivadas** de la configuración sin que se
+    queden viejas: se mete como parte de la clave de caché, y al cambiar la
+    configuración las entradas antiguas dejan de ser alcanzables solas. Es lo
+    mismo que ya hacía ``load_block`` comparando la identidad de ``_configs``,
+    expuesto para quien no puede usar ``@config_block`` — el caso son los
+    datasets de Iris, que se cachean por nombre y no por campo.
+
+    Son dos números y no uno a propósito:
+
+    - El **contador** avanza en cada sustitución hecha por este módulo
+      (``reload``, ``reload_if_changed``, ``save_full_config``).
+    - La **identidad** del diccionario cubre lo que el contador no ve: un test
+      que monkeypatchee ``_configs`` directamente, que es como se prueba media
+      suite. Sin ella, un caché seguiría devolviendo los datos de la
+      configuración real bajo una config falsa.
+
+    Ninguno de los dos basta por su cuenta: la identidad se puede reutilizar
+    cuando el recolector libera el diccionario anterior, y el contador no ve
+    las escrituras que no pasan por aquí.
+    """
+    return (_configs_generation, id(_configs))
+
+
+def _bump_config_generation() -> None:
+    global _configs_generation
+    _configs_generation += 1
+
+
 def reload() -> None:
     """Fuerza la recarga de la configuración desde el archivo."""
     global _configs, _configs_path
     _configs = None
     _configs_path = None
+    _bump_config_generation()
 
 
 def _read_mtime(path: Path) -> float:
@@ -148,6 +185,7 @@ def reload_if_changed() -> bool:
 
     _configs = new_configs
     _configs_mtime = mtime
+    _bump_config_generation()
     logger.info("Configuración recargada desde disco (%s)", _configs_path)
     return True
 
@@ -1051,6 +1089,7 @@ def save_full_config(new_config: dict, expected_version: Optional[str] = None) -
         json.dump(new_config, f, indent=2, ensure_ascii=False)
     _configs = new_config
     _configs_mtime = _read_mtime(_configs_path)
+    _bump_config_generation()
     return new_config
 
 

--- a/API/tests/unit/test_iris_dataset_cache.py
+++ b/API/tests/unit/test_iris_dataset_cache.py
@@ -1,0 +1,129 @@
+"""B18: un cambio de configuración llega al siguiente análisis.
+
+Los datasets de detección de Iris —marcas, proveedores gratuitos, keywords,
+TLDs sospechosos, tabla de homóglifos— se cachean, y con razón: se consultan
+en cada regla de cada análisis. El problema era la clave de esa caché.
+
+Era el nombre del dataset a secas, y las cachés eran permanentes. Recargar la
+configuración (``PUT /system`` en la API, o el ``reload_if_changed()`` que el
+worker hace antes de cada job) sustituía el árbol ``_configs`` pero dejaba en
+pie los valores viejos. Un cambio guardado desde ConfigView no llegaba al
+siguiente análisis, y no había forma de enterarse: nada fallaba, simplemente
+se seguía analizando con los datos anteriores.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.features.iris.services import wordlists
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def config_tree(monkeypatch):
+    """Devuelve una función que instala un árbol de configuración completo.
+
+    Sustituye ``_configs`` entero, que es lo que hacen de verdad ``reload()``,
+    ``reload_if_changed()`` y ``save_full_config()`` — no se parchea el getter,
+    porque entonces el test no probaría el mecanismo que se está arreglando.
+    """
+    def _install(iris_data: dict):
+        monkeypatch.setattr(
+            CR, "_configs",
+            {"features": {"iris": {"data": iris_data}}},
+            raising=False,
+        )
+    return _install
+
+
+def test_a_changed_dataset_reaches_the_next_analysis(config_tree):
+    """El caso del issue: se añade una marca y el siguiente análisis la ve."""
+    config_tree({"canonical_brands": ["paypal"]})
+    assert "acmebank" not in wordlists.canonical_brands()
+
+    config_tree({"canonical_brands": ["paypal", "acmebank"]})
+
+    assert "acmebank" in wordlists.canonical_brands()
+
+
+def test_a_removed_entry_also_disappears(config_tree):
+    """Y en la otra dirección: quitar una marca tiene que quitarla de verdad.
+
+    Importa tanto o más que añadir — una entrada que sobrevive a su borrado
+    sigue generando hallazgos que el operador cree haber desactivado.
+    """
+    config_tree({"canonical_brands": ["paypal", "acmebank"]})
+    assert "acmebank" in wordlists.canonical_brands()
+
+    config_tree({"canonical_brands": ["paypal"]})
+
+    assert "acmebank" not in wordlists.canonical_brands()
+
+
+def test_tuple_datasets_follow_the_configuration_too(config_tree):
+    """Los datasets ordenados usan otra caché (``_cached_tuple``): también."""
+    config_tree({"free_provider_domains": ["gmail.com"]})
+    assert wordlists.free_provider_domains() == ("gmail.com",)
+
+    config_tree({"free_provider_domains": ["gmail.com", "correo.example"]})
+
+    assert wordlists.free_provider_domains() == ("gmail.com", "correo.example")
+
+
+def test_the_homoglyph_table_follows_the_configuration(config_tree):
+    """La tabla de homóglifos se construye una vez y se cachea aparte."""
+    config_tree({"homoglyph_map": {"0": "o"}})
+    # Con solo el 0 mapeado, el 1 se queda como está.
+    assert "paypa1".translate(wordlists.homoglyph_table()) == "paypa1"
+
+    config_tree({"homoglyph_map": {"0": "o", "1": "l"}})
+
+    assert "paypa1".translate(wordlists.homoglyph_table()) == "paypal"
+
+
+def test_phrase_patterns_are_recompiled(config_tree):
+    """Las frases se compilan a una expresión regular, que es la caché más
+    cara de todas y por tanto la más tentadora de dejar permanente."""
+    config_tree({"bec_phrases": ["cambio de cuenta"]})
+    assert wordlists.phrase_matches("bec_phrases", "urge un pago inmediato") == []
+
+    config_tree({"bec_phrases": ["cambio de cuenta", "pago inmediato"]})
+
+    assert wordlists.phrase_matches("bec_phrases", "urge un pago inmediato") == ["pago inmediato"]
+
+
+def test_brand_trusted_domains_follow_the_configuration(config_tree):
+    config_tree({"brand_trusted_domains": [{"keywords": ["paypal"], "domains": ["paypal.com"]}]})
+    assert wordlists.brand_trusted_domains() == ((("paypal",), ("paypal.com",)),)
+
+    config_tree({"brand_trusted_domains": [{"keywords": ["acme"], "domains": ["acme.example"]}]})
+
+    assert wordlists.brand_trusted_domains() == ((("acme",), ("acme.example",)),)
+
+
+def test_reading_twice_without_changes_uses_the_cache(config_tree):
+    """La invalidación no puede costar la caché: leer dos veces con la misma
+    configuración tiene que devolver **el mismo objeto**, no reconstruirlo.
+
+    Estos datasets se consultan en cada regla de cada análisis; recalcularlos
+    cada vez es precisamente lo que la caché existe para evitar.
+    """
+    config_tree({"canonical_brands": ["paypal"]})
+
+    first = wordlists.canonical_brands()
+    second = wordlists.canonical_brands()
+
+    assert first is second
+
+
+def test_config_version_changes_when_the_tree_is_replaced(config_tree):
+    """La pieza en la que se apoya todo lo anterior."""
+    config_tree({"canonical_brands": ["paypal"]})
+    before = CR.config_version()
+
+    config_tree({"canonical_brands": ["acmebank"]})
+
+    assert CR.config_version() != before

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -821,15 +821,40 @@ def test_generate_ai_summary_rejects_unfinished_analysis(monkeypatch):
 
 
 def test_generate_ai_summary_submits_task_for_finished_analysis(monkeypatch):
+    """B10 añadió dos pasos con estado a esta función —reclamar la fila y
+    cobrar cuota— que un test sin base de datos no puede ejercitar.
+
+    Aquí se sustituyen los dos por dobles para que el test siga siendo lo que
+    era: la comprobación de que el trabajo se encola con los argumentos y la
+    categoría correctos. La idempotencia y el reembolso, que son lo que esos
+    pasos aportan, se prueban contra la base de datos real en
+    ``tests/integration/test_iris_ai_summary.py``.
+    """
     from types import SimpleNamespace
-    fake_analysis = SimpleNamespace(id=10, status="finished")
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    fake_analysis = SimpleNamespace(id=10, status="finished", ai_summary=None)
     monkeypatch.setattr(
         IrisManager, "assert_analysis_ownership",
         classmethod(lambda cls, analysis_id, user_id: fake_analysis),
     )
+    monkeypatch.setattr(
+        IrisManager, "_claim_ai_summary",
+        staticmethod(lambda analysis_id, regenerate=False: True),
+    )
+    monkeypatch.setattr(IrisManager, "_update_analysis",
+                        lambda self, analysis_id, **fields: True)
+
+    class _FreeQuota:
+        def consume(self, user_id, key, amount=1): pass
+        def refund(self, user_id, key, amount=1): pass
+
+    monkeypatch.setattr(analysis_mod, "QuotaManager", _FreeQuota)
+
     fake_queue = _FakeTaskQueue()
     IrisManager(task_queue=fake_queue).generate_ai_summary(analysis_id=10, user_id=1)
-    assert fake_queue.submitted["args"] == (10,)
+
+    assert fake_queue.submitted["args"] == (10, 1)
     assert fake_queue.submitted["category"] == "iris.ai_summary"
 
 


### PR DESCRIPTION
## Resumen

Cambiar un dataset de detección de Iris desde la configuración no tenía efecto: las cachés seguían devolviendo los valores anteriores, y nada lo delataba. Este PR mete la versión de la configuración en la clave de esas cachés.

Cierra #245.

## El problema, en llano

Las reglas de Iris consultan listas configurables: marcas conocidas, dominios de proveedores gratuitos, TLDs sospechosos, frases de BEC, tabla de homóglifos... Están en `SecOpsConfig.json` bajo `features.iris.data`, y se pueden editar desde ConfigView sin desplegar nada.

Como se consultan **en cada regla de cada análisis**, están cacheadas. Correcto. Lo que no lo era es cómo:

```python
@lru_cache(maxsize=None)
def _cached_set(key: str) -> frozenset[str]:
    return frozenset(_data(key))
```

La clave es el **nombre del dataset**, y la caché es permanente (`maxsize=None`, sin invalidación). Así que la primera lectura de `canonical_brands` congela esa lista para toda la vida del proceso.

Mientras tanto, la configuración sí se recarga:

- `PUT /system` llama a `CR.reload()` en el proceso de la API.
- El worker de RQ es otro proceso y no ve ese `PUT`, así que llama a `reload_if_changed()` **antes de cada job** (es lo que documenta `CLAUDE.md` y lo que hace que una edición guardada llegue al siguiente trabajo de fondo sin reiniciar nada).

Las dos rutas sustituyen el árbol `_configs`. **Ninguna tocaba las cachés de `wordlists.py`.**

El resultado es un fallo silencioso de los peores: el operador añade una marca en ConfigView, ve que se guarda, y el siguiente análisis no la usa. Nada falla, nada se registra. Y si el proceso se reinicia por cualquier motivo, empieza a funcionar — con lo que el síntoma es además intermitente.

## Por qué no bastaba un hook de invalidación

El issue propone dos caminos: *"Asociar cada caché al `config_version`/mtime, invalidarla desde un **único** hook, o eliminar la caché"*.

Un hook `invalidate_iris_dataset_caches()` llamado desde `reload()` funcionaría, pero tiene dos costes que la versión en la clave no tiene:

1. **Hay que acordarse.** Son tres puntos donde `_configs` se sustituye (`reload`, `reload_if_changed`, `save_full_config`), y cualquier cuarto que aparezca en el futuro tendría que acordarse de llamar al hook. Olvidarlo reintroduce exactamente este bug, otra vez en silencio.
2. **Obligaría a `system` a conocer a `iris`**, o a montar un registro de hooks para evitarlo.

Meter la versión en la clave hace que el problema **no se pueda tener**: una configuración nueva simplemente no puede acertar con una entrada vieja, porque su clave es distinta. Nadie tiene que invalidar nada.

Además es el criterio que el proyecto ya usa: `load_block` cachea los bloques `@config_block` comparando la identidad de `_configs`. Esto expone lo mismo para quien no puede usar `@config_block` — los datasets de Iris, que se cachean **por nombre** y no por campo.

## Qué cambia

### `CR.config_version()`

Identifica el árbol de configuración vigente. Devuelve **dos** números, y la razón de que no sea uno merece explicarse:

- El **contador** avanza en cada sustitución hecha por `config_reading` (`reload`, `reload_if_changed`, `save_full_config`).
- La **identidad del diccionario** cubre lo que el contador no ve: un test que monkeypatchee `_configs` directamente, que es como se prueba media suite. Sin esto, una caché seguiría sirviendo datos de la configuración real bajo una configuración falsa — y los tests pasarían mientras el bug seguía ahí.

Ninguno basta por su cuenta: la identidad se puede reutilizar cuando el recolector libera el diccionario anterior, y el contador no ve las escrituras que no pasan por el módulo.

### `wordlists.py`

Las cinco funciones cacheadas reciben la versión como primer argumento, detrás de un envoltorio fino que la inyecta (`_set_of`, `_tuple_of`, etc.). Los 24 accesores públicos no cambian de firma.

`maxsize` pasa de `None` a 256: con la versión en la clave, las entradas de generaciones pasadas quedan **inalcanzables** pero seguirían ocupando memoria si la caché fuera infinita. Con tope, la LRU las expulsa sola. 256 da holgura para varias generaciones de los ~31 datasets a la vez, y lo que pasa al desbordar es una recarga, no un error.

## Validación

- `tests/unit/test_iris_dataset_cache.py` (nuevo, 8 tests) — sustituyen el árbol `_configs` entero, que es lo que hacen de verdad las tres rutas de recarga (no se parchea el getter, porque entonces el test no probaría el mecanismo que se arregla). Cubren: añadir una entrada llega al siguiente análisis; **quitarla también la quita** —importa tanto o más, porque una entrada que sobrevive a su borrado sigue generando hallazgos que el operador cree haber desactivado—; los datasets de tupla, la tabla de homóglifos, los patrones de frases compilados y `brand_trusted_domains`, que son cachés distintas; y que `config_version()` cambia al sustituir el árbol.

  Y uno que protege la otra mitad: **leer dos veces sin cambios devuelve el mismo objeto**. La invalidación no puede costar la caché — recalcular estos datasets en cada regla de cada análisis es precisamente lo que la caché existe para evitar.
- Suite unitaria completa (1 100+ tests) y tests de integración de Iris, configuración y sistema en verde.

## Notas

- **Este PR arregla además un test que B10 (#220) dejó roto** y que se me escapó allí por no ejecutar `test_iris_rules.py` en aquella rama: `test_generate_ai_summary_submits_task_for_finished_analysis` usaba un stub que ya no tenía todos los atributos que la función lee. Va en su propio commit, separado del cambio de cachés. La cobertura real de esa función vive en el test de integración que #220 añadió; el unitario vuelve a ser lo que era, la comprobación de que se encola con los argumentos correctos.
- El issue menciona registrar qué versión de datasets usó cada análisis, solapando con `M05`. Eso no entra aquí: `config_version()` es un identificador **en memoria** (incluye `id()`), útil para cachear pero no para persistir ni comparar entre procesos. `M05` necesita un fingerprint estable del contenido, que es otra cosa y merece definirse una sola vez cuando se aborde.
- Sin migración y sin cambios de contrato.
