### PR TITLE
test(ci): matriz de integración contra PostgreSQL y Redis reales (B20)

### DIFF
--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -1,0 +1,88 @@
+name: API Tests (PostgreSQL + Redis)
+
+# La suite normal (tests.yml) corre sobre SQLite con Redis y la red cortados:
+# tarda ~2 minutos y su resultado no depende de lo que tenga levantado la
+# máquina. El precio es que hay invariantes de producción que ese entorno no
+# puede comprobar — longitudes de columna, claves foráneas, JSONB y las
+# carreras entre transacciones reales.
+#
+# Este job las cubre con PostgreSQL y Redis efímeros. Va aparte a propósito:
+# la matriz de servicios no debe ralentizar el ciclo rápido, que es el que se
+# ejecuta en cada push.
+
+on:
+  push:
+    branches: [main, 'v[0-9]+.[0-9]+']
+  pull_request:
+    branches: [main, 'v[0-9]+.[0-9]+']
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: API
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: ellysia
+          POSTGRES_PASSWORD: ellysia
+          POSTGRES_DB: ellysia_test
+        ports:
+          - 5432:5432
+        # Sin el health check, el primer test puede llegar antes de que el
+        # servidor acepte conexiones y fallar por una carrera de arranque en
+        # lugar de por el código.
+        options: >-
+          --health-cmd "pg_isready -U ellysia"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      JWT_SECRET_KEY: ci-secret-key-not-for-production
+      JWT_ALGORITHM: HS256
+      ACCESS_TOKEN_EXPIRY_MINUTES: "30"
+      REFRESH_TOKEN_EXPIRY_DAYS: "7"
+      FLASK_ENV: development
+      CREATE_DATABASE: "false"
+      DEBUG: "false"
+      # Estas dos son las que activan la matriz: sin ellas, tests/postgres se
+      # salta entero (ver su conftest). Así el mismo código corre en un
+      # portátil sin contenedores sin fallar ni pedir nada.
+      POSTGRES_TEST_URL: postgresql+psycopg2://ellysia:ellysia@localhost:5432/ellysia_test
+      REDIS_TEST_URL: redis://localhost:6379/1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            API/requirements.txt
+            API/requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run the real-engine matrix
+        # Solo los tests marcados: el resto de la suite ya corrió en tests.yml
+        # sobre SQLite y repetirla aquí no añadiría nada.
+        run: python -m pytest -q -m postgres --no-cov

--- a/API/pyproject.toml
+++ b/API/pyproject.toml
@@ -8,6 +8,7 @@ addopts = "-q --strict-markers --cov=src --cov-report=term-missing"
 markers = [
     "unit: tests unitarios rápidos, sin base de datos ni aplicación Flask",
     "integration: tests que arrancan la aplicación y usan el cliente HTTP de pruebas",
+    "postgres: matriz de integración contra motores reales (PostgreSQL + Redis efímeros, ver tests/postgres/). Se salta sola sin POSTGRES_TEST_URL; su job de CI es tests-postgres.yml. La suite rápida no la necesita ni se ralentiza por ella.",
     "oracle: banco de pruebas con oráculo diferencial (roadmap Lybra §7) — levanta contenedores Docker reales y hace red de verdad, nada mockeado. Excluido del run por defecto de CI (ver tests.yml); se salta solo si no hay Docker disponible.",
 ]
 filterwarnings = [

--- a/API/tests/postgres/conftest.py
+++ b/API/tests/postgres/conftest.py
@@ -1,0 +1,226 @@
+"""B20: fixtures para la matriz de integración contra motores reales.
+
+La suite normal corre sobre SQLite con Redis y la red cortados de raíz, y eso
+es deliberado: la mantiene en ~2 minutos y hace que el resultado no dependa de
+lo que tenga levantado la máquina. Pero significa que hay invariantes de
+producción que **hoy no prueba nadie**, porque solo existen en el motor real:
+
+- SQLite ignora la longitud de un ``VARCHAR``, así que una columna demasiado
+  corta no falla nunca (es lo que dejó pasar el `sync_cursor` de `B12`).
+- SQLite no aplica claves foráneas salvo que se active explícitamente, así que
+  ``ON DELETE CASCADE`` y ``ON DELETE SET NULL`` no se ejercitan.
+- ``JSONB`` se sustituye por ``JSON`` genérico con un shim, así que ni el tipo
+  ni sus operadores son los de producción.
+- Las carreras reales entre transacciones no se pueden montar con un fichero
+  SQLite compartido por un solo hilo.
+
+Estos tests **no** sustituyen a los de la suite rápida: la complementan en el
+único sitio donde SQLite no puede decir la verdad. Y no la ralentizan, porque
+se saltan solos cuando no hay motores conectados.
+
+Las fixtures tienen nombres propios (``pg_engine``, ``pg_session``…) en vez de
+sobrescribir las de la raíz. Sobrescribir ``_initialized_db`` o ``app`` —que
+son de sesión— haría que el primer test en pedirlas fijara el motor para toda
+la ejecución, y el resultado dependería del orden de recolección.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+import redis as redis_lib
+
+# Se captura ANTES de que la fixture de sesión de la raíz parchee el pool: los
+# conftest se importan en la recolección, y las fixtures autouse no corren
+# hasta el primer test. Sin esta referencia no habría forma de volver a hablar
+# con un Redis de verdad desde dentro de la suite.
+_REAL_REDIS_GET_CONNECTION = redis_lib.connection.ConnectionPool.get_connection
+
+
+#: URL del PostgreSQL efímero. Sin ella, todo este directorio se salta.
+POSTGRES_URL_ENV = "POSTGRES_TEST_URL"
+
+#: URL del Redis efímero. Los tests que lo necesitan se saltan sin ella.
+REDIS_URL_ENV = "REDIS_TEST_URL"
+
+
+def _postgres_url() -> str | None:
+    return os.getenv(POSTGRES_URL_ENV) or None
+
+
+def _redis_url() -> str | None:
+    return os.getenv(REDIS_URL_ENV) or None
+
+
+def pytest_collection_modifyitems(config, items):
+    """Marca y salta todo el directorio cuando no hay PostgreSQL conectado.
+
+    Se hace aquí y no con un ``skipif`` por módulo para que no haya forma de
+    escribir un test nuevo en esta carpeta y olvidarse del guardia: en un
+    portátil sin contenedores la carpeta entera se salta, y en el runner de CI
+    con el servicio levantado corre entera.
+    """
+    if _postgres_url():
+        return
+    skip = pytest.mark.skip(
+        reason=f"sin {POSTGRES_URL_ENV}: la matriz de motores reales solo corre en su job de CI"
+    )
+    for item in items:
+        if "tests/postgres/" in item.nodeid.replace("\\", "/"):
+            item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def _clean_db():
+    """Neutraliza la limpieza de la base SQLite de la suite rápida.
+
+    ``tests/conftest.py`` la declara autouse, así que **cada** test la arrastra
+    — y con ella ``_initialized_db``, que aplica el shim de tipos
+    PostgreSQL→SQLite. Ese shim sustituye ``JSONB`` por ``JSON`` genérico
+    **mutando ``Base.metadata`` en el sitio**, de modo que a partir de ese
+    momento el proceso entero cree que esas columnas son ``JSON``: el esquema
+    que se crea aquí saldría con el tipo equivocado y los operadores de JSONB
+    no existirían.
+
+    Sobrescribirla por nombre es el mecanismo de pytest para esto y solo aplica
+    a este directorio. Aquí no hace falta lo que hacía: cada test usa su propia
+    sesión, que se deshace al terminar.
+    """
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _unlimited_default_plan():
+    """Igual que arriba: la siembra de planes de la suite rápida arrastra la
+    fixture ``app``, que también construye el engine SQLite."""
+    yield
+
+
+@pytest.fixture(scope="session")
+def pg_engine() -> Iterator[sa.Engine]:
+    """Engine contra el PostgreSQL efímero, con el esquema real creado.
+
+    **Sin el shim de tipos** que la suite normal aplica: aquí las columnas son
+    ``JSONB`` de verdad, que es justo lo que se quiere comprobar.
+    """
+    url = _postgres_url()
+    if not url:
+        pytest.skip(f"sin {POSTGRES_URL_ENV}")
+
+    # Importar run arrastra todos los blueprints y con ellos cada modelo a
+    # Base.metadata, igual que hace el conftest de la raíz.
+    import run  # noqa: F401
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from src.modules.shared import Base
+
+    # Guardia contra el shim de la suite rápida. Si algo ha llegado a
+    # construir el engine SQLite en este proceso, ``Base.metadata`` ya tiene
+    # las columnas JSONB degradadas a JSON y todo lo que se cree aquí sería
+    # una imitación del esquema real. Es preferible saltarse la matriz con un
+    # motivo legible que dar por buenas unas comprobaciones que no comprueban
+    # lo que dicen. En su job de CI (``pytest -m postgres``) no pasa: nada
+    # pide el engine SQLite.
+    if not isinstance(Base.metadata.tables["IrisAnalysis"].c.failed_rules.type, JSONB):
+        pytest.skip(
+            "Base.metadata ya tiene aplicado el shim SQLite (JSONB->JSON): "
+            "esta matriz debe ejecutarse en su propia invocación, con "
+            "`pytest -m postgres`"
+        )
+
+    engine = sa.create_engine(url, pool_pre_ping=True, future=True)
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _truncate_everything(engine: sa.Engine) -> None:
+    """Vacía todas las tablas de la aplicación.
+
+    Hace falta porque estos tests **confirman** sus transacciones: un rollback
+    al terminar no deshace nada de lo ya escrito, y el siguiente test que
+    consulte "todos los análisis" dependería de lo que dejaron los anteriores.
+    ``TRUNCATE ... CASCADE`` en una sola sentencia evita además tener que
+    ordenar las tablas por sus claves foráneas.
+    """
+    from src.modules.shared import Base
+
+    names = ", ".join(f'"{table.name}"' for table in Base.metadata.sorted_tables)
+    if not names:
+        return
+    with engine.begin() as connection:
+        connection.execute(sa.text(f"TRUNCATE {names} RESTART IDENTITY CASCADE"))
+
+
+@pytest.fixture()
+def pg_session(pg_engine) -> Iterator[Session]:
+    """Sesión limpia por test, sobre una base vacía."""
+    factory = sessionmaker(bind=pg_engine, expire_on_commit=False, future=True)
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        _truncate_everything(pg_engine)
+
+
+@pytest.fixture()
+def pg_sessions(pg_engine):
+    """Factory de sesiones **independientes**, para montar carreras de verdad.
+
+    Dos sesiones distintas son dos transacciones distintas contra el mismo
+    PostgreSQL, que es la única forma de comprobar que una restricción de
+    unicidad o un UPDATE condicional aguantan la concurrencia. Con una sola
+    sesión, el ORM resolvería el conflicto en su propio identity map y el test
+    pasaría sin haber tocado la base de datos.
+    """
+    factory = sessionmaker(bind=pg_engine, expire_on_commit=False, future=True)
+    opened: list[Session] = []
+
+    def _open() -> Session:
+        session = factory()
+        opened.append(session)
+        return session
+
+    try:
+        yield _open
+    finally:
+        for session in opened:
+            session.rollback()
+            session.close()
+
+
+@pytest.fixture()
+def real_redis():
+    """Cliente contra el Redis efímero, con el corte de la suite levantado.
+
+    El conftest de la raíz parchea ``ConnectionPool.get_connection`` para toda
+    la sesión, así que aquí se restaura la función original mientras dure el
+    test. Es local y temporal a propósito: fuera de este directorio el corte
+    sigue en pie.
+    """
+    url = _redis_url()
+    if not url:
+        pytest.skip(f"sin {REDIS_URL_ENV}")
+
+    from unittest import mock
+
+    with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection",
+                           _REAL_REDIS_GET_CONNECTION):
+        client = redis_lib.Redis.from_url(url, decode_responses=True)
+        client.flushdb()
+        try:
+            yield client
+        finally:
+            client.flushdb()
+            client.close()

--- a/API/tests/postgres/test_concurrency.py
+++ b/API/tests/postgres/test_concurrency.py
@@ -1,0 +1,142 @@
+"""B20: las carreras que solo existen con transacciones de verdad.
+
+El motor de cuotas y la reserva del resumen de IA se apoyan los dos en la
+misma idea: la condición vive **dentro** del UPDATE, para que dos peticiones
+simultáneas no puedan gastar el mismo hueco. Esa propiedad no se puede
+comprobar con un fichero SQLite y una sola sesión — hacen falta dos
+transacciones concurrentes contra el mismo servidor.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.users.model import User
+
+pytestmark = pytest.mark.postgres
+
+
+def _user(pg_session, username: str) -> User:
+    user = User(
+        username=username, email=f"{username}@ellysia.test",
+        first_name="Postgres", last_name="Tester",
+        password_hash="x", password_salt="", role="role_user",
+    )
+    pg_session.add(user)
+    pg_session.commit()
+    return user
+
+
+def _claim(session, analysis_id: int) -> bool:
+    """El mismo UPDATE condicional que usa ``IrisManager._claim_ai_summary``.
+
+    Se reproduce aquí en vez de llamar al manager porque el manager abre su
+    propia ``UnitOfWork`` contra el engine global de la aplicación, y lo que
+    este test necesita es controlar las dos transacciones.
+    """
+    result = session.execute(
+        sa.update(IrisAnalysis)
+        .where(sa.and_(
+            IrisAnalysis.id == analysis_id,
+            sa.or_(IrisAnalysis.ai_summary_status.is_(None),
+                   IrisAnalysis.ai_summary_status == "failed"),
+        ))
+        .values(ai_summary_status="running")
+    )
+    return bool(result.rowcount)
+
+
+def test_only_one_of_two_concurrent_claims_wins(pg_session, pg_sessions):
+    """B10 contra concurrencia real.
+
+    Dos peticiones simultáneas del resumen de IA del mismo análisis. La
+    exclusión se apoya en que el segundo UPDATE no afecte a ninguna fila; si
+    la comprobación viviera en Python entre una lectura y una escritura, las
+    dos ganarían y el usuario pagaría dos veces.
+    """
+    user = _user(pg_session, "carrera-resumen")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    first, second = pg_sessions(), pg_sessions()
+
+    first_won = _claim(first, analysis.id)
+    first.commit()
+    second_won = _claim(second, analysis.id)
+    second.commit()
+
+    assert [first_won, second_won] == [True, False]
+
+
+def test_a_failed_claim_can_be_taken_again(pg_session, pg_sessions):
+    """`failed` es reclamable: reintentar tiene que funcionar, o un fallo del
+    backend de IA dejaría el resumen bloqueado para siempre."""
+    user = _user(pg_session, "reintento-resumen")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="finished", ai_summary_status="failed")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    session = pg_sessions()
+    assert _claim(session, analysis.id) is True
+    session.commit()
+
+
+def test_two_transactions_cannot_spend_the_same_last_slot(pg_session, pg_sessions):
+    """El patrón del motor de cuotas, aislado.
+
+    Es el mismo UPDATE condicional que usa ``QuotaManager._consume_counter``:
+    ``SET used = used + 1 WHERE used + 1 <= limite``. Con el límite en 1 y dos
+    transacciones a la vez, PostgreSQL serializa los dos UPDATE y el segundo no
+    encuentra fila. Sobre SQLite, con una sola conexión, esta comprobación no
+    demostraría nada.
+    """
+    user = _user(pg_session, "carrera-cuota")
+    counter = sa.table(
+        "IrisAnalysis",
+        sa.column("id"), sa.column("total_score"), sa.column("user_id"),
+    )
+
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="finished", total_score=0)
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    def spend(session) -> bool:
+        result = session.execute(
+            sa.update(counter)
+            .where(sa.and_(counter.c.id == analysis.id, counter.c.total_score + 1 <= 1))
+            .values(total_score=counter.c.total_score + 1)
+        )
+        return bool(result.rowcount)
+
+    first, second = pg_sessions(), pg_sessions()
+
+    first_spent = spend(first)
+    first.commit()
+    second_spent = spend(second)
+    second.commit()
+
+    assert [first_spent, second_spent] == [True, False]
+
+
+def test_redis_round_trips_a_cancel_signal(real_redis):
+    """La otra mitad de la matriz: un Redis de verdad.
+
+    La suite normal corta Redis de raíz, así que la señal de cancelación
+    cooperativa —la clave ``taskqueue:cancel:<job>`` que los workers sondean—
+    nunca se escribe ni se lee contra el servidor real. Es poco código, pero es
+    el mecanismo del que depende que un escaneo o un análisis se puedan parar.
+    """
+    key = "taskqueue:cancel:job-de-prueba"
+
+    assert real_redis.get(key) is None
+
+    real_redis.set(key, "1", ex=60)
+    assert real_redis.get(key) == "1"
+
+    real_redis.delete(key)
+    assert real_redis.get(key) is None

--- a/API/tests/postgres/test_migrations.py
+++ b/API/tests/postgres/test_migrations.py
@@ -1,0 +1,160 @@
+"""B20: las migraciones, ejecutadas de verdad.
+
+Alembic solo se ejerce contra PostgreSQL, y la suite rápida crea el esquema
+con ``Base.metadata.create_all``, que salta por encima de todas las
+migraciones. Es decir que hasta ahora **ninguna migración se ejecutaba en
+ningún test**: un ``down_revision`` mal puesto, un identificador repetido, un
+tipo que PostgreSQL no acepta o una bajada rota solo se descubrían al
+desplegar.
+
+Este módulo cierra ese hueco aplicando la cadena entera sobre una base de
+datos vacía creada para la ocasión — que es exactamente lo que ocurre en un
+despliegue nuevo.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import sqlalchemy as sa
+
+pytestmark = pytest.mark.postgres
+
+_MIGRATIONS_DB = "ellysia_migrations_test"
+
+
+def _api_dir() -> str:
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture()
+def migrations_url(pg_engine):
+    """Crea una base de datos vacía y devuelve su URL; la borra al terminar.
+
+    Se usa una base aparte y no el esquema de ``pg_engine`` porque las
+    migraciones tienen que correr sobre algo realmente vacío, y ``pg_engine``
+    ya tiene el esquema creado por los modelos para el resto de tests.
+    ``CREATE DATABASE`` no puede ir dentro de una transacción, de ahí el
+    ``AUTOCOMMIT``.
+    """
+    maintenance = sa.create_engine(
+        pg_engine.url.set(database="postgres"),
+        isolation_level="AUTOCOMMIT", future=True,
+    )
+    with maintenance.connect() as connection:
+        connection.execute(sa.text(f'DROP DATABASE IF EXISTS "{_MIGRATIONS_DB}"'))
+        connection.execute(sa.text(f'CREATE DATABASE "{_MIGRATIONS_DB}"'))
+
+    try:
+        yield pg_engine.url.set(database=_MIGRATIONS_DB)
+    finally:
+        with maintenance.connect() as connection:
+            connection.execute(sa.text(f'DROP DATABASE IF EXISTS "{_MIGRATIONS_DB}"'))
+        maintenance.dispose()
+
+
+@pytest.fixture()
+def alembic_config(migrations_url):
+    from alembic.config import Config
+
+    config = Config(os.path.join(_api_dir(), "alembic.ini"))
+    config.set_main_option("script_location", os.path.join(_api_dir(), "alembic"))
+    # `%` es el carácter de interpolación de ConfigParser: una contraseña con
+    # un `%` rompería la lectura si no se escapa.
+    config.set_main_option("sqlalchemy.url", migrations_url.render_as_string(
+        hide_password=False).replace("%", "%%"))
+    return config
+
+
+def test_the_migration_graph_is_linear_and_has_one_head():
+    """Un segundo head significa dos ramas de esquema sin mezclar: el arranque
+    de la aplicación falla y hay que resolverlo a mano.
+
+    Y los identificadores de este repositorio se han venido escribiendo a mano
+    siguiendo un patrón (``a1b2c3d4e5f6``, ``d7e8f9a0b1c2``…), que es justo el
+    modo de acabar con dos revisiones con el mismo identificador — ha pasado.
+    """
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    config = Config(os.path.join(_api_dir(), "alembic.ini"))
+    config.set_main_option("script_location", os.path.join(_api_dir(), "alembic"))
+    script = ScriptDirectory.from_config(config)
+
+    assert len(script.get_heads()) == 1, f"se esperaba un head, hay {script.get_heads()}"
+
+    identifiers = [revision.revision for revision in script.walk_revisions()]
+    assert len(identifiers) == len(set(identifiers)), "hay identificadores repetidos"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Bug preexistente destapado por esta matriz (#356): la revisión "
+        "b2c3d4e5f6a7 inserta en PlanLimit diez migraciones antes de que "
+        "f2b3c4d5e6f7 cree la tabla, así que `alembic upgrade head` sobre una "
+        "base vacía falla. No se nota en producción porque el primer "
+        "despliegue crea el esquema con CREATE_DATABASE=True (create_all) y "
+        "Alembic solo aplica los incrementos posteriores. Al arreglarlo, este "
+        "test pasa a XPASS y hay que quitar el marcador."
+    ),
+)
+def test_the_whole_chain_applies_to_an_empty_database(alembic_config, migrations_url):
+    """``alembic upgrade head`` sobre una base vacía: el despliegue nuevo."""
+    from alembic import command
+
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        tables = set(sa.inspect(engine).get_table_names())
+        assert "IrisAnalysis" in tables
+        assert "IrisMailboxConnection" in tables
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Depende de que `upgrade head` funcione sobre una base vacía, que hoy "
+        "no lo hace (#356). Se quita junto con el marcador del test anterior."
+    ),
+)
+def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_config,
+                                                                   migrations_url):
+    """Las cuatro migraciones de la fase 0, en los dos sentidos.
+
+    Bajar y volver a subir es lo que hace falta cuando un despliegue se
+    revierte, y es donde se ve si una bajada olvidó una columna: la subida
+    siguiente fallaría al intentar añadirla otra vez.
+    """
+    from alembic import command
+
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        columns = {column["name"] for column in sa.inspect(engine).get_columns("IrisAnalysis")}
+        assert {"failure_code", "failure_reason"} <= columns                              # B03
+        assert {"analysis_quality", "failed_rules", "detector_version"} <= columns        # B05
+        assert {"ai_summary_status", "ai_summary_job_id",
+                "ai_summary_model", "ai_summary_prompt_version"} <= columns               # B10
+
+        cursor = next(column for column in sa.inspect(engine).get_columns("IrisMailboxConnection")
+                      if column["name"] == "sync_cursor")
+        assert cursor["type"].length is None, "sync_cursor volvió a tener un límite (B12)"
+    finally:
+        engine.dispose()
+
+    # Cuatro pasos atrás: las cuatro migraciones de la fase 0.
+    command.downgrade(alembic_config, "-4")
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        columns = {column["name"] for column in sa.inspect(engine).get_columns("IrisAnalysis")}
+        assert {"failure_code", "analysis_quality", "ai_summary_status"} <= columns
+    finally:
+        engine.dispose()

--- a/API/tests/postgres/test_schema_invariants.py
+++ b/API/tests/postgres/test_schema_invariants.py
@@ -1,0 +1,265 @@
+"""B20: las invariantes del esquema que SQLite no puede comprobar.
+
+Cada test de aquí falla en PostgreSQL y **pasa en SQLite**, que es exactamente
+por lo que hacen falta. No repiten cobertura: la añaden donde el motor de la
+suite rápida es incapaz de decir la verdad.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import DataError, IntegrityError
+
+from src.modules.features.iris.model import (
+    IrisAnalysis,
+    IrisDocument,
+    IrisMailboxConnection,
+    IrisRuleResult,
+)
+from src.modules.users.model import User
+
+pytestmark = pytest.mark.postgres
+
+
+def _user(pg_session, username: str = "postgres-tester") -> User:
+    user = User(
+        username=username,
+        email=f"{username}@ellysia.test",
+        first_name="Postgres",
+        last_name="Tester",
+        password_hash="x",
+        password_salt="",
+        role="role_user",
+    )
+    pg_session.add(user)
+    pg_session.commit()
+    return user
+
+
+def _connection(pg_session, user: User, email: str = "buzon@outlook.example") -> IrisMailboxConnection:
+    connection = IrisMailboxConnection(
+        user_id=user.id, provider="microsoft", account_email=email,
+        scopes="Mail.Read", refresh_token_enc="cifrado",
+    )
+    pg_session.add(connection)
+    pg_session.commit()
+    return connection
+
+
+# ---------------------------------------------------------------------------
+# Longitud de columna
+# ---------------------------------------------------------------------------
+
+def test_a_long_graph_delta_link_fits_in_sync_cursor(pg_session):
+    """B12 contra el motor real.
+
+    SQLite ignora la longitud declarada de un ``VARCHAR``, así que con la
+    columna en ``String(255)`` el test equivalente de la suite rápida pasaba
+    igualmente. Aquí no: si alguien la volviera a estrechar, este INSERT falla.
+    """
+    user = _user(pg_session, "cursor-largo")
+    connection = _connection(pg_session, user, "cursor@outlook.example")
+
+    cursor = (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + "Ag0AAA" + "Z" * 1500
+    )
+    connection.sync_cursor = cursor
+    pg_session.commit()
+    pg_session.expire_all()
+
+    assert pg_session.get(IrisMailboxConnection, connection.id).sync_cursor == cursor
+
+
+def test_an_oversized_value_is_rejected_rather_than_truncated(pg_session):
+    """La otra cara: PostgreSQL **rechaza** lo que no cabe, no lo recorta.
+
+    Importa dejarlo escrito, porque es la diferencia de comportamiento que hace
+    que un desbordamiento se vea en desarrollo (nunca) y en producción (siempre).
+    """
+    user = _user(pg_session, "estado-largo")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="x" * 200)  # la columna son 20
+    pg_session.add(analysis)
+
+    with pytest.raises((DataError, IntegrityError)):
+        pg_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Unicidad e idempotencia
+# ---------------------------------------------------------------------------
+
+def test_the_same_ingested_message_cannot_be_analysed_twice(pg_session, pg_sessions):
+    """La idempotencia de la ingesta de buzón, contra una carrera real.
+
+    ``UniqueConstraint(connection_id, source_message_uid)`` es lo que hace que
+    un reintento de sincronización sea un no-op en vez de un análisis
+    duplicado. Se monta con **dos sesiones independientes** porque con una sola
+    el ORM resolvería el conflicto en su propio identity map y el test pasaría
+    sin haber llegado a la base de datos.
+    """
+    user = _user(pg_session, "idempotencia")
+    connection = _connection(pg_session, user, "idem@outlook.example")
+
+    first, second = pg_sessions(), pg_sessions()
+    first.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                           connection_id=connection.id, source_message_uid="msg-1"))
+    first.commit()
+
+    second.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            connection_id=connection.id, source_message_uid="msg-1"))
+    with pytest.raises(IntegrityError):
+        second.commit()
+
+
+def test_manual_submissions_never_collide(pg_session):
+    """Y la contrapartida: dos análisis manuales no chocan.
+
+    Ambos tienen ``connection_id`` y ``source_message_uid`` a NULL, y el UNIQUE
+    de SQL estándar trata cada NULL como distinto de todos los demás. Es de lo
+    que depende que la restricción no rompa el flujo normal de la aplicación.
+    """
+    user = _user(pg_session, "manuales")
+
+    pg_session.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id))
+    pg_session.add(IrisAnalysis(raw_headers="From: c@d.com", user_id=user.id))
+    pg_session.commit()  # no debe lanzar
+
+    assert pg_session.query(IrisAnalysis).filter_by(user_id=user.id).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Claves foráneas
+# ---------------------------------------------------------------------------
+
+def test_deleting_a_connection_keeps_its_analyses(pg_session):
+    """``ondelete="SET NULL"``: desconectar un buzón no puede borrar el
+    historial de análisis que llegaron por él.
+
+    SQLite no aplica claves foráneas salvo que se active explícitamente el
+    pragma, así que en la suite rápida esta cláusula no se ejercita nunca.
+    """
+    user = _user(pg_session, "fk-set-null")
+    connection = _connection(pg_session, user, "setnull@outlook.example")
+
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            connection_id=connection.id, source_message_uid="msg-9")
+    pg_session.add(analysis)
+    pg_session.commit()
+    analysis_id = analysis.id
+
+    pg_session.delete(connection)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    survivor = pg_session.get(IrisAnalysis, analysis_id)
+    assert survivor is not None
+    assert survivor.connection_id is None
+
+
+def test_deleting_an_analysis_takes_its_documents_with_it(pg_session):
+    """``ondelete="CASCADE"``: lo contrario del anterior, y también sin
+    cobertura hasta ahora. Un documento huérfano apuntaría a un análisis que ya
+    no existe y reventaría al listarlo."""
+    user = _user(pg_session, "fk-cascade")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    document = IrisDocument(analysis_id=analysis.id, user_id=user.id,
+                            document_type="iris", filename="", format="pdf",
+                            status="done", verdict="Phishing")
+    pg_session.add(document)
+    pg_session.commit()
+    document_id = document.id
+
+    pg_session.delete(analysis)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    assert pg_session.get(IrisDocument, document_id) is None
+
+
+# ---------------------------------------------------------------------------
+# JSONB
+# ---------------------------------------------------------------------------
+
+def test_the_json_columns_really_are_jsonb(pg_engine):
+    """El shim de la suite rápida sustituye ``JSONB`` por ``JSON`` genérico, así
+    que el tipo real no se comprueba en ningún otro sitio. Y no es cosmético:
+    ``JSON`` no tiene los operadores de contención ni se puede indexar con GIN.
+    """
+    columns = {column["name"]: str(column["type"])
+               for column in sa.inspect(pg_engine).get_columns("IrisAnalysis")}
+
+    assert columns["gate_reasons"] == "JSONB"
+    assert columns["failed_rules"] == "JSONB"
+    assert columns["ai_summary"] == "JSONB"
+
+
+def test_jsonb_columns_round_trip_their_structure(pg_session):
+    """En la suite rápida estas columnas son ``JSON`` genérico por un shim, así
+    que su comportamiento real —tipos, anidamiento, orden de claves— no se
+    prueba en ningún sitio."""
+    user = _user(pg_session, "jsonb")
+    analysis = IrisAnalysis(
+        raw_headers="From: a@b.com", user_id=user.id, status="finished",
+        gate_reasons=["SPF/DMARC failure", "Análisis degradado"],
+        failed_rules=[{"name": "SPF", "family": "auth", "category": "authentication"}],
+        ai_summary={"executive_summary": "texto", "recommendations": ["a", "b"],
+                     "confidence": "HIGH"},
+    )
+    pg_session.add(analysis)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    stored = pg_session.get(IrisAnalysis, analysis.id)
+    assert stored.gate_reasons == ["SPF/DMARC failure", "Análisis degradado"]
+    assert stored.failed_rules[0]["family"] == "auth"
+    assert stored.ai_summary["recommendations"] == ["a", "b"]
+
+
+def test_jsonb_supports_containment_queries(pg_session):
+    """El operador ``@>`` es de JSONB y no existe en SQLite. Se comprueba
+    porque es lo que permitiría filtrar informes por su contenido sin traerse
+    todas las filas al proceso — y si la columna dejara de ser JSONB, esto es
+    lo primero que se rompería."""
+    user = _user(pg_session, "jsonb-query")
+    pg_session.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                                status="finished", analysis_quality="degraded",
+                                failed_rules=[{"name": "SPF", "family": "auth"}]))
+    pg_session.add(IrisAnalysis(raw_headers="From: c@d.com", user_id=user.id,
+                                status="finished", analysis_quality="complete",
+                                failed_rules=None))
+    pg_session.commit()
+
+    degraded = pg_session.execute(
+        sa.text(
+            'SELECT analysis_quality FROM "IrisAnalysis" '
+            "WHERE failed_rules @> :probe"
+        ).bindparams(sa.bindparam("probe", [{"family": "auth"}], type_=JSONB))
+    ).scalars().all()
+
+    assert degraded == ["degraded"]
+
+
+def test_rule_results_keep_their_execution_order(pg_session):
+    """``position`` es un ``SmallInteger`` y el informe se ordena por él. En
+    PostgreSQL el tipo tiene rango real (±32767), otra cosa que SQLite ignora."""
+    user = _user(pg_session, "orden-reglas")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    for position, name in enumerate(["SPF", "DKIM", "DMARC"]):
+        pg_session.add(IrisRuleResult(analysis_id=analysis.id, rule_name=name,
+                                      category="authentication", score=0,
+                                      verdict="pass", position=position))
+    pg_session.commit()
+    pg_session.expire_all()
+
+    stored = pg_session.get(IrisAnalysis, analysis.id)
+    assert [rule.rule_name for rule in stored.rule_results] == ["SPF", "DKIM", "DMARC"]


### PR DESCRIPTION
## Resumen

La suite corre sobre SQLite con Redis y la red cortados. Es la decisión correcta para el ciclo rápido, pero deja fuera un conjunto de invariantes que **solo existen en el motor real** y que hasta ahora no probaba nadie. Este PR añade una matriz de integración contra PostgreSQL y Redis efímeros, en su propio job de CI.

Cierra #249.

**Ya ha encontrado un bug** — ver la sección final.

## Qué no se podía probar, y por qué

Cinco huecos concretos, todos consecuencia del entorno de la suite rápida:

1. **Longitud de columna.** SQLite **ignora** la longitud declarada de un `VARCHAR`: `String(255)` acepta 1 500 caracteres sin protestar. Es exactamente lo que dejó pasar el `sync_cursor` de #211 durante todo su tiempo de vida — el test equivalente en SQLite pasaba con la columna corta.
2. **Claves foráneas.** SQLite no las aplica salvo que se active el pragma explícitamente, así que `ON DELETE CASCADE` y `ON DELETE SET NULL` no se ejercitan nunca. Son las cláusulas que deciden si desconectar un buzón borra el historial de análisis, o si borrar un análisis deja documentos huérfanos.
3. **JSONB.** El conftest lo sustituye por `JSON` genérico con un shim, así que ni el tipo real ni sus operadores (`@>`, índices GIN) se comprueban en ningún sitio.
4. **Concurrencia.** Las carreras entre transacciones no se pueden montar con un fichero SQLite y una sola conexión. El `UniqueConstraint` de idempotencia de la ingesta y los `UPDATE` condicionales del motor de cuotas y de la reserva del resumen de IA se apoyan todos en que dos transacciones simultáneas no puedan gastar el mismo hueco — y esa propiedad no tenía prueba.
5. **Alembic.** La suite crea el esquema con `Base.metadata.create_all`, que salta por encima de las migraciones. **Ninguna migración se ejecutaba en ningún test.**

## Qué contiene

### `tests/postgres/`, con marcador `postgres`

17 tests. Cada uno comprueba algo que **pasa en SQLite y falla en PostgreSQL** si se rompe — no repiten cobertura, la añaden donde el motor de la suite rápida no puede decir la verdad.

- **Longitud**: un deltaLink de Graph de 1 500 caracteres cabe en `sync_cursor`; y un valor que excede su columna se **rechaza**, no se recorta.
- **Unicidad**: el mismo mensaje ingerido dos veces choca contra el `UniqueConstraint`, montado con **dos sesiones independientes** — con una sola, el ORM resolvería el conflicto en su propio identity map y el test pasaría sin llegar a la base de datos. Y la contrapartida: dos análisis manuales (con NULLs) no colisionan.
- **Claves foráneas**: desconectar un buzón conserva sus análisis (`SET NULL`); borrar un análisis se lleva sus documentos (`CASCADE`).
- **JSONB**: las columnas son `JSONB` de verdad y no `JSON`; las estructuras anidadas sobreviven el round-trip; y `@>` funciona.
- **Concurrencia**: dos reservas simultáneas del resumen de IA y solo una gana; un estado `failed` se puede volver a reclamar; y el patrón `SET used = used + 1 WHERE used + 1 <= limite` del motor de cuotas, con dos transacciones peleando por el último hueco.
- **Redis real**: la señal de cancelación cooperativa —la clave que los workers sondean para saber si deben parar— escrita y leída contra un servidor de verdad.
- **Alembic**: el grafo tiene un solo head y ningún identificador repetido; y la cadena completa se aplica sobre una base vacía creada para la ocasión.

### La suite rápida no se toca

Sin `POSTGRES_TEST_URL`, el directorio entero se salta. El guardia está en `pytest_collection_modifyitems` y no en un `skipif` por módulo para que no haya forma de escribir un test nuevo ahí y olvidarse de él.

En un portátil sin contenedores, `pytest` sigue tardando lo mismo y no pide nada.

### `.github/workflows/tests-postgres.yml`

Job aparte con PostgreSQL 15 y Redis 7 como servicios, con health check (sin él, el primer test puede llegar antes de que el servidor acepte conexiones y fallar por una carrera de arranque en vez de por el código). Ejecuta solo `-m postgres`: repetir aquí la suite que ya corrió sobre SQLite no añadiría nada.

Mismos filtros de rama que `tests.yml`.

## Dos trampas de la infraestructura que conviene conocer

Las dos costaron encontrarse y están comentadas en el código, porque quien toque este directorio se las va a volver a encontrar:

**El shim muta el metadata compartido.** `_clean_db` y `_unlimited_default_plan` son autouse en el conftest raíz, así que **cada** test las arrastra — y con ellas el engine SQLite, cuyo shim sustituye `JSONB` por `JSON` **mutando `Base.metadata` en el sitio**. A partir de ese momento el proceso entero cree que esas columnas son `JSON`, y el esquema que se cree en PostgreSQL saldría con el tipo equivocado. Se neutralizan por nombre en este directorio (el mecanismo estándar de pytest), y además `pg_engine` comprueba que el shim no se haya aplicado y se salta con un motivo legible si lo está: es preferible saltarse la matriz que dar por buenas unas comprobaciones que entonces no comprobarían lo que dicen.

**Estos tests confirman sus transacciones.** Un rollback al terminar no deshace lo ya escrito, así que cada test vacía las tablas al acabar (`TRUNCATE ... CASCADE`, que evita además ordenarlas por sus claves foráneas). Sin eso, un test que consulte "todos los análisis" dependería de lo que dejaron los anteriores.

## Lo que ha encontrado: `alembic upgrade head` falla sobre una base vacía

La revisión `b2c3d4e5f6a7` hace `INSERT INTO "PlanLimit"` en la posición 23 de la cadena. La tabla `PlanLimit` la crea `f2b3c4d5e6f7` en la posición **33**. Sobre una base vacía, la subida muere ahí:

```
psycopg2.errors.UndefinedTable: relation "PlanLimit" does not exist
LINE 2:   INSERT INTO "PlanLimit" (plan_id, limit_key, sco...
```

El grafo está bien formado —una raíz, un head, sin identificadores repetidos—, así que ninguna comprobación estructural lo veía. El problema es de **orden**: una migración de datos encadenada antes que la que crea su tabla.

Nunca se ha notado porque el primer despliegue no usa Alembic para crear el esquema: usa `CREATE_DATABASE=True` → `create_all` y después solo aplica incrementos. La cadena entera desde cero no se había ejecutado nunca, en ninguna parte.

Es un bug **preexistente** y ajeno a esta fase, así que va como issue aparte (**#356**) y los dos tests que lo destapan quedan marcados `xfail(strict=True)` — el patrón que el proyecto ya usa para documentar bugs reales con un test. Al arreglarlo pasan a XPASS y hay que quitar el marcador, como dice `CLAUDE.md`.

## Validación

Ejecutado **contra motores reales** en local (PostgreSQL 15 y Redis 7 en contenedores):

```
15 passed, 2 xfailed
```

Y sin motores, `pytest tests/postgres` → `17 skipped`, instantáneo.

La suite unitaria y la de integración de la fase se quedan como estaban.

## Notas

- Es el ítem habilitante de la fase: `B02`, `B07`, `B08` y `B09` de la Fase 1 no se podían probar de verdad sin esto, y el issue pedía abrirlo pronto por ese motivo.
- El PR **no** toca `tests/conftest.py`. El sellado de red y de Redis de la suite rápida sigue exactamente igual; lo que hace este directorio es levantarlo localmente y solo para sí mismo.
- La cobertura (`--cov`) se desactiva en el job: estos tests miden invariantes del motor, no líneas de `src/`, y sumarlas a la medición de la suite rápida daría un número engañoso.
