### PR TITLE
docs(readme): sincronizar el contrato con la fase 0 de Iris

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,24 +231,35 @@ Content-Type: application/json
 | Method | Endpoint | Permission | Description |
 |---|---|---|---|
 | `POST` | `/iris/analyze` | `IRIS_CREATE` | Submit email headers/content (optional: `title`) |
-| `GET` | `/iris/status?id=` | `IRIS_READ` | Analysis progress and status |
+| `GET` | `/iris/capabilities` | `IRIS_READ` | Server-side limits the UI must honour (max message size, min headers, accepted modes, verdict thresholds) |
+| `GET` | `/iris/status?id=` | `IRIS_READ` | Analysis progress and status; carries `failureCode`/`failureReason` when the analysis failed |
 | `GET` | `/iris/results` | `IRIS_READ` | List analyses (paginated) |
-| `GET` | `/iris/results/<id>` | `IRIS_READ` | Full report with per-rule scores |
+| `GET` | `/iris/results/<id>` | `IRIS_READ` | Full report with per-rule scores, analysis quality and detector version |
 | `GET` | `/iris/results/<id>/path` | `IRIS_READ` | Which rules fired and why |
 | `GET` | `/iris/results/<id>/iocs` | `IRIS_READ` | Extracted indicators of compromise |
-| `POST` | `/iris/results/<id>/reanalyze` | `IRIS_UPDATE` | Re-run the rules engine against a stored analysis |
-| `POST` | `/iris/results/<id>/ai-summary` | `IRIS_UPDATE` | Generate an AI plain-language summary (background task) |
+| `POST` | `/iris/results/<id>/reanalyze` | `IRIS_CREATE` | Re-run the current ruleset as a **new** analysis (returns the new id) |
+| `POST` | `/iris/results/<id>/ai-summary` | `IRIS_CREATE` | Generate an AI plain-language summary (background task); idempotent per analysis, `?regenerate=true` forces a new one |
 | `POST` | `/iris/analyze/<id>/cancel` | `IRIS_UPDATE` | Cancel a running analysis |
 | `DELETE` | `/iris/results/<id>` | `IRIS_DELETE` | Delete an analysis |
-| `POST` | `/iris/results/<id>/document` | `IRIS_UPDATE` | Generate a PDF report for an analysis |
-| `GET/DELETE` | `/iris/document-status` · `/iris/documents` · `/iris/document/<id>/download` · `/iris/document/<id>` | Report status, listing, download, delete |
+| `POST` | `/iris/results/<id>/document` | `IRIS_CREATE` | Generate a PDF report for an analysis |
+| `GET` | `/iris/document-status` · `/iris/documents` · `/iris/results/<id>/documents` · `/iris/document/<id>/download` | `IRIS_READ` | Report status, listing and download |
+| `DELETE` | `/iris/document/<id>` | `IRIS_DELETE` | Delete a generated report |
 | `GET` | `/iris/mailbox/providers` | `IRIS_READ` | Supported mailbox providers (Gmail, Microsoft 365) |
 | `POST` | `/iris/mailbox/connect` | `IRIS_CREATE` | Start OAuth connection to an external mailbox |
 | `GET` | `/iris/mailbox/callback` | — (public) | OAuth redirect target; CSRF-protected by a signed `state` |
-| `GET/PATCH/DELETE` | `/iris/mailbox/connections[/<id>]` | `IRIS_*` | List, pause/resume, or disconnect a monitored mailbox |
+| `GET` | `/iris/mailbox/connections` | `IRIS_READ` | List monitored mailboxes |
+| `PATCH` | `/iris/mailbox/connections/<id>` | `IRIS_UPDATE` | Pause, resume or reconfigure a connection |
+| `DELETE` | `/iris/mailbox/connections/<id>` | `IRIS_DELETE` | Disconnect a monitored mailbox |
 | `POST` | `/iris/mailbox/connections/<id>/sync` | `IRIS_UPDATE` | Trigger an out-of-cycle mailbox poll |
 
+> [!NOTE]
+> **`CREATE` vs `UPDATE` in Iris.** `IRIS_CREATE` guards the operations that bring a *new* entity into existence and consume quota for it — submitting an analysis, re-analysing (which inserts a brand-new analysis and returns its id, leaving the original untouched), generating an AI summary, generating a PDF. `IRIS_UPDATE` guards changes to something that already exists: cancelling a running analysis, pausing a connection, forcing a poll. The full matrix is pinned by `API/tests/integration/test_iris_permissions.py`, which asserts both that the documented attribute opens each endpoint and that every other Iris attribute is refused.
+
 Iris applies rules across authentication (SPF, DKIM, DMARC, ARC), header anomalies, reply-chain/thread attacks, content heuristics (including QR-code/quishing detection), and domain spoofing, producing verdicts `Legitimate` / `Suspicious` / `Phishing`. Connected mailboxes are polled periodically by the scheduler and analyzed automatically; when a monitored mailbox receives mail judged `Phishing`, the user is notified by email (`iris.notify`). Thresholds are configured in `SecOpsConfig.json`.
+
+**Trust boundary.** `Authentication-Results` and `Received` headers are partly written by whoever sent the message: MTAs *prepend* their own `Received`, so the lower hops are supplied by the sender and can be fabricated. Iris only trusts an `Authentication-Results` whose `authserv-id` matches a hop **above** the trust boundary — the contiguous run of hops belonging to the delivering organisation, plus any verifier listed in `features.iris.data.trusted_authserv_ids` (empty by default; without it trust is derived from the chain itself). An `ARC-Seal: cv=pass` is treated as context, never as permission to suppress SPF/DMARC/alignment gates, unless a trusted verifier confirms it with `arc=pass` in its own `Authentication-Results`.
+
+**Analysis quality.** A rule that raises does not abort the analysis, but it is no longer invisible: the report carries `analysisQuality` (`complete`/`degraded`), `failedRules` (the rules that could not *execute* — not the ones that found something) and `detectorVersion` (which rule catalogue produced the result). Losing an authentication or attachment rule prevents a `Legitimate` verdict, because those two families answer questions no other rule answers.
 
 ### Aegis — awareness and alerts
 
@@ -388,9 +399,6 @@ Each entry point is a `@staticmethod` on the owning module's manager class — p
 | `iris.notify` | Iris | `IrisPhishingNotifyManager.execute_notify_phishing` | `iris-phishing-notify:<id>` |
 | `hygeia.notify` | Hygeia | `HygeiaNotifyManager.execute_notify_critical_anomaly` | `hygeia-notify:<id>` |
 
-> [!NOTE]
-> `iris.ai_summary` has no registered queue, so its jobs run on `default` (the TaskQueue logs a warning for it).
-
 - **Progress reporting**: workers update `job.meta["progress"]` via `_Task(progress_callback=...)`.
 - **Cooperative cancellation**: set Redis key `taskqueue:cancel:{job_id}`; workers check via `_Task.wait(cancel_check=...)` and terminate the subprocess tree.
 - The `max_workers` setting is read at worker startup only — changes via `PUT /system/tasks/config` apply on the next worker restart.
@@ -409,15 +417,29 @@ pytest                    # full suite + coverage (SQLite, external services moc
 pytest -m unit            # fast unit tests only (no app, no DB)
 pytest -m integration     # boots create_app() + test HTTP client
 pytest -m oracle          # differential-oracle bench against real Docker containers (skipped in CI by default)
+pytest -m postgres        # real-engine matrix (PostgreSQL + Redis); skipped unless POSTGRES_TEST_URL is set
 ```
 
-CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
+The `postgres` matrix (`API/tests/postgres/`) covers the invariants SQLite cannot express — declared column lengths, foreign-key actions, real `JSONB`, races between concurrent transactions, and the Alembic chain applied to an empty database. It skips itself without the env vars, so it neither slows the fast suite nor requires containers to work on the project:
+
+```bash
+docker run -d --name pg -e POSTGRES_USER=ellysia -e POSTGRES_PASSWORD=ellysia \
+  -e POSTGRES_DB=ellysia_test -p 55432:5432 postgres:15
+docker run -d --name rd -p 56379:6379 redis:7
+POSTGRES_TEST_URL=postgresql+psycopg2://ellysia:ellysia@localhost:55432/ellysia_test \
+  REDIS_TEST_URL=redis://localhost:56379/1 python -m pytest -m postgres
+```
+
+Run it in its **own** pytest invocation. The fast suite's SQLite shim rewrites `JSONB` to generic `JSON` in the shared model metadata, so a mixed run would build the wrong schema; the fixtures detect that and skip with an explanatory message rather than assert against an imitation.
+
+CI runs two workflows on push/PR to `main` and the `vX.Y` release branches: `.github/workflows/tests.yml` (`python -m pytest -q -m "not oracle"`, on SQLite) and `.github/workflows/tests-postgres.yml` (`python -m pytest -q -m postgres`, with ephemeral PostgreSQL and Redis services). They are separate jobs on purpose — the service matrix must not slow down the cycle that runs on every push. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
 
 ### Web SPA (node, no framework)
 
 ```bash
 cd web/app
 npm run test:acheron      # crypto interop + CRUD + sync tests for the Acheron vault client
+npm run test:iris         # file-intake limits (the size threshold comes from GET /iris/capabilities)
 npm run test:hygeia       # metric-formatting tests for the Hygeia dashboard
 npm run test:polling      # usePolling composable tests
 npm run test:quiz         # aegis quiz-shuffle permutation tests


### PR DESCRIPTION
## Resumen

Sincroniza `README.md` —el contrato público del repositorio— con todo lo que cambió la fase 0 de Iris. Va en un único commit y en un PR propio, según la regla de `CLAUDE.md` de que los cambios de README no se mezclan con los de feature ni se reparten entre varios.

Referencia: #200 (paraguas de la fase) y en concreto #207, #209, #212, #220, #221, #249.

## Qué se corrige

### Los permisos, que era el desfase que hacía daño (#221)

El README documentaba `IRIS_UPDATE` para reanálisis, resumen de IA y generación de PDF mientras el código exige `IRIS_CREATE`. Un cliente que integrara siguiendo la documentación pedía el atributo equivocado a su administrador y se llevaba un 403 sin explicación posible desde su lado.

Al contrastar las dos versiones contra lo que las operaciones hacen de verdad, **la equivocada era la documentación**: las tres crean una entidad nueva y consumen cuota por ella. El reanálisis, en particular, no re-puntúa nada — inserta un análisis nuevo y devuelve 201 con su id, dejando el original intacto.

Se añade además la nota que explica el criterio (`CREATE` = entidad nueva y cuota; `UPDATE` = modificar lo que ya existe) y apunta al test que lo fija, para que la próxima duda se resuelva sin volver a leer los decoradores.

### Los endpoints que se resumían de más

Dos filas de la tabla agrupaban varios endpoints bajo `IRIS_*` y `GET/DELETE` sin decir qué pide cada uno. Se desglosan: los cuatro de documentos y los cuatro de mailbox, cada uno con su método y su atributo.

Y se añade `GET /iris/capabilities` (#212), que no existía.

### Los campos nuevos del informe

- `failureCode` / `failureReason` en `GET /iris/status` (#207): un análisis fallido ya no es un estado mudo. Se documenta ahí y no en el informe completo porque `GET /iris/results/<id>` exige un análisis `finished`, y uno que murió nunca lo estará.
- `analysisQuality`, `failedRules` y `detectorVersion` en el informe (#209).

### Dos párrafos nuevos, porque son contrato y no detalle

**Frontera de confianza** (#219). Cambia qué mensajes considera Iris autenticados, así que un integrador que lea el README tiene que saberlo: un `Authentication-Results` solo cuenta si su `authserv-id` corresponde a un salto por encima de la frontera, y un `ARC-Seal: cv=pass` es contexto, nunca permiso para suprimir los gates de SPF/DMARC/alignment. Incluye la clave de configuración (`features.iris.data.trusted_authserv_ids`, vacía por defecto).

**Calidad del análisis** (#209). Explica qué significan los tres campos nuevos y, sobre todo, deja claro que `failedRules` son las reglas que no se pudieron **ejecutar** — no las que encontraron algo. Los dos sentidos conviven en el módulo y confundirlos invierte la lectura del informe.

### Cosas que dejaron de ser ciertas

Se retira la nota que decía que `iris.ai_summary` no tiene cola registrada y sus trabajos caen en `default`. Ya está registrada (#220).

### Tests y CI

- `pytest -m postgres` y `npm run test:iris` en sus listas de comandos.
- El segundo workflow (`tests-postgres.yml`) junto al existente, diciendo qué corre cada uno y por qué van separados.
- Cómo levantar los contenedores para correr la matriz en local, y el aviso de que necesita **su propia invocación de pytest**: el shim de la suite rápida reescribe `JSONB` a `JSON` en el metadata compartido, así que una ejecución mezclada construiría el esquema equivocado. Las fixtures lo detectan y se saltan con un motivo legible, pero sabiéndolo de antemano uno se ahorra el desconcierto.

## Validación

- Todas las rutas, métodos y atributos de la tabla se comprobaron contra `endpoints.py` y contra `API/tests/integration/test_iris_permissions.py`, que es el que fija la matriz.
- La clave de configuración se verificó contra `SecOpsConfig.json`: es `trusted_authserv_ids` en snake_case, como el resto del bloque `features.iris.data` (y a diferencia del resto del JSON, que es camelCase).
- Solo se toca `README.md`.

## Notas

- La rama se llama `chore/readme/...` y no `docs/readme/...` porque existe una rama remota llamada literalmente `docs`, y Git no admite una referencia que sea a la vez fichero y directorio: cualquier `docs/algo` es rechazada por el servidor.
