### PR TITLE
Iris — Fase 0: veredicto confiable y contrato correcto

### DIFF
--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -1,0 +1,88 @@
+name: API Tests (PostgreSQL + Redis)
+
+# La suite normal (tests.yml) corre sobre SQLite con Redis y la red cortados:
+# tarda ~2 minutos y su resultado no depende de lo que tenga levantado la
+# máquina. El precio es que hay invariantes de producción que ese entorno no
+# puede comprobar — longitudes de columna, claves foráneas, JSONB y las
+# carreras entre transacciones reales.
+#
+# Este job las cubre con PostgreSQL y Redis efímeros. Va aparte a propósito:
+# la matriz de servicios no debe ralentizar el ciclo rápido, que es el que se
+# ejecuta en cada push.
+
+on:
+  push:
+    branches: [main, 'v[0-9]+.[0-9]+']
+  pull_request:
+    branches: [main, 'v[0-9]+.[0-9]+']
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: API
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: ellysia
+          POSTGRES_PASSWORD: ellysia
+          POSTGRES_DB: ellysia_test
+        ports:
+          - 5432:5432
+        # Sin el health check, el primer test puede llegar antes de que el
+        # servidor acepte conexiones y fallar por una carrera de arranque en
+        # lugar de por el código.
+        options: >-
+          --health-cmd "pg_isready -U ellysia"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      JWT_SECRET_KEY: ci-secret-key-not-for-production
+      JWT_ALGORITHM: HS256
+      ACCESS_TOKEN_EXPIRY_MINUTES: "30"
+      REFRESH_TOKEN_EXPIRY_DAYS: "7"
+      FLASK_ENV: development
+      CREATE_DATABASE: "false"
+      DEBUG: "false"
+      # Estas dos son las que activan la matriz: sin ellas, tests/postgres se
+      # salta entero (ver su conftest). Así el mismo código corre en un
+      # portátil sin contenedores sin fallar ni pedir nada.
+      POSTGRES_TEST_URL: postgresql+psycopg2://ellysia:ellysia@localhost:5432/ellysia_test
+      REDIS_TEST_URL: redis://localhost:6379/1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            API/requirements.txt
+            API/requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run the real-engine matrix
+        # Solo los tests marcados: el resto de la suite ya corrió en tests.yml
+        # sobre SQLite y repetirla aquí no añadiría nada.
+        run: python -m pytest -q -m postgres --no-cov

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1108,6 +1108,7 @@
           "application/java-archive",
           "application/octet-stream"
         ],
+        "trusted_authserv_ids": [],
         "suspicious_tlds": [
           ".tk",
           ".ml",

--- a/API/alembic/versions/b46e50206411_add_iris_analysis_failure_reason.py
+++ b/API/alembic/versions/b46e50206411_add_iris_analysis_failure_reason.py
@@ -1,0 +1,46 @@
+"""Motivo terminal de un análisis de Iris fallido (#207)
+
+Revision ID: b46e50206411
+Revises: d7e8f9a0b1c2
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b46e50206411'
+down_revision: Union[str, Sequence[str], None] = 'd7e8f9a0b1c2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Un análisis que acababa en ``failed`` no decía por qué. Las dos causas son
+    muy distintas para quien lo mira —el texto enviado no era un correo
+    analizable, o el motor se rompió por dentro— y sin distinguirlas el estado
+    terminal no es accionable: el usuario no sabe si reintentar o corregir su
+    entrada.
+
+    ``failure_code`` guarda esa distinción (``invalid_input`` /
+    ``internal_error``) y ``failure_reason`` el mensaje legible que la
+    acompaña. Ambas son NULL para cualquier análisis que no haya fallado, así
+    que las filas existentes no necesitan relleno.
+    """
+    op.add_column("IrisAnalysis", sa.Column("failure_code", sa.String(length=32), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("failure_reason", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierden los motivos ya registrados; los análisis fallidos vuelven a
+    quedarse en un ``failed`` sin explicación, que es el estado previo.
+    """
+    op.drop_column("IrisAnalysis", "failure_reason")
+    op.drop_column("IrisAnalysis", "failure_code")

--- a/API/alembic/versions/c93b8545601b_add_iris_analysis_quality.py
+++ b/API/alembic/versions/c93b8545601b_add_iris_analysis_quality.py
@@ -1,0 +1,60 @@
+"""Calidad del análisis de Iris y catálogo de reglas que lo produjo (#209)
+
+Revision ID: c93b8545601b
+Revises: b46e50206411
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c93b8545601b'
+down_revision: Union[str, Sequence[str], None] = 'b46e50206411'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Una regla que reventaba se convertía en una fila más de ``IrisRuleResult``
+    con veredicto ``error`` y ahí se acababa: el análisis podía presentarse
+    como limpio sin ninguna advertencia, aunque la regla que faltó fuera la
+    que decide si el mensaje está autenticado.
+
+    ``analysis_quality`` distingue un análisis completo de uno degradado,
+    ``failed_rules`` guarda cuáles no llegaron a ejecutarse (nombre, familia y
+    categoría), y ``detector_version`` marca con qué catálogo de reglas se
+    produjo el resultado, para que un informe guardado siga siendo
+    interpretable cuando el catálogo cambie.
+
+    Las tres son NULL para los análisis ya existentes. No se rellenan: no hay
+    forma de saber a posteriori si una regla falló en un análisis de hace tres
+    meses, y un ``complete`` inventado sería peor que un NULL honesto — la
+    lectura correcta de NULL es "de este análisis no se registró la calidad",
+    no "fue completo".
+
+    El esquema de campos es el que comparten `B05` y `M02` (confianza e
+    incertidumbre en el veredicto): `M02` añadirá sus propias columnas de
+    confianza, pero reutiliza este ``analysis_quality`` en vez de definir un
+    segundo indicador paralelo.
+    """
+    op.add_column("IrisAnalysis", sa.Column("analysis_quality", sa.String(length=16), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("failed_rules", postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("detector_version", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde el registro de qué análisis fueron degradados y con qué catálogo
+    se produjeron; los veredictos ya calculados no cambian.
+    """
+    op.drop_column("IrisAnalysis", "detector_version")
+    op.drop_column("IrisAnalysis", "failed_rules")
+    op.drop_column("IrisAnalysis", "analysis_quality")

--- a/API/alembic/versions/dd19efde1d08_alter_iris_sync_cursor_to_text.py
+++ b/API/alembic/versions/dd19efde1d08_alter_iris_sync_cursor_to_text.py
@@ -1,0 +1,63 @@
+"""sync_cursor de Iris a Text: el deltaLink de Graph no cabe en 255 (#211)
+
+Revision ID: dd19efde1d08
+Revises: c93b8545601b
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'dd19efde1d08'
+down_revision: Union[str, Sequence[str], None] = 'c93b8545601b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    ``sync_cursor`` guarda el marcador de hasta dónde ha llegado la ingesta de
+    un buzón conectado. Para Gmail es un ``historyId`` corto, pero para
+    Microsoft Graph es un ``@odata.deltaLink``: una URL completa con un token
+    de estado opaco dentro, que rebasa con holgura los 255 caracteres.
+
+    El propio docstring del modelo ya decía que el valor es opaco —es decir,
+    que no debe interpretarse ni recortarse—, pero la columna lo acotaba. Un
+    truncado silencioso rompe la sincronización incremental: el cursor
+    guardado deja de ser válido, Graph responde 410 y la conexión vuelve a
+    hacer bootstrap, perdiendo el punto en el que iba.
+
+    ``Text`` no tiene límite práctico en PostgreSQL y no cuesta nada frente a
+    ``varchar``: internamente son el mismo tipo, solo cambia la comprobación
+    de longitud. La conversión ensancha la columna, así que ningún valor
+    existente se pierde.
+    """
+    op.alter_column(
+        "IrisMailboxConnection", "sync_cursor",
+        existing_type=sa.String(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Estrecha la columna de vuelta a 255. **Cualquier cursor más largo que eso
+    hace fallar la bajada**, que es el comportamiento correcto: truncarlo en
+    silencio dejaría conexiones con un marcador inválido que solo se
+    manifestaría en la siguiente sincronización. Si hiciera falta bajar de
+    verdad, lo seguro es poner a NULL los cursores largos primero — la
+    conexión rehará el bootstrap, que es lento pero no pierde correo.
+    """
+    op.alter_column(
+        "IrisMailboxConnection", "sync_cursor",
+        existing_type=sa.Text(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/API/alembic/versions/f1e0d1ee8820_add_iris_ai_summary_state.py
+++ b/API/alembic/versions/f1e0d1ee8820_add_iris_ai_summary_state.py
@@ -1,0 +1,61 @@
+"""Estado del resumen IA de Iris: idempotencia y trazabilidad (#220)
+
+Revision ID: f1e0d1ee8820
+Revises: dd19efde1d08
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1e0d1ee8820'
+down_revision: Union[str, Sequence[str], None] = 'dd19efde1d08'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    El resumen ejecutivo de IA solo tenía dónde guardar su resultado
+    (``ai_summary``), no su estado. Sin estado no hay forma de saber si ya hay
+    una generación en curso, así que dos peticiones seguidas consumían cuota
+    dos veces y encolaban dos trabajos para el mismo análisis.
+
+    ``ai_summary_status`` es la pieza que hace idempotente la operación: el
+    manager reclama la fila con una transición condicional, y quien pierde la
+    carrera no cobra ni encola. ``ai_summary_job_id`` permite relacionar la
+    fila con su trabajo en la cola.
+
+    ``ai_summary_model`` y ``ai_summary_prompt_version`` son trazabilidad: un
+    resumen generado hace tres meses lo escribió otro modelo con otro prompt,
+    y sin registrarlo no hay manera de saber cuál — el mismo problema que
+    ``detector_version`` resuelve para las reglas.
+
+    Todas son NULL para las filas existentes. Los resúmenes ya generados se
+    reconocen igualmente por tener ``ai_summary`` no nulo, así que no hace
+    falta rellenar nada: el manager trata "hay resumen, sin estado" como
+    terminado.
+    """
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_status", sa.String(length=16), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_job_id", sa.String(length=64), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_model", sa.String(length=64), nullable=True))
+    op.add_column("IrisAnalysis", sa.Column("ai_summary_prompt_version", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Los resúmenes generados se conservan (``ai_summary`` no se toca); lo que
+    se pierde es su estado y su procedencia, y con ello la idempotencia:
+    volver aquí reabre la posibilidad de encolar dos generaciones del mismo
+    análisis.
+    """
+    op.drop_column("IrisAnalysis", "ai_summary_prompt_version")
+    op.drop_column("IrisAnalysis", "ai_summary_model")
+    op.drop_column("IrisAnalysis", "ai_summary_job_id")
+    op.drop_column("IrisAnalysis", "ai_summary_status")

--- a/API/pyproject.toml
+++ b/API/pyproject.toml
@@ -8,6 +8,7 @@ addopts = "-q --strict-markers --cov=src --cov-report=term-missing"
 markers = [
     "unit: tests unitarios rápidos, sin base de datos ni aplicación Flask",
     "integration: tests que arrancan la aplicación y usan el cliente HTTP de pruebas",
+    "postgres: matriz de integración contra motores reales (PostgreSQL + Redis efímeros, ver tests/postgres/). Se salta sola sin POSTGRES_TEST_URL; su job de CI es tests-postgres.yml. La suite rápida no la necesita ni se ralentiza por ella.",
     "oracle: banco de pruebas con oráculo diferencial (roadmap Lybra §7) — levanta contenedores Docker reales y hace red de verdad, nada mockeado. Excluido del run por defecto de CI (ver tests.yml); se salta solo si no hay Docker disponible.",
 ]
 filterwarnings = [

--- a/API/src/modules/accounts/services/quotas.py
+++ b/API/src/modules/accounts/services/quotas.py
@@ -130,6 +130,54 @@ class QuotaManager:
         else:
             self._consume_counter(entitlement, amount)
 
+    def refund(self, user_id: int, key: LimitKey, amount: int = 1) -> None:
+        """Devuelve ``amount`` usos ya apuntados de ``key``.
+
+        Existe porque ``consume()`` ocurre **antes** que el trabajo que se está
+        pagando, y tiene que ser así: cobrar después dejaría la puerta abierta
+        a lanzar N trabajos concurrentes con cupo para uno. El precio de ese
+        orden es que un trabajo que nunca llega a hacerse —el encolado lo
+        rechaza, el worker revienta— deja al usuario pagando por nada.
+
+        No es lo contrario exacto de ``consume()`` y no debe usarse como tal:
+        no resucita una fila de periodo que ya no existe (si el mes cambió
+        entre el cobro y el reembolso, el cargo pertenece al periodo anterior
+        y ya no se puede deshacer ahí), ni baja de cero. Nunca lanza: un
+        reembolso fallido no puede tumbar el camino de error que lo invocó, y
+        cobrar de más una vez es preferible a perder el error original.
+
+        Las claves de nivel (TIER) y de existencias (STOCK) no llevan
+        contador que devolver — su "consumo" es la tabla real — así que
+        reembolsarlas es un no-op.
+        """
+        try:
+            entitlement = resolve_entitlement(user_id, key)
+            if entitlement.period in (LimitPeriod.TIER, LimitPeriod.STOCK):
+                return
+            if entitlement.is_unlimited:
+                return
+
+            period_start = period_start_for(entitlement.period)
+            with UnitOfWork() as uow:
+                # Igual que el cobro: la resta va dentro del UPDATE, con el
+                # suelo en la condición, para no leer-decidir-escribir.
+                uow.session.execute(
+                    update(UsageCounter)
+                    .where(and_(
+                        UsageCounter.holder_kind == entitlement.holder_kind,
+                        UsageCounter.holder_id == entitlement.holder_id,
+                        UsageCounter.limit_key == entitlement.key.db_name,
+                        UsageCounter.period_start == period_start,
+                        UsageCounter.used >= amount,
+                    ))
+                    .values(used=UsageCounter.used - amount)
+                )
+        except Exception as exc:
+            logger.warning(
+                "No se pudo reembolsar cuota | user=%s key=%s: %s",
+                user_id, key.db_name, exc,
+            )
+
     # ------------------------------------------------------------- internos
 
     @staticmethod

--- a/API/src/modules/features/iris/__init__.py
+++ b/API/src/modules/features/iris/__init__.py
@@ -8,6 +8,7 @@ from .endpoints import iris_blp
 
 # Registro de las categorías de cola de este módulo (OCP).
 QueueRegistry.register("iris.analyze")
+QueueRegistry.register("iris.ai_summary")
 QueueRegistry.register("iris.report")
 QueueRegistry.register("iris.ingest")
 QueueRegistry.register("iris.notify")

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -3,6 +3,7 @@ Iris REST API endpoints for email header analysis.
 
 Provides:
 - POST /iris/analyze         — submit headers for analysis
+- GET  /iris/capabilities     — server-side limits the UI must honour
 - GET  /iris/status?id=...   — check analysis status/progress
 - GET  /iris/results         — list all analyses for the current user
 - GET  /iris/results/{id}    — full analysis report
@@ -40,6 +41,7 @@ from .exceptions import (
 )
 from .schemas import (
     AnalysisIdQuerySchema,
+    IrisCapabilitiesResponseSchema,
     AnalyzeRequestSchema,
     AnalyzeResponseSchema,
     AnalysisStatusResponseSchema,
@@ -110,6 +112,19 @@ def analyze_headers(data):
         "analysisId": analysis_id,
         "status": "pending",
     }
+
+
+@iris_blp.get("/capabilities")
+@iris_blp.response(200, IrisCapabilitiesResponseSchema, description="Iris limits and analysis modes")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(logger=logger)
+def get_capabilities():
+    """Limites y modos de analisis que aplica el servidor"""
+    return IrisManager.get_capabilities()
 
 
 @iris_blp.get("/status")

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -488,7 +488,11 @@ def download_document(document_id: int):
         document.filename,
         mimetype="application/pdf",
         as_attachment=True,
-        download_name=f"iris_analysis_{document.analysis_id}.pdf",
+        # B11: el nombre descargable identifica el documento, no solo el
+        # análisis. Dos informes del mismo análisis llegaban al navegador con
+        # el mismo nombre y el segundo sobrescribía al primero en la carpeta
+        # de descargas.
+        download_name=f"iris_analysis_{document.analysis_id}_{document.id}.pdf",
     )
 
 

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -53,6 +53,7 @@ from .schemas import (
     AnalysisIocsResponseSchema,
     ResultsQuerySchema,
     GenerateDocumentResponseSchema,
+    GenerateAiSummaryRequestSchema,
     GenerateAiSummaryResponseSchema,
     DocumentStatusQuerySchema,
     IrisDocumentStatusResponseSchema,
@@ -277,6 +278,7 @@ def reanalyze_analysis(analysis_id: int):
 
 
 @iris_blp.post("/results/<int:analysis_id>/ai-summary")
+@iris_blp.arguments(GenerateAiSummaryRequestSchema, location="query")
 @iris_blp.response(202, GenerateAiSummaryResponseSchema, description="AI summary generation started")
 @iris_blp.alt_response(400, schema=ErrorSchema, description="Analysis not finished")
 @iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
@@ -286,18 +288,20 @@ def reanalyze_analysis(analysis_id: int):
 @require_attributes(at_least_one=[AttributeType.IRIS_CREATE])
 @limiter.limit("20 per hour; 100 per day")
 @handle_exceptions(default_exception=IrisAnalysisNotFoundError, logger=logger)
-def generate_ai_summary(analysis_id: int):
+def generate_ai_summary(args: dict, analysis_id: int):
     """Solicitar la generacion asincrona de la narrativa ejecutiva IA (IrisAIWriter)"""
     user = get_current_user()
 
     manager = IrisManager()
-    manager.generate_ai_summary(analysis_id, user.id)
+    status = manager.generate_ai_summary(analysis_id, user.id,
+                                         regenerate=args["regenerate"])
 
     logger.info(f"AI summary solicitado para analysis {analysis_id} por usuario {user.username}")
     return {
-        "message": "Generacion de resumen ejecutivo IA iniciada",
+        "message": ("Resumen ejecutivo IA ya disponible" if status == "done"
+                    else "Generacion de resumen ejecutivo IA iniciada"),
         "analysisId": analysis_id,
-        "status": "running",
+        "status": status,
     }, 202
 
 

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -139,6 +139,11 @@ def get_analysis_status(args: dict):
         "status": status,
         "totalScore": analysis.total_score if analysis else None,
         "verdict": analysis.verdict if analysis else None,
+        # B03: el motivo solo tiene sentido cuando el análisis murió. Enviarlo
+        # siempre dejaría un `failureReason` colgando de un análisis que
+        # terminó bien tras un reintento y confundiría a quien lea el estado.
+        "failureCode": analysis.failure_code if analysis else None,
+        "failureReason": analysis.failure_reason if analysis else None,
     }
     if progress is not None:
         response["progress"] = progress

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -46,6 +46,7 @@ from ..services.failures import (
     classify_failure,
 )
 from ..services.parsers import build_path, parse_received_line
+from ..services.quality import AnalysisQuality, assess_quality, cap_verdict, detector_version
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
 
@@ -288,6 +289,9 @@ class IrisManager(TaskTrackingMixin):
             "wrapperSubject": context.wrapper_subject or None,
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
+            "analysisQuality": analysis.analysis_quality,
+            "failedRules": analysis.failed_rules or [],
+            "detectorVersion": analysis.detector_version,
             "failureCode": analysis.failure_code,
             "failureReason": analysis.failure_reason,
             "user": username,
@@ -575,6 +579,7 @@ class IrisManager(TaskTrackingMixin):
                 "title": analysis_record.title,
                 "status": analysis_record.status,
                 "failureCode": analysis_record.failure_code,
+                "analysisQuality": analysis_record.analysis_quality,
                 "totalScore": analysis_record.total_score,
                 "verdict": analysis_record.verdict,
                 "startedAt": isoformat_utc(analysis_record.started_at), # type: ignore
@@ -706,10 +711,11 @@ class IrisManager(TaskTrackingMixin):
                 chosen = self._evaluate_contexts(analysis_id, context, job, rules_defs)
                 if chosen is None:
                     return  # cancelado: no es un fallo, no hay nada que persistir
-                verdict, total_score, gate_reasons, results = chosen
+                verdict, total_score, gate_reasons, results, quality = chosen
 
                 self._persist_analysis_results(analysis_id, rules_defs, results,
-                                               verdict, total_score, gate_reasons)
+                                               verdict, total_score, gate_reasons,
+                                               quality, detector_version(rules_defs))
             except Exception as e:
                 logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
                 self._fail_analysis(analysis_id, classify_failure(e))
@@ -721,7 +727,7 @@ class IrisManager(TaskTrackingMixin):
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
 
     def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
-                           ) -> Optional[tuple[str, float, list[str], List[RuleResult]]]:
+                           ) -> Optional[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]]:
         """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
 
         Extraído de :meth:`_run_analysis` al envolver esa función en un único
@@ -730,8 +736,8 @@ class IrisManager(TaskTrackingMixin):
         protegiendo exactamente.
 
         Returns:
-            La tupla ``(verdict, total_score, gate_reasons, results)`` de la
-            evaluación ganadora, o ``None`` si la tarea fue cancelada a mitad
+            La tupla ``(verdict, total_score, gate_reasons, results, quality)``
+            de la evaluación ganadora, o ``None`` si fue cancelada a mitad
             (que no es un fallo: no se persiste nada y la cancelación ya dejó
             su propio estado terminal).
         """
@@ -750,7 +756,7 @@ class IrisManager(TaskTrackingMixin):
         total_steps = len(rules_defs) * len(contexts_to_evaluate)
         completed_steps = 0
 
-        evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
+        evaluations: List[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]] = []
         for evaluated_context in contexts_to_evaluate:
             results: List[RuleResult] = []
             named_results: Dict[str, RuleResult] = {}
@@ -788,7 +794,16 @@ class IrisManager(TaskTrackingMixin):
             total_score = self._aggregate_score(rules_defs, results)
             base_verdict = self._determine_verdict(total_score)
             verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
-            evaluations.append((verdict, total_score, gate_reasons, results))
+
+            # B05: una regla que revienta no aborta el análisis, pero tampoco
+            # puede desaparecer sin dejar rastro. La política conservadora se
+            # aplica aquí, junto al resto de gates, para que la degradación se
+            # lea entre los demás motivos del veredicto y no en un rincón
+            # aparte de la interfaz.
+            quality = assess_quality(rules_defs, results)
+            verdict, quality_reasons = cap_verdict(verdict, quality)
+            evaluations.append((verdict, total_score, gate_reasons + quality_reasons,
+                                results, quality))
 
         # Worse verdict wins across contexts; on a tie, keep the first
         # (the unwrapped/inner message — the one ``contexts_to_evaluate``
@@ -802,7 +817,8 @@ class IrisManager(TaskTrackingMixin):
 
     @staticmethod
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
-                                   verdict: str, total_score: float, gate_reasons: list[str]) -> None:
+                                   verdict: str, total_score: float, gate_reasons: list[str],
+                                   quality: AnalysisQuality, detector: str) -> None:
         """Persist every rule row and the final analysis state in one transaction.
 
         Previously each rule opened (and committed) its own
@@ -834,6 +850,9 @@ class IrisManager(TaskTrackingMixin):
             analysis.total_score = total_score
             analysis.verdict = verdict
             analysis.gate_reasons = gate_reasons
+            analysis.analysis_quality = quality.quality
+            analysis.failed_rules = quality.failed_rules or None
+            analysis.detector_version = detector
             analysis.finished_at = utcnow_naive()
             analysis_repo.update(analysis)
 

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -956,8 +956,16 @@ class IrisManager(TaskTrackingMixin):
         # what those three signals are suppressed for below. "cv=fail"
         # (the chain itself declares a prior hop broken) is its own gate,
         # see D7 in ROADMAP.md.
+        #
+        # B06: la supresión exige además que la cadena la haya validado un
+        # verificador de confianza (`details["verified"]`). Un `cv=pass` a
+        # secas es una afirmación del propio mensaje sobre sí mismo, y como
+        # Iris no verifica firmas, bastaba escribirlo para desactivar los tres
+        # gates que cazan suplantación. Un ARC sin confirmar sigue viajando en
+        # el informe como contexto; lo que ya no hace es dar permisos.
         arc = res("ARC Chain")
-        arc_pass = arc is not None and arc.verdict == "pass"
+        arc_pass = (arc is not None and arc.verdict == "pass"
+                    and bool(arc.details.get("verified")))
         arc_fail = arc is not None and arc.verdict == "fail"
 
         spf_fail = verdict_is("SPF", "fail", "hardfail") and not arc_pass

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -195,6 +195,33 @@ class IrisManager(TaskTrackingMixin):
         """
         return build_repository(IrisAnalysisRepository).get_by_id(analysis_id)
 
+    @staticmethod
+    def get_capabilities() -> Dict[str, Any]:
+        """Límites y modos de análisis que la interfaz necesita conocer (B13).
+
+        El backend rechazaba mensajes por encima de un tamaño que la UI no
+        tenía forma de saber: el usuario elegía un fichero que la interfaz
+        daba por bueno, esperaba a que se cargara entero en memoria y recibía
+        un rechazo del API al enviarlo. Cualquier constante duplicada en el
+        frontend deriva antes o después —de hecho ya había derivado a 2×—, así
+        que el límite se publica en lugar de replicarse.
+
+        Se lee de la configuración en cada llamada, no se hornea al importar
+        el módulo, para que un cambio vía ``PUT /system`` surta efecto sin
+        reiniciar (mismo patrón que ``AnalyzeRequestSchema.validate_max_size``,
+        que es la validación que este endpoint describe).
+        """
+        config = CR.iris_config()
+        return {
+            "maxMessageBytes": config.max_message_bytes,
+            "minHeaders": config.min_headers,
+            "analysisModes": ["headers", "message"],
+            "verdictThresholds": {
+                "legitimate": config.legitimate_threshold,
+                "suspicious": config.suspicious_threshold,
+            },
+        }
+
     def get_analysis_status(self, analysis_id: int) -> Optional[str]:
         """Return the current lifecycle status string of an analysis.
 

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -39,7 +39,12 @@ from ..repositories import IrisAnalysisRepository, IrisRuleResultRepository
 from ..services.rules import iris_rules, RuleResult
 from ..services.text import extract_domain, is_free_provider, url_host
 from ..services import parse_raw_message
-from ..services.failures import AnalysisFailure, classify_failure
+from ..services.failures import (
+    FAILURE_WORKER_LOST,
+    WORKER_LOST_REASON,
+    AnalysisFailure,
+    classify_failure,
+)
 from ..services.parsers import build_path, parse_received_line
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
@@ -1218,19 +1223,35 @@ class IrisManager(TaskTrackingMixin):
         tarea viva en TaskQueue que lo actualice tras reiniciar, y el registro
         se queda así para siempre. Se llama una vez al arrancar la API.
 
+        `B04`: antes se conservaba el análisis **solo** si su tarea estaba
+        exactamente en ``pending``. Un job ``running`` puede estar avanzando en
+        otro proceso —los workers son procesos aparte, y reiniciar la API no
+        los para—, así que ese criterio marcaba como fallidos análisis que
+        estaban perfectamente vivos: el usuario veía `failed` mientras el
+        worker seguía trabajando, y al rato el worker escribía `finished`
+        encima de esa misma fila. La pregunta correcta no es "¿en qué estado
+        está el job?" sino "¿queda alguien que vaya a terminarlo?", y esa la
+        responde ``TaskQueue.is_recoverable()``, que para un job en ejecución
+        comprueba además si su worker sigue vivo de verdad.
+
         Returns:
             Número de análisis marcados como failed.
         """
         task_queue = TaskQueue.get_instance()
+        # Una instancia para componer los external_id con el prefijo canónico
+        # (``EXTERNAL_ID_PREFIX``) en vez de repetir el formato a mano; comparte
+        # la cola que ya se acaba de resolver, así que no cuesta nada.
+        manager = cls(task_queue=task_queue)
         fixed = 0
         with UnitOfWork() as uow:
             repo = IrisAnalysisRepository(uow)
             for analysis in repo.get_active_analyses():
-                external_id = f"{cls.EXTERNAL_ID_PREFIX}{analysis.id}"
-                task = task_queue.get_task_by_external_id(external_id, cls.TASK_CATEGORY)
-                if task is not None and str(task.status) == "pending":
+                external_id = manager.external_id_for(analysis.id)
+                if task_queue.is_recoverable(external_id, cls.TASK_CATEGORY):
                     continue
                 analysis.status = "failed"
+                analysis.failure_code = FAILURE_WORKER_LOST
+                analysis.failure_reason = WORKER_LOST_REASON
                 analysis.finished_at = utcnow_naive()
                 repo.update(analysis)
                 fixed += 1

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -21,6 +21,8 @@ from dataclasses import replace
 from typing import Any, Dict, List, Optional
 
 import src.modules.system.config_reading as CR
+from sqlalchemy import and_, or_, update
+
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
@@ -311,6 +313,9 @@ class IrisManager(TaskTrackingMixin):
             "gateReasons": analysis.gate_reasons or [],
             "topSignals": self._top_signals(rules_data),
             "aiSummary": analysis.ai_summary,
+            "aiSummaryStatus": analysis.ai_summary_status,
+            "aiSummaryModel": analysis.ai_summary_model,
+            "aiSummaryPromptVersion": analysis.ai_summary_prompt_version,
             "unwrappedFromForward": context.unwrapped_from_forward,
             "wrapperFrom": context.wrapper_from or None,
             "wrapperSubject": context.wrapper_subject or None,
@@ -450,57 +455,171 @@ class IrisManager(TaskTrackingMixin):
             "hashes": sorted(hashes),
         }
 
-    def generate_ai_summary(self, analysis_id: int, user_id: int) -> None:
-        """Trigger async generation of the AI executive narrative (IA1).
+    AI_SUMMARY_EXTERNAL_ID_PREFIX = "iris-ai-summary:"
 
-        Fire-and-forget: submits a TaskQueue job and returns immediately.
-        The caller re-fetches ``get_analysis_results`` (``aiSummary``) to
-        see the result once ``execute_ai_summary_generation`` finishes —
-        there is no separate status to poll, matching how gate reasons
-        and top signals are already just part of the main report.
+    #: Estados desde los que se puede reclamar una generación de resumen.
+    #: ``None`` es "nunca se pidió" y ``failed`` es un reintento legítimo;
+    #: ``running`` no está porque ya hay una en curso, y ``done`` solo se
+    #: reclama con una regeneración explícita.
+    _AI_SUMMARY_CLAIMABLE = (None, "failed")
+
+    def generate_ai_summary(self, analysis_id: int, user_id: int,
+                            regenerate: bool = False) -> str:
+        """Encola la narrativa ejecutiva de IA (IA1), una sola vez.
+
+        Fire-and-forget: encola y vuelve. El llamante relee
+        ``get_analysis_results`` (``aiSummary``) para ver el resultado.
+
+        `B10`: la operación es **idempotente por análisis**. Antes consumía
+        cuota y encolaba sin mirar si ya había un resumen o un trabajo en
+        curso, así que dos peticiones seguidas —dos clics, un reintento del
+        navegador— cobraban dos veces y lanzaban dos generaciones del mismo
+        análisis. El ``external_id`` era determinista pero nadie lo consultaba.
+
+        La exclusión se apoya en una transición condicional sobre
+        ``ai_summary_status``, no en leer-decidir-escribir: bajo dos peticiones
+        simultáneas la base de datos serializa los dos UPDATE y el segundo no
+        afecta a ninguna fila. Quien pierde esa carrera no cobra cuota ni
+        encola nada.
+
+        Args:
+            regenerate: Pedir explícitamente una regeneración de un resumen
+                que ya existe. Sin esto, repetir la petición devuelve el
+                resultado que ya hay — que es lo que quiere quien hace doble
+                clic, y no lo que quiere quien busca otra redacción; el issue
+                pedía decidirlo explícitamente y esta es la decisión.
+
+        Returns:
+            ``"running"`` si esta llamada encoló el trabajo, ``"done"`` si ya
+            había resumen y no se pidió regenerar.
 
         Raises:
-            IrisAnalysisNotFoundError: If *analysis_id* does not exist or
-                does not belong to *user_id*.
-            IrisAnalysisNotReadyError: If the analysis is not ``finished``.
+            IrisAnalysisNotFoundError: si el análisis no existe o no es suyo.
+            IrisAnalysisNotReadyError: si el análisis no está ``finished``.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
         if analysis.status != "finished":
             raise IrisAnalysisNotReadyError(analysis_id, analysis.status)
 
+        # Un resumen ya generado se devuelve tal cual: no cuesta cuota, no
+        # encola y no sorprende a quien solo hizo doble clic.
+        if analysis.ai_summary is not None and not regenerate:
+            return "done"
+
+        if not self._claim_ai_summary(analysis_id, regenerate=regenerate):
+            # Otra petición se lo llevó (o ya estaba en curso). Sin cobro.
+            return "running"
+
         # La concreta y el techo agregado de IA, en ese orden, para que el 402
         # nombre lo que el usuario estaba pidiendo.
         quota_manager = QuotaManager()
-        quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
-        quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
+        try:
+            quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
+            quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
+        except Exception:
+            # Sin cupo no hay trabajo: se suelta la reserva para que el
+            # análisis no se quede en `running` para siempre y el usuario
+            # pueda reintentar cuando renueve su plan.
+            self._release_ai_summary(analysis_id)
+            raise
 
-        self._task_queue.submit(
-            func=IrisManager.execute_ai_summary_generation,
-            args=(analysis_id,),
-            name=f"AISummary-Analysis-{analysis_id}",
-            category="iris.ai_summary",
-            external_id=f"iris-ai-summary:{analysis_id}",
-        )
+        try:
+            task = self._task_queue.submit(
+                func=IrisManager.execute_ai_summary_generation,
+                args=(analysis_id, user_id),
+                name=f"AISummary-Analysis-{analysis_id}",
+                category="iris.ai_summary",
+                external_id=f"{self.AI_SUMMARY_EXTERNAL_ID_PREFIX}{analysis_id}",
+            )
+        except Exception:
+            # El encolado rechazó el trabajo: nadie lo va a ejecutar, así que
+            # ni la reserva ni el cobro tienen sentido.
+            self._release_ai_summary(analysis_id)
+            self._refund_ai_summary_quota(user_id)
+            raise
+
+        self._update_analysis(analysis_id, ai_summary_job_id=getattr(task, "id", None))
+        return "running"
 
     @staticmethod
-    def execute_ai_summary_generation(analysis_id: int) -> None:
+    def _claim_ai_summary(analysis_id: int, regenerate: bool = False) -> bool:
+        """Reclama la generación con un UPDATE condicional. True si se ganó.
+
+        La condición vive dentro del UPDATE a propósito, igual que en el
+        consumo de cuota: leer el estado, decidir en Python y escribir después
+        regala una segunda generación cada vez que dos peticiones coinciden.
+        """
+        claimable = list(IrisManager._AI_SUMMARY_CLAIMABLE)
+        if regenerate:
+            claimable.append("done")
+
+        with UnitOfWork() as uow:
+            condition = IrisAnalysis.id == analysis_id
+            if None in claimable:
+                states = [state for state in claimable if state is not None]
+                status_matches = or_(
+                    IrisAnalysis.ai_summary_status.is_(None),
+                    IrisAnalysis.ai_summary_status.in_(states),
+                )
+            else:
+                status_matches = IrisAnalysis.ai_summary_status.in_(claimable)
+
+            result = uow.session.execute(
+                update(IrisAnalysis)
+                .where(and_(condition, status_matches))
+                .values(ai_summary_status="running")
+            )
+            return bool(result.rowcount)
+
+    def _release_ai_summary(self, analysis_id: int) -> None:
+        """Deshace la reserva cuando el trabajo no va a llegar a ejecutarse."""
+        self._update_analysis(analysis_id, ai_summary_status=None, ai_summary_job_id=None)
+
+    @staticmethod
+    def _refund_ai_summary_quota(user_id: int) -> None:
+        """Devuelve los dos cargos del resumen (el concreto y el agregado)."""
+        quota_manager = QuotaManager()
+        quota_manager.refund(user_id, LimitKey.IRIS_AI_SUMMARIES)
+        quota_manager.refund(user_id, LimitKey.AI_REQUESTS)
+
+    @staticmethod
+    def execute_ai_summary_generation(analysis_id: int, user_id: Optional[int] = None) -> None:
         """Entry point submitted to the TaskQueue for background AI narrative generation.
 
         Degrades cleanly on any failure (missing/misconfigured AI backend,
         circuit breaker open, malformed model response): logs the error
         and leaves ``ai_summary`` as ``NULL`` rather than failing the
         already-finished analysis it's attached to.
+
+        `B10`: además deja el estado en terminal y, si no hubo resumen,
+        devuelve la cuota. Cobrar antes de trabajar es correcto —cobrar
+        después permitiría lanzar N generaciones concurrentes con cupo para
+        una— pero obliga a devolver el dinero cuando el trabajo no se hace.
+
+        ``user_id`` es opcional para que un trabajo ya encolado con la firma
+        anterior no reviente al ejecutarse tras el despliegue; sin él
+        simplemente no hay a quién reembolsar.
         """
         with job_context():
+            manager = IrisManager()
             try:
-                report = IrisManager().get_analysis_results(analysis_id)
+                report = manager.get_analysis_results(analysis_id)
                 summary = IrisAIWriter().generate(report)
 
-                IrisManager()._update_analysis(analysis_id, ai_summary=summary)
+                manager._update_analysis(
+                    analysis_id,
+                    ai_summary=summary,
+                    ai_summary_status="done",
+                    ai_summary_model=IrisAIWriter.model_name(),
+                    ai_summary_prompt_version=IrisAIWriter.prompt_version(),
+                )
 
                 logger.info(f"AI summary generado para analysis {analysis_id}")
             except Exception as e:
                 logger.error(f"Error generando AI summary para analysis {analysis_id}: {e}", exc_info=True)
+                manager._update_analysis(analysis_id, ai_summary_status="failed")
+                if user_id is not None:
+                    IrisManager._refund_ai_summary_quota(user_id)
 
     def cancel_analysis(self, analysis_id: int, user_id: int) -> bool:
         """Cancel a running or pending analysis.

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -39,6 +39,7 @@ from ..repositories import IrisAnalysisRepository, IrisRuleResultRepository
 from ..services.rules import iris_rules, RuleResult
 from ..services.text import extract_domain, is_free_provider, url_host
 from ..services import parse_raw_message
+from ..services.failures import AnalysisFailure, classify_failure
 from ..services.parsers import build_path, parse_received_line
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
@@ -282,6 +283,8 @@ class IrisManager(TaskTrackingMixin):
             "wrapperSubject": context.wrapper_subject or None,
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
+            "failureCode": analysis.failure_code,
+            "failureReason": analysis.failure_reason,
             "user": username,
             "rules": rules_data,
             "recommendations": recommendations,
@@ -566,6 +569,7 @@ class IrisManager(TaskTrackingMixin):
                 "analysisId": analysis_record.id,
                 "title": analysis_record.title,
                 "status": analysis_record.status,
+                "failureCode": analysis_record.failure_code,
                 "totalScore": analysis_record.total_score,
                 "verdict": analysis_record.verdict,
                 "startedAt": isoformat_utc(analysis_record.started_at), # type: ignore
@@ -656,7 +660,7 @@ class IrisManager(TaskTrackingMixin):
         3. Runs every registered rule against the message (N1: against
            *both* the message and its ``message/rfc822`` wrapper when one
            is present, keeping the worse verdict — see
-           ``_evaluate_context``).
+           ``_evaluate_contexts``).
         4. Persists the winning context's rule results and the final
            score/verdict in a single transaction (C2/C3: no partial rows
            survive a mid-run cancellation, and there's one commit per
@@ -669,96 +673,127 @@ class IrisManager(TaskTrackingMixin):
                 self._update_analysis(analysis_id, status="running", started_at=utcnow_naive())
             except Exception as e:
                 logger.error(f"Failed to mark analysis {analysis_id} as running: {e}", exc_info=True)
-                self._fail_analysis(analysis_id)
+                self._fail_analysis(analysis_id, classify_failure(e))
                 return
 
-            # A single parse feeds both header-only and needs_context rules:
-            # when raw_input is a "report phishing" forward (message/rfc822
-            # attachment), context.headers already describes the *unwrapped
-            # original*, not the forwarding envelope — a separate
-            # parse_raw_headers(raw_input) here would silently re-introduce
-            # the envelope's headers and analyze the wrong message.
-            context = parse_raw_message(raw_input)
-            self._validate_headers_parsed(context.headers)
-
-            # N1: a "report phishing" forward is safe to unwrap unconditionally
-            # for a human-submitted analysis, but the same message/rfc822
-            # mechanism lets an attacker send their own phishing as the outer
-            # message and staple a benign .eml on as an attachment — analyzing
-            # only the unwrapped inner message would then score the wrong
-            # mail entirely. Evaluate both when a wrapper exists and keep the
-            # worse verdict; this matters most for unattended ingestion
-            # (Fase 3+), where there is no human eyeballing the wrapper first.
-            contexts_to_evaluate = [context]
-            if context.wrapper_context is not None:
-                contexts_to_evaluate.append(context.wrapper_context)
-
-            rules_defs = iris_rules.get_rules()
-            total_steps = len(rules_defs) * len(contexts_to_evaluate)
-            completed_steps = 0
-
-            evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
-            for evaluated_context in contexts_to_evaluate:
-                results: List[RuleResult] = []
-                named_results: Dict[str, RuleResult] = {}
-
-                for rule_def in rules_defs:
-                    if job.cancelled():
-                        logger.info(f"Analysis {analysis_id} was cancelled")
-                        return
-
-                    try:
-                        rule_input = (evaluated_context if rule_def.get("needs_context")
-                                      else evaluated_context.headers)
-                        result = rule_def["func"](rule_input)
-                    except Exception as e:
-                        logger.error(f"Rule '{rule_def['name']}' failed for analysis {analysis_id}: {e}", exc_info=True)
-                        result = RuleResult(
-                            score=0, verdict="error",
-                            details={"error": str(e)},
-                            recommendation=f"La regla '{rule_def['name']}' falló durante la ejecución.",
-                        )
-
-                    # Subtractive contract: a rule can only *subtract*. Whatever a
-                    # rule returns on a pass (historically +5/+3/+1 "credibility"
-                    # bonuses), the score it contributes — and the score shown in
-                    # the UI — is clamped to <= 0. Passing a rule means "no
-                    # deduction", never a bonus. The verdict/details are untouched.
-                    result = replace(result, score=min(0.0, float(result.score)))
-
-                    results.append(result)
-                    named_results[rule_def["name"]] = result
-
-                    completed_steps += 1
-                    job.progress(int((completed_steps / total_steps) * 100))
-
-                total_score = self._aggregate_score(rules_defs, results)
-                base_verdict = self._determine_verdict(total_score)
-                verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
-                evaluations.append((verdict, total_score, gate_reasons, results))
-
-            # Worse verdict wins across contexts; on a tie, keep the first
-            # (the unwrapped/inner message — the one ``contexts_to_evaluate``
-            # is ordered by, and the one every other persisted field
-            # describes) rather than the wrapper.
-            chosen = evaluations[0]
-            for evaluation in evaluations[1:]:
-                if _VERDICT_SEVERITY[evaluation[0]] > _VERDICT_SEVERITY[chosen[0]]:
-                    chosen = evaluation
-            verdict, total_score, gate_reasons, results = chosen
-
+            # B03: parseo, validación y evaluación comparten manejador con la
+            # persistencia. Estaban fuera de todo `try`, así que un parser roto
+            # o un `.eml` que no lo era dejaban la fila en `running` para
+            # siempre: RQ marcaba el job como fallido, pero nadie tocaba la
+            # base de datos y el usuario veía un análisis que no terminaba
+            # nunca. Ahora cualquier excepción de esta ventana acaba en un
+            # estado terminal con motivo consultable.
             try:
+                # A single parse feeds both header-only and needs_context rules:
+                # when raw_input is a "report phishing" forward (message/rfc822
+                # attachment), context.headers already describes the *unwrapped
+                # original*, not the forwarding envelope — a separate
+                # parse_raw_headers(raw_input) here would silently re-introduce
+                # the envelope's headers and analyze the wrong message.
+                context = parse_raw_message(raw_input)
+                self._validate_headers_parsed(context.headers)
+
+                # Un solo `get_rules()` para evaluar y para persistir: son dos
+                # recorridos que se emparejan por posición (`zip` en
+                # `_persist_analysis_results`), y leer el registro dos veces
+                # los desalinearía si alguien registrara una regla entremedias.
+                rules_defs = iris_rules.get_rules()
+                chosen = self._evaluate_contexts(analysis_id, context, job, rules_defs)
+                if chosen is None:
+                    return  # cancelado: no es un fallo, no hay nada que persistir
+                verdict, total_score, gate_reasons, results = chosen
+
                 self._persist_analysis_results(analysis_id, rules_defs, results,
-                                                verdict, total_score, gate_reasons)
+                                               verdict, total_score, gate_reasons)
             except Exception as e:
-                logger.error(f"Failed to finalise analysis {analysis_id}: {e}", exc_info=True)
-                self._fail_analysis(analysis_id)
+                logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
+                self._fail_analysis(analysis_id, classify_failure(e))
                 return
 
             if verdict == "Phishing":
                 self._enqueue_phishing_notification(analysis_id, verdict)
 
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
+
+    def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
+                           ) -> Optional[tuple[str, float, list[str], List[RuleResult]]]:
+        """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
+
+        Extraído de :meth:`_run_analysis` al envolver esa función en un único
+        manejador de ciclo de vida (`B03`): el bucle es la parte larga, y
+        dejarlo en línea dentro del ``try`` habría escondido qué se está
+        protegiendo exactamente.
+
+        Returns:
+            La tupla ``(verdict, total_score, gate_reasons, results)`` de la
+            evaluación ganadora, o ``None`` si la tarea fue cancelada a mitad
+            (que no es un fallo: no se persiste nada y la cancelación ya dejó
+            su propio estado terminal).
+        """
+        # N1: a "report phishing" forward is safe to unwrap unconditionally
+        # for a human-submitted analysis, but the same message/rfc822
+        # mechanism lets an attacker send their own phishing as the outer
+        # message and staple a benign .eml on as an attachment — analyzing
+        # only the unwrapped inner message would then score the wrong
+        # mail entirely. Evaluate both when a wrapper exists and keep the
+        # worse verdict; this matters most for unattended ingestion
+        # (Fase 3+), where there is no human eyeballing the wrapper first.
+        contexts_to_evaluate = [context]
+        if context.wrapper_context is not None:
+            contexts_to_evaluate.append(context.wrapper_context)
+
+        total_steps = len(rules_defs) * len(contexts_to_evaluate)
+        completed_steps = 0
+
+        evaluations: List[tuple[str, float, list[str], List[RuleResult]]] = []
+        for evaluated_context in contexts_to_evaluate:
+            results: List[RuleResult] = []
+            named_results: Dict[str, RuleResult] = {}
+
+            for rule_def in rules_defs:
+                if job.cancelled():
+                    logger.info(f"Analysis {analysis_id} was cancelled")
+                    return None
+
+                try:
+                    rule_input = (evaluated_context if rule_def.get("needs_context")
+                                  else evaluated_context.headers)
+                    result = rule_def["func"](rule_input)
+                except Exception as e:
+                    logger.error(f"Rule '{rule_def['name']}' failed for analysis {analysis_id}: {e}", exc_info=True)
+                    result = RuleResult(
+                        score=0, verdict="error",
+                        details={"error": str(e)},
+                        recommendation=f"La regla '{rule_def['name']}' falló durante la ejecución.",
+                    )
+
+                # Subtractive contract: a rule can only *subtract*. Whatever a
+                # rule returns on a pass (historically +5/+3/+1 "credibility"
+                # bonuses), the score it contributes — and the score shown in
+                # the UI — is clamped to <= 0. Passing a rule means "no
+                # deduction", never a bonus. The verdict/details are untouched.
+                result = replace(result, score=min(0.0, float(result.score)))
+
+                results.append(result)
+                named_results[rule_def["name"]] = result
+
+                completed_steps += 1
+                job.progress(int((completed_steps / total_steps) * 100))
+
+            total_score = self._aggregate_score(rules_defs, results)
+            base_verdict = self._determine_verdict(total_score)
+            verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
+            evaluations.append((verdict, total_score, gate_reasons, results))
+
+        # Worse verdict wins across contexts; on a tie, keep the first
+        # (the unwrapped/inner message — the one ``contexts_to_evaluate``
+        # is ordered by, and the one every other persisted field
+        # describes) rather than the wrapper.
+        chosen = evaluations[0]
+        for evaluation in evaluations[1:]:
+            if _VERDICT_SEVERITY[evaluation[0]] > _VERDICT_SEVERITY[chosen[0]]:
+                chosen = evaluation
+        return chosen
 
     @staticmethod
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
@@ -1201,10 +1236,24 @@ class IrisManager(TaskTrackingMixin):
                 fixed += 1
         return fixed
 
-    def _fail_analysis(self, analysis_id: int) -> None:
-        """Mark an analysis as ``failed`` with a finished timestamp."""
+    def _fail_analysis(self, analysis_id: int, failure: Optional[AnalysisFailure] = None) -> None:
+        """Deja el análisis en estado terminal ``failed`` con su motivo.
+
+        ``failure`` es opcional solo para no romper a un llamador que ya no
+        tenga la excepción a mano; en la práctica todos los caminos de
+        ``_run_analysis`` la traen, porque un ``failed`` sin motivo es
+        justamente lo que `B03` venía a quitar de en medio.
+
+        No se propaga ninguna excepción desde aquí: esto es el último
+        recurso de la tarea, y un fallo escribiendo el fallo solo puede
+        empeorar las cosas.
+        """
+        fields: Dict[str, Any] = {"status": "failed", "finished_at": utcnow_naive()}
+        if failure is not None:
+            fields["failure_code"] = failure.code
+            fields["failure_reason"] = failure.reason
         try:
-            self._update_analysis(analysis_id, status="failed", finished_at=utcnow_naive())
+            self._update_analysis(analysis_id, **fields)
         except Exception as e:
             logger.error(f"Failed to mark analysis {analysis_id} as failed: {e}", exc_info=True)
 

--- a/API/src/modules/features/iris/managers/reports.py
+++ b/API/src/modules/features/iris/managers/reports.py
@@ -116,7 +116,8 @@ class IrisReportManager(DocumentManager):
             if analysis is not None:
                 context = parse_raw_message(analysis.raw_headers or "")
                 path = {"analysisId": analysis_id, **build_path(context.received_headers)}
-            return IrisPDFCreator(report=report, path=path).print_pdf()
+            return IrisPDFCreator(report=report, path=path,
+                                  document_id=document_id).print_pdf()
 
         run_report_generation(
             document_id=document_id,

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -151,7 +151,10 @@ class IrisMailboxConnection(Base):
                  until the first bootstrap sync runs (see
                  ``services/mailbox`` connectors: the first sync never
                  backfills historical mail, it only captures the starting
-                 cursor).
+                 cursor). Es ``Text`` y no ``String(n)`` a propósito: el
+                 ``@odata.deltaLink`` de Graph es una URL completa con un
+                 token de estado dentro y rebasa los 255 caracteres. Opaco
+                 significa opaco — no se interpreta, no se recorta.
         status: "active" | "reauth_required" | "revoked" | "paused".
         ingested_today / ingested_reset_date: Per-connection daily ingest
                  counter enforcing ``iris.maxIngestedPerDay`` — reset when
@@ -178,7 +181,7 @@ class IrisMailboxConnection(Base):
 
     folder = Column(String(255), nullable=True)
     full_message_mode = Column(Boolean, nullable=False, default=False)
-    sync_cursor = Column(String(255), nullable=True)
+    sync_cursor = Column(Text, nullable=True)
 
     status = Column(String(20), nullable=False, default="active")
     ingested_today = Column(Integer, nullable=False, default=0)

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -37,6 +37,16 @@ class IrisAnalysis(Base):
         gate_reasons: List of human-readable reasons for the
                  high-confidence gates that fired (empty when the verdict
                  comes purely from the numeric score).
+        analysis_quality: "complete" cuando todas las reglas se ejecutaron,
+                 "degraded" cuando alguna no llegó a hacerlo. Un análisis
+                 degradado no puede presentarse como limpio sin contexto —
+                 ver ``services/quality.py``.
+        failed_rules: Reglas que no se pudieron **ejecutar** (una excepción,
+                 no un hallazgo), con su nombre, familia y categoría. NULL
+                 cuando el análisis fue completo.
+        detector_version: Marca del catálogo de reglas que produjo el
+                 resultado (``iris-rules:<n>:<hash>``). Sin ella, un informe
+                 guardado deja de ser interpretable cuando el catálogo cambia.
         failure_code: Why a ``failed`` analysis failed — "invalid_input"
                  (the submitted text is not an analysable message) or
                  "internal_error" (the pipeline broke). NULL for every
@@ -74,6 +84,9 @@ class IrisAnalysis(Base):
     total_score = Column(Float, nullable=True)
     verdict = Column(String(20), nullable=True)
     gate_reasons = Column(JSONB, nullable=True)
+    analysis_quality = Column(String(16), nullable=True)
+    failed_rules = Column(JSONB, nullable=True)
+    detector_version = Column(String(64), nullable=True)
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -37,6 +37,14 @@ class IrisAnalysis(Base):
         gate_reasons: List of human-readable reasons for the
                  high-confidence gates that fired (empty when the verdict
                  comes purely from the numeric score).
+        failure_code: Why a ``failed`` analysis failed — "invalid_input"
+                 (the submitted text is not an analysable message) or
+                 "internal_error" (the pipeline broke). NULL for every
+                 non-failed analysis. See ``services/failures.py``.
+        failure_reason: Human-readable, **non-sensitive** companion to
+                 ``failure_code``. Never contains the raw email: an
+                 internal error collapses to a generic message and only
+                 the server log keeps the traceback.
         ai_summary: AI-generated executive narrative (IA1) — dict with
                  executive_summary/attacker_intent/recommendations/
                  confidence, or None until generated (or if generation
@@ -66,6 +74,8 @@ class IrisAnalysis(Base):
     total_score = Column(Float, nullable=True)
     verdict = Column(String(20), nullable=True)
     gate_reasons = Column(JSONB, nullable=True)
+    failure_code = Column(String(32), nullable=True)
+    failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
     started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     finished_at = Column(DateTime, nullable=True)

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -59,6 +59,15 @@ class IrisAnalysis(Base):
                  executive_summary/attacker_intent/recommendations/
                  confidence, or None until generated (or if generation
                  failed/was never requested).
+        ai_summary_status: "running" | "done" | "failed", o NULL si nunca se
+                 pidió. Es lo que hace idempotente la generación: el manager
+                 reclama la fila con una transición condicional sobre esta
+                 columna, y quien pierde la carrera no cobra cuota ni encola.
+        ai_summary_job_id: Id del trabajo en la cola que lo está generando.
+        ai_summary_model / ai_summary_prompt_version: Con qué se generó. Un
+                 resumen de hace tres meses lo escribió otro modelo con otro
+                 prompt, y sin esto no hay forma de saber cuál (mismo papel
+                 que ``detector_version`` para las reglas).
         started_at: Timestamp when the analysis was created.
         finished_at: Timestamp when the analysis reached a terminal state.
         user_id: Foreign key to the owning User.
@@ -90,6 +99,10 @@ class IrisAnalysis(Base):
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
+    ai_summary_status = Column(String(16), nullable=True)
+    ai_summary_job_id = Column(String(64), nullable=True)
+    ai_summary_model = Column(String(64), nullable=True)
+    ai_summary_prompt_version = Column(String(32), nullable=True)
     started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     finished_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow_naive)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -50,6 +50,24 @@ class AnalyzeRequestSchema(Schema):
                 )
 
 
+class IrisCapabilitiesResponseSchema(Schema):
+    """Límites y modos que la interfaz necesita para decidir igual que el API.
+
+    Existe para que el frontend no tenga que replicar constantes del backend:
+    una copia en el navegador deriva en cuanto alguien cambia la config del
+    servidor, y el usuario se lleva el rechazo después de haber cargado el
+    fichero entero en memoria.
+
+    ``verdictThresholds`` viaja ya en la respuesta del listado; se repite aquí
+    para que una vista que aún no ha listado nada pueda pintar la escala de
+    riesgo sin pedir primero una página de resultados.
+    """
+    maxMessageBytes = fields.Integer()
+    minHeaders = fields.Integer()
+    analysisModes = fields.List(fields.String())
+    verdictThresholds = fields.Nested(lambda: VerdictThresholdsSchema())
+
+
 class AnalysisIdQuerySchema(Schema):
     """Query parameter for ``GET /iris/status`` — supplied as ``?id=...``."""
     id = fields.Integer(required=True)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -127,6 +127,18 @@ class AiSummarySchema(Schema):
     confidence = fields.String()
 
 
+class FailedRuleSchema(Schema):
+    """Regla que no se pudo **ejecutar** durante un análisis (B05).
+
+    No confundir con una regla que detectó algo: esas van en ``rules`` con su
+    puntuación negativa. Estas son las que lanzaron una excepción, así que su
+    parte del mensaje se quedó sin inspeccionar.
+    """
+    name = fields.String()
+    family = fields.String(load_default=None, allow_none=True)
+    category = fields.String(load_default=None, allow_none=True)
+
+
 class AnalysisDetailResponseSchema(Schema):
     """Full analysis report: headers, per-rule results, verdict."""
     analysisId = fields.Integer()
@@ -136,6 +148,9 @@ class AnalysisDetailResponseSchema(Schema):
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     gateReasons = fields.List(fields.String(), load_default=None)
+    analysisQuality = fields.String(load_default=None, allow_none=True)
+    failedRules = fields.List(fields.Nested(FailedRuleSchema), load_default=None)
+    detectorVersion = fields.String(load_default=None, allow_none=True)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)
     unwrappedFromForward = fields.Boolean(load_default=False)
@@ -156,6 +171,7 @@ class AnalysisListItemSchema(Schema):
     title = fields.String(load_default=None)
     status = fields.String()
     failureCode = fields.String(load_default=None, allow_none=True)
+    analysisQuality = fields.String(load_default=None, allow_none=True)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     startedAt = fields.String(load_default=None)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -171,6 +171,9 @@ class AnalysisDetailResponseSchema(Schema):
     detectorVersion = fields.String(load_default=None, allow_none=True)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)
+    aiSummaryStatus = fields.String(load_default=None, allow_none=True)
+    aiSummaryModel = fields.String(load_default=None, allow_none=True)
+    aiSummaryPromptVersion = fields.String(load_default=None, allow_none=True)
     unwrappedFromForward = fields.Boolean(load_default=False)
     wrapperFrom = fields.String(load_default=None, allow_none=True)
     wrapperSubject = fields.String(load_default=None, allow_none=True)
@@ -298,12 +301,28 @@ class GenerateDocumentResponseSchema(Schema):
     downloadUrl = fields.String(load_default=None)
 
 
+class GenerateAiSummaryRequestSchema(Schema):
+    """Parámetros de ``POST /iris/results/<id>/ai-summary``.
+
+    ``regenerate`` distingue las dos intenciones que antes eran una sola
+    petición indistinguible: repetirla porque el navegador reintentó o porque
+    el usuario hizo doble clic (y entonces lo correcto es devolver el resumen
+    que ya hay, sin cobrar), o pedir explícitamente otra redacción (y entonces
+    sí se genera de nuevo, y se cobra).
+    """
+    regenerate = fields.Boolean(load_default=False)
+
+
 class GenerateAiSummaryResponseSchema(Schema):
     """Response returned immediately after queuing AI summary generation (IA1).
 
     There is no separate status to poll: the caller re-fetches
     ``GET /iris/results/<id>`` (``aiSummary``) to see the result once the
     background task finishes.
+
+    ``status`` dice qué pasó de verdad con esta llamada: ``running`` si encoló
+    la generación (o si ya había una en curso) y ``done`` si el resumen ya
+    existía y se devolvió sin trabajo ni cobro.
     """
     message = fields.String()
     analysisId = fields.Integer()

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -85,12 +85,20 @@ class AnalyzeResponseSchema(Schema):
 
 
 class AnalysisStatusResponseSchema(Schema):
-    """Current lifecycle status and optional progress of an analysis."""
+    """Current lifecycle status and optional progress of an analysis.
+
+    ``failureCode``/``failureReason`` solo viajan cuando ``status`` es
+    ``failed``. Es aquí donde se consultan, y no en el informe completo,
+    porque ``GET /iris/results/<id>`` exige un análisis ``finished``: un
+    análisis que murió no tiene informe que devolver, solo un motivo.
+    """
     analysisId = fields.Integer()
     status = fields.String()
     progress = fields.Integer(load_default=None)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
+    failureCode = fields.String(load_default=None, allow_none=True)
+    failureReason = fields.String(load_default=None, allow_none=True)
 
 
 class RuleResultSchema(Schema):
@@ -135,6 +143,8 @@ class AnalysisDetailResponseSchema(Schema):
     wrapperSubject = fields.String(load_default=None, allow_none=True)
     startedAt = fields.String(load_default=None)
     finishedAt = fields.String(load_default=None)
+    failureCode = fields.String(load_default=None, allow_none=True)
+    failureReason = fields.String(load_default=None, allow_none=True)
     user = fields.String()
     rules = fields.List(fields.Nested(RuleResultSchema))
     recommendations = fields.List(fields.String())
@@ -145,6 +155,7 @@ class AnalysisListItemSchema(Schema):
     analysisId = fields.Integer()
     title = fields.String(load_default=None)
     status = fields.String()
+    failureCode = fields.String(load_default=None, allow_none=True)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     startedAt = fields.String(load_default=None)

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -17,6 +17,7 @@ PDF export.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from typing import Any, Dict, Optional
@@ -58,6 +59,34 @@ class IrisAIWriter:
 
     def _build_prompts(self) -> dict:
         return CR.iris_config().prompts.get("summary", {})
+
+    @staticmethod
+    def model_name() -> str:
+        """Qué backend de IA produjo el resumen.
+
+        Es el nombre de la estrategia de scribe configurada para Iris
+        (``ollama``/``openai``/``google``), que es la identidad que la
+        aplicación controla de verdad: el modelo concreto lo elige cada
+        estrategia por su cuenta y puede cambiar bajo los pies sin que aquí se
+        note.
+        """
+        return str(CR.scribe_config().strategy_for("iris"))
+
+    @classmethod
+    def prompt_version(cls) -> str:
+        """Marca del prompt con el que se generó un resumen.
+
+        Los prompts viven en ``SecOpsConfig.json`` y se pueden editar en
+        caliente, así que dos resúmenes guardados pueden venir de instrucciones
+        distintas sin que nada lo delate. Se resume el par
+        (system, userTemplate) para que cualquier edición cambie la marca —
+        mismo criterio que ``detector_version`` con el catálogo de reglas:
+        derivado, no escrito a mano, así que no puede quedarse desactualizado.
+        """
+        prompts = CR.iris_config().prompts.get("summary", {})
+        material = f"{prompts.get('system', '')}\n{prompts.get('userTemplate', '')}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+        return f"iris-summary:{digest}"
 
     @staticmethod
     def _degradation_note(report: Dict[str, Any]) -> str:

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -59,6 +59,33 @@ class IrisAIWriter:
     def _build_prompts(self) -> dict:
         return CR.iris_config().prompts.get("summary", {})
 
+    @staticmethod
+    def _degradation_note(report: Dict[str, Any]) -> str:
+        """Aviso que se añade al prompt cuando el análisis fue degradado (B05).
+
+        Va anexado al final del prompt en vez de como marcador de la plantilla
+        porque las plantillas viven en ``SecOpsConfig.json``: un marcador nuevo
+        obligaría a editar la configuración desplegada para que este aviso
+        apareciera, y un despliegue con la plantilla vieja se quedaría
+        silenciosamente sin él — justo el fallo silencioso que B05 corrige.
+
+        Sin esto, el modelo redacta un resumen ejecutivo seguro sobre un
+        análisis que no lo es: no tiene forma de saber que faltan reglas,
+        porque lo único que recibe son las que sí se ejecutaron.
+        """
+        if report.get("analysisQuality") != "degraded":
+            return ""
+        names = ", ".join(
+            rule.get("name", "?") for rule in (report.get("failedRules") or [])
+        ) or "desconocidas"
+        return (
+            "\n\nAVISO IMPORTANTE: este análisis está DEGRADADO. No se pudieron "
+            f"ejecutar estas reglas: {names}. La parte del mensaje que les "
+            "correspondía no se ha inspeccionado. Dilo explícitamente en el "
+            "resumen y no afirmes que el mensaje es seguro basándote en la "
+            "ausencia de hallazgos."
+        )
+
     def _build_user_prompt(self, report: Dict[str, Any]) -> str:
         failed_rules = [
             {
@@ -72,13 +99,14 @@ class IrisAIWriter:
         ]
 
         template = self._build_prompts().get("userTemplate", "")
-        return (
+        prompt = (
             template
             .replace("{{verdict}}", str(report.get("verdict") or "Suspicious"))
             .replace("{{score}}", str(report.get("totalScore")))
             .replace("{{gate_reasons_json}}", json.dumps(report.get("gateReasons") or [], ensure_ascii=False))
             .replace("{{failed_rules_json}}", json.dumps(failed_rules, indent=2, ensure_ascii=False))
         )
+        return prompt + self._degradation_note(report)
 
     def generate(self, report: Dict[str, Any]) -> dict:
         """Generate the AI narrative for a finished analysis report dict.

--- a/API/src/modules/features/iris/services/auth_trust.py
+++ b/API/src/modules/features/iris/services/auth_trust.py
@@ -1,0 +1,231 @@
+"""
+Frontera de confianza de la cadena ``Received`` de un mensaje.
+
+El problema que resuelve este módulo es que **una parte de las cabeceras de un
+correo las escribe el atacante**. Los MTA *anteponen* su ``Received``, así que
+la cadena se lee de arriba abajo desde el último salto (el servidor del
+destinatario) hasta el origen. Los saltos de abajo los aportó quien envió el
+mensaje, y puede inventárselos: nada le impide fabricar tres ``Received``
+falsos que describan un recorrido que nunca ocurrió.
+
+Eso importa porque ``Authentication-Results`` —la cabecera donde un servidor
+apunta el resultado de SPF, DKIM y DMARC— **también la puede escribir el
+remitente**. Iris ya comprobaba que el ``authserv-id`` que la firma apareciera
+como host ``by`` de algún salto de la cadena, pero aceptaba *cualquier* salto,
+incluidos los de abajo. Un atacante que inyecte a la vez su propio ``Received``
+(``by: mx.suservidor.example``) y su propio ``Authentication-Results``
+(``mx.suservidor.example; spf=pass; dkim=pass; dmarc=pass``) pasaba la
+comprobación: los dos elementos que se estaban contrastando eran suyos.
+
+La frontera de confianza es el punto de la cadena por debajo del cual nada es
+verificable. Este módulo la calcula y responde a la única pregunta que las
+reglas necesitan: *¿escribió esta cabecera alguien en quien podemos confiar?*
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import src.modules.system.config_reading as CR
+
+from .parsers import parse_received_line
+from .text import registrable_domain
+
+
+#: Veredictos de :func:`assess_authserv_trust`.
+TRUST_CONFIGURED = "configured"
+"""El verificador está en la lista explícita de confianza del despliegue."""
+
+TRUST_BOUNDARY = "boundary"
+"""El verificador es la propia infraestructura receptora (por encima de la
+frontera). Es el caso normal del correo legítimo."""
+
+TRUST_BELOW_BOUNDARY = "below_boundary"
+"""El ``authserv-id`` solo aparece en saltos que el remitente pudo fabricar.
+Es el bypass que cierra `B06`: la cabecera existe y "cuadra" con la cadena,
+pero cuadra con la parte de la cadena que escribió el atacante."""
+
+TRUST_ABSENT = "absent"
+"""El ``authserv-id`` no aparece en ningún salto: la cabecera la estampó un
+servidor que nunca tocó el mensaje."""
+
+TRUST_UNKNOWN = "unknown"
+"""No hay cadena ``Received`` que contrastar. No es una acusación: sin base
+para juzgar, la regla se queda neutral."""
+
+
+def trusted_authserv_ids() -> frozenset[str]:
+    """Verificadores declarados de confianza en ``features.iris.data``.
+
+    Sirve para el despliegue que sabe qué servidor autentica su correo —el
+    gateway corporativo, el proveedor gestionado— y quiere que se acepte
+    aunque no encabece la cadena. Vacío por defecto: sin configuración, la
+    confianza se deduce de la propia cadena (ver :func:`trust_boundary`), que
+    es lo que hace que el módulo funcione en cualquier despliegue sin tocar
+    nada.
+    """
+    configured = CR.get_iris_data("trusted_authserv_ids") or []
+    return frozenset(str(entry).strip().lower() for entry in configured if str(entry).strip())
+
+
+@dataclass(frozen=True)
+class ReceivedHop:
+    """Un salto de la cadena, reducido a lo que la frontera necesita."""
+
+    position: int
+    """0 es el último salto (el servidor del destinatario), el más fiable."""
+
+    by_host: Optional[str]
+    by_domain: Optional[str]
+
+
+def parse_hops(received_headers: Sequence[str]) -> List[ReceivedHop]:
+    """Reduce la cadena a sus hosts ``by``, conservando el orden de entrega.
+
+    ``received_headers[0]`` es el salto final y ``[-1]`` el origen — el mismo
+    orden que produce ``MessageContext.received_headers`` y que consume
+    ``build_path``.
+    """
+    hops: List[ReceivedHop] = []
+    for position, line in enumerate(received_headers):
+        by_host = (parse_received_line(line).get("by") or "").strip().rstrip(".,;").lower()
+        hops.append(ReceivedHop(
+            position=position,
+            by_host=by_host or None,
+            by_domain=registrable_domain(by_host) if by_host else None,
+        ))
+    return hops
+
+
+def trust_boundary(hops: Sequence[ReceivedHop]) -> int:
+    """Cuántos saltos, contando desde el final de entrega, son fiables.
+
+    La regla es la contigüidad organizativa desde arriba: el salto 0 lo escribió
+    el servidor que entregó el mensaje —el nuestro, o el de nuestro proveedor—
+    y por tanto no lo pudo fabricar el remitente. Los saltos inmediatamente
+    siguientes que pertenecen a **la misma organización** (mismo dominio
+    registrable) son el recorrido interno de esa misma infraestructura, y
+    tampoco. En cuanto la cadena cambia de organización se ha salido del
+    perímetro receptor y ya no hay nada que garantice que lo de abajo ocurrió.
+
+    Un salto declarado de confianza en la configuración extiende la frontera
+    aunque cambie de dominio: es el caso del gateway corporativo que entrega a
+    un buzón alojado en otro proveedor.
+
+    Sin cadena, la frontera es 0 — no hay nada fiable, pero tampoco nada que
+    acusar; de eso se encarga el llamante.
+    """
+    if not hops:
+        return 0
+
+    anchor_domain = hops[0].by_domain
+    configured = trusted_authserv_ids()
+
+    boundary = 0
+    for hop in hops:
+        is_same_organisation = anchor_domain is not None and hop.by_domain == anchor_domain
+        is_configured = (hop.by_host in configured) or (hop.by_domain in configured)
+        if is_same_organisation or is_configured:
+            boundary = hop.position + 1
+            continue
+        break
+
+    # Una cadena de un solo salto sin `by` legible no ancla nada, pero el salto
+    # final sigue siendo el final: se cuenta como frontera para no tratar como
+    # forjado un mensaje cuya cadena simplemente no se pudo parsear.
+    return boundary or 1
+
+
+@dataclass(frozen=True)
+class AuthservTrust:
+    """Resultado de contrastar un ``authserv-id`` con la cadena real."""
+
+    verdict: str
+    is_trusted: bool
+    boundary: int
+    matched_position: Optional[int] = None
+    trusted_by_domains: tuple[str, ...] = ()
+    untrusted_by_domains: tuple[str, ...] = ()
+
+
+def assess_authserv_trust(authserv_id: str, received_headers: Sequence[str]) -> AuthservTrust:
+    """¿Escribió esta cabecera alguien en quien podemos confiar?
+
+    Distingue tres desenlaces que antes eran dos. Que el ``authserv-id``
+    aparezca *en algún sitio* de la cadena ya no basta: importa **dónde**.
+    Aparecer solo por debajo de la frontera (``below_boundary``) es la firma de
+    la inyección que este módulo existe para detectar, y es un caso más grave
+    que no aparecer en absoluto — quien fabrica los dos elementos a la vez para
+    que se corroboren mutuamente sabe exactamente lo que hace.
+    """
+    normalised = (authserv_id or "").strip().lower()
+    configured = trusted_authserv_ids()
+    hops = parse_hops(received_headers)
+
+    if normalised in configured or (registrable_domain(normalised) or "") in configured:
+        return AuthservTrust(verdict=TRUST_CONFIGURED, is_trusted=True,
+                             boundary=len(hops))
+
+    if not hops or all(hop.by_domain is None for hop in hops):
+        return AuthservTrust(verdict=TRUST_UNKNOWN, is_trusted=False, boundary=0)
+
+    boundary = trust_boundary(hops)
+    authserv_domain = registrable_domain(normalised)
+
+    trusted_domains = tuple(sorted({
+        hop.by_domain for hop in hops[:boundary] if hop.by_domain
+    }))
+    untrusted_domains = tuple(sorted({
+        hop.by_domain for hop in hops[boundary:] if hop.by_domain
+    }))
+
+    for hop in hops[:boundary]:
+        if hop.by_domain and hop.by_domain == authserv_domain:
+            return AuthservTrust(verdict=TRUST_BOUNDARY, is_trusted=True, boundary=boundary,
+                                 matched_position=hop.position,
+                                 trusted_by_domains=trusted_domains,
+                                 untrusted_by_domains=untrusted_domains)
+
+    for hop in hops[boundary:]:
+        if hop.by_domain and hop.by_domain == authserv_domain:
+            return AuthservTrust(verdict=TRUST_BELOW_BOUNDARY, is_trusted=False, boundary=boundary,
+                                 matched_position=hop.position,
+                                 trusted_by_domains=trusted_domains,
+                                 untrusted_by_domains=untrusted_domains)
+
+    return AuthservTrust(verdict=TRUST_ABSENT, is_trusted=False, boundary=boundary,
+                         trusted_by_domains=trusted_domains,
+                         untrusted_by_domains=untrusted_domains)
+
+
+# ``arc=pass`` dentro de un Authentication-Results: el resultado de que **el
+# servidor receptor** validara criptográficamente la cadena ARC. Es distinto de
+# ``ARC-Seal: cv=pass``, que es lo que la propia cadena dice de sí misma.
+_ARC_RESULT_RE = re.compile(r"\barc\s*=\s*pass\b", re.IGNORECASE)
+
+
+def is_arc_verified_by_trusted_hop(headers: dict, received_headers: Sequence[str]) -> bool:
+    """¿Ha validado la cadena ARC alguien en quien confiamos?
+
+    Iris no verifica firmas criptográficas —ni de DKIM, ni de ARC—, así que un
+    ``ARC-Seal: cv=pass`` es solo una afirmación del propio mensaje sobre sí
+    mismo. Cualquiera puede escribirla, incluido quien tenga interés en que su
+    correo parezca un reenvío legítimo.
+
+    Quien sí la verifica es el MTA receptor, que apunta el resultado como
+    ``arc=pass`` dentro de **su** ``Authentication-Results`` (RFC 8617 §5.2).
+    Esa afirmación sí vale, con la condición de siempre: que la cabecera la
+    haya escrito un verificador por encima de la frontera de confianza. Si no,
+    estaríamos otra vez creyéndonos algo que pudo escribir el remitente, solo
+    que con un rodeo más.
+    """
+    auth_results = (headers.get("authentication-results") or "").strip()
+    if not auth_results:
+        return False
+    if not _ARC_RESULT_RE.search(auth_results):
+        return False
+
+    authserv_id = auth_results.split(";", 1)[0].strip().lower()
+    return assess_authserv_trust(authserv_id, received_headers).is_trusted

--- a/API/src/modules/features/iris/services/failures.py
+++ b/API/src/modules/features/iris/services/failures.py
@@ -29,6 +29,19 @@ FAILURE_INVALID_INPUT = "invalid_input"
 #: El pipeline se rompió por dentro (parser, regla, persistencia).
 FAILURE_INTERNAL_ERROR = "internal_error"
 
+#: El proceso que ejecutaba el análisis desapareció sin dejar resultado.
+#: No es un error del motor —nunca llegó a fallar nada— sino la constatación,
+#: al arrancar, de que ya no queda nadie que vaya a terminar ese trabajo.
+FAILURE_WORKER_LOST = "worker_lost"
+
+#: Razón asociada a ``FAILURE_WORKER_LOST``. Vive aquí, y no en el manager,
+#: porque es el mismo tipo de dato que produce ``classify_failure``: texto
+#: legible, no sensible y persistible.
+WORKER_LOST_REASON = (
+    "El proceso que ejecutaba este análisis se detuvo antes de terminarlo. "
+    "Vuelve a lanzarlo para obtener un resultado."
+)
+
 # Tope del mensaje persistido: `failure_reason` es una columna Text, pero un
 # traceback repr-eado de una librería de terceros puede ser enorme y no aporta
 # nada más allá de la primera línea.

--- a/API/src/modules/features/iris/services/failures.py
+++ b/API/src/modules/features/iris/services/failures.py
@@ -1,0 +1,71 @@
+"""
+Clasificación de fallos terminales de un análisis de Iris.
+
+Un análisis puede morir por dos motivos muy distintos, y confundirlos hace
+inútil el estado terminal: o el usuario mandó algo que no es un correo
+analizable (culpa suya, accionable), o el pipeline se rompió por dentro
+(culpa nuestra, no accionable por el usuario). ``classify_failure`` traduce
+la excepción que aborta ``IrisManager._run_analysis`` en ese par
+``(código, razón)``.
+
+La razón es **texto técnico no sensible**: nunca el ``raw_input`` ni ningún
+fragmento del correo. El motivo es que se persiste en ``IrisAnalysis`` y se
+devuelve por API a quien consulte el estado, mientras que el cuerpo del
+mensaje analizado puede contener datos personales o credenciales — el propio
+informe ya lo trata como material sensible (ver la nota de consentimiento del
+PDF en ``services/reports.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..exceptions import IrisInvalidInputError
+
+
+#: El usuario mandó algo que no es un correo analizable.
+FAILURE_INVALID_INPUT = "invalid_input"
+
+#: El pipeline se rompió por dentro (parser, regla, persistencia).
+FAILURE_INTERNAL_ERROR = "internal_error"
+
+# Tope del mensaje persistido: `failure_reason` es una columna Text, pero un
+# traceback repr-eado de una librería de terceros puede ser enorme y no aporta
+# nada más allá de la primera línea.
+_MAX_REASON_LENGTH = 500
+
+_INTERNAL_REASON = (
+    "El análisis falló por un error interno del motor. El equipo puede "
+    "consultar el detalle en los registros del servidor."
+)
+
+
+@dataclass(frozen=True)
+class AnalysisFailure:
+    """Motivo terminal de un análisis fallido, listo para persistir.
+
+    Attributes:
+        code: ``invalid_input`` o ``internal_error``.
+        reason: Mensaje legible y no sensible, apto para devolver por API.
+    """
+
+    code: str
+    reason: str
+
+
+def classify_failure(error: BaseException) -> AnalysisFailure:
+    """Traduce la excepción que abortó un análisis en un motivo persistible.
+
+    ``IrisInvalidInputError`` es la única excepción cuyo mensaje se propaga
+    tal cual: lo construye este módulo a partir de un recuento de cabeceras,
+    nunca del contenido del correo. Cualquier otra excepción —incluido un
+    parser roto, que es el caso que motiva `B03`— se colapsa en un mensaje
+    genérico: el ``str(error)`` de una librería de terceros puede arrastrar
+    el fragmento de entrada que la hizo reventar.
+    """
+    if isinstance(error, IrisInvalidInputError):
+        return AnalysisFailure(
+            code=FAILURE_INVALID_INPUT,
+            reason=str(error)[:_MAX_REASON_LENGTH],
+        )
+    return AnalysisFailure(code=FAILURE_INTERNAL_ERROR, reason=_INTERNAL_REASON)

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -1,0 +1,151 @@
+"""
+Calidad de un análisis: qué se pudo inspeccionar de verdad y qué no.
+
+Una regla que revienta no aborta el análisis —eso sería peor: un solo fallo
+tiraría un informe entero por 47 reglas que sí funcionaron—, pero tampoco
+puede desaparecer sin dejar rastro. Hasta `B05`, una excepción de regla se
+convertía en un ``RuleResult(score=0, verdict="error")`` y ahí se acababa
+todo: el análisis podía terminar como ``Legitimate`` sin ninguna advertencia,
+aunque la regla que faltó fuera la que decide si el mensaje está autenticado.
+
+Este módulo produce las tres cosas que hacen visible esa diferencia:
+
+- ``analysis_quality``: ``complete`` o ``degraded``.
+- ``failed_rules``: qué reglas no se pudieron ejecutar (el nombre es el que
+  fija el issue; léase "reglas que fallaron **al ejecutarse**", no "reglas
+  que detectaron algo malo" — esas son las que puntúan negativo).
+- ``detector_version``: qué catálogo de reglas produjo el resultado, para que
+  un informe guardado siga siendo interpretable cuando el catálogo cambie.
+
+Y la política conservadora que las acompaña, que depende de **qué familia** de
+regla se perdió (ver ``DEGRADING_FAMILIES``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+#: Valor de ``verdict`` con el que el motor marca una regla que lanzó una
+#: excepción, en lugar de devolver un resultado (ver ``_evaluate_contexts``).
+RULE_ERROR_VERDICT = "error"
+
+QUALITY_COMPLETE = "complete"
+QUALITY_DEGRADED = "degraded"
+
+#: Familias cuya ausencia impide presentar el mensaje como limpio.
+#:
+#: No todas las reglas pesan igual cuando faltan. El catálogo tiene ocho
+#: familias, y las de contenido, enlaces, identidad, camino de respuesta y
+#: cadena Received son muchas y cada una individualmente pequeña: perder una
+#: degrada la confianza, pero las demás siguen mirando el mismo mensaje desde
+#: ángulos parecidos.
+#:
+#: ``auth`` y ``attachment`` no funcionan así. Son las dos únicas familias que
+#: responden a una pregunta que ninguna otra regla responde —«¿es quien dice
+#: ser?» y «¿lo que trae dentro es peligroso?»— y ahí el silencio no es un
+#: dato menos: es no haber mirado. Un mensaje cuyo bloque de autenticación no
+#: se pudo evaluar no puede presentarse como legítimo por el hecho de que el
+#: resto de reglas no encontrara nada.
+DEGRADING_FAMILIES = frozenset({"auth", "attachment"})
+
+
+@dataclass(frozen=True)
+class AnalysisQuality:
+    """Veredicto sobre el propio análisis, no sobre el correo.
+
+    Attributes:
+        quality: ``complete`` si se ejecutaron todas las reglas,
+            ``degraded`` si alguna no llegó a ejecutarse.
+        failed_rules: Una entrada por regla que no se pudo ejecutar, con su
+            nombre, familia y categoría. Serializable a JSONB tal cual.
+        blocks_clean_verdict: True si alguna de las reglas perdidas pertenece
+            a una familia de ``DEGRADING_FAMILIES``, es decir, si el análisis
+            no puede presentarse como limpio.
+    """
+
+    quality: str
+    failed_rules: List[Dict[str, Any]] = field(default_factory=list)
+    blocks_clean_verdict: bool = False
+
+    @property
+    def is_degraded(self) -> bool:
+        return self.quality == QUALITY_DEGRADED
+
+
+def assess_quality(rules_defs: List[dict], results: List[Any]) -> AnalysisQuality:
+    """Compara el catálogo ejecutado con sus resultados y resume qué faltó.
+
+    ``rules_defs`` y ``results`` se emparejan **por posición**: es el mismo
+    contrato que usa ``_persist_analysis_results`` para guardar las filas de
+    ``IrisRuleResult``, y por eso el motor lee el registro de reglas una sola
+    vez por análisis.
+    """
+    failed_rules = [
+        {
+            "name": rule_def["name"],
+            "family": rule_def.get("family") or None,
+            "category": rule_def.get("category") or None,
+        }
+        for rule_def, result in zip(rules_defs, results)
+        if getattr(result, "verdict", None) == RULE_ERROR_VERDICT
+    ]
+
+    if not failed_rules:
+        return AnalysisQuality(quality=QUALITY_COMPLETE)
+
+    blocks = any(rule["family"] in DEGRADING_FAMILIES for rule in failed_rules)
+    return AnalysisQuality(
+        quality=QUALITY_DEGRADED,
+        failed_rules=failed_rules,
+        blocks_clean_verdict=blocks,
+    )
+
+
+def detector_version(rules_defs: List[dict]) -> str:
+    """Identifica el catálogo de reglas que produjo un resultado.
+
+    Un informe guardado hace tres meses se leyó con un catálogo que ya no es
+    el actual, y sin esta marca no hay forma de saber cuál. Se compone del
+    número de reglas y de un resumen del conjunto **ordenado** de sus nombres:
+    ordenado a propósito, para que reordenar el registro no cambie la marca,
+    pero añadir, quitar o renombrar una regla sí lo haga.
+
+    Cabe de sobra en los 64 caracteres de la columna (``iris-rules:48:`` más
+    12 hexadecimales).
+    """
+    names = sorted(rule_def["name"] for rule_def in rules_defs)
+    digest = hashlib.sha256("\n".join(names).encode("utf-8")).hexdigest()[:12]
+    return f"iris-rules:{len(names)}:{digest}"
+
+
+def cap_verdict(verdict: str, quality: AnalysisQuality) -> tuple[str, List[str]]:
+    """Aplica la política conservadora del análisis degradado.
+
+    Devuelve el veredicto ya ajustado y las razones a añadir a
+    ``gate_reasons`` — la misma lista que ya explica por qué un veredicto es
+    el que es, para que la degradación se lea junto al resto de motivos en
+    lugar de en un rincón aparte de la interfaz.
+
+    La única corrección es impedir el ``Legitimate``: un análisis degradado
+    puede seguir siendo ``Suspicious`` o ``Phishing`` sin problema —esos
+    veredictos ya avisan— pero no puede decir "limpio" sobre un mensaje cuya
+    autenticación o cuyos adjuntos nunca llegó a mirar. Nunca **mejora** un
+    veredicto, igual que los gates existentes.
+    """
+    if not quality.is_degraded:
+        return verdict, []
+
+    lost = ", ".join(rule["name"] for rule in quality.failed_rules)
+    reasons = [f"Análisis degradado: no se pudieron ejecutar estas reglas ({lost})."]
+
+    if quality.blocks_clean_verdict and verdict == "Legitimate":
+        reasons.append(
+            "El veredicto no puede ser Legítimo: falló alguna regla de "
+            "autenticación o de adjuntos, así que el mensaje no llegó a "
+            "inspeccionarse por completo. Revisión manual recomendada."
+        )
+        return "Suspicious", reasons
+
+    return verdict, reasons

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import logging
+import uuid
 from datetime import datetime
 from email.utils import parseaddr
 from typing import Any, Dict, Optional
@@ -224,9 +225,11 @@ class IrisPDFCreator:
     direct database access.
     """
 
-    def __init__(self, report: Dict[str, Any], path: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, report: Dict[str, Any], path: Optional[Dict[str, Any]] = None,
+                 document_id: Optional[int] = None) -> None:
         self.report = report
         self.path = path or {}
+        self.document_id = document_id
         self.directory = CR.get_directory_of(CR.DirectoryType.OUTPUT_IRIS)
 
     def _set_pdf_metadata(self, document) -> None:
@@ -716,15 +719,40 @@ class IrisPDFCreator:
         elements.append(Spacer(1, 0.2 * inch))
         elements.append(Paragraph(f"Informe generado automáticamente | {timestamp}", theme.footer))
 
+    def _output_path(self) -> str:
+        """Ruta del PDF, única por **documento** y no por análisis (B11).
+
+        El modelo permite N ``IrisDocument`` por análisis, pero el nombre solo
+        dependía del ``analysis_id``, así que todos escribían el mismo fichero:
+        dos generaciones a la vez se pisaban, y borrar un documento destruía el
+        PDF del otro (``delete_document_with_file`` borra por ``filename``, que
+        era el mismo para ambos).
+
+        Cuando no hay ``document_id`` —ningún camino de la aplicación llega
+        así hoy; queda para que la clase siga siendo usable a pelo— se cae a un
+        sufijo aleatorio, que no colisiona aunque tampoco sea reproducible.
+        """
+        analysis_id = self.report.get("analysisId")
+        suffix = self.document_id if self.document_id is not None else uuid.uuid4().hex
+        return os.path.join(self.directory, f"{analysis_id}_{suffix}_Iris.pdf")
+
     def print_pdf(self) -> str:
-        """Generate the complete PDF report and return its file path."""
+        """Generate the complete PDF report and return its file path.
+
+        Se escribe en un temporal del mismo directorio y se mueve con
+        ``os.replace()``, que es atómico dentro de un mismo sistema de
+        ficheros. Sin eso, un lector que descargue el informe mientras se
+        regenera recibe un PDF a medio escribir: ``document.status`` pasa a
+        ``done`` una sola vez, pero el fichero al que apunta se reescribe en
+        sitio en cada regeneración.
+        """
         os.makedirs(self.directory, exist_ok=True)
 
-        analysis_id = self.report.get("analysisId")
-        filename = os.path.join(self.directory, f"{analysis_id}_Iris.pdf")
+        filename = self._output_path()
+        temporary = f"{filename}.{uuid.uuid4().hex}.tmp"
 
         document = SimpleDocTemplate(
-            filename, pagesize=A4,
+            temporary, pagesize=A4,
             rightMargin=36, leftMargin=36, topMargin=60, bottomMargin=40,
         )
 
@@ -745,6 +773,17 @@ class IrisPDFCreator:
         self.append_footer(elements, theme)
 
         self._set_pdf_metadata(document)
-        document.build(elements, onFirstPage=self._on_page, onLaterPages=self._on_page)
+        try:
+            document.build(elements, onFirstPage=self._on_page, onLaterPages=self._on_page)
+            os.replace(temporary, filename)
+        except Exception:
+            # Un temporal huérfano no lo limpia nadie: el nombre lleva un UUID,
+            # así que ni siquiera lo pisaría el siguiente intento.
+            if os.path.exists(temporary):
+                try:
+                    os.remove(temporary)
+                except OSError:
+                    logger.warning("No se pudo borrar el temporal %s", temporary)
+            raise
 
         return filename

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -452,6 +452,43 @@ class IrisPDFCreator:
 
         elements.append(Spacer(1, 0.22 * inch))
 
+    def append_quality_warning(self, elements: list, theme: IrisReportTheme) -> None:
+        """Aviso de análisis degradado (B05), justo debajo del veredicto.
+
+        Va aquí y no entre las señales de más abajo porque contradice
+        parcialmente lo que el lector acaba de leer: el veredicto grande de la
+        portada se calculó sin una parte del examen, y quien imprima el
+        informe tiene que verlo antes de actuar sobre él.
+        """
+        failed_rules = self.report.get("failedRules") or []
+        if self.report.get("analysisQuality") != "degraded" and not failed_rules:
+            return
+
+        names = ", ".join(rule.get("name", "?") for rule in failed_rules) or "desconocidas"
+        warning_style = ParagraphStyle(
+            "IrisQualityWarning", parent=theme.body,
+            textColor=colors.HexColor("#7a4100"),
+        )
+        text = (
+            f"<b>Análisis incompleto.</b> No se pudieron ejecutar estas reglas: "
+            f"{_esc(names)}. La parte del mensaje que les correspondía no se ha "
+            "inspeccionado, así que este informe describe menos de lo que "
+            "describiría un análisis completo."
+        )
+
+        card = Table([[Paragraph(text, warning_style)]], colWidths=[6.4 * inch])
+        card.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), colors.HexColor("#FFF4E5")),
+            ("LINEBEFORE", (0, 0), (0, -1), 3, colors.HexColor("#f57c00")),
+            ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor("#FFD8A8")),
+            ("LEFTPADDING", (0, 0), (-1, -1), 14),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 14),
+            ("TOPPADDING", (0, 0), (-1, -1), 10),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+        ]))
+        elements.append(card)
+        elements.append(Spacer(1, 0.22 * inch))
+
     def append_gate_reasons(self, elements: list, theme: IrisReportTheme) -> None:
         """Señales de alta confianza que fijaron el veredicto (S1).
 
@@ -697,6 +734,7 @@ class IrisPDFCreator:
 
         self.append_cover_page(elements, theme)
         self.append_verdict_hero(elements, theme)
+        self.append_quality_warning(elements, theme)
         self.append_email_preview(elements, theme)
         self.append_gate_reasons(elements, theme)
         self.append_rules(elements, theme)

--- a/API/src/modules/features/iris/services/rules/auth_rules.py
+++ b/API/src/modules/features/iris/services/rules/auth_rules.py
@@ -36,8 +36,14 @@ import re
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..auth_trust import (
+    TRUST_ABSENT,
+    TRUST_BELOW_BOUNDARY,
+    TRUST_UNKNOWN,
+    assess_authserv_trust,
+    is_arc_verified_by_trusted_hop,
+)
 from ..text import extract_domain, registrable_domain
-from ..parsers import parse_received_line
 
 
 def _dmarc_is_conclusive(auth_lower: str) -> bool:
@@ -389,9 +395,13 @@ _ARC_CV_RE = re.compile(r"\bcv=(\w+)", re.IGNORECASE)
 
 @iris_rules.register(
     name="ARC Chain", category="authentication",
-    description="Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated Received Chain, RFC 8617)",
+    description=(
+        "Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated "
+        "Received Chain, RFC 8617) y si la validó un verificador de confianza"
+    ),
+    needs_context=True,
 )
-def check_arc_chain(headers: dict) -> RuleResult:
+def check_arc_chain(context) -> RuleResult:
     """Evaluate the ``cv=`` (chain validation) status of an ARC seal.
 
     ARC lets a legitimate intermediary (mailing list, forwarding service)
@@ -400,11 +410,21 @@ def check_arc_chain(headers: dict) -> RuleResult:
     chain *declares* — it does not re-verify the ARC cryptographic
     signatures itself (same accepted limitation as SPF/DKIM/DMARC above).
 
+    `B06`: ``cv=pass`` por sí solo ya **no** ablanda ningún gate. Esa
+    afirmación la hace el propio mensaje sobre sí mismo, y Iris no verifica
+    firmas criptográficas, así que un atacante podía escribir un ``ARC-Seal:
+    cv=pass`` inventado y con eso suprimir los gates de SPF, DMARC y
+    alignment — precisamente los que existen para cazar suplantación. Quien sí
+    valida la cadena es el MTA receptor, que lo apunta como ``arc=pass`` en su
+    propio ``Authentication-Results``; ``details["verified"]`` recoge si esa
+    confirmación existe y viene de un verificador por encima de la frontera de
+    confianza, y es lo único que ``_extract_verdict_signals`` acepta ya como
+    permiso para ablandar.
+
     Returns:
         - ``pass`` (score +2) when ``cv=pass`` — a prior legitimate hop's
-          authentication validated correctly; consumed by
-          ``managers._extract_verdict_signals`` to soften the SPF/DMARC/
-          alignment gates for genuine forwards.
+          authentication validated correctly. Solo ablanda los gates de
+          SPF/DMARC/alignment si ``details["verified"]`` es True.
         - ``fail`` (score -8) when ``cv=fail`` — the chain itself declares
           a previous hop's authentication broken.
         - ``missing`` (score 0) when no ARC headers are present at all
@@ -413,6 +433,7 @@ def check_arc_chain(headers: dict) -> RuleResult:
           chain — genuinely uninformative, not suspicious) or any other
           value.
     """
+    headers = context.headers
     arc_seal = headers.get("arc-seal", "")
     arc_msg_sig = headers.get("arc-message-signature", "")
     arc_auth_results = headers.get("arc-authentication-results", "")
@@ -428,10 +449,16 @@ def check_arc_chain(headers: dict) -> RuleResult:
     chain_validation = match.group(1).lower() if match else None
 
     if chain_validation == "pass":
+        is_verified = is_arc_verified_by_trusted_hop(headers, context.received_headers)
         return RuleResult(
             score=2, verdict="pass",
-            details={"cv": chain_validation},
-            recommendation=None,
+            details={"cv": chain_validation, "verified": is_verified},
+            recommendation=None if is_verified else (
+                "La cadena ARC declara haberse validado correctamente (cv=pass), "
+                "pero ningún servidor de confianza lo confirma en su propia "
+                "cabecera Authentication-Results. Se toma como contexto, no como "
+                "prueba: esa declaración la puede escribir el propio remitente."
+            ),
         )
 
     if chain_validation == "fail":
@@ -492,6 +519,13 @@ def check_auth_results_provenance(context) -> RuleResult:
     hecho que el atacante SÍ controla mucho menos: la cadena Received real
     del mensaje. Si el authserv-id que reclama "pass" no aparece como host
     `by` de ningún salto, la línea es forjada.
+
+    `B06`: aparecer en la cadena tampoco basta. Los saltos de abajo los aporta
+    quien envía el mensaje, así que un atacante podía inyectar a la vez su
+    propio `Received` y su propio `Authentication-Results` y hacer que se
+    corroboraran entre sí — los dos elementos contrastados eran suyos. La
+    comprobación la hace ahora `services/auth_trust.py`, que exige que el
+    salto coincidente esté **por encima de la frontera de confianza**.
     """
     headers = context.headers
     auth_results = headers.get("authentication-results", "")
@@ -508,30 +542,44 @@ def check_auth_results_provenance(context) -> RuleResult:
         # cabecera -- fallar la autenticación no le compra nada al atacante.
         return RuleResult(score=0, verdict="neutral", details={"authserv_id": authserv_id, "statuses": statuses})
 
-    by_domains: set[str] = set()
-    for line in context.received_headers:
-        by_host = (parse_received_line(line).get("by") or "").strip().rstrip(".,;")
-        if by_host:
-            dom = registrable_domain(by_host)
-            if dom:
-                by_domains.add(dom)
+    trust = assess_authserv_trust(authserv_id, context.received_headers)
 
-    if not by_domains:
+    if trust.verdict == TRUST_UNKNOWN:
         # Sin cadena Received que verificar, no hay base para acusar de
         # forjado -- neutral, no "sospechoso por defecto".
-        return RuleResult(score=0, verdict="neutral", details={"reason": "no hay cadena Received que verificar"})
+        return RuleResult(score=0, verdict="neutral",
+                          details={"reason": "no hay cadena Received que verificar"})
 
-    authserv_reg = registrable_domain(authserv_id)
-    if authserv_reg in by_domains:
-        return RuleResult(score=0, verdict="pass", details={"authserv_id": authserv_id})
+    evidence = {
+        "authserv_id": authserv_id,
+        "statuses": statuses,
+        "trust": trust.verdict,
+        "trust_boundary": trust.boundary,
+        "trusted_by_domains": list(trust.trusted_by_domains),
+        "untrusted_by_domains": list(trust.untrusted_by_domains),
+    }
+
+    if trust.is_trusted:
+        return RuleResult(score=0, verdict="pass", details=evidence)
+
+    if trust.verdict == TRUST_BELOW_BOUNDARY:
+        return RuleResult(
+            score=CR.get_iris_scoring_weight("auth_provenance.below_boundary", -12),
+            verdict="fail",
+            details=evidence,
+            recommendation=(
+                f"La cabecera Authentication-Results declara autenticación 'pass' y está "
+                f"estampada por '{authserv_id}', que sí aparece en la cadena Received "
+                "del mensaje -- pero solo por debajo de la frontera de confianza, en la "
+                "parte de la cadena que aporta quien envía. Un remitente puede fabricar "
+                "a la vez el salto y la línea de autenticación para que se respalden "
+                "mutuamente; ninguno de los dos lo escribió un servidor verificable."
+            ),
+        )
 
     return RuleResult(
         score=CR.get_iris_scoring_weight("auth_provenance.forged", -12), verdict="fail",
-        details={
-            "authserv_id": authserv_id,
-            "statuses": statuses,
-            "received_by_domains": sorted(by_domains),
-        },
+        details=evidence,
         recommendation=(
             f"La cabecera Authentication-Results declara autenticación 'pass' pero fue "
             f"estampada por '{authserv_id}', un servidor que no aparece en ningún salto "

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -427,105 +427,142 @@ def _data(key: str) -> Any:
     return value if value is not None else _DEFAULTS[key]
 
 
-@lru_cache(maxsize=None)
-def _cached_set(key: str) -> frozenset[str]:
+# B18: las cachés se indexan por (versión de configuración, nombre del
+# dataset), no solo por el nombre.
+#
+# Antes la clave era el nombre a secas y eran permanentes, así que recargar la
+# configuración —``PUT /system``, o el ``reload_if_changed()`` que el worker
+# hace antes de cada job— sustituía ``_configs`` pero dejaba en pie las marcas,
+# proveedores, keywords y TLDs viejos. Un cambio guardado desde ConfigView no
+# llegaba al siguiente análisis, y el operador no tenía forma de enterarse: no
+# fallaba nada, simplemente se seguía analizando con los datos anteriores.
+#
+# Con la versión dentro de la clave, una configuración nueva no puede acertar
+# con una entrada vieja. No hace falta invalidar nada a mano —que es lo que se
+# olvida— y las entradas de generaciones pasadas quedan inalcanzables; el tope
+# de las cachés hace el resto, expulsándolas por LRU. Es el mismo criterio que
+# ``load_block`` aplica a los bloques de configuración.
+#
+# El tope da holgura para varias generaciones de los ~31 datasets a la vez, y
+# lo que pasa al desbordar es una recarga, no un error.
+_CACHE_SIZE = 256
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _cached_set(config_version: tuple, key: str) -> frozenset[str]:
     return frozenset(_data(key))
 
 
-@lru_cache(maxsize=None)
-def _cached_tuple(key: str) -> tuple[str, ...]:
+@lru_cache(maxsize=_CACHE_SIZE)
+def _cached_tuple(config_version: tuple, key: str) -> tuple[str, ...]:
     return tuple(_data(key))
+
+
+def _set_of(key: str) -> frozenset[str]:
+    return _cached_set(CR.config_version(), key)
+
+
+def _tuple_of(key: str) -> tuple[str, ...]:
+    return _cached_tuple(CR.config_version(), key)
 
 
 # --- Accessors públicos (uno por dataset) ------------------------------------
 
 def multi_level_tlds() -> frozenset[str]:
-    return _cached_set("multi_level_tlds")
+    return _set_of("multi_level_tlds")
 
 def canonical_brands() -> frozenset[str]:
-    return _cached_set("canonical_brands")
+    return _set_of("canonical_brands")
 
 def free_provider_domains() -> tuple[str, ...]:
-    return _cached_tuple("free_provider_domains")
+    return _tuple_of("free_provider_domains")
 
 def shortener_domains() -> frozenset[str]:
-    return _cached_set("shortener_domains")
+    return _set_of("shortener_domains")
 
 def dangerous_extensions() -> frozenset[str]:
-    return _cached_set("dangerous_extensions")
+    return _set_of("dangerous_extensions")
 
 def suspicious_mime_types() -> tuple[str, ...]:
-    return _cached_tuple("suspicious_mime_types")
+    return _tuple_of("suspicious_mime_types")
 
 def macro_extensions() -> frozenset[str]:
-    return _cached_set("macro_extensions")
+    return _set_of("macro_extensions")
 
 def credential_phrases() -> tuple[str, ...]:
-    return _cached_tuple("credential_phrases")
+    return _tuple_of("credential_phrases")
 
 def high_signal_keywords() -> tuple[str, ...]:
-    return _cached_tuple("high_signal_keywords")
+    return _tuple_of("high_signal_keywords")
 
 def low_signal_keywords() -> tuple[str, ...]:
-    return _cached_tuple("low_signal_keywords")
+    return _tuple_of("low_signal_keywords")
 
 def alarming_emojis() -> tuple[str, ...]:
-    return _cached_tuple("alarming_emojis")
+    return _tuple_of("alarming_emojis")
 
 def suspicious_tlds() -> frozenset[str]:
-    return _cached_set("suspicious_tlds")
+    return _set_of("suspicious_tlds")
 
 def generic_greetings() -> tuple[str, ...]:
-    return _cached_tuple("generic_greetings")
+    return _tuple_of("generic_greetings")
 
 def action_verbs() -> tuple[str, ...]:
-    return _cached_tuple("action_verbs")
+    return _tuple_of("action_verbs")
 
 def bec_phrases() -> tuple[str, ...]:
-    return _cached_tuple("bec_phrases")
+    return _tuple_of("bec_phrases")
 
 def toad_phrases() -> tuple[str, ...]:
-    return _cached_tuple("toad_phrases")
+    return _tuple_of("toad_phrases")
 
 def subdomain_action_words() -> frozenset[str]:
-    return _cached_set("subdomain_action_words")
+    return _set_of("subdomain_action_words")
 
 def esp_tracker_domains() -> frozenset[str]:
-    return _cached_set("esp_tracker_domains")
+    return _set_of("esp_tracker_domains")
 
 def esp_msgid_domains() -> frozenset[str]:
-    return _cached_set("esp_msgid_domains")
+    return _set_of("esp_msgid_domains")
 
 def redirect_params() -> frozenset[str]:
-    return _cached_set("redirect_params")
+    return _set_of("redirect_params")
 
 def undisclosed_patterns() -> tuple[str, ...]:
-    return _cached_tuple("undisclosed_patterns")
+    return _tuple_of("undisclosed_patterns")
 
 def url_phishing_keywords() -> tuple[str, ...]:
-    return _cached_tuple("url_phishing_keywords")
+    return _tuple_of("url_phishing_keywords")
 
 def multitenant_hosting_domains() -> frozenset[str]:
-    return _cached_set("multitenant_hosting_domains")
+    return _set_of("multitenant_hosting_domains")
 
 def exotic_charsets() -> tuple[str, ...]:
-    return _cached_tuple("exotic_charsets")
+    return _tuple_of("exotic_charsets")
 
 
-@lru_cache(maxsize=None)
-def homoglyph_table() -> dict[int, str]:
-    """Tabla para ``str.translate`` construida desde ``homoglyph_map``."""
+@lru_cache(maxsize=_CACHE_SIZE)
+def _homoglyph_table(config_version: tuple) -> dict[int, str]:
     mapping = {str(k): str(v) for k, v in dict(_data("homoglyph_map")).items()}
     return str.maketrans(mapping)
 
 
-@lru_cache(maxsize=None)
-def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
-    """Pares (keywords, dominios legítimos) por marca, desde ``brand_trusted_domains``."""
+def homoglyph_table() -> dict[int, str]:
+    """Tabla para ``str.translate`` construida desde ``homoglyph_map``."""
+    return _homoglyph_table(CR.config_version())
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _brand_trusted_domains(config_version: tuple) -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
     return tuple(
         (tuple(entry["keywords"]), tuple(entry["domains"]))
         for entry in _data("brand_trusted_domains")
     )
+
+
+def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]:
+    """Pares (keywords, dominios legítimos) por marca, desde ``brand_trusted_domains``."""
+    return _brand_trusted_domains(CR.config_version())
 
 
 # =============================================================================
@@ -541,11 +578,15 @@ def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ..
 # completa(s), en el mismo orden que el dataset (para no cambiar el
 # comportamiento de "primeros N matches" que ya consumían las reglas).
 
-@lru_cache(maxsize=None)
-def _phrase_pattern(key: str) -> re.Pattern:
+@lru_cache(maxsize=_CACHE_SIZE)
+def _compiled_phrase_pattern(config_version: tuple, key: str) -> re.Pattern:
     phrases = sorted(_data(key), key=len, reverse=True)
     alternation = "|".join(re.escape(phras) for phras in phrases)
     return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
+
+
+def _phrase_pattern(key: str) -> re.Pattern:
+    return _compiled_phrase_pattern(CR.config_version(), key)
 
 
 def phrase_matches(key: str, text: str) -> list[str]:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -97,11 +97,48 @@ def _lazy_load(func):
 # UTILIDADES
 # =============================================================================
 
+#: Contador que avanza cada vez que la configuración cargada es sustituida.
+#: Ver ``config_version``.
+_configs_generation = 0
+
+
+def config_version() -> tuple[int, int]:
+    """Identifica el árbol de configuración vigente ahora mismo.
+
+    Sirve para cachear cosas **derivadas** de la configuración sin que se
+    queden viejas: se mete como parte de la clave de caché, y al cambiar la
+    configuración las entradas antiguas dejan de ser alcanzables solas. Es lo
+    mismo que ya hacía ``load_block`` comparando la identidad de ``_configs``,
+    expuesto para quien no puede usar ``@config_block`` — el caso son los
+    datasets de Iris, que se cachean por nombre y no por campo.
+
+    Son dos números y no uno a propósito:
+
+    - El **contador** avanza en cada sustitución hecha por este módulo
+      (``reload``, ``reload_if_changed``, ``save_full_config``).
+    - La **identidad** del diccionario cubre lo que el contador no ve: un test
+      que monkeypatchee ``_configs`` directamente, que es como se prueba media
+      suite. Sin ella, un caché seguiría devolviendo los datos de la
+      configuración real bajo una config falsa.
+
+    Ninguno de los dos basta por su cuenta: la identidad se puede reutilizar
+    cuando el recolector libera el diccionario anterior, y el contador no ve
+    las escrituras que no pasan por aquí.
+    """
+    return (_configs_generation, id(_configs))
+
+
+def _bump_config_generation() -> None:
+    global _configs_generation
+    _configs_generation += 1
+
+
 def reload() -> None:
     """Fuerza la recarga de la configuración desde el archivo."""
     global _configs, _configs_path
     _configs = None
     _configs_path = None
+    _bump_config_generation()
 
 
 def _read_mtime(path: Path) -> float:
@@ -148,6 +185,7 @@ def reload_if_changed() -> bool:
 
     _configs = new_configs
     _configs_mtime = mtime
+    _bump_config_generation()
     logger.info("Configuración recargada desde disco (%s)", _configs_path)
     return True
 
@@ -1051,6 +1089,7 @@ def save_full_config(new_config: dict, expected_version: Optional[str] = None) -
         json.dump(new_config, f, indent=2, ensure_ascii=False)
     _configs = new_config
     _configs_mtime = _read_mtime(_configs_path)
+    _bump_config_generation()
     return new_config
 
 

--- a/API/src/modules/system/taskqueue/queue.py
+++ b/API/src/modules/system/taskqueue/queue.py
@@ -270,6 +270,20 @@ class ITaskQueue(Protocol):
         """
         ...
 
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        """¿Queda alguien que vaya a terminar el trabajo de este external_id?
+
+        La usan las reconciliaciones de arranque para no marcar como huérfano
+        un trabajo que sigue vivo en otro proceso. Un job en cola es
+        recuperable; uno en ejecución lo es solo si su worker sigue vivo; uno
+        terminado o inexistente, no.
+
+        Está en el contrato —y no solo en la implementación— porque un doble de
+        tests que la olvide haría que la reconciliación se comiera trabajo
+        vivo, que es justo el fallo que esta operación existe para evitar.
+        """
+        ...
+
     def update_progress(self, task_id: str, progress: int) -> None:
         """Actualiza el progreso (0-100) de un job en ejecución.
 
@@ -568,6 +582,62 @@ class TaskQueue:
             )
             return None
         return task
+
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        """¿Queda alguien que vaya a terminar el trabajo de *external_id*?
+
+        La usa la reconciliación de arranque de cada módulo para decidir si un
+        registro que quedó en pending/running está realmente huérfano. La
+        pregunta no la responde el estado del job por sí solo: un job
+        ``started`` puede estar avanzando en otro proceso ahora mismo, o
+        pertenecer a un worker que murió de un ``kill -9`` y no va a volver.
+
+        Estado por estado:
+
+        - **Sin job** (no hay mapeo, o el historial de RQ ya lo purgó por TTL):
+          no recuperable. Nadie va a tocar ese registro nunca más.
+        - **PENDING** (``queued``/``scheduled``/``deferred``): recuperable. El
+          job sigue en la cola y el primer worker libre lo tomará.
+        - **RUNNING** (``started``): recuperable **solo si su worker sigue
+          vivo**. Se comprueba con la misma verificación de PID que usa
+          ``cancel()``: la clave ``rq:worker:<name>`` sobrevive con TTL
+          completo a una muerte abrupta, así que su mera existencia no prueba
+          nada.
+        - **Terminal** (``finished``/``failed``/``stopped``): no recuperable.
+          El job acabó; si el registro sigue activo es porque el proceso murió
+          entre el trabajo y su escritura final.
+
+        Si Redis no responde se devuelve ``True``. Es deliberado y conservador:
+        sin poder mirar, no hay prueba de que el trabajo esté perdido, y el
+        precio de equivocarse es asimétrico — un huérfano que sobrevive un
+        arranque más se reconcilia en el siguiente, mientras que marcar
+        ``failed`` un trabajo vivo se lo enseña al usuario como fallido justo
+        antes de que el worker escriba su resultado encima.
+        """
+        try:
+            job_id = self._external.get(external_id)
+            if job_id is None:
+                return False
+
+            job = self._try_fetch_job(job_id)
+            if job is None:
+                return False
+
+            task = Task.from_rq_job(job)
+            if category is not None and task.category != category:
+                return False
+
+            if task.status is TaskStatus.PENDING:
+                return True
+            if task.status is TaskStatus.RUNNING:
+                return self._worker_alive(job.worker_name)
+            return False
+        except Exception as exc:
+            logger.warning(
+                "is_recoverable: no se pudo consultar %s (%s); se asume recuperable",
+                external_id, exc,
+            )
+            return True
 
     def get_running(self, category: Optional[str] = None) -> List[dict]:
         all_job_ids = []

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -1,8 +1,36 @@
 """Tests de integración del módulo Iris (análisis de cabeceras)."""
 
+from typing import Callable, Optional
+from unittest import mock
+
 import pytest
 
+from src.modules.system.taskqueue import Task, TaskStatus
+
 pytestmark = pytest.mark.integration
+
+
+class _NoopQueue:
+    """Cola que acepta el encolado y no ejecuta nada.
+
+    Los tests de aceptación de tamaño solo miran si la validación del schema
+    deja pasar la petición; ejecutar el análisis de verdad no aporta nada y
+    saldría a Redis, que la suite tiene deshabilitado.
+    """
+
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        return Task(id=name or "job", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
 
 
 def test_analyze_requires_authentication(client):
@@ -37,4 +65,88 @@ def test_analyze_rejects_request_without_headers_or_message(client, root_headers
     # Fase 2: 'headers' ya no es obligatorio si se envía 'message', pero al
     # menos uno de los dos debe estar presente (validado en el schema).
     resp = client.post("/iris/analyze", headers=root_headers, json={"title": "x"})
+    assert resp.status_code == 422
+
+
+# --------------------------------------------------------------- B13: capacidades
+
+def test_capabilities_requires_authentication(client):
+    assert client.get("/iris/capabilities").status_code == 401
+
+
+def test_capabilities_requires_read_attribute(client, stripped_user, auth_headers):
+    resp = client.get("/iris/capabilities", headers=auth_headers(stripped_user))
+    assert resp.status_code == 403
+
+
+def test_capabilities_publishes_the_limit_the_api_actually_enforces(client, regular_user,
+                                                                   auth_headers):
+    """B13: el frontend tenía su propio tope, y había derivado a 2× del real.
+
+    La única defensa contra que vuelva a derivar es que el número que publica
+    este endpoint sea el mismo que aplica la validación, leído del mismo sitio.
+    """
+    import src.modules.system.config_reading as CR
+
+    resp = client.get("/iris/capabilities", headers=auth_headers(regular_user))
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["maxMessageBytes"] == CR.iris_config().max_message_bytes
+    assert body["minHeaders"] == CR.iris_config().min_headers
+    assert set(body["analysisModes"]) == {"headers", "message"}
+
+
+def test_a_message_at_the_published_limit_is_accepted(client, regular_user, auth_headers,
+                                                      monkeypatch):
+    """Misma entrada, misma decisión: justo en el límite el API acepta."""
+    import src.modules.features.iris.schemas as schemas_mod
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    class _Limited:
+        max_message_bytes = 2048
+        min_headers = 2
+        legitimate_threshold = 80
+        suspicious_threshold = 55
+
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+
+    limit = client.get("/iris/capabilities",
+                       headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]
+
+    prefix = "From: a@b.com\r\nSubject: "
+    headers_block = prefix + "x" * (limit - len(prefix))
+    assert len(headers_block.encode("utf-8")) == limit
+
+    with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+        resp = client.post("/iris/analyze", headers=auth_headers(regular_user),
+                           json={"headers": headers_block})
+
+    assert resp.status_code != 422, resp.get_json()
+
+
+def test_a_message_over_the_published_limit_is_rejected(client, regular_user, auth_headers,
+                                                        monkeypatch):
+    """Y un byte por encima lo rechaza, que es la otra mitad del contrato: si
+    la UI corta por este número, no puede recibir sorpresas a ninguno de los
+    dos lados."""
+    import src.modules.features.iris.schemas as schemas_mod
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    class _Limited:
+        max_message_bytes = 2048
+        min_headers = 2
+        legitimate_threshold = 80
+        suspicious_threshold = 55
+
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+
+    limit = client.get("/iris/capabilities",
+                       headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]
+
+    resp = client.post("/iris/analyze", headers=auth_headers(regular_user),
+                       json={"headers": "From: a@b.com\r\nSubject: " + "x" * limit})
+
     assert resp.status_code == 422

--- a/API/tests/integration/test_iris_ai_summary.py
+++ b/API/tests/integration/test_iris_ai_summary.py
@@ -1,0 +1,285 @@
+"""B10: el resumen ejecutivo de IA se pide una vez y se cobra una vez.
+
+Antes, `generate_ai_summary` consumía cuota y encolaba sin mirar si ya había
+un resumen o un trabajo en curso. Dos peticiones seguidas —dos clics, un
+reintento del navegador, dos pestañas— cobraban dos veces y lanzaban dos
+generaciones del mismo análisis. El `external_id` era determinista, así que la
+información para evitarlo estaba ahí; simplemente nadie la consultaba.
+
+Además, la cola `iris.ai_summary` no estaba registrada: los trabajos caían en
+la cola `default` en lugar de en la suya.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.system.taskqueue import QueueRegistry, Task, TaskStatus
+
+pytestmark = pytest.mark.integration
+
+
+class _RecordingQueue:
+    """Cola que apunta lo que se le encola, sin ejecutarlo."""
+
+    def __init__(self) -> None:
+        self.submitted: list[dict] = []
+
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        self.submitted.append({"name": name, "category": category,
+                               "external_id": external_id, "args": args})
+        return Task(id=f"job-{len(self.submitted)}", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
+
+
+class _RejectingQueue(_RecordingQueue):
+    def submit(self, *args, **kwargs):
+        raise RuntimeError("la cola rechazó el trabajo")
+
+
+class _CountingQuota:
+    """Doble de QuotaManager que cuenta cobros y devoluciones."""
+
+    consumed: list[str] = []
+    refunded: list[str] = []
+
+    @classmethod
+    def reset(cls):
+        cls.consumed = []
+        cls.refunded = []
+
+    def consume(self, user_id, key, amount=1):
+        type(self).consumed.append(key.db_name)
+
+    def refund(self, user_id, key, amount=1):
+        type(self).refunded.append(key.db_name)
+
+
+@pytest.fixture()
+def counting_quota(monkeypatch):
+    _CountingQuota.reset()
+    monkeypatch.setattr(analysis_mod, "QuotaManager", _CountingQuota)
+    return _CountingQuota
+
+
+def _seed_finished_analysis(app, user_id: int, ai_summary=None) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(
+                raw_headers="From: a@b.com\nSubject: Test\n",
+                user_id=user_id, status="finished",
+                total_score=-25.0, verdict="Phishing",
+                ai_summary=ai_summary,
+            )
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+# ---------------------------------------------------------------------------
+# La cola nominal
+# ---------------------------------------------------------------------------
+
+def test_the_ai_summary_queue_is_registered():
+    """Sin registrar, `QueueRegistry.resolve_queue_name` cae a `default` y el
+    trabajo acaba compartiendo cola con todo lo demás, en vez de en la suya."""
+    assert QueueRegistry.is_registered("iris.ai_summary")
+
+
+def test_the_job_is_enqueued_in_its_own_queue(app, regular_user, counting_quota):
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(queue.submitted) == 1
+    assert queue.submitted[0]["category"] == "iris.ai_summary"
+    assert queue.submitted[0]["external_id"] == f"iris-ai-summary:{analysis_id}"
+
+
+# ---------------------------------------------------------------------------
+# Idempotencia
+# ---------------------------------------------------------------------------
+
+def test_two_requests_produce_a_single_job(app, regular_user, counting_quota):
+    """El caso del issue: dos peticiones concurrentes del mismo análisis."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        manager = IrisManager(task_queue=queue)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(queue.submitted) == 1
+
+
+def test_the_second_request_does_not_consume_quota(app, regular_user, counting_quota):
+    """La otra mitad, y la que le cuesta dinero al usuario: perder la carrera
+    no puede cobrarse."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        manager = IrisManager(task_queue=queue)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+        first_charges = list(counting_quota.consumed)
+        manager.generate_ai_summary(analysis_id, regular_user.id)
+
+    assert counting_quota.consumed == first_charges
+    assert "iris.ai_summaries" in first_charges
+
+
+def test_an_existing_summary_is_returned_without_working_or_charging(app, regular_user,
+                                                                    counting_quota):
+    """Doble clic sobre un análisis que ya tiene resumen: se devuelve el que
+    hay. Es lo que quiere quien hizo doble clic, y no cuesta nada."""
+    analysis_id = _seed_finished_analysis(
+        app, regular_user.id, ai_summary={"executive_summary": "ya estaba"})
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        status = IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert status == "done"
+    assert queue.submitted == []
+    assert counting_quota.consumed == []
+
+
+def test_an_explicit_regeneration_does_work_and_charge(app, regular_user, counting_quota):
+    """Y quien sí quiere otra redacción lo pide explícitamente."""
+    analysis_id = _seed_finished_analysis(
+        app, regular_user.id, ai_summary={"executive_summary": "ya estaba"})
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        status = IrisManager(task_queue=queue).generate_ai_summary(
+            analysis_id, regular_user.id, regenerate=True)
+
+    assert status == "running"
+    assert len(queue.submitted) == 1
+    assert counting_quota.consumed
+
+
+# ---------------------------------------------------------------------------
+# Reembolso
+# ---------------------------------------------------------------------------
+
+def test_a_rejected_enqueue_refunds_the_quota(app, regular_user, counting_quota):
+    """Cobrar antes de trabajar es correcto —cobrar después dejaría lanzar N
+    generaciones con cupo para una—, pero obliga a devolver el dinero cuando
+    el trabajo no llega a hacerse."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with pytest.raises(RuntimeError):
+            IrisManager(task_queue=_RejectingQueue()).generate_ai_summary(
+                analysis_id, regular_user.id)
+
+    assert counting_quota.refunded == counting_quota.consumed
+    assert counting_quota.refunded  # y algo se cobró, no es un empate vacío
+
+
+def test_a_rejected_enqueue_leaves_the_analysis_retryable(app, regular_user, counting_quota):
+    """Si la reserva no se soltara, el análisis se quedaría en `running` para
+    siempre y el usuario no podría volver a pedirlo nunca."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with pytest.raises(RuntimeError):
+            IrisManager(task_queue=_RejectingQueue()).generate_ai_summary(
+                analysis_id, regular_user.id)
+
+    assert _reload(app, analysis_id).ai_summary_status is None
+
+    queue = _RecordingQueue()
+    with app.app_context():
+        IrisManager(task_queue=queue).generate_ai_summary(analysis_id, regular_user.id)
+    assert len(queue.submitted) == 1
+
+
+def test_a_failed_generation_refunds_and_ends_in_a_terminal_state(app, regular_user,
+                                                                  counting_quota):
+    """El backend de IA puede estar caído o devolver basura. El análisis ya
+    terminado no se toca, pero el resumen no puede quedarse en `running` ni
+    cobrado."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        counting_quota.reset()
+
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               side_effect=RuntimeError("modelo caído")):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.ai_summary_status == "failed"
+    assert analysis.ai_summary is None
+    assert analysis.status == "finished"  # el análisis en sí no se ve afectado
+    assert counting_quota.refunded
+
+
+def test_a_failed_generation_can_be_retried(app, regular_user, counting_quota):
+    """`failed` es un estado reclamable: reintentar es legítimo."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               side_effect=RuntimeError("modelo caído")):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+        retry_queue = _RecordingQueue()
+        IrisManager(task_queue=retry_queue).generate_ai_summary(analysis_id, regular_user.id)
+
+    assert len(retry_queue.submitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Trazabilidad
+# ---------------------------------------------------------------------------
+
+def test_a_generated_summary_records_how_it_was_made(app, regular_user, counting_quota):
+    """Un resumen de hace tres meses lo escribió otro modelo con otro prompt.
+    Sin registrarlo no hay forma de saber cuál."""
+    analysis_id = _seed_finished_analysis(app, regular_user.id)
+
+    with app.app_context():
+        IrisManager(task_queue=_RecordingQueue()).generate_ai_summary(
+            analysis_id, regular_user.id)
+        with mock.patch.object(analysis_mod.IrisAIWriter, "generate",
+                               return_value={"executive_summary": "resumen"}):
+            IrisManager.execute_ai_summary_generation(analysis_id, regular_user.id)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.ai_summary_status == "done"
+    assert analysis.ai_summary == {"executive_summary": "resumen"}
+    assert analysis.ai_summary_model
+    assert analysis.ai_summary_prompt_version.startswith("iris-summary:")

--- a/API/tests/integration/test_iris_analysis_failures.py
+++ b/API/tests/integration/test_iris_analysis_failures.py
@@ -1,0 +1,155 @@
+"""B03: un análisis que se rompe acaba en un estado terminal con motivo.
+
+Antes, el parseo y la validación del mensaje vivían **fuera** de todo bloque
+``try`` de ``IrisManager._run_analysis``. Una excepción ahí —un parser que
+revienta con un ``.eml`` raro, por ejemplo— dejaba la fila en ``running``
+para siempre: RQ marcaba el job como fallido, pero nadie escribía en la base
+de datos y el usuario veía un análisis que no terminaba nunca.
+
+Estos tests recorren el mismo camino que el worker (``_run_analysis`` a pelo,
+que fuera de RQ funciona igual porque ``job_context()`` es un no-op sin job) y
+comprueban las tres cosas que el issue pide: estado terminal, ``finishedAt``
+presente y una razón consultable que no filtre el correo original.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.failures import (
+    FAILURE_INTERNAL_ERROR,
+    FAILURE_INVALID_INPUT,
+)
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+
+# Un correo con datos que no deben acabar nunca en la respuesta de la API.
+_SENSITIVE_RAW = (
+    "From: nomina@empresa.example\r\n"
+    "To: victima@empresa.example\r\n"
+    "Subject: Cambio de cuenta bancaria\r\n"
+    "X-Secreto: ES91-2100-0418-4502-0005-1332\r\n"
+    "\r\n"
+    "Transfiere la nómina a la nueva cuenta.\r\n"
+)
+
+
+def _make_analysis(app, user_id: int, raw: str = _SENSITIVE_RAW) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def test_broken_parser_leaves_a_terminal_state(app, regular_user):
+    """El caso literal del issue: ``parse_raw_message`` revienta."""
+    analysis_id = _make_analysis(app, regular_user.id)
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod, "parse_raw_message",
+                               side_effect=RuntimeError("boom en el parser")):
+            IrisManager()._run_analysis(analysis_id, _SENSITIVE_RAW)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "failed"
+    assert analysis.finished_at is not None
+    assert analysis.failure_code == FAILURE_INTERNAL_ERROR
+
+
+def test_broken_parser_reason_does_not_leak_the_raw_email(app, regular_user):
+    """Un ``str(exception)`` de terceros puede arrastrar el fragmento de
+    entrada que lo hizo fallar; por eso un error interno se colapsa en un
+    mensaje genérico en lugar de propagarse."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    leaking_error = RuntimeError(f"no pude parsear: {_SENSITIVE_RAW}")
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod, "parse_raw_message", side_effect=leaking_error):
+            IrisManager()._run_analysis(analysis_id, _SENSITIVE_RAW)
+
+    reason = _reload(app, analysis_id).failure_reason
+    assert reason
+    assert "ES91-2100-0418-4502-0005-1332" not in reason
+    assert "victima@empresa.example" not in reason
+
+
+def test_unparseable_input_is_invalid_not_internal(app, regular_user):
+    """Un texto que no es un correo es culpa del que lo manda, y el motivo
+    debe decírselo: ``invalid_input``, no un error interno opaco."""
+    analysis_id = _make_analysis(app, regular_user.id, raw="esto no es un correo")
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, "esto no es un correo")
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "failed"
+    assert analysis.finished_at is not None
+    assert analysis.failure_code == FAILURE_INVALID_INPUT
+    assert "cabeceras" in analysis.failure_reason
+
+
+class _NoTaskQueue:
+    """Doble mínimo de TaskQueue: el job ya no existe.
+
+    ``GET /iris/status`` consulta primero la cola (ruta rápida para tareas en
+    curso) y solo cae a la base de datos si no hay tarea viva. Sin este doble
+    la llamada saldría a Redis, que la suite tiene deshabilitado a propósito.
+    """
+
+    def get_task_by_external_id(self, external_id, category=None):
+        return None
+
+
+def test_status_endpoint_exposes_the_reason(client, app, regular_user, auth_headers):
+    """La razón tiene que ser consultable: ``GET /iris/results/<id>`` exige un
+    análisis ``finished``, así que el sitio donde se lee es ``/iris/status``."""
+    analysis_id = _make_analysis(app, regular_user.id, raw="esto tampoco es un correo")
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, "esto tampoco es un correo")
+
+    with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoTaskQueue()):
+        response = client.get(f"/iris/status?id={analysis_id}",
+                              headers=auth_headers(regular_user))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "failed"
+    assert body["failureCode"] == FAILURE_INVALID_INPUT
+    assert body["failureReason"]
+
+
+def test_successful_analysis_carries_no_failure_reason(app, regular_user):
+    """Un análisis que termina bien no debe arrastrar un motivo de fallo."""
+    raw = (
+        "From: alguien@example.com\r\n"
+        "To: destino@example.com\r\n"
+        "Subject: Hola\r\n"
+        "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "\r\n"
+        "Cuerpo.\r\n"
+    )
+    analysis_id = _make_analysis(app, regular_user.id, raw=raw)
+
+    with app.app_context():
+        IrisManager()._run_analysis(analysis_id, raw)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "finished"
+    assert analysis.failure_code is None
+    assert analysis.failure_reason is None

--- a/API/tests/integration/test_iris_degraded_analysis.py
+++ b/API/tests/integration/test_iris_degraded_analysis.py
@@ -1,0 +1,156 @@
+"""B05: una regla rota no puede pasar inadvertida en el informe.
+
+El criterio de cierre del issue pide las tres familias de regla fallida —
+autenticación, adjuntos y contenido— con comportamiento conservador. Estos
+tests las recorren de punta a punta: rompen una regla real del catálogo,
+ejecutan el análisis como lo haría el worker y comprueban qué acaba
+persistido y qué se devuelve por API.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.quality import QUALITY_COMPLETE, QUALITY_DEGRADED
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+
+# Un correo sin ninguna señal de phishing: sin romper nada sale Legitimate,
+# que es justo el veredicto que la degradación tiene que poder impedir.
+_CLEAN_RAW = (
+    "From: equipo@example.com\r\n"
+    "To: destinatario@example.com\r\n"
+    "Subject: Acta de la reunión\r\n"
+    "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+    "Message-ID: <abc123@example.com>\r\n"
+    "\r\n"
+    "Adjunto el acta de ayer.\r\n"
+)
+
+
+def _make_analysis(app, user_id: int) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=_CLEAN_RAW, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id: int) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def _run_with_broken_rule(app, analysis_id: int, rule_name: str | None) -> None:
+    """Ejecuta el análisis rompiendo una regla concreta del catálogo real.
+
+    Se parchea la función de la regla, no el registro entero: así el resto del
+    catálogo se ejecuta de verdad y el test comprueba el comportamiento en un
+    análisis completo, no en un laboratorio de una sola regla.
+    """
+    original_rules = iris_rules.get_rules()
+    patched = []
+    for rule_def in original_rules:
+        if rule_name is not None and rule_def["name"] == rule_name:
+            broken = dict(rule_def)
+            broken["func"] = mock.Mock(side_effect=RuntimeError("regla rota"))
+            patched.append(broken)
+        else:
+            patched.append(rule_def)
+
+    with app.app_context():
+        with mock.patch.object(iris_rules, "get_rules", return_value=patched):
+            IrisManager()._run_analysis(analysis_id, _CLEAN_RAW)
+
+
+def _rule_name_in_family(family: str) -> str:
+    for rule_def in iris_rules.get_rules():
+        if rule_def.get("family") == family:
+            return rule_def["name"]
+    raise AssertionError(f"el catálogo no tiene ninguna regla de familia {family!r}")
+
+
+def test_a_clean_message_is_legitimate_and_complete(app, regular_user):
+    """Punto de partida: sin romper nada, este correo sale limpio. Sin esto,
+    los tests de abajo no probarían nada — un Suspicious podría venir del
+    propio mensaje en vez de la degradación."""
+    analysis_id = _make_analysis(app, regular_user.id)
+
+    _run_with_broken_rule(app, analysis_id, None)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "finished"
+    assert analysis.verdict == "Legitimate"
+    assert analysis.analysis_quality == QUALITY_COMPLETE
+    assert analysis.failed_rules is None
+    assert analysis.detector_version
+
+
+def test_a_broken_auth_rule_blocks_the_clean_verdict(app, regular_user):
+    """Si la regla que decide si el mensaje está autenticado no se ejecutó,
+    presentarlo como limpio es afirmar algo que nadie comprobó."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("auth")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Suspicious"
+    assert [rule["name"] for rule in analysis.failed_rules] == [broken]
+    assert any("no puede ser Legítimo" in reason for reason in analysis.gate_reasons)
+
+
+def test_a_broken_attachment_rule_blocks_the_clean_verdict(app, regular_user):
+    """Mismo razonamiento: nadie miró lo que el mensaje trae dentro."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("attachment")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Suspicious"
+
+
+def test_a_broken_content_rule_degrades_but_keeps_the_verdict(app, regular_user):
+    """Las reglas de contenido son muchas y solapadas: perder una degrada la
+    confianza, pero no ciega el análisis del mismo modo."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("content")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.analysis_quality == QUALITY_DEGRADED
+    assert analysis.verdict == "Legitimate"
+    assert [rule["name"] for rule in analysis.failed_rules] == [broken]
+    # El aviso sí aparece, aunque el veredicto no cambie.
+    assert any("Análisis degradado" in reason for reason in analysis.gate_reasons)
+
+
+def test_the_report_exposes_the_degradation(client, app, regular_user, auth_headers):
+    """El frontend y el PDF leen esto: si no viaja por API, no hay forma de
+    enseñar la degradación en ningún sitio."""
+    analysis_id = _make_analysis(app, regular_user.id)
+    broken = _rule_name_in_family("auth")
+
+    _run_with_broken_rule(app, analysis_id, broken)
+
+    response = client.get(f"/iris/results/{analysis_id}",
+                          headers=auth_headers(regular_user))
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["analysisQuality"] == QUALITY_DEGRADED
+    assert [rule["name"] for rule in body["failedRules"]] == [broken]
+    assert body["detectorVersion"].startswith("iris-rules:")

--- a/API/tests/integration/test_iris_documents.py
+++ b/API/tests/integration/test_iris_documents.py
@@ -196,3 +196,49 @@ def test_delete_document(client, app, root_user, root_headers, fake_queue):
 
     after = client.get(f"/iris/document-status?documentId={doc_id}", headers=root_headers)
     assert after.status_code == 404
+
+
+# --------------------------------------------------------------- B11: PDFs independientes
+
+def test_two_documents_of_the_same_analysis_are_independent(client, app, root_user,
+                                                            root_headers, fake_queue):
+    """B11 de punta a punta.
+
+    El modelo permite N ``IrisDocument`` por análisis (relación ``documents``
+    con ``cascade="all, delete-orphan"``), pero el PDF se llamaba
+    ``<analysis_id>_Iris.pdf`` para todos: el segundo informe pisaba el fichero
+    del primero, y borrar cualquiera de los dos dejaba al otro apuntando a una
+    ruta que ya no existía.
+    """
+    import os
+    from src.modules.features.iris.repositories import IrisReportRepository
+    from src.modules.infrastructure import UnitOfWork
+
+    analysis_id = _seed_analysis(app, root_user.id)
+
+    first = client.post(f"/iris/results/{analysis_id}/document", headers=root_headers)
+    second = client.post(f"/iris/results/{analysis_id}/document", headers=root_headers)
+    assert first.status_code == 202 and second.status_code == 202
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            documents = IrisReportRepository(uow).get_documents_by_parent(analysis_id)
+            assert len(documents) == 2
+            paths = {document.filename for document in documents}
+            assert len(paths) == 2, "los dos informes escribieron el mismo fichero"
+            assert all(os.path.exists(path) for path in paths)
+
+    # Ambos se descargan, y cada uno con su propio nombre.
+    ids = sorted(document["documentId"] for document in
+                 client.get(f"/iris/results/{analysis_id}/documents",
+                            headers=root_headers).get_json()["documents"])
+    for document_id in ids:
+        download = client.get(f"/iris/document/{document_id}/download", headers=root_headers)
+        assert download.status_code == 200
+        assert f"_{document_id}.pdf" in download.headers["Content-Disposition"]
+
+    # Y borrar uno no destruye el fichero del otro.
+    assert client.delete(f"/iris/document/{ids[0]}", headers=root_headers).status_code == 200
+    survivor = client.get(f"/iris/document/{ids[1]}/download", headers=root_headers)
+    assert survivor.status_code == 200
+    assert len(survivor.data) > 0

--- a/API/tests/integration/test_iris_mailbox_model.py
+++ b/API/tests/integration/test_iris_mailbox_model.py
@@ -100,3 +100,51 @@ def test_analysis_source_message_uid_unique_per_connection(app, regular_user):
             repo = IrisAnalysisRepository(uow)
             repo.save(IrisAnalysis(raw_headers="From: a@b.com", user_id=regular_user.id))
             repo.save(IrisAnalysis(raw_headers="From: c@d.com", user_id=regular_user.id))
+
+
+# --------------------------------------------------------------- B12: cursor opaco
+
+def test_sync_cursor_column_has_no_length_limit():
+    """B12: la columna era ``String(255)``, pero el ``@odata.deltaLink`` de
+    Microsoft Graph es una URL con un token de estado dentro que la rebasa.
+
+    Esta comprobación mira el **tipo declarado**, no un round-trip, a
+    propósito: la suite corre sobre SQLite, que ignora la longitud de un
+    ``VARCHAR`` y por tanto guardaría feliz un cursor de 900 caracteres
+    incluso con la columna acotada. En PostgreSQL, que es donde corre de
+    verdad, ese INSERT falla. El tipo es lo único que distingue las dos cosas
+    desde aquí.
+    """
+    column_type = IrisMailboxConnection.__table__.c.sync_cursor.type
+
+    assert not getattr(column_type, "length", None), (
+        "sync_cursor volvió a tener un límite de longitud; un deltaLink de "
+        "Graph no cabe y la sincronización incremental se rompe en silencio"
+    )
+
+
+def test_a_long_opaque_cursor_survives_a_round_trip(app, regular_user):
+    """Complemento del anterior: el valor vuelve **exactamente** igual.
+
+    Aunque SQLite no valide la longitud, este test protege contra cualquier
+    recorte o normalización que alguien introdujera en el camino de guardado —
+    el cursor es opaco y un solo carácter de diferencia lo invalida.
+    """
+    cursor = (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + "Ag0AAA" + "Z" * 1200
+    )
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = IrisMailboxConnectionRepository(uow)
+            connection = _make_connection(regular_user.id, "cursor@outlook.com")
+            connection.provider = "microsoft"
+            connection.sync_cursor = cursor
+            repo.save(connection)
+            connection_id = connection.id
+
+        with UnitOfWork() as uow:
+            fetched = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert fetched.sync_cursor == cursor
+            assert len(fetched.sync_cursor) > 255

--- a/API/tests/integration/test_iris_permissions.py
+++ b/API/tests/integration/test_iris_permissions.py
@@ -1,0 +1,165 @@
+"""B14: la matriz ABAC de Iris, atada a un test.
+
+El `README.md` documentaba `IRIS_UPDATE` para reanálisis, resumen de IA y
+generación de PDF, mientras el código exigía `IRIS_CREATE`. Un cliente que
+siguiera el contrato publicado se llevaba un 403 inesperado.
+
+Al contrastar las dos versiones contra lo que las operaciones **hacen de
+verdad**, la que estaba mal era la documentación: las tres crean una entidad
+nueva (un análisis, un resumen, un documento) y consumen cuota por ella, que
+es exactamente lo que distingue `CREATE` de `UPDATE`. `UPDATE` queda para lo
+que modifica algo que ya existe: cancelar un análisis en curso, pausar una
+conexión de buzón, forzar una sincronización.
+
+Este fichero fija esa matriz para que la divergencia no pueda repetirse en
+silencio: si alguien cambia un decorador, aquí falla algo.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.system.taskqueue import Task, TaskStatus
+from src.modules.users.services.permissions import AttributeType
+
+pytestmark = pytest.mark.integration
+
+
+class _NoopQueue:
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        return Task(id=name or "job", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
+
+
+# Cada fila es (método, ruta, atributo exigido, cuerpo). La ruta usa un id que
+# no existe a propósito: lo que se comprueba aquí es la puerta de entrada, y un
+# 404 ya demuestra que el guardia dejó pasar.
+#
+# Los dos endpoints con cuerpo obligatorio lo llevan relleno porque
+# flask-smorest valida el schema **antes** de que corra `@require_attributes`:
+# sin cuerpo válido, la petición muere en un 422 y la comprobación de permisos
+# nunca llega a ejecutarse — con lo que el test no probaría nada.
+_ENDPOINTS = [
+    ("post", "/iris/analyze", AttributeType.IRIS_CREATE,
+     {"headers": "From: a@b.com\nSubject: Hola"}),
+    ("get", "/iris/status?id=999999", AttributeType.IRIS_READ, None),
+    ("get", "/iris/results", AttributeType.IRIS_READ, None),
+    ("get", "/iris/capabilities", AttributeType.IRIS_READ, None),
+    ("get", "/iris/results/999999", AttributeType.IRIS_READ, None),
+    ("get", "/iris/results/999999/path", AttributeType.IRIS_READ, None),
+    ("get", "/iris/results/999999/iocs", AttributeType.IRIS_READ, None),
+    ("post", "/iris/results/999999/reanalyze", AttributeType.IRIS_CREATE, None),
+    ("post", "/iris/results/999999/ai-summary", AttributeType.IRIS_CREATE, None),
+    ("post", "/iris/results/999999/document", AttributeType.IRIS_CREATE, None),
+    ("post", "/iris/analyze/999999/cancel", AttributeType.IRIS_UPDATE, None),
+    ("delete", "/iris/results/999999", AttributeType.IRIS_DELETE, None),
+    ("get", "/iris/documents", AttributeType.IRIS_READ, None),
+    ("get", "/iris/results/999999/documents", AttributeType.IRIS_READ, None),
+    ("get", "/iris/document/999999/download", AttributeType.IRIS_READ, None),
+    ("delete", "/iris/document/999999", AttributeType.IRIS_DELETE, None),
+    ("get", "/iris/mailbox/providers", AttributeType.IRIS_READ, None),
+    ("post", "/iris/mailbox/connect", AttributeType.IRIS_CREATE, {"provider": "gmail"}),
+    ("get", "/iris/mailbox/connections", AttributeType.IRIS_READ, None),
+    ("patch", "/iris/mailbox/connections/999999", AttributeType.IRIS_UPDATE, None),
+    ("delete", "/iris/mailbox/connections/999999", AttributeType.IRIS_DELETE, None),
+    ("post", "/iris/mailbox/connections/999999/sync", AttributeType.IRIS_UPDATE, None),
+]
+
+_ALL_IRIS_ATTRIBUTES = [
+    AttributeType.IRIS_READ,
+    AttributeType.IRIS_CREATE,
+    AttributeType.IRIS_UPDATE,
+    AttributeType.IRIS_DELETE,
+]
+
+
+def _call(client, method: str, path: str, headers: dict, body):
+    if body is None:
+        return getattr(client, method)(path, headers=headers)
+    return getattr(client, method)(path, headers=headers, json=body)
+
+
+_IDS = [f"{method.upper()} {path.split('?')[0]}" for method, path, _, _ in _ENDPOINTS]
+
+
+@pytest.mark.parametrize("method,path,required,body", _ENDPOINTS, ids=_IDS)
+def test_the_documented_attribute_opens_the_door(client, make_user, auth_headers,
+                                                 method, path, required, body, monkeypatch):
+    """Con el atributo que el contrato dice, la petición **no** da 403.
+
+    El resultado puede ser 404 (el id no existe), 422 (falta cuerpo) o 200:
+    cualquiera de ellos significa que la autorización dejó pasar, que es lo
+    único que este test juzga.
+    """
+    monkeypatch.setattr(analysis_mod.TaskQueue, "get_instance", lambda: _NoopQueue())
+    user = make_user(role="role_user", attributes=[required.db_name])
+
+    response = _call(client, method, path, auth_headers(user), body)
+
+    assert response.status_code != 403, (
+        f"{method.upper()} {path} exige más que {required}, "
+        "pero el contrato publica ese atributo"
+    )
+
+
+@pytest.mark.parametrize("method,path,required,body", _ENDPOINTS, ids=_IDS)
+def test_every_other_attribute_is_refused(client, make_user, auth_headers,
+                                          method, path, required, body, monkeypatch):
+    """Y con cualquier **otro** atributo de Iris, 403.
+
+    Esta es la mitad que convierte la matriz en un contrato de verdad. Sin
+    ella, dar todos los permisos a todo el mundo pasaría el test de arriba.
+    """
+    monkeypatch.setattr(analysis_mod.TaskQueue, "get_instance", lambda: _NoopQueue())
+    others = [attribute for attribute in _ALL_IRIS_ATTRIBUTES if attribute is not required]
+    user = make_user(role="role_user", attributes=[attribute.db_name for attribute in others])
+
+    response = _call(client, method, path, auth_headers(user), body)
+
+    assert response.status_code == 403, (
+        f"{method.upper()} {path} deja pasar sin {required}"
+    )
+
+
+def test_a_refusal_reveals_nothing_about_the_resource(client, app, make_user, auth_headers):
+    """Criterio de cierre del issue: un 403 no puede filtrar existencia ni
+    contenido.
+
+    Se piden dos análisis, uno que no existe y otro que sí existe pero es de
+    otro usuario. Las dos respuestas tienen que ser indistinguibles: si el
+    cuerpo o el código cambiaran, el 403 se convertiría en un oráculo para
+    enumerar qué análisis hay.
+    """
+    from src.modules.features.iris.model import IrisAnalysis
+    from src.modules.features.iris.repositories import IrisAnalysisRepository
+    from src.modules.infrastructure import UnitOfWork
+
+    owner = make_user(role="role_user")
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=owner.id,
+                                    status="finished")
+            IrisAnalysisRepository(uow).save(analysis)
+            existing_id = analysis.id
+
+    intruder = make_user(role="role_user", attributes=[])
+    headers = auth_headers(intruder)
+
+    missing = client.get("/iris/results/999999", headers=headers)
+    existing = client.get(f"/iris/results/{existing_id}", headers=headers)
+
+    assert missing.status_code == existing.status_code == 403
+    assert missing.get_json() == existing.get_json()

--- a/API/tests/integration/test_iris_reconciliation.py
+++ b/API/tests/integration/test_iris_reconciliation.py
@@ -1,9 +1,16 @@
-"""C1: reconciliación de análisis Iris huérfanos tras un apagado abrupto.
+"""C1/B04: reconciliación de análisis Iris huérfanos tras un apagado abrupto.
 
 Espejo de la reconciliación que ya existía para Themis (ScanManager.
 reconcile_orphaned_scans) — sin esto, un análisis que queda en pending/running
 cuando el proceso muere se queda así para siempre, porque no hay ninguna tarea
 viva en TaskQueue que lo actualice tras reiniciar.
+
+`B04` cambió el criterio. Antes se conservaba el análisis solo si su tarea
+estaba exactamente en ``pending``, y eso se comía trabajo vivo: los workers son
+procesos aparte, reiniciar la API no los para, y un job ``running`` puede estar
+avanzando ahora mismo en otro proceso. La pregunta correcta no es "¿en qué
+estado está el job?" sino "¿queda alguien que vaya a terminarlo?", que es lo que
+responde ``TaskQueue.is_recoverable()``.
 """
 
 from __future__ import annotations
@@ -19,18 +26,34 @@ from src.modules.system.taskqueue import Task, TaskStatus
 import src.modules.features.iris.managers.analysis as managers_mod
 from src.modules.features.iris.model import IrisAnalysis
 from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.failures import FAILURE_WORKER_LOST
 
 pytestmark = pytest.mark.integration
 
 
 class _FakeQueue:
-    """Cola fake: devuelve lo que el test necesite por external_id."""
+    """Cola fake que responde lo que el test necesite por external_id.
 
-    def __init__(self, tasks_by_external_id: dict[str, Optional[Task]]):
+    ``recoverable`` modela la respuesta de ``is_recoverable()``, que en la
+    implementación real combina el estado del job con la comprobación de si el
+    worker que lo tomó sigue vivo. Aquí se declara directamente: lo que estos
+    tests fijan es qué hace la reconciliación con esa respuesta, no cómo la
+    calcula la cola (eso vive en ``tests/unit/test_taskqueue.py``).
+    """
+
+    def __init__(self, tasks_by_external_id: dict[str, Optional[Task]],
+                 recoverable: Optional[dict[str, bool]] = None):
         self._tasks = tasks_by_external_id
+        self._recoverable = recoverable or {}
 
     def get_task_by_external_id(self, external_id: str, category: Optional[str] = None):
         return self._tasks.get(external_id)
+
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        if external_id in self._recoverable:
+            return self._recoverable[external_id]
+        task = self._tasks.get(external_id)
+        return task is not None and task.status is TaskStatus.PENDING
 
     def submit(self, func: Callable, **kwargs): raise NotImplementedError
     def cancel(self, task_id: str) -> bool: return True
@@ -48,39 +71,112 @@ def _make_analysis(app, user_id, status="running"):
             return analysis.id
 
 
-def test_reconcile_marks_orphan_without_any_task_as_failed(app, regular_user):
-    analysis_id = _make_analysis(app, regular_user.id, status="running")
-    queue = _FakeQueue({})  # sin tarea en TaskQueue -> huérfano
-
+def _reconcile(app, queue) -> int:
     with app.app_context():
         with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 1
+            return managers_mod.IrisManager.reconcile_orphaned_analyses()
+
+
+def _reload(app, analysis_id) -> IrisAnalysis:
+    with app.app_context():
         with UnitOfWork() as uow:
-            assert IrisAnalysisRepository(uow).get_by_id(analysis_id).status == "failed"
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+def _task(external_id: str, status: TaskStatus) -> Task:
+    return Task(id="job1", name="job1", category="iris.analyze",
+                external_id=external_id, status=status)
+
+
+def test_reconcile_marks_orphan_without_any_task_as_failed(app, regular_user):
+    """Sin tarea en TaskQueue no hay nadie que vaya a terminar el análisis."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    assert _reconcile(app, _FakeQueue({})) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_records_why_the_analysis_was_orphaned(app, regular_user):
+    """Un `failed` sin explicación no le dice nada al usuario: aquí la causa no
+    es que el motor fallara, sino que el proceso que lo ejecutaba desapareció."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    _reconcile(app, _FakeQueue({}))
+
+    analysis = _reload(app, analysis_id)
+    assert analysis.failure_code == FAILURE_WORKER_LOST
+    assert analysis.failure_reason
+    assert analysis.finished_at is not None
 
 
 def test_reconcile_leaves_still_queued_analysis_alone(app, regular_user):
+    """Un job en cola lo tomará el primer worker libre: no está huérfano."""
     analysis_id = _make_analysis(app, regular_user.id, status="pending")
     external_id = f"iris-analysis:{analysis_id}"
-    queue = _FakeQueue({external_id: Task(
-        id="job1", name="job1", category="iris.analyze",
-        external_id=external_id, status=TaskStatus.PENDING,
-    )})
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.PENDING)})
 
-    with app.app_context():
-        with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 0
-        with UnitOfWork() as uow:
-            assert IrisAnalysisRepository(uow).get_by_id(analysis_id).status == "pending"
+    assert _reconcile(app, queue) == 0
+    assert _reload(app, analysis_id).status == "pending"
+
+
+def test_reconcile_leaves_a_running_analysis_alone(app, regular_user):
+    """El caso que motiva B04.
+
+    El worker está analizando ahora mismo en otro proceso. Con el criterio
+    viejo —conservar solo si el estado es exactamente ``pending``— este
+    análisis se marcaba ``failed``, el usuario lo veía fallido, y poco después
+    el worker escribía ``finished`` encima de esa misma fila.
+    """
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: True},  # su worker sigue vivo
+    )
+
+    assert _reconcile(app, queue) == 0
+    analysis = _reload(app, analysis_id)
+    assert analysis.status == "running"
+    assert analysis.finished_at is None
+
+
+def test_reconcile_recovers_a_running_analysis_whose_worker_died(app, regular_user):
+    """Mismo estado ``running``, decisión contraria: si el worker que tomó el
+    job ya no existe, nadie va a leer su señal ni a escribir su resultado."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: False},  # kill -9 al worker
+    )
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_recovers_an_analysis_whose_job_expired(app, regular_user):
+    """RQ purga su historial por TTL: el job existió, pero ya no está y su
+    resultado nunca llegó a la fila."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue({external_id: None}, recoverable={external_id: False})
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
+
+
+def test_reconcile_recovers_an_analysis_whose_job_already_failed(app, regular_user):
+    """Un job en estado terminal no va a volver a tocar la fila: si el análisis
+    sigue activo es porque el proceso murió entre el trabajo y su escritura."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+    external_id = f"iris-analysis:{analysis_id}"
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.FAILED)})
+
+    assert _reconcile(app, queue) == 1
+    assert _reload(app, analysis_id).status == "failed"
 
 
 def test_reconcile_ignores_already_finished_analyses(app, regular_user):
     _make_analysis(app, regular_user.id, status="finished")
-    queue = _FakeQueue({})
 
-    with app.app_context():
-        with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
-            fixed = managers_mod.IrisManager.reconcile_orphaned_analyses()
-        assert fixed == 0
+    assert _reconcile(app, _FakeQueue({})) == 0

--- a/API/tests/integration/test_quotas.py
+++ b/API/tests/integration/test_quotas.py
@@ -407,3 +407,61 @@ def test_usage_flags_a_key_over_its_limit(
     assert body["usage"]["hygeia.assets"]["used"] == 3
     # Lo ya creado sigue ahí: degradar nunca borra.
     assert len(client.get("/hygeia/assets", headers=headers).get_json()["assets"]) == 3
+
+
+# ------------------------------------------------------------------ reembolso
+
+def test_refund_gives_the_room_back(app, regular_user, set_plan_limits):
+    """B10: `consume()` ocurre antes que el trabajo que se paga, y tiene que
+    ser así — cobrar después dejaría lanzar N trabajos concurrentes con cupo
+    para uno. El precio de ese orden es que un trabajo que nunca llega a
+    hacerse deja al usuario pagando por nada."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 2})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 2
+
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 1
+        # Y el hueco devuelto se puede volver a gastar de verdad.
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+
+
+def test_refund_never_goes_below_zero(app, regular_user, set_plan_limits):
+    """Un reembolso de más regalaría cupo. La condición vive dentro del UPDATE,
+    igual que en el cobro, para no leer-decidir-escribir."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 5})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 0
+
+
+def test_refund_without_a_previous_charge_is_harmless(app, regular_user, set_plan_limits):
+    """No resucita filas ni inventa cupo: si no había contador, no hay nada
+    que devolver."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 3})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.refund(regular_user.id, LimitKey.AI_REQUESTS)
+
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 0
+
+
+def test_refund_never_raises(app, regular_user, set_plan_limits):
+    """Se invoca desde caminos de error. Un reembolso que lanzara taparía la
+    excepción original, que es la que el usuario necesita ver."""
+    set_plan_limits({LimitKey.AI_REQUESTS: 1})
+
+    with app.app_context():
+        # Usuario inexistente: resolver el derecho no puede prosperar.
+        QuotaManager().refund(999999, LimitKey.AI_REQUESTS)

--- a/API/tests/postgres/conftest.py
+++ b/API/tests/postgres/conftest.py
@@ -1,0 +1,226 @@
+"""B20: fixtures para la matriz de integración contra motores reales.
+
+La suite normal corre sobre SQLite con Redis y la red cortados de raíz, y eso
+es deliberado: la mantiene en ~2 minutos y hace que el resultado no dependa de
+lo que tenga levantado la máquina. Pero significa que hay invariantes de
+producción que **hoy no prueba nadie**, porque solo existen en el motor real:
+
+- SQLite ignora la longitud de un ``VARCHAR``, así que una columna demasiado
+  corta no falla nunca (es lo que dejó pasar el `sync_cursor` de `B12`).
+- SQLite no aplica claves foráneas salvo que se active explícitamente, así que
+  ``ON DELETE CASCADE`` y ``ON DELETE SET NULL`` no se ejercitan.
+- ``JSONB`` se sustituye por ``JSON`` genérico con un shim, así que ni el tipo
+  ni sus operadores son los de producción.
+- Las carreras reales entre transacciones no se pueden montar con un fichero
+  SQLite compartido por un solo hilo.
+
+Estos tests **no** sustituyen a los de la suite rápida: la complementan en el
+único sitio donde SQLite no puede decir la verdad. Y no la ralentizan, porque
+se saltan solos cuando no hay motores conectados.
+
+Las fixtures tienen nombres propios (``pg_engine``, ``pg_session``…) en vez de
+sobrescribir las de la raíz. Sobrescribir ``_initialized_db`` o ``app`` —que
+son de sesión— haría que el primer test en pedirlas fijara el motor para toda
+la ejecución, y el resultado dependería del orden de recolección.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+import redis as redis_lib
+
+# Se captura ANTES de que la fixture de sesión de la raíz parchee el pool: los
+# conftest se importan en la recolección, y las fixtures autouse no corren
+# hasta el primer test. Sin esta referencia no habría forma de volver a hablar
+# con un Redis de verdad desde dentro de la suite.
+_REAL_REDIS_GET_CONNECTION = redis_lib.connection.ConnectionPool.get_connection
+
+
+#: URL del PostgreSQL efímero. Sin ella, todo este directorio se salta.
+POSTGRES_URL_ENV = "POSTGRES_TEST_URL"
+
+#: URL del Redis efímero. Los tests que lo necesitan se saltan sin ella.
+REDIS_URL_ENV = "REDIS_TEST_URL"
+
+
+def _postgres_url() -> str | None:
+    return os.getenv(POSTGRES_URL_ENV) or None
+
+
+def _redis_url() -> str | None:
+    return os.getenv(REDIS_URL_ENV) or None
+
+
+def pytest_collection_modifyitems(config, items):
+    """Marca y salta todo el directorio cuando no hay PostgreSQL conectado.
+
+    Se hace aquí y no con un ``skipif`` por módulo para que no haya forma de
+    escribir un test nuevo en esta carpeta y olvidarse del guardia: en un
+    portátil sin contenedores la carpeta entera se salta, y en el runner de CI
+    con el servicio levantado corre entera.
+    """
+    if _postgres_url():
+        return
+    skip = pytest.mark.skip(
+        reason=f"sin {POSTGRES_URL_ENV}: la matriz de motores reales solo corre en su job de CI"
+    )
+    for item in items:
+        if "tests/postgres/" in item.nodeid.replace("\\", "/"):
+            item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def _clean_db():
+    """Neutraliza la limpieza de la base SQLite de la suite rápida.
+
+    ``tests/conftest.py`` la declara autouse, así que **cada** test la arrastra
+    — y con ella ``_initialized_db``, que aplica el shim de tipos
+    PostgreSQL→SQLite. Ese shim sustituye ``JSONB`` por ``JSON`` genérico
+    **mutando ``Base.metadata`` en el sitio**, de modo que a partir de ese
+    momento el proceso entero cree que esas columnas son ``JSON``: el esquema
+    que se crea aquí saldría con el tipo equivocado y los operadores de JSONB
+    no existirían.
+
+    Sobrescribirla por nombre es el mecanismo de pytest para esto y solo aplica
+    a este directorio. Aquí no hace falta lo que hacía: cada test usa su propia
+    sesión, que se deshace al terminar.
+    """
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _unlimited_default_plan():
+    """Igual que arriba: la siembra de planes de la suite rápida arrastra la
+    fixture ``app``, que también construye el engine SQLite."""
+    yield
+
+
+@pytest.fixture(scope="session")
+def pg_engine() -> Iterator[sa.Engine]:
+    """Engine contra el PostgreSQL efímero, con el esquema real creado.
+
+    **Sin el shim de tipos** que la suite normal aplica: aquí las columnas son
+    ``JSONB`` de verdad, que es justo lo que se quiere comprobar.
+    """
+    url = _postgres_url()
+    if not url:
+        pytest.skip(f"sin {POSTGRES_URL_ENV}")
+
+    # Importar run arrastra todos los blueprints y con ellos cada modelo a
+    # Base.metadata, igual que hace el conftest de la raíz.
+    import run  # noqa: F401
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from src.modules.shared import Base
+
+    # Guardia contra el shim de la suite rápida. Si algo ha llegado a
+    # construir el engine SQLite en este proceso, ``Base.metadata`` ya tiene
+    # las columnas JSONB degradadas a JSON y todo lo que se cree aquí sería
+    # una imitación del esquema real. Es preferible saltarse la matriz con un
+    # motivo legible que dar por buenas unas comprobaciones que no comprueban
+    # lo que dicen. En su job de CI (``pytest -m postgres``) no pasa: nada
+    # pide el engine SQLite.
+    if not isinstance(Base.metadata.tables["IrisAnalysis"].c.failed_rules.type, JSONB):
+        pytest.skip(
+            "Base.metadata ya tiene aplicado el shim SQLite (JSONB->JSON): "
+            "esta matriz debe ejecutarse en su propia invocación, con "
+            "`pytest -m postgres`"
+        )
+
+    engine = sa.create_engine(url, pool_pre_ping=True, future=True)
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _truncate_everything(engine: sa.Engine) -> None:
+    """Vacía todas las tablas de la aplicación.
+
+    Hace falta porque estos tests **confirman** sus transacciones: un rollback
+    al terminar no deshace nada de lo ya escrito, y el siguiente test que
+    consulte "todos los análisis" dependería de lo que dejaron los anteriores.
+    ``TRUNCATE ... CASCADE`` en una sola sentencia evita además tener que
+    ordenar las tablas por sus claves foráneas.
+    """
+    from src.modules.shared import Base
+
+    names = ", ".join(f'"{table.name}"' for table in Base.metadata.sorted_tables)
+    if not names:
+        return
+    with engine.begin() as connection:
+        connection.execute(sa.text(f"TRUNCATE {names} RESTART IDENTITY CASCADE"))
+
+
+@pytest.fixture()
+def pg_session(pg_engine) -> Iterator[Session]:
+    """Sesión limpia por test, sobre una base vacía."""
+    factory = sessionmaker(bind=pg_engine, expire_on_commit=False, future=True)
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        _truncate_everything(pg_engine)
+
+
+@pytest.fixture()
+def pg_sessions(pg_engine):
+    """Factory de sesiones **independientes**, para montar carreras de verdad.
+
+    Dos sesiones distintas son dos transacciones distintas contra el mismo
+    PostgreSQL, que es la única forma de comprobar que una restricción de
+    unicidad o un UPDATE condicional aguantan la concurrencia. Con una sola
+    sesión, el ORM resolvería el conflicto en su propio identity map y el test
+    pasaría sin haber tocado la base de datos.
+    """
+    factory = sessionmaker(bind=pg_engine, expire_on_commit=False, future=True)
+    opened: list[Session] = []
+
+    def _open() -> Session:
+        session = factory()
+        opened.append(session)
+        return session
+
+    try:
+        yield _open
+    finally:
+        for session in opened:
+            session.rollback()
+            session.close()
+
+
+@pytest.fixture()
+def real_redis():
+    """Cliente contra el Redis efímero, con el corte de la suite levantado.
+
+    El conftest de la raíz parchea ``ConnectionPool.get_connection`` para toda
+    la sesión, así que aquí se restaura la función original mientras dure el
+    test. Es local y temporal a propósito: fuera de este directorio el corte
+    sigue en pie.
+    """
+    url = _redis_url()
+    if not url:
+        pytest.skip(f"sin {REDIS_URL_ENV}")
+
+    from unittest import mock
+
+    with mock.patch.object(redis_lib.connection.ConnectionPool, "get_connection",
+                           _REAL_REDIS_GET_CONNECTION):
+        client = redis_lib.Redis.from_url(url, decode_responses=True)
+        client.flushdb()
+        try:
+            yield client
+        finally:
+            client.flushdb()
+            client.close()

--- a/API/tests/postgres/test_concurrency.py
+++ b/API/tests/postgres/test_concurrency.py
@@ -1,0 +1,142 @@
+"""B20: las carreras que solo existen con transacciones de verdad.
+
+El motor de cuotas y la reserva del resumen de IA se apoyan los dos en la
+misma idea: la condición vive **dentro** del UPDATE, para que dos peticiones
+simultáneas no puedan gastar el mismo hueco. Esa propiedad no se puede
+comprobar con un fichero SQLite y una sola sesión — hacen falta dos
+transacciones concurrentes contra el mismo servidor.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.users.model import User
+
+pytestmark = pytest.mark.postgres
+
+
+def _user(pg_session, username: str) -> User:
+    user = User(
+        username=username, email=f"{username}@ellysia.test",
+        first_name="Postgres", last_name="Tester",
+        password_hash="x", password_salt="", role="role_user",
+    )
+    pg_session.add(user)
+    pg_session.commit()
+    return user
+
+
+def _claim(session, analysis_id: int) -> bool:
+    """El mismo UPDATE condicional que usa ``IrisManager._claim_ai_summary``.
+
+    Se reproduce aquí en vez de llamar al manager porque el manager abre su
+    propia ``UnitOfWork`` contra el engine global de la aplicación, y lo que
+    este test necesita es controlar las dos transacciones.
+    """
+    result = session.execute(
+        sa.update(IrisAnalysis)
+        .where(sa.and_(
+            IrisAnalysis.id == analysis_id,
+            sa.or_(IrisAnalysis.ai_summary_status.is_(None),
+                   IrisAnalysis.ai_summary_status == "failed"),
+        ))
+        .values(ai_summary_status="running")
+    )
+    return bool(result.rowcount)
+
+
+def test_only_one_of_two_concurrent_claims_wins(pg_session, pg_sessions):
+    """B10 contra concurrencia real.
+
+    Dos peticiones simultáneas del resumen de IA del mismo análisis. La
+    exclusión se apoya en que el segundo UPDATE no afecte a ninguna fila; si
+    la comprobación viviera en Python entre una lectura y una escritura, las
+    dos ganarían y el usuario pagaría dos veces.
+    """
+    user = _user(pg_session, "carrera-resumen")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    first, second = pg_sessions(), pg_sessions()
+
+    first_won = _claim(first, analysis.id)
+    first.commit()
+    second_won = _claim(second, analysis.id)
+    second.commit()
+
+    assert [first_won, second_won] == [True, False]
+
+
+def test_a_failed_claim_can_be_taken_again(pg_session, pg_sessions):
+    """`failed` es reclamable: reintentar tiene que funcionar, o un fallo del
+    backend de IA dejaría el resumen bloqueado para siempre."""
+    user = _user(pg_session, "reintento-resumen")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="finished", ai_summary_status="failed")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    session = pg_sessions()
+    assert _claim(session, analysis.id) is True
+    session.commit()
+
+
+def test_two_transactions_cannot_spend_the_same_last_slot(pg_session, pg_sessions):
+    """El patrón del motor de cuotas, aislado.
+
+    Es el mismo UPDATE condicional que usa ``QuotaManager._consume_counter``:
+    ``SET used = used + 1 WHERE used + 1 <= limite``. Con el límite en 1 y dos
+    transacciones a la vez, PostgreSQL serializa los dos UPDATE y el segundo no
+    encuentra fila. Sobre SQLite, con una sola conexión, esta comprobación no
+    demostraría nada.
+    """
+    user = _user(pg_session, "carrera-cuota")
+    counter = sa.table(
+        "IrisAnalysis",
+        sa.column("id"), sa.column("total_score"), sa.column("user_id"),
+    )
+
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="finished", total_score=0)
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    def spend(session) -> bool:
+        result = session.execute(
+            sa.update(counter)
+            .where(sa.and_(counter.c.id == analysis.id, counter.c.total_score + 1 <= 1))
+            .values(total_score=counter.c.total_score + 1)
+        )
+        return bool(result.rowcount)
+
+    first, second = pg_sessions(), pg_sessions()
+
+    first_spent = spend(first)
+    first.commit()
+    second_spent = spend(second)
+    second.commit()
+
+    assert [first_spent, second_spent] == [True, False]
+
+
+def test_redis_round_trips_a_cancel_signal(real_redis):
+    """La otra mitad de la matriz: un Redis de verdad.
+
+    La suite normal corta Redis de raíz, así que la señal de cancelación
+    cooperativa —la clave ``taskqueue:cancel:<job>`` que los workers sondean—
+    nunca se escribe ni se lee contra el servidor real. Es poco código, pero es
+    el mecanismo del que depende que un escaneo o un análisis se puedan parar.
+    """
+    key = "taskqueue:cancel:job-de-prueba"
+
+    assert real_redis.get(key) is None
+
+    real_redis.set(key, "1", ex=60)
+    assert real_redis.get(key) == "1"
+
+    real_redis.delete(key)
+    assert real_redis.get(key) is None

--- a/API/tests/postgres/test_migrations.py
+++ b/API/tests/postgres/test_migrations.py
@@ -1,0 +1,160 @@
+"""B20: las migraciones, ejecutadas de verdad.
+
+Alembic solo se ejerce contra PostgreSQL, y la suite rápida crea el esquema
+con ``Base.metadata.create_all``, que salta por encima de todas las
+migraciones. Es decir que hasta ahora **ninguna migración se ejecutaba en
+ningún test**: un ``down_revision`` mal puesto, un identificador repetido, un
+tipo que PostgreSQL no acepta o una bajada rota solo se descubrían al
+desplegar.
+
+Este módulo cierra ese hueco aplicando la cadena entera sobre una base de
+datos vacía creada para la ocasión — que es exactamente lo que ocurre en un
+despliegue nuevo.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import sqlalchemy as sa
+
+pytestmark = pytest.mark.postgres
+
+_MIGRATIONS_DB = "ellysia_migrations_test"
+
+
+def _api_dir() -> str:
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture()
+def migrations_url(pg_engine):
+    """Crea una base de datos vacía y devuelve su URL; la borra al terminar.
+
+    Se usa una base aparte y no el esquema de ``pg_engine`` porque las
+    migraciones tienen que correr sobre algo realmente vacío, y ``pg_engine``
+    ya tiene el esquema creado por los modelos para el resto de tests.
+    ``CREATE DATABASE`` no puede ir dentro de una transacción, de ahí el
+    ``AUTOCOMMIT``.
+    """
+    maintenance = sa.create_engine(
+        pg_engine.url.set(database="postgres"),
+        isolation_level="AUTOCOMMIT", future=True,
+    )
+    with maintenance.connect() as connection:
+        connection.execute(sa.text(f'DROP DATABASE IF EXISTS "{_MIGRATIONS_DB}"'))
+        connection.execute(sa.text(f'CREATE DATABASE "{_MIGRATIONS_DB}"'))
+
+    try:
+        yield pg_engine.url.set(database=_MIGRATIONS_DB)
+    finally:
+        with maintenance.connect() as connection:
+            connection.execute(sa.text(f'DROP DATABASE IF EXISTS "{_MIGRATIONS_DB}"'))
+        maintenance.dispose()
+
+
+@pytest.fixture()
+def alembic_config(migrations_url):
+    from alembic.config import Config
+
+    config = Config(os.path.join(_api_dir(), "alembic.ini"))
+    config.set_main_option("script_location", os.path.join(_api_dir(), "alembic"))
+    # `%` es el carácter de interpolación de ConfigParser: una contraseña con
+    # un `%` rompería la lectura si no se escapa.
+    config.set_main_option("sqlalchemy.url", migrations_url.render_as_string(
+        hide_password=False).replace("%", "%%"))
+    return config
+
+
+def test_the_migration_graph_is_linear_and_has_one_head():
+    """Un segundo head significa dos ramas de esquema sin mezclar: el arranque
+    de la aplicación falla y hay que resolverlo a mano.
+
+    Y los identificadores de este repositorio se han venido escribiendo a mano
+    siguiendo un patrón (``a1b2c3d4e5f6``, ``d7e8f9a0b1c2``…), que es justo el
+    modo de acabar con dos revisiones con el mismo identificador — ha pasado.
+    """
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    config = Config(os.path.join(_api_dir(), "alembic.ini"))
+    config.set_main_option("script_location", os.path.join(_api_dir(), "alembic"))
+    script = ScriptDirectory.from_config(config)
+
+    assert len(script.get_heads()) == 1, f"se esperaba un head, hay {script.get_heads()}"
+
+    identifiers = [revision.revision for revision in script.walk_revisions()]
+    assert len(identifiers) == len(set(identifiers)), "hay identificadores repetidos"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Bug preexistente destapado por esta matriz (#356): la revisión "
+        "b2c3d4e5f6a7 inserta en PlanLimit diez migraciones antes de que "
+        "f2b3c4d5e6f7 cree la tabla, así que `alembic upgrade head` sobre una "
+        "base vacía falla. No se nota en producción porque el primer "
+        "despliegue crea el esquema con CREATE_DATABASE=True (create_all) y "
+        "Alembic solo aplica los incrementos posteriores. Al arreglarlo, este "
+        "test pasa a XPASS y hay que quitar el marcador."
+    ),
+)
+def test_the_whole_chain_applies_to_an_empty_database(alembic_config, migrations_url):
+    """``alembic upgrade head`` sobre una base vacía: el despliegue nuevo."""
+    from alembic import command
+
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        tables = set(sa.inspect(engine).get_table_names())
+        assert "IrisAnalysis" in tables
+        assert "IrisMailboxConnection" in tables
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Depende de que `upgrade head` funcione sobre una base vacía, que hoy "
+        "no lo hace (#356). Se quita junto con el marcador del test anterior."
+    ),
+)
+def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_config,
+                                                                   migrations_url):
+    """Las cuatro migraciones de la fase 0, en los dos sentidos.
+
+    Bajar y volver a subir es lo que hace falta cuando un despliegue se
+    revierte, y es donde se ve si una bajada olvidó una columna: la subida
+    siguiente fallaría al intentar añadirla otra vez.
+    """
+    from alembic import command
+
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        columns = {column["name"] for column in sa.inspect(engine).get_columns("IrisAnalysis")}
+        assert {"failure_code", "failure_reason"} <= columns                              # B03
+        assert {"analysis_quality", "failed_rules", "detector_version"} <= columns        # B05
+        assert {"ai_summary_status", "ai_summary_job_id",
+                "ai_summary_model", "ai_summary_prompt_version"} <= columns               # B10
+
+        cursor = next(column for column in sa.inspect(engine).get_columns("IrisMailboxConnection")
+                      if column["name"] == "sync_cursor")
+        assert cursor["type"].length is None, "sync_cursor volvió a tener un límite (B12)"
+    finally:
+        engine.dispose()
+
+    # Cuatro pasos atrás: las cuatro migraciones de la fase 0.
+    command.downgrade(alembic_config, "-4")
+    command.upgrade(alembic_config, "head")
+
+    engine = sa.create_engine(migrations_url, future=True)
+    try:
+        columns = {column["name"] for column in sa.inspect(engine).get_columns("IrisAnalysis")}
+        assert {"failure_code", "analysis_quality", "ai_summary_status"} <= columns
+    finally:
+        engine.dispose()

--- a/API/tests/postgres/test_schema_invariants.py
+++ b/API/tests/postgres/test_schema_invariants.py
@@ -1,0 +1,265 @@
+"""B20: las invariantes del esquema que SQLite no puede comprobar.
+
+Cada test de aquí falla en PostgreSQL y **pasa en SQLite**, que es exactamente
+por lo que hacen falta. No repiten cobertura: la añaden donde el motor de la
+suite rápida es incapaz de decir la verdad.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import DataError, IntegrityError
+
+from src.modules.features.iris.model import (
+    IrisAnalysis,
+    IrisDocument,
+    IrisMailboxConnection,
+    IrisRuleResult,
+)
+from src.modules.users.model import User
+
+pytestmark = pytest.mark.postgres
+
+
+def _user(pg_session, username: str = "postgres-tester") -> User:
+    user = User(
+        username=username,
+        email=f"{username}@ellysia.test",
+        first_name="Postgres",
+        last_name="Tester",
+        password_hash="x",
+        password_salt="",
+        role="role_user",
+    )
+    pg_session.add(user)
+    pg_session.commit()
+    return user
+
+
+def _connection(pg_session, user: User, email: str = "buzon@outlook.example") -> IrisMailboxConnection:
+    connection = IrisMailboxConnection(
+        user_id=user.id, provider="microsoft", account_email=email,
+        scopes="Mail.Read", refresh_token_enc="cifrado",
+    )
+    pg_session.add(connection)
+    pg_session.commit()
+    return connection
+
+
+# ---------------------------------------------------------------------------
+# Longitud de columna
+# ---------------------------------------------------------------------------
+
+def test_a_long_graph_delta_link_fits_in_sync_cursor(pg_session):
+    """B12 contra el motor real.
+
+    SQLite ignora la longitud declarada de un ``VARCHAR``, así que con la
+    columna en ``String(255)`` el test equivalente de la suite rápida pasaba
+    igualmente. Aquí no: si alguien la volviera a estrechar, este INSERT falla.
+    """
+    user = _user(pg_session, "cursor-largo")
+    connection = _connection(pg_session, user, "cursor@outlook.example")
+
+    cursor = (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + "Ag0AAA" + "Z" * 1500
+    )
+    connection.sync_cursor = cursor
+    pg_session.commit()
+    pg_session.expire_all()
+
+    assert pg_session.get(IrisMailboxConnection, connection.id).sync_cursor == cursor
+
+
+def test_an_oversized_value_is_rejected_rather_than_truncated(pg_session):
+    """La otra cara: PostgreSQL **rechaza** lo que no cabe, no lo recorta.
+
+    Importa dejarlo escrito, porque es la diferencia de comportamiento que hace
+    que un desbordamiento se vea en desarrollo (nunca) y en producción (siempre).
+    """
+    user = _user(pg_session, "estado-largo")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            status="x" * 200)  # la columna son 20
+    pg_session.add(analysis)
+
+    with pytest.raises((DataError, IntegrityError)):
+        pg_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Unicidad e idempotencia
+# ---------------------------------------------------------------------------
+
+def test_the_same_ingested_message_cannot_be_analysed_twice(pg_session, pg_sessions):
+    """La idempotencia de la ingesta de buzón, contra una carrera real.
+
+    ``UniqueConstraint(connection_id, source_message_uid)`` es lo que hace que
+    un reintento de sincronización sea un no-op en vez de un análisis
+    duplicado. Se monta con **dos sesiones independientes** porque con una sola
+    el ORM resolvería el conflicto en su propio identity map y el test pasaría
+    sin haber llegado a la base de datos.
+    """
+    user = _user(pg_session, "idempotencia")
+    connection = _connection(pg_session, user, "idem@outlook.example")
+
+    first, second = pg_sessions(), pg_sessions()
+    first.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                           connection_id=connection.id, source_message_uid="msg-1"))
+    first.commit()
+
+    second.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            connection_id=connection.id, source_message_uid="msg-1"))
+    with pytest.raises(IntegrityError):
+        second.commit()
+
+
+def test_manual_submissions_never_collide(pg_session):
+    """Y la contrapartida: dos análisis manuales no chocan.
+
+    Ambos tienen ``connection_id`` y ``source_message_uid`` a NULL, y el UNIQUE
+    de SQL estándar trata cada NULL como distinto de todos los demás. Es de lo
+    que depende que la restricción no rompa el flujo normal de la aplicación.
+    """
+    user = _user(pg_session, "manuales")
+
+    pg_session.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id))
+    pg_session.add(IrisAnalysis(raw_headers="From: c@d.com", user_id=user.id))
+    pg_session.commit()  # no debe lanzar
+
+    assert pg_session.query(IrisAnalysis).filter_by(user_id=user.id).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Claves foráneas
+# ---------------------------------------------------------------------------
+
+def test_deleting_a_connection_keeps_its_analyses(pg_session):
+    """``ondelete="SET NULL"``: desconectar un buzón no puede borrar el
+    historial de análisis que llegaron por él.
+
+    SQLite no aplica claves foráneas salvo que se active explícitamente el
+    pragma, así que en la suite rápida esta cláusula no se ejercita nunca.
+    """
+    user = _user(pg_session, "fk-set-null")
+    connection = _connection(pg_session, user, "setnull@outlook.example")
+
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                            connection_id=connection.id, source_message_uid="msg-9")
+    pg_session.add(analysis)
+    pg_session.commit()
+    analysis_id = analysis.id
+
+    pg_session.delete(connection)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    survivor = pg_session.get(IrisAnalysis, analysis_id)
+    assert survivor is not None
+    assert survivor.connection_id is None
+
+
+def test_deleting_an_analysis_takes_its_documents_with_it(pg_session):
+    """``ondelete="CASCADE"``: lo contrario del anterior, y también sin
+    cobertura hasta ahora. Un documento huérfano apuntaría a un análisis que ya
+    no existe y reventaría al listarlo."""
+    user = _user(pg_session, "fk-cascade")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    document = IrisDocument(analysis_id=analysis.id, user_id=user.id,
+                            document_type="iris", filename="", format="pdf",
+                            status="done", verdict="Phishing")
+    pg_session.add(document)
+    pg_session.commit()
+    document_id = document.id
+
+    pg_session.delete(analysis)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    assert pg_session.get(IrisDocument, document_id) is None
+
+
+# ---------------------------------------------------------------------------
+# JSONB
+# ---------------------------------------------------------------------------
+
+def test_the_json_columns_really_are_jsonb(pg_engine):
+    """El shim de la suite rápida sustituye ``JSONB`` por ``JSON`` genérico, así
+    que el tipo real no se comprueba en ningún otro sitio. Y no es cosmético:
+    ``JSON`` no tiene los operadores de contención ni se puede indexar con GIN.
+    """
+    columns = {column["name"]: str(column["type"])
+               for column in sa.inspect(pg_engine).get_columns("IrisAnalysis")}
+
+    assert columns["gate_reasons"] == "JSONB"
+    assert columns["failed_rules"] == "JSONB"
+    assert columns["ai_summary"] == "JSONB"
+
+
+def test_jsonb_columns_round_trip_their_structure(pg_session):
+    """En la suite rápida estas columnas son ``JSON`` genérico por un shim, así
+    que su comportamiento real —tipos, anidamiento, orden de claves— no se
+    prueba en ningún sitio."""
+    user = _user(pg_session, "jsonb")
+    analysis = IrisAnalysis(
+        raw_headers="From: a@b.com", user_id=user.id, status="finished",
+        gate_reasons=["SPF/DMARC failure", "Análisis degradado"],
+        failed_rules=[{"name": "SPF", "family": "auth", "category": "authentication"}],
+        ai_summary={"executive_summary": "texto", "recommendations": ["a", "b"],
+                     "confidence": "HIGH"},
+    )
+    pg_session.add(analysis)
+    pg_session.commit()
+    pg_session.expire_all()
+
+    stored = pg_session.get(IrisAnalysis, analysis.id)
+    assert stored.gate_reasons == ["SPF/DMARC failure", "Análisis degradado"]
+    assert stored.failed_rules[0]["family"] == "auth"
+    assert stored.ai_summary["recommendations"] == ["a", "b"]
+
+
+def test_jsonb_supports_containment_queries(pg_session):
+    """El operador ``@>`` es de JSONB y no existe en SQLite. Se comprueba
+    porque es lo que permitiría filtrar informes por su contenido sin traerse
+    todas las filas al proceso — y si la columna dejara de ser JSONB, esto es
+    lo primero que se rompería."""
+    user = _user(pg_session, "jsonb-query")
+    pg_session.add(IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id,
+                                status="finished", analysis_quality="degraded",
+                                failed_rules=[{"name": "SPF", "family": "auth"}]))
+    pg_session.add(IrisAnalysis(raw_headers="From: c@d.com", user_id=user.id,
+                                status="finished", analysis_quality="complete",
+                                failed_rules=None))
+    pg_session.commit()
+
+    degraded = pg_session.execute(
+        sa.text(
+            'SELECT analysis_quality FROM "IrisAnalysis" '
+            "WHERE failed_rules @> :probe"
+        ).bindparams(sa.bindparam("probe", [{"family": "auth"}], type_=JSONB))
+    ).scalars().all()
+
+    assert degraded == ["degraded"]
+
+
+def test_rule_results_keep_their_execution_order(pg_session):
+    """``position`` es un ``SmallInteger`` y el informe se ordena por él. En
+    PostgreSQL el tipo tiene rango real (±32767), otra cosa que SQLite ignora."""
+    user = _user(pg_session, "orden-reglas")
+    analysis = IrisAnalysis(raw_headers="From: a@b.com", user_id=user.id, status="finished")
+    pg_session.add(analysis)
+    pg_session.commit()
+
+    for position, name in enumerate(["SPF", "DKIM", "DMARC"]):
+        pg_session.add(IrisRuleResult(analysis_id=analysis.id, rule_name=name,
+                                      category="authentication", score=0,
+                                      verdict="pass", position=position))
+    pg_session.commit()
+    pg_session.expire_all()
+
+    stored = pg_session.get(IrisAnalysis, analysis.id)
+    assert [rule.rule_name for rule in stored.rule_results] == ["SPF", "DKIM", "DMARC"]

--- a/API/tests/unit/test_iris_auth_trust.py
+++ b/API/tests/unit/test_iris_auth_trust.py
@@ -1,0 +1,256 @@
+"""B06: frontera de confianza de la cadena ``Received``.
+
+El corpus de ataque que pide el criterio de cierre del issue: **ningún
+``Authentication-Results`` aportado por el atacante convierte por sí solo un
+mensaje en autenticado**.
+
+La idea que se prueba aquí es sencilla de enunciar y fácil de perder de vista:
+los MTA *anteponen* su ``Received``, así que la cadena va del último salto (el
+servidor del destinatario) al origen, y **los saltos de abajo los escribió
+quien envió el mensaje**. Contrastar una cabecera que aporta el remitente
+contra otra cabecera que también aporta el remitente no verifica nada.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.services.auth_trust import (
+    TRUST_ABSENT,
+    TRUST_BELOW_BOUNDARY,
+    TRUST_BOUNDARY,
+    TRUST_CONFIGURED,
+    TRUST_UNKNOWN,
+    assess_authserv_trust,
+    is_arc_verified_by_trusted_hop,
+    parse_hops,
+    trust_boundary,
+)
+from src.modules.features.iris.services.parsers import MessageContext
+from src.modules.features.iris.services.rules.auth_rules import (
+    check_auth_results_provenance,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _hop(sender: str, receiver: str, when: str = "Wed, 25 Jun 2025 10:00:00 +0000") -> str:
+    return f"from {sender} by {receiver}; {when}"
+
+
+# La cadena legítima: dos saltos internos del proveedor del destinatario y,
+# debajo, el servidor real del remitente.
+_LEGITIMATE_CHAIN = [
+    _hop("mx-in.destino.example", "mx2.destino.example"),
+    _hop("smtp.remitente.example", "mx-in.destino.example"),
+]
+
+
+# ---------------------------------------------------------------------------
+# La frontera en sí
+# ---------------------------------------------------------------------------
+
+def test_boundary_covers_the_receiving_infrastructure():
+    """Los saltos contiguos de la misma organización que entregó el mensaje
+    son recorrido interno suyo: nadie de fuera los pudo escribir."""
+    hops = parse_hops(_LEGITIMATE_CHAIN)
+
+    # Los dos saltos entregan a destino.example (mx2 y mx-in): son el recorrido
+    # interno del proveedor del destinatario, así que ninguno de los dos lo
+    # pudo escribir el remitente. El salto de origen ya queda fuera.
+    assert [hop.by_domain for hop in hops] == ["destino.example", "destino.example"]
+    assert trust_boundary(hops) == 2
+
+
+def test_boundary_extends_across_contiguous_hops_of_the_same_organisation():
+    chain = [
+        _hop("mx1.destino.example", "mx2.destino.example"),
+        _hop("gateway.destino.example", "mx1.destino.example"),
+        _hop("smtp.remitente.example", "gateway.destino.example"),
+    ]
+
+    # Los tres primeros `by` son destino.example; el cuarto salto ya no existe.
+    assert trust_boundary(parse_hops(chain)) == 3
+
+
+def test_boundary_stops_at_the_first_foreign_organisation():
+    chain = [
+        _hop("relay.tercero.example", "mx.destino.example"),
+        _hop("origen.example", "relay.tercero.example"),
+        _hop("otro.example", "mx.destino.example"),  # vuelve a "los nuestros"
+    ]
+
+    # La frontera es contigua desde arriba: que un salto de más abajo vuelva a
+    # nombrar nuestro dominio no lo hace fiable — eso es justamente lo que
+    # escribiría quien quisiera colarse.
+    assert trust_boundary(parse_hops(chain)) == 1
+
+
+# ---------------------------------------------------------------------------
+# El ataque que cierra B06
+# ---------------------------------------------------------------------------
+
+def test_injected_received_plus_auth_results_no_longer_passes():
+    """El bypass, en su forma exacta.
+
+    El atacante añade a su propio correo dos cabeceras que se respaldan
+    mutuamente: un ``Received`` que dice ``by: mx.atacante.example`` y un
+    ``Authentication-Results`` firmado por ``mx.atacante.example``. Antes, la
+    regla comprobaba que el authserv-id apareciera en *algún* salto — y
+    aparecía, porque el propio atacante lo había puesto ahí.
+    """
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx.atacante.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=[
+            _hop("mx.atacante.example", "mx2.destino.example"),   # salto real
+            _hop("origen.atacante.example", "mx.atacante.example"),  # inventado
+        ],
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "fail"
+    assert result.score < 0
+    assert result.details["trust"] == TRUST_BELOW_BOUNDARY
+
+
+def test_the_same_header_from_the_real_delivering_server_still_passes():
+    """La otra mitad: el correo legítimo no puede empezar a fallar."""
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx2.destino.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=_LEGITIMATE_CHAIN,
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "pass"
+    assert result.details["trust"] == TRUST_BOUNDARY
+
+
+def test_an_authserv_id_that_never_touched_the_message_still_fails():
+    """El caso que ya se detectaba antes de B06 sigue detectándose."""
+    context = MessageContext(
+        headers={
+            "authentication-results": "inventado.example; spf=pass; dkim=pass; dmarc=pass",
+        },
+        received_headers=_LEGITIMATE_CHAIN,
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "fail"
+    assert result.details["trust"] == TRUST_ABSENT
+
+
+def test_duplicate_authentication_results_cannot_be_smuggled_below():
+    """Cabeceras duplicadas.
+
+    El dict de cabeceras conserva una sola aparición por nombre, así que el
+    atacante no gana nada duplicando ``Authentication-Results``: la que se
+    evalúa se contrasta igualmente contra la frontera, y su salto sigue
+    estando por debajo.
+    """
+    context = MessageContext(
+        headers={
+            "authentication-results": "mx.atacante.example; spf=pass; dmarc=pass",
+        },
+        received_headers=[
+            _hop("mx.atacante.example", "mx2.destino.example"),
+            _hop("a.example", "mx.atacante.example"),
+            _hop("b.example", "mx.atacante.example"),
+        ],
+    )
+
+    assert check_auth_results_provenance(context).verdict == "fail"
+
+
+def test_no_received_chain_stays_neutral():
+    """Sin cadena que contrastar no hay base para acusar de forjado; neutral,
+    no "sospechoso por defecto" — pegar solo unas cabeceras sueltas es un uso
+    legítimo de Iris."""
+    context = MessageContext(
+        headers={"authentication-results": "cualquiera.example; spf=pass"},
+        received_headers=[],
+    )
+
+    result = check_auth_results_provenance(context)
+
+    assert result.verdict == "neutral"
+    assert result.score == 0
+    assert assess_authserv_trust("cualquiera.example", []).verdict == TRUST_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Lista explícita de verificadores de confianza
+# ---------------------------------------------------------------------------
+
+def test_a_configured_verifier_is_trusted_wherever_it_appears(monkeypatch):
+    """Para el despliegue que sabe qué servidor autentica su correo — un
+    gateway corporativo que entrega a un buzón alojado en otro proveedor y
+    que, por tanto, no encabeza la cadena."""
+    import src.modules.features.iris.services.auth_trust as auth_trust
+
+    monkeypatch.setattr(auth_trust.CR, "get_iris_data",
+                        lambda key: ["gateway.corporativo.example"] if key == "trusted_authserv_ids" else None)
+
+    trust = assess_authserv_trust("gateway.corporativo.example", _LEGITIMATE_CHAIN)
+
+    assert trust.verdict == TRUST_CONFIGURED
+    assert trust.is_trusted is True
+
+
+def test_without_configuration_trust_comes_from_the_chain_alone():
+    """El dataset está vacío por defecto: el módulo tiene que funcionar en
+    cualquier despliegue sin que nadie configure nada."""
+    trust = assess_authserv_trust("mx2.destino.example", _LEGITIMATE_CHAIN)
+
+    assert trust.is_trusted is True
+    assert trust.verdict == TRUST_BOUNDARY
+
+
+# ---------------------------------------------------------------------------
+# ARC
+# ---------------------------------------------------------------------------
+
+def test_a_forged_arc_seal_is_not_verified():
+    """``ARC-Seal: cv=pass`` es lo que el mensaje dice de sí mismo. Iris no
+    verifica firmas, así que no puede valer como prueba."""
+    headers = {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=atacante.example; s=s1; b=xyz"}
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is False
+
+
+def test_arc_is_verified_when_the_delivering_server_says_so():
+    """Quien sí valida la cadena es el MTA receptor, que lo apunta como
+    ``arc=pass`` en su propio Authentication-Results (RFC 8617 §5.2)."""
+    headers = {
+        "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=lista.example; s=s1; b=xyz",
+        "authentication-results": "mx2.destino.example; arc=pass; spf=fail; dmarc=fail",
+    }
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is True
+
+
+def test_arc_confirmation_signed_below_the_boundary_does_not_count():
+    """Y el rodeo obvio tampoco funciona: escribir uno mismo el ``arc=pass``
+    en un Authentication-Results propio es el mismo ataque con un paso más."""
+    headers = {
+        "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=atacante.example; s=s1; b=xyz",
+        "authentication-results": "mx.atacante.example; arc=pass; spf=pass; dmarc=pass",
+    }
+    chain = [
+        _hop("mx.atacante.example", "mx2.destino.example"),
+        _hop("origen.example", "mx.atacante.example"),
+    ]
+
+    assert is_arc_verified_by_trusted_hop(headers, chain) is False
+
+
+def test_arc_without_any_authentication_results_is_not_verified():
+    headers = {"arc-seal": "i=1; cv=pass; d=lista.example"}
+
+    assert is_arc_verified_by_trusted_hop(headers, _LEGITIMATE_CHAIN) is False

--- a/API/tests/unit/test_iris_dataset_cache.py
+++ b/API/tests/unit/test_iris_dataset_cache.py
@@ -1,0 +1,129 @@
+"""B18: un cambio de configuración llega al siguiente análisis.
+
+Los datasets de detección de Iris —marcas, proveedores gratuitos, keywords,
+TLDs sospechosos, tabla de homóglifos— se cachean, y con razón: se consultan
+en cada regla de cada análisis. El problema era la clave de esa caché.
+
+Era el nombre del dataset a secas, y las cachés eran permanentes. Recargar la
+configuración (``PUT /system`` en la API, o el ``reload_if_changed()`` que el
+worker hace antes de cada job) sustituía el árbol ``_configs`` pero dejaba en
+pie los valores viejos. Un cambio guardado desde ConfigView no llegaba al
+siguiente análisis, y no había forma de enterarse: nada fallaba, simplemente
+se seguía analizando con los datos anteriores.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.features.iris.services import wordlists
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def config_tree(monkeypatch):
+    """Devuelve una función que instala un árbol de configuración completo.
+
+    Sustituye ``_configs`` entero, que es lo que hacen de verdad ``reload()``,
+    ``reload_if_changed()`` y ``save_full_config()`` — no se parchea el getter,
+    porque entonces el test no probaría el mecanismo que se está arreglando.
+    """
+    def _install(iris_data: dict):
+        monkeypatch.setattr(
+            CR, "_configs",
+            {"features": {"iris": {"data": iris_data}}},
+            raising=False,
+        )
+    return _install
+
+
+def test_a_changed_dataset_reaches_the_next_analysis(config_tree):
+    """El caso del issue: se añade una marca y el siguiente análisis la ve."""
+    config_tree({"canonical_brands": ["paypal"]})
+    assert "acmebank" not in wordlists.canonical_brands()
+
+    config_tree({"canonical_brands": ["paypal", "acmebank"]})
+
+    assert "acmebank" in wordlists.canonical_brands()
+
+
+def test_a_removed_entry_also_disappears(config_tree):
+    """Y en la otra dirección: quitar una marca tiene que quitarla de verdad.
+
+    Importa tanto o más que añadir — una entrada que sobrevive a su borrado
+    sigue generando hallazgos que el operador cree haber desactivado.
+    """
+    config_tree({"canonical_brands": ["paypal", "acmebank"]})
+    assert "acmebank" in wordlists.canonical_brands()
+
+    config_tree({"canonical_brands": ["paypal"]})
+
+    assert "acmebank" not in wordlists.canonical_brands()
+
+
+def test_tuple_datasets_follow_the_configuration_too(config_tree):
+    """Los datasets ordenados usan otra caché (``_cached_tuple``): también."""
+    config_tree({"free_provider_domains": ["gmail.com"]})
+    assert wordlists.free_provider_domains() == ("gmail.com",)
+
+    config_tree({"free_provider_domains": ["gmail.com", "correo.example"]})
+
+    assert wordlists.free_provider_domains() == ("gmail.com", "correo.example")
+
+
+def test_the_homoglyph_table_follows_the_configuration(config_tree):
+    """La tabla de homóglifos se construye una vez y se cachea aparte."""
+    config_tree({"homoglyph_map": {"0": "o"}})
+    # Con solo el 0 mapeado, el 1 se queda como está.
+    assert "paypa1".translate(wordlists.homoglyph_table()) == "paypa1"
+
+    config_tree({"homoglyph_map": {"0": "o", "1": "l"}})
+
+    assert "paypa1".translate(wordlists.homoglyph_table()) == "paypal"
+
+
+def test_phrase_patterns_are_recompiled(config_tree):
+    """Las frases se compilan a una expresión regular, que es la caché más
+    cara de todas y por tanto la más tentadora de dejar permanente."""
+    config_tree({"bec_phrases": ["cambio de cuenta"]})
+    assert wordlists.phrase_matches("bec_phrases", "urge un pago inmediato") == []
+
+    config_tree({"bec_phrases": ["cambio de cuenta", "pago inmediato"]})
+
+    assert wordlists.phrase_matches("bec_phrases", "urge un pago inmediato") == ["pago inmediato"]
+
+
+def test_brand_trusted_domains_follow_the_configuration(config_tree):
+    config_tree({"brand_trusted_domains": [{"keywords": ["paypal"], "domains": ["paypal.com"]}]})
+    assert wordlists.brand_trusted_domains() == ((("paypal",), ("paypal.com",)),)
+
+    config_tree({"brand_trusted_domains": [{"keywords": ["acme"], "domains": ["acme.example"]}]})
+
+    assert wordlists.brand_trusted_domains() == ((("acme",), ("acme.example",)),)
+
+
+def test_reading_twice_without_changes_uses_the_cache(config_tree):
+    """La invalidación no puede costar la caché: leer dos veces con la misma
+    configuración tiene que devolver **el mismo objeto**, no reconstruirlo.
+
+    Estos datasets se consultan en cada regla de cada análisis; recalcularlos
+    cada vez es precisamente lo que la caché existe para evitar.
+    """
+    config_tree({"canonical_brands": ["paypal"]})
+
+    first = wordlists.canonical_brands()
+    second = wordlists.canonical_brands()
+
+    assert first is second
+
+
+def test_config_version_changes_when_the_tree_is_replaced(config_tree):
+    """La pieza en la que se apoya todo lo anterior."""
+    config_tree({"canonical_brands": ["paypal"]})
+    before = CR.config_version()
+
+    config_tree({"canonical_brands": ["acmebank"]})
+
+    assert CR.config_version() != before

--- a/API/tests/unit/test_iris_failures.py
+++ b/API/tests/unit/test_iris_failures.py
@@ -1,0 +1,52 @@
+"""B03: clasificación del motivo por el que un análisis de Iris muere.
+
+Un ``failed`` sin motivo no es accionable: quien lo mira no sabe si el
+problema era su fichero o el motor. ``classify_failure`` es la costura que
+separa esos dos casos, y estos tests fijan la parte que importa de verdad —
+que el mensaje persistido nunca arrastre contenido del correo analizado.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.exceptions import IrisInvalidInputError
+from src.modules.features.iris.services.failures import (
+    FAILURE_INTERNAL_ERROR,
+    FAILURE_INVALID_INPUT,
+    classify_failure,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_invalid_input_keeps_its_own_message():
+    """El mensaje de ``IrisInvalidInputError`` lo redacta el propio módulo a
+    partir de un recuento de cabeceras, así que puede viajar tal cual."""
+    failure = classify_failure(
+        IrisInvalidInputError("Tras parsear se obtuvieron 0 cabeceras (mínimo: 2).")
+    )
+
+    assert failure.code == FAILURE_INVALID_INPUT
+    assert "0 cabeceras" in failure.reason
+
+
+def test_unexpected_error_never_leaks_the_exception_text():
+    """El caso que motiva B03: un parser que revienta y arrastra en su
+    ``str()`` el fragmento de entrada que no supo digerir."""
+    leaked = "b'From: victima@banco.example\\r\\nAuthorization: Bearer s3cr3t'"
+    failure = classify_failure(ValueError(f"cannot decode {leaked}"))
+
+    assert failure.code == FAILURE_INTERNAL_ERROR
+    assert "s3cr3t" not in failure.reason
+    assert "victima@banco.example" not in failure.reason
+    assert failure.reason  # hay algo que enseñar, no una cadena vacía
+
+
+def test_reason_is_bounded():
+    """Un traceback repr-eado de una librería de terceros puede ser enorme y
+    no aporta nada más allá de la primera línea; la columna es Text, pero la
+    respuesta de la API no debería serlo."""
+    failure = classify_failure(IrisInvalidInputError("x" * 5000))
+
+    assert len(failure.reason) <= 500

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -225,6 +225,72 @@ def test_graph_list_new_with_cursor_caches_headers_from_delta_response():
     assert raw == "From: a@b.com\r\n"
 
 
+# B12: el deltaLink de Graph es un token opaco que puede rebasar los 255
+# caracteres que la columna `sync_cursor` permitía. Estos tests fijan que el
+# conector lo devuelve intacto — cualquier recorte lo invalida, y un cursor
+# inválido tira la sincronización incremental al bootstrap.
+
+def _long_delta_link(length: int = 900) -> str:
+    """Un deltaLink realista: URL de Graph más un token de estado largo.
+
+    Los deltaLink reales llevan dentro un `$deltatoken` codificado cuyo tamaño
+    depende del estado de la carpeta; 900 caracteres está dentro de lo que
+    devuelve un buzón con actividad, y en todo caso lo que importa aquí es que
+    pase de 255.
+    """
+    return (
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta"
+        "?$deltatoken=" + ("Ag0AAA" + "X" * length)
+    )
+
+
+def test_graph_bootstrap_preserves_a_delta_link_longer_than_255_chars():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    delta_link = _long_delta_link()
+    assert len(delta_link) > 255
+
+    page = _response({"value": [], "@odata.deltaLink": delta_link})
+    with mock.patch("requests.get", return_value=page):
+        _refs, cursor = connector.list_new("access-token", cursor=None)
+
+    assert cursor == delta_link
+
+
+def test_graph_incremental_sync_preserves_a_long_delta_link_exactly():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    previous = _long_delta_link(600)
+    next_link = _long_delta_link(950)
+
+    page = _response({"value": [{"id": "msg-1"}], "@odata.deltaLink": next_link})
+    with mock.patch("requests.get", return_value=page) as get:
+        refs, cursor = connector.list_new("access-token", cursor=previous)
+
+    # El cursor anterior se usa como URL tal cual, sin reconstruirlo.
+    assert get.call_args.args[0] == previous
+    assert len(refs) == 1
+    assert cursor == next_link
+    assert len(cursor) > 255
+
+
+def test_graph_expired_cursor_rebootstraps_instead_of_failing():
+    """410 Gone: el deltaLink cayó fuera de la ventana de retención de Graph.
+
+    La única salida es volver a capturar un cursor desde cero. No se pierde
+    correo local: el bootstrap no hace backfill, solo marca el punto de
+    partida, y los análisis ya ingeridos siguen donde estaban.
+    """
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    fresh = _long_delta_link(400)
+
+    gone = _response(status_code=410)
+    bootstrap = _response({"value": [], "@odata.deltaLink": fresh})
+    with mock.patch("requests.get", side_effect=[gone, bootstrap]):
+        refs, cursor = connector.list_new("access-token", cursor=_long_delta_link(300))
+
+    assert refs == []
+    assert cursor == fresh
+
+
 def test_graph_fetch_raw_returns_response_text_directly():
     connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
     resp = _response(text="From: a@b.com\r\nSubject: Hi\r\n\r\nBody")

--- a/API/tests/unit/test_iris_quality.py
+++ b/API/tests/unit/test_iris_quality.py
@@ -1,0 +1,143 @@
+"""B05: calidad del análisis — qué se inspeccionó de verdad y qué no.
+
+Una regla que revienta se convertía en un ``RuleResult(verdict="error")`` y
+ahí se acababa todo: el análisis podía terminar como ``Legitimate`` sin
+ninguna advertencia, aunque la regla que faltó fuera la que decide si el
+mensaje está autenticado. Estos tests fijan la política conservadora que lo
+sustituye, que depende de **qué familia** de regla se perdió.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.services.quality import (
+    QUALITY_COMPLETE,
+    QUALITY_DEGRADED,
+    assess_quality,
+    cap_verdict,
+    detector_version,
+)
+from src.modules.features.iris.services.rules import RuleResult
+
+pytestmark = pytest.mark.unit
+
+
+def _rule(name: str, family: str = "", category: str = "header_analysis") -> dict:
+    return {"name": name, "family": family, "category": category}
+
+
+def _ok(score: float = 0.0) -> RuleResult:
+    return RuleResult(score=score, verdict="pass")
+
+
+def _errored() -> RuleResult:
+    """Lo que el motor pone cuando una regla lanza una excepción."""
+    return RuleResult(score=0, verdict="error", details={"error": "boom"})
+
+
+# ---------------------------------------------------------------------------
+# assess_quality
+# ---------------------------------------------------------------------------
+
+def test_all_rules_executed_is_complete():
+    rules = [_rule("SPF", "auth"), _rule("Body Links", "links")]
+    quality = assess_quality(rules, [_ok(), _ok()])
+
+    assert quality.quality == QUALITY_COMPLETE
+    assert quality.failed_rules == []
+    assert quality.blocks_clean_verdict is False
+
+
+def test_a_broken_rule_degrades_and_is_recorded():
+    rules = [_rule("SPF", "auth"), _rule("Body Links", "links")]
+    quality = assess_quality(rules, [_ok(), _errored()])
+
+    assert quality.quality == QUALITY_DEGRADED
+    assert quality.failed_rules == [
+        {"name": "Body Links", "family": "links", "category": "header_analysis"}
+    ]
+
+
+def test_a_rule_that_merely_found_something_is_not_a_failure():
+    """La distinción que da nombre al campo: una regla que puntúa negativo
+    hizo su trabajo. Solo cuenta como fallida la que no llegó a ejecutarse."""
+    rules = [_rule("SPF", "auth")]
+    quality = assess_quality(rules, [RuleResult(score=-12, verdict="fail")])
+
+    assert quality.quality == QUALITY_COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Política por familia
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("family", ["auth", "attachment"])
+def test_losing_auth_or_attachment_blocks_a_clean_verdict(family):
+    """Son las dos familias que responden a una pregunta que ninguna otra
+    responde: si faltan, el silencio no es un dato — es no haber mirado."""
+    rules = [_rule("Regla", family)]
+    quality = assess_quality(rules, [_errored()])
+
+    verdict, reasons = cap_verdict("Legitimate", quality)
+
+    assert quality.blocks_clean_verdict is True
+    assert verdict == "Suspicious"
+    assert any("no puede ser Legítimo" in reason for reason in reasons)
+
+
+def test_losing_a_content_rule_degrades_without_changing_the_verdict():
+    """Las familias de contenido son muchas y cada una individualmente
+    pequeña: perder una degrada la confianza, pero las demás siguen mirando
+    el mismo mensaje desde ángulos parecidos."""
+    rules = [_rule("Alarming Keywords", "content")]
+    quality = assess_quality(rules, [_errored()])
+
+    verdict, reasons = cap_verdict("Legitimate", quality)
+
+    assert quality.is_degraded
+    assert quality.blocks_clean_verdict is False
+    assert verdict == "Legitimate"
+    assert reasons  # pero el aviso de degradación sí aparece
+
+
+def test_cap_never_improves_a_verdict():
+    """Mismo contrato que los gates existentes: solo pueden empeorar."""
+    rules = [_rule("SPF", "auth")]
+    quality = assess_quality(rules, [_errored()])
+
+    assert cap_verdict("Phishing", quality)[0] == "Phishing"
+    assert cap_verdict("Suspicious", quality)[0] == "Suspicious"
+
+
+def test_complete_analysis_adds_no_reasons():
+    quality = assess_quality([_rule("SPF", "auth")], [_ok()])
+
+    assert cap_verdict("Legitimate", quality) == ("Legitimate", [])
+
+
+# ---------------------------------------------------------------------------
+# detector_version
+# ---------------------------------------------------------------------------
+
+def test_detector_version_is_stable_across_ordering():
+    """Reordenar el registro no cambia el catálogo, así que no debe cambiar
+    la marca; si lo hiciera, dos informes idénticos parecerían distintos."""
+    a = [_rule("SPF"), _rule("DKIM"), _rule("DMARC")]
+    b = [_rule("DMARC"), _rule("SPF"), _rule("DKIM")]
+
+    assert detector_version(a) == detector_version(b)
+
+
+def test_detector_version_changes_when_the_catalogue_changes():
+    base = [_rule("SPF"), _rule("DKIM")]
+
+    assert detector_version(base) != detector_version(base + [_rule("ARC Chain")])
+    assert detector_version(base) != detector_version([_rule("SPF"), _rule("DKIM v2")])
+
+
+def test_detector_version_fits_the_column():
+    """La columna son 64 caracteres; con 48 reglas debe caber de sobra."""
+    rules = [_rule(f"Regla número {i} con nombre largo") for i in range(200)]
+
+    assert len(detector_version(rules)) <= 64

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -49,11 +49,74 @@ def _sample_report(**overrides):
 
 
 def test_print_pdf_creates_a_file():
-    creator = IrisPDFCreator(report=_sample_report())
+    creator = IrisPDFCreator(report=_sample_report(), document_id=7)
     path = creator.print_pdf()
     assert os.path.exists(path)
     assert os.path.getsize(path) > 0
-    assert path.endswith("42_Iris.pdf")
+    assert path.endswith("42_7_Iris.pdf")
+
+
+def test_two_documents_of_the_same_analysis_do_not_collide():
+    """B11: el modelo permite N documentos por análisis, pero el nombre del
+    fichero solo dependía del análisis, así que todos escribían el mismo PDF."""
+    first = IrisPDFCreator(report=_sample_report(), document_id=1).print_pdf()
+    second = IrisPDFCreator(report=_sample_report(), document_id=2).print_pdf()
+
+    assert first != second
+    assert os.path.exists(first) and os.path.exists(second)
+
+
+def test_deleting_one_document_leaves_the_other_intact():
+    """El caso que hacía daño de verdad: ``delete_document_with_file`` borra
+    por ``filename``, que era el mismo para los dos documentos."""
+    first = IrisPDFCreator(report=_sample_report(), document_id=1).print_pdf()
+    second = IrisPDFCreator(report=_sample_report(), document_id=2).print_pdf()
+
+    os.remove(first)
+
+    assert not os.path.exists(first)
+    assert os.path.exists(second)
+    assert os.path.getsize(second) > 0
+
+
+def test_without_a_document_id_the_name_is_still_unique():
+    """Ningún camino de la aplicación llega así, pero la clase sigue siendo
+    usable a pelo y no debe reintroducir la colisión por la puerta de atrás."""
+    first = IrisPDFCreator(report=_sample_report()).print_pdf()
+    second = IrisPDFCreator(report=_sample_report()).print_pdf()
+
+    assert first != second
+    assert os.path.exists(first) and os.path.exists(second)
+
+
+def test_no_temporary_file_survives_a_successful_render(tmp_path):
+    """El PDF se escribe en un temporal y se mueve con ``os.replace()``; si el
+    temporal sobreviviera, cada informe dejaría basura en el directorio."""
+    path = IrisPDFCreator(report=_sample_report(), document_id=3).print_pdf()
+
+    leftovers = [name for name in os.listdir(os.path.dirname(path)) if name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_a_failed_render_leaves_neither_temporary_nor_output(tmp_path, monkeypatch):
+    """Un fallo a mitad no debe dejar un PDF truncado en la ruta final: el
+    lector que lo descargue recibiría un fichero corrupto sin saberlo."""
+    import src.modules.features.iris.services.reports as reports_mod
+
+    creator = IrisPDFCreator(report=_sample_report(), document_id=4)
+    expected = creator._output_path()
+
+    monkeypatch.setattr(
+        reports_mod.SimpleDocTemplate, "build",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError):
+        creator.print_pdf()
+
+    assert not os.path.exists(expected)
+    leftovers = [name for name in os.listdir(str(tmp_path)) if name.endswith(".tmp")]
+    assert leftovers == []
 
 
 def test_print_pdf_without_path_data_does_not_fail():

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -128,27 +128,88 @@ def test_dmarc_missing_is_neutral():
 
 # -------------------------------------------------------------------- ARC (D7)
 
+class _ArcContext:
+    """Contexto mínimo para ``check_arc_chain``.
+
+    B06 pasó la regla a ``needs_context=True``: ya no le basta con las
+    cabeceras, necesita la cadena Received para saber si quien dice haber
+    validado la cadena ARC está por encima de la frontera de confianza.
+    """
+
+    def __init__(self, headers, received_headers=()):
+        self.headers = headers
+        self.received_headers = list(received_headers)
+
+
 def test_arc_missing_is_neutral_missing_verdict():
-    result = check_arc_chain({})
+    result = check_arc_chain(_ArcContext({}))
     assert result.verdict == "missing"
     assert result.score == 0
 
 
 def test_arc_cv_pass_is_positive():
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "pass"
     assert result.score > 0
 
 
+def test_arc_cv_pass_alone_is_not_verified():
+    """B06: `cv=pass` es lo que el mensaje dice de sí mismo.
+
+    Iris no verifica firmas criptográficas, así que esa declaración no puede
+    valer como prueba — cualquiera puede escribirla. La regla sigue
+    reportándola, pero marcada como no verificada.
+    """
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=pass; d=reenviador.example; s=s1; b=xyz"}))
+    assert result.verdict == "pass"
+    assert result.details["verified"] is False
+    assert result.recommendation  # y se le explica al usuario por qué
+
+
+def test_arc_cv_pass_is_verified_when_a_trusted_hop_confirms_it():
+    """Quien sí valida la cadena es el MTA receptor, que lo apunta como
+    `arc=pass` en su propio Authentication-Results."""
+    result = check_arc_chain(_ArcContext(
+        headers={
+            "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=reenviador.example; s=s1; b=xyz",
+            "authentication-results": "mx.destino.example; arc=pass; spf=fail; dmarc=fail",
+        },
+        received_headers=["from relay.example by mx.destino.example; Mon, 1 Jan 2026 10:00:00 +0000"],
+    ))
+    assert result.verdict == "pass"
+    assert result.details["verified"] is True
+    assert result.recommendation is None
+
+
+def test_arc_confirmation_from_an_untrusted_hop_does_not_count():
+    """Un `arc=pass` firmado por un servidor que solo aparece por debajo de la
+    frontera lo pudo escribir el propio remitente: no verifica nada."""
+    result = check_arc_chain(_ArcContext(
+        headers={
+            "arc-seal": "i=1; a=rsa-sha256; cv=pass; d=malo.example; s=s1; b=xyz",
+            "authentication-results": "mx.malo.example; arc=pass; spf=pass; dmarc=pass",
+        },
+        received_headers=[
+            "from relay.example by mx.destino.example; Mon, 1 Jan 2026 10:00:00 +0000",
+            "from origen.example by mx.malo.example; Mon, 1 Jan 2026 09:59:00 +0000",
+        ],
+    ))
+    assert result.details["verified"] is False
+
+
 def test_arc_cv_fail_is_negative():
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=fail; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=fail; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "fail"
     assert result.score < 0
 
 
 def test_arc_cv_none_is_neutral_first_hop():
     # cv=none just means "I'm the first ARC seal in the chain" -- not suspicious.
-    result = check_arc_chain({"arc-seal": "i=1; a=rsa-sha256; cv=none; d=example.com; s=s1; b=xyz"})
+    result = check_arc_chain(_ArcContext(
+        {"arc-seal": "i=1; a=rsa-sha256; cv=none; d=example.com; s=s1; b=xyz"}))
     assert result.verdict == "neutral"
     assert result.score == 0
 
@@ -418,18 +479,38 @@ def test_gating_caps_at_suspicious_on_domain_misalignment():
     assert _gated("Legitimate", named) == "Suspicious"
 
 
-def test_gating_arc_pass_softens_spf_dmarc_alignment_gates():
+def test_gating_verified_arc_pass_softens_spf_dmarc_alignment_gates():
     # D7: a legitimate forward validated by ARC (cv=pass) must not trip
     # the SPF/DMARC/alignment gates that exist to catch spoofing --
     # mailing lists/forwarders routinely break raw SPF/alignment as a
     # side effect of legitimate relaying.
+    #
+    # B06 añade la condición que faltaba: la validación tiene que venir
+    # confirmada por un verificador de confianza (`verified`), no del propio
+    # sello del mensaje.
     named = {
         "SPF": _rr("fail"),
         "DMARC": _rr("fail"),
         "Domain Alignment": _rr("fail"),
-        "ARC Chain": _rr("pass"),
+        "ARC Chain": _rr("pass", verified=True),
     }
     assert _gated("Legitimate", named) == "Legitimate"
+
+
+def test_gating_unverified_arc_pass_no_longer_softens_the_gates():
+    """B06, el bypass que se cierra.
+
+    Antes bastaba con escribir `ARC-Seal: cv=pass` en el propio correo para
+    desactivar de golpe los tres gates que cazan suplantación. Ahora un ARC sin
+    confirmar es contexto: aparece en el informe, pero no da permisos.
+    """
+    named = {
+        "SPF": _rr("fail"),
+        "DMARC": _rr("fail"),
+        "Domain Alignment": _rr("fail"),
+        "ARC Chain": _rr("pass", verified=False),
+    }
+    assert _gated("Legitimate", named) == "Suspicious"
 
 
 def test_gating_arc_fail_escalates_to_suspicious():

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -821,15 +821,40 @@ def test_generate_ai_summary_rejects_unfinished_analysis(monkeypatch):
 
 
 def test_generate_ai_summary_submits_task_for_finished_analysis(monkeypatch):
+    """B10 añadió dos pasos con estado a esta función —reclamar la fila y
+    cobrar cuota— que un test sin base de datos no puede ejercitar.
+
+    Aquí se sustituyen los dos por dobles para que el test siga siendo lo que
+    era: la comprobación de que el trabajo se encola con los argumentos y la
+    categoría correctos. La idempotencia y el reembolso, que son lo que esos
+    pasos aportan, se prueban contra la base de datos real en
+    ``tests/integration/test_iris_ai_summary.py``.
+    """
     from types import SimpleNamespace
-    fake_analysis = SimpleNamespace(id=10, status="finished")
+    import src.modules.features.iris.managers.analysis as analysis_mod
+
+    fake_analysis = SimpleNamespace(id=10, status="finished", ai_summary=None)
     monkeypatch.setattr(
         IrisManager, "assert_analysis_ownership",
         classmethod(lambda cls, analysis_id, user_id: fake_analysis),
     )
+    monkeypatch.setattr(
+        IrisManager, "_claim_ai_summary",
+        staticmethod(lambda analysis_id, regenerate=False: True),
+    )
+    monkeypatch.setattr(IrisManager, "_update_analysis",
+                        lambda self, analysis_id, **fields: True)
+
+    class _FreeQuota:
+        def consume(self, user_id, key, amount=1): pass
+        def refund(self, user_id, key, amount=1): pass
+
+    monkeypatch.setattr(analysis_mod, "QuotaManager", _FreeQuota)
+
     fake_queue = _FakeTaskQueue()
     IrisManager(task_queue=fake_queue).generate_ai_summary(analysis_id=10, user_id=1)
-    assert fake_queue.submitted["args"] == (10,)
+
+    assert fake_queue.submitted["args"] == (10, 1)
     assert fake_queue.submitted["category"] == "iris.ai_summary"
 
 

--- a/API/tests/unit/test_taskqueue.py
+++ b/API/tests/unit/test_taskqueue.py
@@ -69,6 +69,11 @@ class FakeTaskQueue:
             return None
         return task
 
+    def is_recoverable(self, external_id: str,
+                       category: Optional[str] = None) -> bool:
+        task = self.get_task_by_external_id(external_id, category)
+        return task is not None and task.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
+
     def update_progress(self, task_id: str, progress: int) -> None:
         pass
 

--- a/API/tests/unit/test_taskqueue_recoverable.py
+++ b/API/tests/unit/test_taskqueue_recoverable.py
@@ -1,0 +1,128 @@
+"""B04: ``TaskQueue.is_recoverable()`` — ¿queda alguien que termine este trabajo?
+
+Las reconciliaciones de arranque necesitan distinguir un trabajo abandonado de
+uno que sigue vivo en otro proceso. Mirar solo el estado del job no basta: un
+job ``started`` puede estar avanzando ahora mismo, o pertenecer a un worker que
+murió de un ``kill -9`` y no va a volver. Estos tests fijan esa tabla de
+decisión sobre la implementación real, con Redis y RQ sustituidos por dobles.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.system.taskqueue.queue import TaskQueue
+
+pytestmark = pytest.mark.unit
+
+_EXTERNAL_ID = "iris-analysis:42"
+_CATEGORY = "iris.analyze"
+
+
+class _ExternalIdStore:
+    """Doble del mapeo external_id → job_id que vive en Redis."""
+
+    def __init__(self, mapping: dict[str, str]):
+        self._mapping = mapping
+
+    def get(self, external_id: str):
+        return self._mapping.get(external_id)
+
+
+def _queue(job_id: str | None = "job-1") -> TaskQueue:
+    """Instancia de TaskQueue sin pasar por ``__init__``.
+
+    El constructor real abre la conexión a Redis; aquí solo se necesitan las
+    tres costuras que ``is_recoverable`` consulta, y cada test las sustituye.
+    """
+    queue = TaskQueue.__new__(TaskQueue)
+    queue._external = _ExternalIdStore({_EXTERNAL_ID: job_id} if job_id else {})
+    return queue
+
+
+def _rq_job(status: str, worker_name: str | None = "worker-1"):
+    """Doble de un ``rq.job.Job`` con lo justo que lee ``Task.from_rq_job``."""
+    job = mock.MagicMock()
+    job.id = "job-1"
+    job.description = "Analysis-42"
+    job.meta = {"category": _CATEGORY, "external_id": _EXTERNAL_ID}
+    job.get_status.return_value = status
+    job.created_at = None
+    job.started_at = None
+    job.ended_at = None
+    job.exc_info = None
+    job.worker_name = worker_name
+    return job
+
+
+def test_no_mapping_means_nobody_will_finish_it():
+    queue = _queue(job_id=None)
+
+    assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_expired_job_is_not_recoverable():
+    """RQ purga su historial por TTL: el mapeo sigue, el job ya no."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=None):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_queued_job_is_recoverable():
+    """Sigue en la cola; el primer worker libre lo tomará."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("queued")):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True
+
+
+def test_started_job_with_a_live_worker_is_recoverable():
+    """El caso que motiva B04: está corriendo, no hay que tocarlo."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=True):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True
+
+
+def test_started_job_whose_worker_died_is_not_recoverable():
+    """La clave ``rq:worker:<name>`` sobrevive con TTL completo a un ``kill -9``,
+    así que "el job dice started" no prueba que alguien lo esté ejecutando."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=False):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+@pytest.mark.parametrize("rq_status", ["finished", "failed", "stopped"])
+def test_terminal_jobs_are_not_recoverable(rq_status):
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job(rq_status)):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is False
+
+
+def test_category_mismatch_is_not_recoverable():
+    """Un external_id reutilizado por otro módulo no responde por este trabajo."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job", return_value=_rq_job("started")), \
+         mock.patch.object(TaskQueue, "_worker_alive", return_value=True):
+        assert queue.is_recoverable(_EXTERNAL_ID, "themis.scan") is False
+
+
+def test_redis_failure_assumes_recoverable():
+    """Conservador a propósito: sin poder mirar no hay prueba de que el trabajo
+    esté perdido, y el precio de equivocarse es asimétrico — un huérfano que
+    sobrevive un arranque se reconcilia en el siguiente, pero marcar `failed`
+    un trabajo vivo se lo enseña al usuario como fallido justo antes de que el
+    worker escriba su resultado encima."""
+    queue = _queue()
+
+    with mock.patch.object(TaskQueue, "_try_fetch_job",
+                           side_effect=ConnectionError("Redis caído")):
+        assert queue.is_recoverable(_EXTERNAL_ID, _CATEGORY) is True

--- a/README.md
+++ b/README.md
@@ -231,24 +231,35 @@ Content-Type: application/json
 | Method | Endpoint | Permission | Description |
 |---|---|---|---|
 | `POST` | `/iris/analyze` | `IRIS_CREATE` | Submit email headers/content (optional: `title`) |
-| `GET` | `/iris/status?id=` | `IRIS_READ` | Analysis progress and status |
+| `GET` | `/iris/capabilities` | `IRIS_READ` | Server-side limits the UI must honour (max message size, min headers, accepted modes, verdict thresholds) |
+| `GET` | `/iris/status?id=` | `IRIS_READ` | Analysis progress and status; carries `failureCode`/`failureReason` when the analysis failed |
 | `GET` | `/iris/results` | `IRIS_READ` | List analyses (paginated) |
-| `GET` | `/iris/results/<id>` | `IRIS_READ` | Full report with per-rule scores |
+| `GET` | `/iris/results/<id>` | `IRIS_READ` | Full report with per-rule scores, analysis quality and detector version |
 | `GET` | `/iris/results/<id>/path` | `IRIS_READ` | Which rules fired and why |
 | `GET` | `/iris/results/<id>/iocs` | `IRIS_READ` | Extracted indicators of compromise |
-| `POST` | `/iris/results/<id>/reanalyze` | `IRIS_UPDATE` | Re-run the rules engine against a stored analysis |
-| `POST` | `/iris/results/<id>/ai-summary` | `IRIS_UPDATE` | Generate an AI plain-language summary (background task) |
+| `POST` | `/iris/results/<id>/reanalyze` | `IRIS_CREATE` | Re-run the current ruleset as a **new** analysis (returns the new id) |
+| `POST` | `/iris/results/<id>/ai-summary` | `IRIS_CREATE` | Generate an AI plain-language summary (background task); idempotent per analysis, `?regenerate=true` forces a new one |
 | `POST` | `/iris/analyze/<id>/cancel` | `IRIS_UPDATE` | Cancel a running analysis |
 | `DELETE` | `/iris/results/<id>` | `IRIS_DELETE` | Delete an analysis |
-| `POST` | `/iris/results/<id>/document` | `IRIS_UPDATE` | Generate a PDF report for an analysis |
-| `GET/DELETE` | `/iris/document-status` · `/iris/documents` · `/iris/document/<id>/download` · `/iris/document/<id>` | Report status, listing, download, delete |
+| `POST` | `/iris/results/<id>/document` | `IRIS_CREATE` | Generate a PDF report for an analysis |
+| `GET` | `/iris/document-status` · `/iris/documents` · `/iris/results/<id>/documents` · `/iris/document/<id>/download` | `IRIS_READ` | Report status, listing and download |
+| `DELETE` | `/iris/document/<id>` | `IRIS_DELETE` | Delete a generated report |
 | `GET` | `/iris/mailbox/providers` | `IRIS_READ` | Supported mailbox providers (Gmail, Microsoft 365) |
 | `POST` | `/iris/mailbox/connect` | `IRIS_CREATE` | Start OAuth connection to an external mailbox |
 | `GET` | `/iris/mailbox/callback` | — (public) | OAuth redirect target; CSRF-protected by a signed `state` |
-| `GET/PATCH/DELETE` | `/iris/mailbox/connections[/<id>]` | `IRIS_*` | List, pause/resume, or disconnect a monitored mailbox |
+| `GET` | `/iris/mailbox/connections` | `IRIS_READ` | List monitored mailboxes |
+| `PATCH` | `/iris/mailbox/connections/<id>` | `IRIS_UPDATE` | Pause, resume or reconfigure a connection |
+| `DELETE` | `/iris/mailbox/connections/<id>` | `IRIS_DELETE` | Disconnect a monitored mailbox |
 | `POST` | `/iris/mailbox/connections/<id>/sync` | `IRIS_UPDATE` | Trigger an out-of-cycle mailbox poll |
 
+> [!NOTE]
+> **`CREATE` vs `UPDATE` in Iris.** `IRIS_CREATE` guards the operations that bring a *new* entity into existence and consume quota for it — submitting an analysis, re-analysing (which inserts a brand-new analysis and returns its id, leaving the original untouched), generating an AI summary, generating a PDF. `IRIS_UPDATE` guards changes to something that already exists: cancelling a running analysis, pausing a connection, forcing a poll. The full matrix is pinned by `API/tests/integration/test_iris_permissions.py`, which asserts both that the documented attribute opens each endpoint and that every other Iris attribute is refused.
+
 Iris applies rules across authentication (SPF, DKIM, DMARC, ARC), header anomalies, reply-chain/thread attacks, content heuristics (including QR-code/quishing detection), and domain spoofing, producing verdicts `Legitimate` / `Suspicious` / `Phishing`. Connected mailboxes are polled periodically by the scheduler and analyzed automatically; when a monitored mailbox receives mail judged `Phishing`, the user is notified by email (`iris.notify`). Thresholds are configured in `SecOpsConfig.json`.
+
+**Trust boundary.** `Authentication-Results` and `Received` headers are partly written by whoever sent the message: MTAs *prepend* their own `Received`, so the lower hops are supplied by the sender and can be fabricated. Iris only trusts an `Authentication-Results` whose `authserv-id` matches a hop **above** the trust boundary — the contiguous run of hops belonging to the delivering organisation, plus any verifier listed in `features.iris.data.trusted_authserv_ids` (empty by default; without it trust is derived from the chain itself). An `ARC-Seal: cv=pass` is treated as context, never as permission to suppress SPF/DMARC/alignment gates, unless a trusted verifier confirms it with `arc=pass` in its own `Authentication-Results`.
+
+**Analysis quality.** A rule that raises does not abort the analysis, but it is no longer invisible: the report carries `analysisQuality` (`complete`/`degraded`), `failedRules` (the rules that could not *execute* — not the ones that found something) and `detectorVersion` (which rule catalogue produced the result). Losing an authentication or attachment rule prevents a `Legitimate` verdict, because those two families answer questions no other rule answers.
 
 ### Aegis — awareness and alerts
 
@@ -388,9 +399,6 @@ Each entry point is a `@staticmethod` on the owning module's manager class — p
 | `iris.notify` | Iris | `IrisPhishingNotifyManager.execute_notify_phishing` | `iris-phishing-notify:<id>` |
 | `hygeia.notify` | Hygeia | `HygeiaNotifyManager.execute_notify_critical_anomaly` | `hygeia-notify:<id>` |
 
-> [!NOTE]
-> `iris.ai_summary` has no registered queue, so its jobs run on `default` (the TaskQueue logs a warning for it).
-
 - **Progress reporting**: workers update `job.meta["progress"]` via `_Task(progress_callback=...)`.
 - **Cooperative cancellation**: set Redis key `taskqueue:cancel:{job_id}`; workers check via `_Task.wait(cancel_check=...)` and terminate the subprocess tree.
 - The `max_workers` setting is read at worker startup only — changes via `PUT /system/tasks/config` apply on the next worker restart.
@@ -409,15 +417,29 @@ pytest                    # full suite + coverage (SQLite, external services moc
 pytest -m unit            # fast unit tests only (no app, no DB)
 pytest -m integration     # boots create_app() + test HTTP client
 pytest -m oracle          # differential-oracle bench against real Docker containers (skipped in CI by default)
+pytest -m postgres        # real-engine matrix (PostgreSQL + Redis); skipped unless POSTGRES_TEST_URL is set
 ```
 
-CI (`.github/workflows/tests.yml`) runs `python -m pytest -q -m "not oracle"` on push/PR to `main`. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
+The `postgres` matrix (`API/tests/postgres/`) covers the invariants SQLite cannot express — declared column lengths, foreign-key actions, real `JSONB`, races between concurrent transactions, and the Alembic chain applied to an empty database. It skips itself without the env vars, so it neither slows the fast suite nor requires containers to work on the project:
+
+```bash
+docker run -d --name pg -e POSTGRES_USER=ellysia -e POSTGRES_PASSWORD=ellysia \
+  -e POSTGRES_DB=ellysia_test -p 55432:5432 postgres:15
+docker run -d --name rd -p 56379:6379 redis:7
+POSTGRES_TEST_URL=postgresql+psycopg2://ellysia:ellysia@localhost:55432/ellysia_test \
+  REDIS_TEST_URL=redis://localhost:56379/1 python -m pytest -m postgres
+```
+
+Run it in its **own** pytest invocation. The fast suite's SQLite shim rewrites `JSONB` to generic `JSON` in the shared model metadata, so a mixed run would build the wrong schema; the fixtures detect that and skip with an explanatory message rather than assert against an imitation.
+
+CI runs two workflows on push/PR to `main` and the `vX.Y` release branches: `.github/workflows/tests.yml` (`python -m pytest -q -m "not oracle"`, on SQLite) and `.github/workflows/tests-postgres.yml` (`python -m pytest -q -m postgres`, with ephemeral PostgreSQL and Redis services). They are separate jobs on purpose — the service matrix must not slow down the cycle that runs on every push. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
 
 ### Web SPA (node, no framework)
 
 ```bash
 cd web/app
 npm run test:acheron      # crypto interop + CRUD + sync tests for the Acheron vault client
+npm run test:iris         # file-intake limits (the size threshold comes from GET /iris/capabilities)
 npm run test:hygeia       # metric-formatting tests for the Hygeia dashboard
 npm run test:polling      # usePolling composable tests
 npm run test:quiz         # aegis quiz-shuffle permutation tests

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,7 +12,8 @@
     "test:polling": "node test/usePolling.test.mjs",
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
-    "test:logs": "node test/logTransport.test.mjs"
+    "test:logs": "node test/logTransport.test.mjs",
+    "test:iris": "node test/iris.intake.test.mjs"
   },
   "dependencies": {
     "hash-wasm": "^4.12.0",

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -87,6 +87,25 @@
       <!-- Score + Verdict hero -->
       <IrisVerdictHero :score="reportData.totalScore" :verdict="reportData.verdict" />
 
+      <!-- Análisis degradado (B05): alguna regla no llegó a ejecutarse, así que
+           una parte del mensaje no se ha inspeccionado. Va inmediatamente
+           debajo del veredicto porque lo matiza: quien lea el número grande
+           tiene que saber que se calculó sin parte del examen. -->
+      <div v-if="isDegraded" class="rv-degraded">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="degraded-icon"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <div class="degraded-body">
+          <strong class="degraded-title">Análisis incompleto</strong>
+          <p class="degraded-text">
+            No se pudieron ejecutar {{ failedRuleNames.length }}
+            {{ failedRuleNames.length === 1 ? 'regla' : 'reglas' }}, así que la parte
+            del mensaje que les correspondía no se ha inspeccionado.
+          </p>
+          <p v-if="failedRuleNames.length" class="degraded-rules">
+            {{ failedRuleNames.join(' · ') }}
+          </p>
+        </div>
+      </div>
+
       <!-- Gate reasons: señales de alta confianza que fijaron el veredicto -->
       <div v-if="reportData.gateReasons && reportData.gateReasons.length" class="rv-gates">
         <h3 class="section-title">Por qué este veredicto</h3>
@@ -305,6 +324,17 @@ const rulesWithIndex = computed(() =>
   (props.reportData?.rules ?? []).map((rule, i) => ({ rule, i }))
 )
 const flaggedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict !== 'pass'))
+
+// Análisis degradado (B05): alguna regla lanzó una excepción y no llegó a
+// ejecutarse. No es lo mismo que una regla que encontró algo malo —esas
+// aparecen en flaggedRules con su puntuación— sino una parte del mensaje que
+// nadie miró, y por eso el aviso va arriba y no entre los hallazgos.
+const failedRuleNames = computed(() =>
+  (props.reportData?.failedRules ?? []).map(rule => rule.name).filter(Boolean)
+)
+const isDegraded = computed(() =>
+  props.reportData?.analysisQuality === 'degraded' || failedRuleNames.value.length > 0
+)
 const passedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict === 'pass'))
 const passedRulesOpen = ref(false)
 
@@ -789,6 +819,48 @@ watch(
 }
 
 /* Gate reasons (por qué este veredicto) */
+.rv-degraded {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--warn) 10%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 40%, var(--border));
+  color: var(--text);
+}
+
+.degraded-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  color: var(--warn);
+}
+
+.degraded-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.degraded-title {
+  font-size: var(--fs-md);
+}
+
+.degraded-text {
+  margin: 0;
+  font-size: var(--fs-md);
+  line-height: 1.6;
+}
+
+.degraded-rules {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
 .rv-gates {
   display: flex;
   flex-direction: column;

--- a/web/app/src/components/iris/intake.js
+++ b/web/app/src/components/iris/intake.js
@@ -1,0 +1,84 @@
+/**
+ * Decisiones de admisión de un fichero arrastrado a Iris.
+ *
+ * Vive fuera de `IrisView.vue` por dos motivos. El primero es poder probarlo:
+ * son funciones puras sin DOM, igual que `components/hygeia/format.js`, así
+ * que corren con `node` a secas (ver `test/iris.intake.test.mjs`).
+ *
+ * El segundo es el que motiva B13. El tope de tamaño estaba escrito a mano en
+ * la vista (`20 * 1024 * 1024`) mientras el backend aplicaba otro
+ * (`iris.maxMessageBytes`, 10 MiB): el usuario elegía un fichero que la
+ * interfaz daba por bueno, esperaba a que se cargara entero en memoria y
+ * recibía un rechazo del API. Una constante duplicada en el navegador deriva
+ * en cuanto alguien cambia la configuración del servidor —y ya había
+ * derivado, al doble—, así que el límite se pide a `GET /iris/capabilities` y
+ * aquí solo queda cómo aplicarlo.
+ */
+
+/** Tope de emergencia si `/iris/capabilities` no ha respondido todavía.
+ *
+ *  Coincide con el default de `IrisConfig.max_message_bytes`. No es la fuente
+ *  de verdad —el servidor lo es— sino lo que evita que la vista quede
+ *  inutilizable mientras la petición está en vuelo o si falla. Ante la duda,
+ *  es preferible pecar por defecto: un fichero rechazado de más se puede
+ *  reintentar, uno aceptado de más se rechaza igualmente al enviarlo, pero
+ *  después de habérselo comido entero.
+ */
+export const FALLBACK_MAX_MESSAGE_BYTES = 10 * 1024 * 1024
+
+/** ¿Es un `.eml`? Se acepta por extensión o por tipo MIME: los navegadores no
+ *  siempre rellenan `file.type` para ficheros arrastrados desde el disco. */
+export function isEmlFile(file) {
+  if (!file) return false
+  return /\.eml$/i.test(file.name ?? '') || file.type === 'message/rfc822'
+}
+
+/** Tope efectivo a partir de la respuesta de capacidades del servidor.
+ *
+ *  Solo acepta enteros positivos: un `null`, un `0` o un valor no numérico
+ *  significan "el servidor no me lo ha dicho", no "no hay límite" — tratarlos
+ *  como cero rechazaría absolutamente todo.
+ */
+export function resolveMaxMessageBytes(capabilities) {
+  const declared = capabilities?.maxMessageBytes
+  if (typeof declared === 'number' && Number.isFinite(declared) && declared > 0) {
+    return Math.floor(declared)
+  }
+  return FALLBACK_MAX_MESSAGE_BYTES
+}
+
+/**
+ * Decide qué hacer con un fichero antes de leerlo.
+ *
+ * Devuelve `{ accepted, reason, headersOnly }`:
+ *
+ * - `accepted: false` — no es un `.eml`; no hay nada que leer.
+ * - `headersOnly: true` — es un `.eml` pero pasa del tope, así que solo se
+ *   enviarán las cabeceras extraídas. No es un rechazo: un correo enorme casi
+ *   siempre lo es por sus adjuntos, y sus cabeceras siguen siendo analizables.
+ * - `headersOnly: false` — cabe entero y se manda completo, para que las
+ *   reglas de contenido (cuerpo, enlaces, adjuntos) puedan aplicarse.
+ */
+export function classifyIntake(file, capabilities) {
+  if (!isEmlFile(file)) {
+    return { accepted: false, reason: 'not-eml', headersOnly: false, limit: null }
+  }
+
+  const limit = resolveMaxMessageBytes(capabilities)
+  const headersOnly = (file.size ?? 0) > limit
+
+  return {
+    accepted: true,
+    reason: headersOnly ? 'too-big' : 'ok',
+    headersOnly,
+    limit,
+  }
+}
+
+/** Tamaño legible para el aviso que ve el usuario ("10 MB"). */
+export function formatByteLimit(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return ''
+  const megabytes = bytes / (1024 * 1024)
+  const rounded = megabytes >= 10 ? Math.round(megabytes) : Math.round(megabytes * 10) / 10
+  return `${rounded} MB`
+}

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -27,6 +27,14 @@ export const useIrisStore = defineStore('iris', () => {
   // hardcodee. Los valores por defecto solo se usan hasta el primer fetch.
   const thresholds = reactive({ legitimate: 80, suspicious: 55 })
 
+  // B13: límites que aplica el servidor (`GET /iris/capabilities`). La vista
+  // los necesita para decidir igual que el API en vez de replicar constantes:
+  // el tope de tamaño estaba escrito a mano allí y había derivado al doble
+  // del real, así que el usuario cargaba en memoria ficheros que el backend
+  // iba a rechazar. Se pide una vez y se cachea; si falla, `intake.js` cae a
+  // su respaldo y la interfaz sigue siendo usable.
+  const capabilities = ref(null)
+
   const currentId = ref(null)
   const currentReport = reactive({ loading: false, data: null })
   const currentStatus = reactive({ polling: false, status: null, progress: null })
@@ -48,6 +56,19 @@ export const useIrisStore = defineStore('iris', () => {
   // "message" para que el backend analice cuerpo, enlaces y adjuntos
   // reales; "headers" se mantiene como respaldo cuando solo se pegaron
   // cabeceras a mano.
+  async function fetchCapabilities() {
+    if (capabilities.value) return capabilities.value
+    try {
+      capabilities.value = await apiFetch('/iris/capabilities')
+    } catch {
+      // Silencioso a propósito: no poder leer los límites no impide analizar
+      // nada, solo hace que la interfaz use su respaldo. Un toast de error
+      // aquí sería ruido por algo que el usuario no puede arreglar.
+      capabilities.value = null
+    }
+    return capabilities.value
+  }
+
   async function submitAnalysis({ headers, message, title } = {}) {
     submitting.value = true
     try {
@@ -553,6 +574,7 @@ export const useIrisStore = defineStore('iris', () => {
     submitting.value = false
     totalCount.value = 0
     Object.assign(thresholds, { legitimate: 80, suspicious: 55 })
+    capabilities.value = null
 
     archive.items = []
     archive.total = 0
@@ -578,6 +600,7 @@ export const useIrisStore = defineStore('iris', () => {
   return {
     BENCH_SIZE,
     analyses, loading, listError, submitting, totalCount, thresholds,
+    capabilities, fetchCapabilities,
     currentId, currentReport, currentStatus, aiSummaryLoading,
     documents, documentsLoading,
     archive, archiveHasFilters,

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -99,6 +99,7 @@ import IrisForm from '@/components/iris/IrisForm.vue'
 import { useIrisStore } from '@/stores/irisStore'
 import { useToastStore } from '@/stores/toastStore'
 import { parseEml } from '@/composables/useEml'
+import { classifyIntake, formatByteLimit } from '@/components/iris/intake.js'
 
 const store = useIrisStore()
 const toast = useToastStore()
@@ -109,9 +110,13 @@ const archiveOpen = ref(false)
 const prefill = ref(null)
 
 // Fase 2: enviamos el .eml completo (cuerpo, enlaces, adjuntos) para que las
-// reglas de contenido puedan analizarlo. Tope generoso para correos con
-// adjuntos grandes en base64, evitando cargar archivos descomunales.
-const MESSAGE_READ_LIMIT = 20 * 1024 * 1024
+// reglas de contenido puedan analizarlo.
+//
+// B13: el tope ya no se escribe aquí. Era `20 * 1024 * 1024` mientras el
+// backend aplicaba 10 MiB, así que la vista aceptaba ficheros que el API iba
+// a rechazar — después de haberlos leído enteros en memoria. Ahora sale de
+// `GET /iris/capabilities` y la decisión vive en `intake.js`, que es puro y
+// está cubierto por `npm run test:iris`.
 
 // --- Intake por arrastre ---
 // dragDepth cuenta enter/leave para no parpadear sobre los hijos; rejecting
@@ -158,16 +163,17 @@ async function onDrop(e) {
   const file = e.dataTransfer?.files?.[0]
   if (!file) return
 
-  const isEml = /\.eml$/i.test(file.name) || file.type === 'message/rfc822'
-  if (!isEml) {
+  const capabilities = await store.fetchCapabilities()
+  const intake = classifyIntake(file, capabilities)
+  if (!intake.accepted) {
     flashReject()
     toast.show('Solo se aceptan archivos .eml', 'error')
     return
   }
 
   try {
-    const tooBig = file.size > MESSAGE_READ_LIMIT
-    const text = await (tooBig ? file.slice(0, MESSAGE_READ_LIMIT) : file).text()
+    const tooBig = intake.headersOnly
+    const text = await (tooBig ? file.slice(0, intake.limit) : file).text()
     const { rawHeaders, subject } = parseEml(text)
     if (!rawHeaders) {
       flashReject()
@@ -185,7 +191,12 @@ async function onDrop(e) {
     }
     if (store.currentId || store.currentReport.data) store.selectAnalysis(null)
     if (tooBig) {
-      toast.show('Archivo muy grande: solo se cargaron las cabeceras.', 'info')
+      const readable = formatByteLimit(intake.limit)
+      toast.show(
+        `El archivo supera el máximo que admite el servidor${readable ? ` (${readable})` : ''}: `
+        + 'solo se analizarán las cabeceras.',
+        'info',
+      )
     } else {
       toast.show('Correo cargado.', 'success')
     }
@@ -214,6 +225,10 @@ onBeforeUnmount(() => {
 
 onMounted(async () => {
   window.addEventListener('keydown', handleGlobalShortcut)
+  // Los limites del servidor se piden al entrar, no al soltar un fichero: asi
+  // el arrastre decide con el valor real desde el primer intento en vez de
+  // caer al respaldo mientras la peticion esta en vuelo.
+  store.fetchCapabilities()
   await store.fetchResults()
   const last = store.analyses[0]
   if (last && (last.status === 'running' || last.status === 'pending')) {

--- a/web/app/test/iris.intake.test.mjs
+++ b/web/app/test/iris.intake.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Test de la admisión de ficheros de Iris (`components/iris/intake.js`).
+ *
+ * B13: la vista tenía su propio tope de tamaño (20 MiB) mientras el backend
+ * aplicaba otro (10 MiB). El usuario elegía un fichero que la interfaz daba
+ * por bueno, esperaba a que se cargara entero en memoria y recibía un rechazo
+ * del API. Estos tests fijan que la decisión sale del límite que publica el
+ * servidor y no de una constante escrita a mano.
+ *
+ * Funciones puras sin DOM, así que se ejecutan con `node` a secas — mismo
+ * precedente que los tests de Acheron y Hygeia, sin introducir un framework:
+ *
+ *   node web/app/test/iris.intake.test.mjs
+ */
+
+import {
+  FALLBACK_MAX_MESSAGE_BYTES,
+  classifyIntake,
+  formatByteLimit,
+  isEmlFile,
+  resolveMaxMessageBytes,
+} from '../src/components/iris/intake.js'
+
+let passed = 0
+let failed = 0
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  ✓ ${name}`) }
+  else { failed++; console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`) }
+}
+
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  check(name, a === e, `esperado ${e}, obtenido ${a}`)
+}
+
+const MB = 1024 * 1024
+const file = (name, size, type = '') => ({ name, size, type })
+
+console.log('\nisEmlFile')
+check('acepta por extensión', isEmlFile(file('correo.eml', 10)))
+check('acepta en mayúsculas', isEmlFile(file('CORREO.EML', 10)))
+check('acepta por tipo MIME sin extensión', isEmlFile(file('adjunto', 10, 'message/rfc822')))
+check('rechaza un PDF', !isEmlFile(file('informe.pdf', 10)))
+check('rechaza la ausencia de fichero', !isEmlFile(null))
+
+console.log('\nresolveMaxMessageBytes')
+eq('usa el límite que publica el servidor', resolveMaxMessageBytes({ maxMessageBytes: 5 * MB }), 5 * MB)
+eq('sin capacidades cae al respaldo', resolveMaxMessageBytes(null), FALLBACK_MAX_MESSAGE_BYTES)
+eq('sin el campo cae al respaldo', resolveMaxMessageBytes({}), FALLBACK_MAX_MESSAGE_BYTES)
+// Un 0 o un null significan "el servidor no me lo ha dicho", no "no hay
+// límite": tratarlos como cero rechazaría absolutamente todo.
+eq('un cero no es un límite', resolveMaxMessageBytes({ maxMessageBytes: 0 }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('un null no es un límite', resolveMaxMessageBytes({ maxMessageBytes: null }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('una cadena no es un límite', resolveMaxMessageBytes({ maxMessageBytes: '5000' }), FALLBACK_MAX_MESSAGE_BYTES)
+eq('el respaldo coincide con el default del backend', FALLBACK_MAX_MESSAGE_BYTES, 10 * MB)
+
+console.log('\nclassifyIntake — el límite lo manda el servidor')
+const capabilities = { maxMessageBytes: 10 * MB }
+
+eq('un .eml pequeño se manda entero',
+  classifyIntake(file('a.eml', 2 * MB), capabilities),
+  { accepted: true, reason: 'ok', headersOnly: false, limit: 10 * MB })
+
+eq('justo en el límite todavía cabe entero',
+  classifyIntake(file('a.eml', 10 * MB), capabilities),
+  { accepted: true, reason: 'ok', headersOnly: false, limit: 10 * MB })
+
+eq('un byte por encima pasa a solo cabeceras',
+  classifyIntake(file('a.eml', 10 * MB + 1), capabilities),
+  { accepted: true, reason: 'too-big', headersOnly: true, limit: 10 * MB })
+
+// El caso que motiva el issue: 15 MiB caía en la franja entre el tope viejo
+// del frontend (20 MiB) y el real del backend (10 MiB). La interfaz lo daba
+// por bueno y el API lo rechazaba después.
+eq('los 15 MiB de la franja discordante ya no se mandan enteros',
+  classifyIntake(file('a.eml', 15 * MB), capabilities),
+  { accepted: true, reason: 'too-big', headersOnly: true, limit: 10 * MB })
+
+eq('un fichero que no es .eml no se lee siquiera',
+  classifyIntake(file('informe.pdf', 1), capabilities),
+  { accepted: false, reason: 'not-eml', headersOnly: false, limit: null })
+
+console.log('\nclassifyIntake — sigue la configuración del servidor')
+// Si alguien sube el tope por PUT /system, la interfaz debe seguirlo sin que
+// haya que tocar el código del navegador. Es la propiedad que la constante
+// escrita a mano no podía tener.
+eq('un tope mayor deja pasar enteros ficheros antes truncados',
+  classifyIntake(file('a.eml', 15 * MB), { maxMessageBytes: 20 * MB }).headersOnly,
+  false)
+eq('un tope menor los trunca antes',
+  classifyIntake(file('a.eml', 6 * MB), { maxMessageBytes: 5 * MB }).headersOnly,
+  true)
+
+console.log('\nformatByteLimit')
+eq('10 MB', formatByteLimit(10 * MB), '10 MB')
+eq('20 MB', formatByteLimit(20 * MB), '20 MB')
+eq('decimal por debajo de 10', formatByteLimit(2.5 * MB), '2.5 MB')
+eq('sin límite no hay texto', formatByteLimit(0), '')
+
+console.log(`\n${passed} pasados, ${failed} fallidos`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Resumen

Integra en `v0.5` la **fase 0 completa del roadmap de producto de Iris**: once iniciativas, cada una con su issue, su rama y su PR, ya mergeadas en `proyect/iris/product-roadmap/0`.

El objetivo de la fase, en una frase: **que ningún análisis se presente como terminado, autenticado o limpio cuando el pipeline no puede sostenerlo.**

Cierra #200 y sus once sub-issues: #207, #208, #209, #210, #211, #212, #219, #220, #221, #245, #249.

---

## Contexto para quien no trabaje en Iris

Iris es el módulo anti-phishing: recibe un correo —pegado a mano o traído de un buzón conectado por OAuth—, lo pasa por un catálogo de ~48 reglas independientes (autenticación, cabeceras, cadena de respuesta, contenido, enlaces, adjuntos, suplantación de dominio) y produce un veredicto `Legitimate` / `Suspicious` / `Phishing`.

El análisis real no ocurre en la petición HTTP: se encola un trabajo que ejecuta un **proceso worker aparte**. Ese detalle explica buena parte de los bugs que esta fase arregla, porque el estado del análisis lo escribe un proceso distinto del que atiende al usuario.

Los once diagnósticos venían de una auditoría del módulo y se verificaron uno a uno contra el código antes de tocar nada.

---

## Qué entra

### El análisis ya no puede quedarse colgado ni mentir sobre su estado

**#207 (`B03`).** El parseo del mensaje y su validación vivían **fuera** de todo bloque `try`. Si el parser reventaba —recibe texto arbitrario subido por un usuario y lo pasa por la librería `email` con adjuntos, codificaciones raras y MIME anidado—, la excepción llegaba hasta el sistema de colas, que marcaba su trabajo como fallido... pero el sistema de colas no sabe nada de la tabla de análisis. Nadie escribía en la base de datos y **la fila se quedaba en `running` para siempre**: el usuario veía un análisis eternamente en curso, sin error que lo explicara.

Ahora parseo, validación, evaluación y persistencia comparten manejador, y cualquier fallo deja un estado terminal con motivo. El motivo distingue *"lo que enviaste no es un correo analizable"* (accionable) de *"el motor se rompió"* (no accionable), y en el segundo caso se colapsa en un mensaje genérico: el `str()` de una excepción de terceros suele arrastrar el fragmento de entrada que la hizo fallar, y ese fragmento es el correo del usuario. Tiene test dedicado con un IBAN y una dirección dentro del mensaje de error.

**#208 (`B04`).** Al arrancar, la API reconcilia los análisis que quedaron colgados. El criterio era conservar el análisis **solo** si su tarea estaba exactamente en `pending`; todo lo demás, `running` incluido, se marcaba `failed`.

Eso se comía trabajo vivo. Los workers son procesos aparte y reiniciar la API no los para: un trabajo `running` puede estar analizando ahora mismo. El usuario veía `failed` y minutos después el worker escribía `finished` encima de esa misma fila — dos estados contradictorios con minutos de diferencia.

La pregunta correcta no es *"¿en qué estado está el trabajo?"* sino *"¿queda alguien que vaya a terminarlo?"*, y eso es `TaskQueue.is_recoverable()`. Para un trabajo en ejecución comprueba además que su worker **siga vivo de verdad** (por PID): la clave que RQ deja en Redis sobrevive con su TTL completo a un `kill -9`, así que su existencia no prueba nada.

### Una regla rota deja de ser invisible

**#209 (`B05`).** Cuando una regla lanza una excepción, el motor no aborta el análisis — y hace bien, un solo fallo no debería tirar un informe por el que 47 reglas sí funcionaron. Pero la convertía en un resultado neutro y ahí se acababa todo. Como el modelo de puntuación es *sustractivo* (se parte de 100 y las reglas solo restan), una regla que no se ejecuta resta cero: exactamente lo mismo que una que se ejecutó y no encontró nada.

Resultado: si la regla que revienta es la de autenticación, Iris presentaba como **limpio** un mensaje cuya autenticación nunca llegó a comprobar.

Ahora el informe lleva `analysisQuality`, `failedRules` y `detectorVersion`, y la política es **por familia de regla**, no por umbral global: `auth` y `attachment` son las dos únicas familias que responden a una pregunta que ninguna otra responde —«¿es quien dice ser?» y «¿lo que trae dentro es peligroso?»—, así que perder una de ellas impide el veredicto `Legitimate`. Perder una regla de contenido degrada la confianza pero no cambia el veredicto: son muchas y solapadas. El aviso llega a la API, al PDF, al panel y al prompt de IA.

### El endurecimiento de seguridad de la fase

**#219 (`B06`).** Es el ítem de mayor riesgo, y merece explicarse entero.

Los servidores de correo **anteponen** su cabecera `Received`, así que la cadena se lee del último salto (el servidor del destinatario) hasta el origen. Lo importante: **los saltos de abajo los aporta quien envía el mensaje** y puede inventárselos.

`Authentication-Results` —la cabecera donde un servidor apunta el resultado de SPF, DKIM y DMARC— también la puede escribir el remitente. Iris ya lo sabía y comprobaba que el servidor que la firma apareciera en la cadena `Received`. Pero aceptaba **cualquier** salto. El bypass era directo: inyectar las dos cosas a la vez, un `Received` falso y un `Authentication-Results` firmado por ese mismo host inventado. Los dos elementos que se contrastaban entre sí eran del mismo autor.

El segundo agujero era ARC. Un `ARC-Seal: cv=pass` suprimía los gates de SPF, DMARC y alignment —los que existen para cazar suplantación— y es una afirmación que el mensaje hace sobre sí mismo, sin que Iris verifique ninguna firma. Bastaba escribir una línea.

`services/auth_trust.py` calcula la **frontera de confianza**: el salto que entregó el mensaje y los contiguos de su misma organización no los pudo fabricar el remitente; en cuanto la cadena cambia de organización, de ahí para abajo no hay nada garantizado. Un `authserv-id` que solo aparece por debajo tiene ahora veredicto propio, y es *más* grave que uno que no aparece: quien fabrica las dos piezas para que se respalden sabe lo que hace. Y ARC solo ablanda los gates si un verificador de confianza lo confirma con `arc=pass` en su propia cabecera, que es como lo define el RFC.

**Iris sigue sin verificar firmas criptográficas.** Esto no cambia eso: cambia *de quién se fía* al leer el resultado que otro apuntó.

### Los bugs de contrato y de datos

- **#210 (`B11`)** — Todos los informes PDF de un análisis escribían **el mismo fichero**, y borrar uno destruía el del otro (el borrado va por nombre de fichero). Ahora el nombre lleva el id del documento, y se escribe en un temporal con `os.replace()` para que nadie descargue un PDF a medio escribir.
- **#211 (`B12`)** — `sync_cursor` era `String(255)`, pero el cursor de Microsoft Graph es una URL con un token de estado dentro que pasa de 255 caracteres. Truncarlo rompe la sincronización incremental en silencio: el cursor deja de valer, Graph responde 410 y la conexión rehace el bootstrap en cada ciclo sin que nadie se entere.
- **#212 (`B13`)** — El backend rechazaba mensajes de más de 10 MiB; la interfaz tenía su propia constante de 20 MiB. El usuario elegía un fichero que la UI daba por bueno, esperaba a que se cargara **entero en memoria** y recibía un 422. Ahora el límite se publica en `GET /iris/capabilities` en vez de replicarse.
- **#220 (`B10`)** — La cola `iris.ai_summary` no estaba registrada, así que sus trabajos caían en `default`. Y la generación no era idempotente: dos clics cobraban dos veces y lanzaban dos generaciones. La exclusión se apoya ahora en una transición condicional sobre el estado, no en leer-decidir-escribir.
- **#245 (`B18`)** — Las listas configurables de detección (marcas, keywords, TLDs, homóglifos) se cacheaban por nombre y para siempre. Un cambio guardado desde ConfigView **no llegaba al siguiente análisis**, y nada lo delataba. Ahora la clave de caché incluye la versión de la configuración, así que el problema deja de poder tenerse.
- **#221 (`B14`)** — El README documentaba `IRIS_UPDATE` donde el código exige `IRIS_CREATE`. Al contrastarlo con lo que las operaciones hacen, **el equivocado era el README**: las tres crean una entidad nueva y consumen cuota. El código no cambia; se fija la matriz completa con tests y se corrige la documentación.

### Y la infraestructura que faltaba para probar todo esto

**#249 (`B20`).** La suite corre sobre SQLite con Redis y la red cortados. Es la decisión correcta para el ciclo rápido (~2 min, sin depender de lo que tenga levantado la máquina), pero deja fuera cinco clases de invariante:

SQLite **ignora la longitud declarada de un `VARCHAR`** (justo lo que dejó pasar el bug de `sync_cursor` durante toda su vida), no aplica claves foráneas, sustituye `JSONB` por `JSON` genérico, no permite montar carreras entre transacciones, y —esto es lo más llamativo— **ninguna migración de Alembic se ejecutaba en ningún test**, porque el esquema se crea con `create_all`.

`API/tests/postgres/` cubre esos cinco huecos con PostgreSQL y Redis efímeros, en su propio job de CI. Se salta solo sin las variables de entorno, así que no ralentiza nada ni obliga a levantar contenedores para trabajar en el proyecto.

---

## Nuevos artefactos

**Tres servicios** en `features/iris/services/`: `failures.py` (clasificación del motivo terminal), `quality.py` (calidad del análisis y política por familia) y `auth_trust.py` (frontera de confianza).

**Un endpoint**: `GET /iris/capabilities` (`IRIS_READ`).

**Una categoría de cola registrada**: `iris.ai_summary`.

**Un método compartido**: `QuotaManager.refund()`, en `accounts` — no es específico de Iris. Existe porque el cobro va **antes** que el trabajo, y tiene que ser así (cobrar después dejaría lanzar N trabajos concurrentes con cupo para uno); el precio es tener que devolver el dinero cuando el trabajo no llega a hacerse.

**Una clave de configuración**: `features.iris.data.trusted_authserv_ids`, vacía por defecto — sin ella la confianza se deduce de la propia cadena, para que el módulo proteja en cualquier despliegue sin que nadie lo configure.

**Cuatro migraciones**, todas aditivas y reversibles, con columnas NULL para las filas existentes:

| Revisión | Qué añade |
|---|---|
| `b46e50206411` | `failure_code`, `failure_reason` |
| `c93b8545601b` | `analysis_quality`, `failed_rules`, `detector_version` |
| `dd19efde1d08` | `sync_cursor` de `String(255)` a `Text` |
| `f1e0d1ee8820` | `ai_summary_status`, `ai_summary_job_id`, `ai_summary_model`, `ai_summary_prompt_version` |

Ninguna necesita relleno de datos. Los identificadores son aleatorios y se verificaron contra las 47 existentes: el primer intento usó el patrón manual del repositorio (`a1b2c3d4e5f6`) y **ese ID ya estaba cogido**.

---

## Validación

- **2 014 tests pasan**, 19 se saltan. 12 ficheros de test nuevos.
- **Matriz de motores reales verificada en local** contra PostgreSQL 15 y Redis 7: 15 pasan, 2 `xfail` (ver más abajo).
- `pylint` sobre los ficheros tocados: sin regresión (8.08 → 8.16 en el primer PR, estable después).
- Build del SPA correcto; `npm run test:iris` (nuevo) en verde.
- Alembic: 51 revisiones, **un solo head**, sin identificadores repetidos ni referencias rotas.
- Los seis tests que el issue paraguas exigía para cerrar la fase existen y pasan: parser roto, trabajo `running` durante la reconciliación, regla fallida en las tres familias, ARC/`Authentication-Results` falsificado, PDF concurrente y delta link largo.

**Este PR es la primera vez que todo esto pasa por CI.** Los dos workflows disparan en `v[0-9]+.[0-9]+`, así que aquí se ejecutan tanto la suite normal como el job nuevo de PostgreSQL — en `proyect/iris/product-roadmap/0` no corría ninguno.

---

## Dos bugs preexistentes que salieron por el camino

Ninguno entra aquí: quedan abiertos aparte para no ampliar el alcance de la fase.

- **#346** — `ScanManager.reconcile_orphaned_scans()` de Themis tiene **el mismo defecto** que `B04` arregló en Iris, literal (`scan.py:437`). Con `is_recoverable()` ya disponible, la corrección es sustituir la comprobación de estado por la llamada.
- **#356** — `alembic upgrade head` **falla sobre una base de datos vacía**: la revisión `b2c3d4e5f6a7` inserta en `PlanLimit` diez migraciones antes de que `f2b3c4d5e6f7` cree la tabla. No se ha notado nunca porque el primer despliegue crea el esquema con `CREATE_DATABASE=True` → `create_all` y Alembic solo aplica los incrementos posteriores; la cadena entera desde cero no se había ejecutado jamás. Lo destapó la matriz de `B20`, y sus dos tests quedan marcados `xfail(strict=True)` apuntando a ese issue — el patrón que el proyecto usa para documentar bugs reales con un test.

---

## Notas para revisar y para mergear

- **No hay divergencia.** `v0.5` no se ha movido desde que salió esta rama: 34 commits por delante, 0 por detrás, merge-base en la punta de `v0.5`. El merge es un fast-forward sin conflictos.
- **`appVersion` sigue en `0.5.11`** y este PR no lo toca. Es una decisión tuya si esta fase merece subirlo; `CLAUDE.md` ya contempla que el fichero vaya por detrás del nombre de la rama sin que eso sea un error.
- **Un cambio de comportamiento que conviene mirar con calma**: el endurecimiento de ARC de `B06` puede, en teoría, endurecer el veredicto de reenvíos legítimos cuyo servidor receptor no confirme el `arc=pass`. La suite de regresión de falsos positivos (`test_iris_fp_regression.py`, que recorre correos legítimos reales) pasa **sin tocar nada**, que era la comprobación que más importaba, pero es el sitio donde yo miraría primero si aparece algún falso positivo tras desplegar.
- **`features.themis.areLocalIpsAllowed` sigue a `true`** en `SecOpsConfig.json`, como estaba. No es de esta fase, pero `CLAUDE.md` avisa de devolverlo a `false` antes de cualquier despliegue real y la suite no lo recuerda por su cuenta.
- Los 34 commits conservan su historia por PR, así que se puede revisar iniciativa por iniciativa siguiendo los merges.
