### PR TITLE
CI en verde: construir el writer de IA deja de exigir credenciales reales

### DIFF
--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -85,6 +85,26 @@ os.environ["REDIS_DB"] = "15"
 os.environ.setdefault("REDIS_HOST", "localhost")
 os.environ.setdefault("OLLAMA_HOST", "http://localhost:11434")
 
+# Credenciales de IA: vacías siempre, en cualquier máquina.
+#
+# ``config_reading`` llama a ``load_dotenv()`` sin ruta, y esa función sube por
+# el árbol de directorios hasta encontrar un ``.env``. En un checkout de
+# desarrollo eso encuentra el ``.env`` de la raíz —el de docker-compose, que
+# CLAUDE.md describe como "la API no lo lee"— y de ahí saca una OPENAI_API_KEY
+# de verdad. En CI no hay ningún ``.env``, porque está en .gitignore.
+#
+# Resultado: un test que construya un writer de IA (``build_generator`` monta
+# la estrategia con credenciales en el constructor) pasaba en local y fallaba en
+# CI, sin que nada en el test dijera que dependía de eso. Es la misma clase de
+# fuga que ya sellan Redis y los sockets salientes: algo del entorno de la
+# máquina decidiendo el resultado.
+#
+# Asignación incondicional, no ``setdefault``: tiene que ganar a lo que traiga
+# el ``.env``. Y basta con dejarlas vacías porque ``load_dotenv`` no sobrescribe
+# una variable que ya existe, aunque su valor sea la cadena vacía.
+os.environ["OPENAI_API_KEY"] = ""
+os.environ["GOOGLE_API_KEY"] = ""
+
 from unittest import mock  # noqa: E402
 
 import pytest  # noqa: E402

--- a/API/tests/integration/test_iris_ai_summary.py
+++ b/API/tests/integration/test_iris_ai_summary.py
@@ -18,6 +18,7 @@ from unittest import mock
 import pytest
 
 import src.modules.features.iris.managers.analysis as analysis_mod
+import src.modules.features.iris.services.ai_writer as ai_writer_mod
 from src.modules.features.iris.managers.analysis import IrisManager
 from src.modules.features.iris.model import IrisAnalysis
 from src.modules.features.iris.repositories import IrisAnalysisRepository
@@ -78,6 +79,29 @@ def counting_quota(monkeypatch):
     _CountingQuota.reset()
     monkeypatch.setattr(analysis_mod, "QuotaManager", _CountingQuota)
     return _CountingQuota
+
+
+@pytest.fixture(autouse=True)
+def _inert_ai_backend(monkeypatch):
+    """Construir un ``IrisAIWriter`` no debe necesitar credenciales de OpenAI.
+
+    Los tests de este módulo sustituyen ``IrisAIWriter.generate``, pero eso
+    llega tarde: ``IrisAIWriter.__init__`` llama a ``build_generator("iris")``,
+    que monta la estrategia configurada —OpenAI— y **ésa** sí exige
+    ``OPENAI_API_KEY`` en su constructor. El método sustituido no se alcanzaba
+    nunca.
+
+    En una máquina de desarrollo no se notaba, porque ``load_dotenv()`` sube por
+    el árbol de directorios y encuentra el ``.env`` de la raíz con una clave de
+    verdad. En CI, que no tiene ningún ``.env``, la construcción reventaba, el
+    ``except Exception`` de ``execute_ai_summary_generation`` lo convertía en
+    ``ai_summary_status="failed"``, y el test que esperaba ``"done"`` fallaba.
+
+    Los dos tests que provocan un fallo a propósito también lo agradecen: hasta
+    ahora pasaban en CI por el motivo equivocado —reventaba el constructor, no
+    la generación que decían estar probando—.
+    """
+    monkeypatch.setattr(ai_writer_mod, "build_generator", lambda module=None: object())
 
 
 def _seed_finished_analysis(app, user_id: int, ai_summary=None) -> int:


### PR DESCRIPTION
Arregla el workflow **API Tests** en `v0.5`, en rojo desde que entró la fase 0 de Iris ([#359](https://github.com/ProjectEllysia/EllysiaServer/pull/359)).

## El síntoma

Un solo test:

```
FAILED tests/integration/test_iris_ai_summary.py::test_a_generated_summary_records_how_it_was_made
AssertionError: assert 'failed' == 'done'
```

El otro workflow, **API Tests (PostgreSQL + Redis)**, salía en verde — pero eso no significaba que la cosa estuviera medio bien: ese job corre `pytest -m postgres`, así que nunca llegó a ejecutar este test.

## Qué pasa de verdad

El test comprueba que un resumen generado registra con qué modelo y con qué versión de prompt se hizo. Para no llamar a ninguna IA, sustituye `IrisAIWriter.generate` por un doble que devuelve un resumen fijo.

Esa sustitución **llega tarde**. `execute_ai_summary_generation` hace `IrisAIWriter().generate(report)`, y el constructor —no el método— es el que toca las credenciales:

```python
def __init__(self, generator=None):
    self._generator = generator or build_generator("iris")
```

`build_generator("iris")` resuelve la estrategia configurada para Iris, que por `SecOpsConfig.json` es **OpenAI**, y `OpenAIStrategy.from_config` llama a `CR.get_openai_environment()`, que lanza si falta `OPENAI_API_KEY`. El `generate` sustituido no se alcanzaba nunca.

Y como `execute_ai_summary_generation` envuelve todo en un `except Exception` que deja el análisis en `ai_summary_status="failed"` y devuelve la cuota —comportamiento correcto y deseable en producción, dicho sea de paso—, el error real quedaba reducido a un estado de tres letras. De ahí que la aserción no dijera nada sobre la causa.

## Por qué pasaba en tu máquina y fallaba en CI

Esta es la parte que conviene no olvidar, porque no es específica de Iris.

`config_reading.py` llama a `load_dotenv()` **sin ruta**. Esa función sube por el árbol de directorios hasta encontrar un `.env`. Ejecutando desde `API/`, si no hay `API/.env`, encuentra el **`.env` de la raíz del repositorio** — el de docker-compose, ese que `CLAUDE.md` describe explícitamente como *«solo para docker-compose; la API no lo lee»*.

Resulta que sí lo lee, y ese fichero tiene una `OPENAI_API_KEY` de verdad. Así que en cualquier checkout de desarrollo el constructor funciona. En CI no hay ningún `.env` (está en `.gitignore`), así que revienta.

El resultado es la peor forma de fallo posible: **un test cuyo veredicto lo decide un fichero que no está en el repositorio**. No es que fallara en CI por un problema de CI; es que en local nunca llegó a probarse lo que decía probar.

## Los dos cambios, los dos en `tests/`

**1. El conftest vacía las credenciales de IA para toda la suite.**

```python
os.environ["OPENAI_API_KEY"] = ""
os.environ["GOOGLE_API_KEY"] = ""
```

Asignación incondicional, no `setdefault`, para ganarle al `.env`; y basta con dejarlas vacías porque `load_dotenv` no sobrescribe una variable que ya existe, aunque su valor sea la cadena vacía.

Es exactamente la misma clase de sellado que el conftest ya hace con Redis (`_redis_always_unavailable`) y con los sockets salientes (`_no_outbound_sockets`): cortar de raíz que algo del entorno de la máquina decida el resultado. Con esto, cualquiera reproduce el fallo de CI en local antes de empujar — que es como lo he reproducido para escribir esto.

**2. El módulo de tests del resumen de IA hace inerte `build_generator`.**

Una fixture `autouse` que sustituye la construcción del backend, que es lo que le faltaba al módulo para ser hermético.

Tiene un efecto lateral que merece mencionarse: los **otros dos** tests del fichero, los que provocan un fallo a propósito (`side_effect=RuntimeError("modelo caído")`), en CI pasaban por el motivo equivocado. Lo que reventaba era el constructor, no la generación que decían estar probando. Ahora prueban lo que dicen.

## Lo que NO se cambia, y por qué

**No se toca `src/`.** Es tentador hacer perezoso el `build_generator` del constructor, y hay un argumento decente para ello (`CLAUDE.md` ya establece ese principio para el secreto JWT: *«de forma perezosa, para que un despliegue sin credenciales de OpenAI siga arrancando»*). Pero:

- El comportamiento de producción **es correcto tal como está**: un despliegue sin credenciales de IA degrada el resumen a `failed`, devuelve la cuota, y no afecta al análisis, que sigue `finished`. Nada que arreglar ahí.
- La guía del repositorio es explícita: *«La adaptación a SQLite y los mocks viven solo en `tests/`; nunca modifiques `src/` para acomodar un test»*.

Si en algún momento se quiere que construir un writer sea gratis —para que `model_name()` y `prompt_version()` funcionen sin credenciales, por ejemplo—, eso merece su propio issue y su propia justificación, no colarse en un arreglo de CI.

## Por qué este PR va a `v0.5` y no a la rama de la fase de Lybra

Lo pregunté al revés y la respuesta la da el propio workflow:

```yaml
on:
  push:
    branches: [main, 'v[0-9]+.[0-9]+']
```

**CI no corre en las ramas de proyecto ni en sus PRs.** Un parche que viviera solo en `proyect/lybra/engine-needs/1` no se verificaría hasta que la fase entera se integrara, y mientras tanto `v0.5` seguiría en rojo — para todo el mundo, incluida la fase 1 de Iris si sigue avanzando en paralelo. Un CI rojo que todos saben que "es el conocido" es un CI que nadie mira.

Además no es trabajo de Lybra: es higiene de tests que destapó el merge de Iris. Meterlo en el PR de la fase mezclaría dos historias que no tienen nada que ver.

Una vez esto entre en `v0.5`, traigo `v0.5` a la rama de la fase con un merge normal.

## Validación

- `pytest -q -m "not oracle"` con las credenciales vaciadas (o sea, replicando CI): **en verde**, sin fallos.
- Antes del arreglo, en esas mismas condiciones, falla exactamente ese test y sólo ése — el mismo que reporta CI.
- El README no necesita cambios: no se ha tocado ningún endpoint, categoría de TaskQueue, clave de configuración, variable de entorno ni perfil de Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
