### PR TITLE
Banco de paridad laboratorio/real: la medición pasa a ser un comando (#277, parcial)

### DIFF
--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -105,6 +105,7 @@ os.environ.setdefault("OLLAMA_HOST", "http://localhost:11434")
 os.environ["OPENAI_API_KEY"] = ""
 os.environ["GOOGLE_API_KEY"] = ""
 
+from importlib.util import module_from_spec, spec_from_file_location  # noqa: E402
 from unittest import mock  # noqa: E402
 
 import pytest  # noqa: E402
@@ -241,6 +242,17 @@ def _redis_always_unavailable():
 # 3-ter. Ningún socket sale de loopback
 # ---------------------------------------------------------------------------
 
+# Los objetivos reales declarados (L48) los comparten este sello y el banco de
+# paridad. Se cargan por ruta y no por nombre porque ``conftest`` es ambiguo:
+# hay más de uno en el árbol (``tests/postgres/conftest.py``) y cuál gana
+# depende del orden de recolección.
+_REAL_TARGETS_SPEC = spec_from_file_location(
+    "lybra_real_targets", Path(__file__).resolve().parent / "oracle" / "_real_targets.py"
+)
+_real_targets = module_from_spec(_REAL_TARGETS_SPEC)
+_REAL_TARGETS_SPEC.loader.exec_module(_real_targets)
+
+
 def _is_loopback(address) -> bool:
     """¿Apunta ``address`` (el argumento de ``socket.connect``) a loopback?
 
@@ -276,20 +288,32 @@ def _no_outbound_sockets():
 
     Loopback sí se permite: los tests de herald levantan un servidor SMTP real
     (aiosmtpd) en 127.0.0.1 y tienen que poder hablar con él.
+
+    Y, desde L48, también las direcciones que el operador haya declarado en
+    ``LYBRA_REAL_TARGETS`` (ver :func:`declared_real_targets`). Es una lista
+    blanca de direcciones concretas, resueltas antes de instalar el sello, no
+    un interruptor que lo apague: sin esa variable —el caso por defecto, y el
+    de CI— no sale de aquí ni un paquete.
     """
     real_connect = socket.socket.connect
     real_connect_ex = socket.socket.connect_ex
     real_gethostbyaddr = socket.gethostbyaddr
+    allowed = _real_targets.allowed_outbound_addresses()
+
+    def _is_permitted(address) -> bool:
+        return _is_loopback(address) or (
+            isinstance(address, tuple) and bool(address) and address[0] in allowed
+        )
 
     def guarded_connect(self, address):
-        if not _is_loopback(address):
+        if not _is_permitted(address):
             raise ConnectionRefusedError(
                 f"La suite de tests no permite conexiones fuera de loopback: {address!r}"
             )
         return real_connect(self, address)
 
     def guarded_connect_ex(self, address):
-        if not _is_loopback(address):
+        if not _is_permitted(address):
             return 111  # ECONNREFUSED, la convención de connect_ex
         return real_connect_ex(self, address)
 
@@ -297,7 +321,7 @@ def _no_outbound_sockets():
         # El DNS inverso es la otra forma de irse a la red sin abrir un socket
         # propio: resolver 10.0.0.5 colgaba 16 s en un test de Lybra. El único
         # caller (shared._endpoints) ya trata socket.herror como "no resuelve".
-        if not _is_loopback((ip,)):
+        if not _is_permitted((ip,)):
             raise socket.herror(f"DNS inverso bloqueado en tests: {ip!r}")
         return real_gethostbyaddr(ip)
 

--- a/API/tests/oracle/_real_targets.py
+++ b/API/tests/oracle/_real_targets.py
@@ -1,0 +1,69 @@
+"""Los objetivos reales que el operador declara, y la lista blanca que abren.
+
+Este dato lo leen dos sitios que **no pueden discrepar**: el sello de red de la
+suite (``tests/conftest.py``), que decide a qué direcciones se deja salir, y el
+banco de paridad real (``test_lybra_real_parity_bench.py``), que decide a cuáles
+escanear. Si cada uno releyera la variable por su cuenta, una diferencia tonta
+—un ``strip`` de más, un separador distinto— dejaría al banco intentando llegar
+a un sitio que el sello bloquea, o peor, al sello abriendo una dirección que el
+banco ni usa.
+
+Vive en un módulo propio, y no en el conftest, porque el conftest no se puede
+importar por nombre sin ambigüedad: hay más de uno en el árbol de tests
+(``tests/postgres/conftest.py``), y cuál gana depende del orden de recolección.
+El conftest lo carga por ruta.
+
+Not a test module itself (no ``test_`` prefix) — pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import Set, Tuple
+
+#: La variable que declara el lado real de la paridad laboratorio/real (L48).
+ENVIRONMENT_VARIABLE = "LYBRA_REAL_TARGETS"
+
+
+def declared_real_targets() -> Tuple[str, ...]:
+    """Los objetivos reales declarados por quien ejecuta la suite.
+
+    Una lista separada por comas de hosts o IPs sobre los que quien ejecuta
+    afirma tener autorización de escaneo. Vacía por defecto, que es lo que hace
+    que el banco de paridad real se salte solo y que la suite no salga a la red
+    en ninguna máquina que no lo haya pedido.
+
+    No se lee de ningún fichero del repositorio a propósito: las direcciones de
+    un laboratorio real no tienen por qué publicarse, y una autorización de
+    escaneo es de quien la tiene, no del repositorio.
+    """
+    raw = os.environ.get(ENVIRONMENT_VARIABLE, "")
+    return tuple(target.strip() for target in raw.split(",") if target.strip())
+
+
+def allowed_outbound_addresses() -> Set[str]:
+    """Direcciones IP concretas a las que el sello de red deja salir.
+
+    Se resuelven **una vez**, antes de instalar el sello. No es "abrir la red
+    durante la sesión": es una lista blanca de las direcciones que el operador
+    declaró, y el resto de la suite —incluidos los tests que dependen de que un
+    socket a 10.0.0.5 falle al instante— sigue exactamente igual de sellada.
+
+    Un objetivo que no resuelve no abre ningún agujero ni hunde a los demás: se
+    ignora aquí, y el banco lo reportará como inalcanzable cuando le toque, que
+    es donde se ve.
+    """
+    allowed: Set[str] = set()
+    for target in declared_real_targets():
+        try:
+            allowed.add(ipaddress.ip_address(target).compressed)
+            continue
+        except ValueError:
+            pass
+        try:
+            allowed.update(info[4][0] for info in socket.getaddrinfo(target, None))
+        except OSError:
+            pass
+    return allowed

--- a/API/tests/oracle/test_lybra_real_parity_bench.py
+++ b/API/tests/oracle/test_lybra_real_parity_bench.py
@@ -1,0 +1,226 @@
+"""Paridad laboratorio/real: el mismo motor, contra objetivos de verdad (L48).
+
+El §9 del roadmap declara esta paridad **no negociable** para dar por cerradas
+las fases F (fingerprinting), T (transporte propio) y N (protocolos no-HTTP), y
+lo argumenta bien: *«eso no puede convertirse en la excusa de "el objetivo real
+es más difícil" cuando Nmap identifica con soltura servicios en hosts públicos
+reales. Si aparece un caso como "en localhost identificamos producto y versión,
+pero en un host público real sólo vemos puertos abiertos", no es un resultado
+aceptable por ser "un objetivo más duro": es una brecha concreta que hay que
+cerrar»*.
+
+Un contenedor Docker es un objetivo dócil. Responde al instante, no tiene un
+CDN delante, ni un WAF que corte la conexión al tercer intento, ni una latencia
+que agote un timeout, ni un balanceador que conteste una cosa distinta en cada
+petición. Medir sólo ahí produce un número alto y poco informativo.
+
+## Por qué esto se salta por defecto, y qué hay que hacer para que no
+
+Escanear una máquina ajena sin permiso no es un detalle de configuración. Por
+eso este banco no trae ninguna lista de objetivos: la aporta quien ejecuta la
+suite, en ``LYBRA_REAL_TARGETS``, y esa declaración **es** la afirmación de que
+tiene autorización sobre esos hosts. Sin la variable el módulo entero se salta,
+que es lo que ocurre en CI y en cualquier máquina que no haya decidido lo
+contrario.
+
+El sello de red de la suite (``_no_outbound_sockets``) sigue puesto: lo único
+que cambia es que las direcciones declaradas entran en una lista blanca
+resuelta antes de instalarlo. No se apaga nada.
+
+    LYBRA_REAL_TARGETS="host1.example,host2.example,..." \\
+        pytest tests/oracle/test_lybra_real_parity_bench.py -m oracle -s
+
+El ``-s`` importa: el informe por familia se imprime, porque el entregable de
+este ítem es el número, no un booleano.
+
+## Qué mide
+
+Lo mismo que el banco de laboratorio (``test_lybra_concordance_bench.py``), con
+las mismas funciones, para que los dos números sean comparables:
+
+- **Fase T** — concordancia de puertos: qué encuentra el connect scan propio
+  frente a lo que encuentra Nmap sobre el mismo objetivo.
+- **Fases F y N** — concordancia de fingerprint: si el dissector que aplica a
+  cada servicio identifica el mismo producto que Nmap.
+
+El umbral del roadmap es 0,95 en puertos y 0,90 en fingerprint, y el criterio
+de cierre de L48 pide al menos diez objetivos variados.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from src.modules.features.themis.lybra import (
+    DEFAULT_PORTS,
+    HostRateLimiter,
+    default_dissectors,
+    scan_ports_sync,
+    services_from_discovered_ports,
+)
+
+from ._concordance import agrees_with_nmap, concordance_rate, port_concordance
+from ._docker_helpers import resolve_docker
+from ._nmap_oracle import run_nmap_sv
+# El mismo módulo que lee el sello de red: la lista que este banco escanea y la
+# que el sello permite tienen que ser el mismo dato, no dos lecturas parecidas.
+from ._real_targets import declared_real_targets
+
+pytestmark = [pytest.mark.oracle, pytest.mark.integration]
+
+_TARGETS = declared_real_targets()
+pytestmark.append(pytest.mark.skipif(
+    not _TARGETS,
+    reason="Sin LYBRA_REAL_TARGETS: el lado real de la paridad lo declara el operador",
+))
+
+# El mínimo que pide el criterio de cierre de L48. Se comprueba en su propio
+# test en vez de dentro de la medición: "no hay bastantes objetivos" y "los
+# objetivos que hay concuerdan poco" son dos problemas distintos y merecen dos
+# mensajes distintos.
+_MINIMUM_TARGETS = 10
+
+# Los umbrales del roadmap (§9).
+_PORT_THRESHOLD = 0.95
+_FINGERPRINT_THRESHOLD = 0.90
+
+
+@pytest.fixture(scope="module")
+def measurements() -> List[dict]:
+    """Mide todos los objetivos una vez y reparte el resultado a los tests.
+
+    Un escaneo real no es instantáneo —Nmap con detección de versión sobre una
+    lista de puertos tarda—, así que repetirlo por test convertiría el banco en
+    algo que nadie ejecuta. Se mide una vez por módulo.
+    """
+    docker_path = resolve_docker()
+    results = []
+    for target in _TARGETS:
+        results.append(_measure(target, docker_path))
+    _print_report(results)
+    return results
+
+
+def _measure(target: str, docker_path: Optional[str]) -> dict:
+    """Un objetivo: puertos propios, puertos de Nmap, y fingerprint de cada servicio."""
+    own_ports = scan_ports_sync(target, list(DEFAULT_PORTS))
+    nmap_services = run_nmap_sv(docker_path, DEFAULT_PORTS, host=target)
+
+    # Se compara sobre el mismo conjunto de puertos que ambos examinaron; de lo
+    # contrario el número mediría qué lista de puertos se le pasó a cada uno.
+    ports_score = port_concordance(own_ports, list(nmap_services))
+
+    rate_limiter = HostRateLimiter()
+    dissectors = default_dissectors()
+    pairs: List[Tuple] = []
+    for service in services_from_discovered_ports(own_ports):
+        dissector = next((candidate for candidate in dissectors if candidate.applies(service)), None)
+        if dissector is None:
+            continue
+        try:
+            result = dissector.probe(target, service, rate_limiter)
+        except Exception:
+            result = None
+        nmap = nmap_services.get(service.port)
+        pairs.append((
+            result.product if result else None,
+            result.version if result else None,
+            nmap.product if nmap else None,
+            nmap.version if nmap else None,
+            dissector.label or type(dissector).__name__,
+            service.port,
+        ))
+    return {"target": target, "own_ports": own_ports, "nmap_ports": sorted(nmap_services),
+            "ports_score": ports_score, "pairs": pairs}
+
+
+def _fingerprint_pairs(results: List[dict]) -> List[Tuple]:
+    """Los pares de concordancia de todos los objetivos, sin la etiqueta."""
+    return [pair[:4] for result in results for pair in result["pairs"]]
+
+
+def _by_family(results: List[dict]) -> Dict[str, List[Tuple]]:
+    """Agrupa los pares por la familia del dissector que los produjo.
+
+    La paridad se cierra **por familia**, no en promedio: un número global alto
+    puede esconder que HTTP va perfecto y FTP no identifica nada, que es
+    justamente el caso que el §9 se niega a dar por bueno.
+    """
+    families: Dict[str, List[Tuple]] = defaultdict(list)
+    for result in results:
+        for pair in result["pairs"]:
+            families[pair[4]].append(pair[:4])
+    return families
+
+
+def _print_report(results: List[dict]) -> None:
+    """Imprime la comparativa. El entregable de L48 es el número, no un OK."""
+    print("\n=== Paridad real (L48) — objetivos declarados en LYBRA_REAL_TARGETS ===")
+    for result in results:
+        print(f"  {result['target']}: puertos propios={result['own_ports']} "
+              f"nmap={result['nmap_ports']} concordancia={result['ports_score']:.2f}")
+        for product, version, nmap_product, nmap_version, label, port in result["pairs"]:
+            verdict = "=" if agrees_with_nmap(product, version, nmap_product, nmap_version) else "≠"
+            print(f"      {port:>5}/{label:<6} {verdict} propio={product} {version} "
+                  f"| nmap={nmap_product} {nmap_version}")
+    print("  --- por familia ---")
+    for family, pairs in sorted(_by_family(results).items()):
+        print(f"      {family:<8} n={len(pairs):<3} concordancia={concordance_rate(pairs):.2f}")
+    ports = [result["ports_score"] for result in results]
+    print(f"  puertos (Fase T): {sum(ports) / len(ports):.2f} sobre {len(ports)} objetivos")
+    print(f"  fingerprint (F/N): {concordance_rate(_fingerprint_pairs(results)):.2f} "
+          f"sobre {len(_fingerprint_pairs(results))} servicios")
+
+
+# =========================================================================
+
+def test_the_real_side_has_enough_targets():
+    """El criterio de cierre pide diez objetivos variados, no tres.
+
+    El lado real llevaba desde julio en N=3 (``scanme.nmap.org`` y dos hosts
+    autorizados). Con esa muestra no se cierra ninguna fase: un solo objetivo
+    raro mueve el número medio punto.
+    """
+    assert len(_TARGETS) >= _MINIMUM_TARGETS, (
+        f"Sólo {len(_TARGETS)} objetivos declarados; L48 pide al menos "
+        f"{_MINIMUM_TARGETS} y variados (con y sin CDN/WAF, con y sin TLS, con "
+        f"cabecera Server presente y suprimida, y alguno con servicios no-HTTP)"
+    )
+
+
+def test_port_discovery_matches_nmap_on_real_targets(measurements):
+    """Fase T contra objetivos reales: es donde aparecen el WAF que corta a la
+    tercera conexión y el balanceador que responde distinto en cada intento."""
+    scores = [result["ports_score"] for result in measurements]
+    average = sum(scores) / len(scores)
+    detail = [(result["target"], round(result["ports_score"], 2)) for result in measurements]
+    assert average >= _PORT_THRESHOLD, f"concordancia de puertos real {average:.2f} — {detail}"
+
+
+def test_fingerprinting_matches_nmap_on_real_targets(measurements):
+    """Fases F y N contra objetivos reales."""
+    pairs = _fingerprint_pairs(measurements)
+    assert pairs, "Ningún servicio identificable en los objetivos declarados"
+    rate = concordance_rate(pairs)
+    assert rate >= _FINGERPRINT_THRESHOLD, f"concordancia de fingerprint real {rate:.2f}"
+
+
+def test_no_family_is_left_behind(measurements):
+    """La paridad se cierra por familia, no en promedio.
+
+    Un número global alto puede esconder que HTTP va perfecto y que FTP no
+    identifica nada — que es exactamente el caso que el §9 se niega a dar por
+    bueno. Una familia con un solo servicio observado no se juzga: no hay
+    muestra, y suspender por ella mediría el catálogo de objetivos y no el
+    motor.
+    """
+    behind = {
+        family: round(concordance_rate(pairs), 2)
+        for family, pairs in _by_family(measurements).items()
+        if len(pairs) >= 3 and concordance_rate(pairs) < _FINGERPRINT_THRESHOLD
+    }
+    assert not behind, f"familias por debajo del umbral en objetivos reales: {behind}"

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -1,0 +1,60 @@
+"""La lista blanca del sello de red hace exactamente lo que dice (L48).
+
+El sello ``_no_outbound_sockets`` es lo que mantiene la suite en dos minutos y
+lo que garantiza que su resultado no dependa de lo que haya al otro lado de la
+red. Desde L48 tiene una excepción: las direcciones que el operador declara en
+``LYBRA_REAL_TARGETS`` para el banco de paridad real.
+
+Una excepción a una defensa es justo el sitio donde conviene no fiarse de la
+lectura. Estos casos comprueban las dos mitades que importan:
+
+- que **sin** la variable la lista queda vacía, que es lo que hace que en CI y
+  en cualquier máquina que no haya decidido lo contrario el sello siga entero;
+- que **con** ella entra lo declarado y nada más — ni una dirección de más por
+  un separador mal puesto, ni un fallo entero por un objetivo que no resuelve.
+
+Todo se comprueba sobre direcciones IP literales, que no necesitan DNS: un test
+del sello de red que saliera a la red a resolver nombres sería una contradicción
+en sus propios términos.
+
+Vive en ``tests/oracle/`` porque ahí vive el módulo que prueba, pero **no** lleva
+el marcador ``oracle``: son funciones puras sobre cadenas, sin Docker ni red, y
+tienen que correr en el CI por defecto — es donde importa que la lista blanca
+salga vacía.
+"""
+
+import pytest
+
+from ._real_targets import allowed_outbound_addresses, declared_real_targets
+
+pytestmark = pytest.mark.unit
+
+
+def test_without_the_variable_nothing_is_allowed(monkeypatch):
+    """El caso por defecto, y el único que corre en CI."""
+    monkeypatch.delenv("LYBRA_REAL_TARGETS", raising=False)
+    assert declared_real_targets() == ()
+    assert allowed_outbound_addresses() == set()
+
+
+def test_an_empty_or_blank_variable_is_the_same_as_none(monkeypatch):
+    """Una variable declarada pero vacía —o con comas sueltas de una edición a
+    medias— no puede abrir la red "un poco"."""
+    for value in ("", "   ", ",", " , , "):
+        monkeypatch.setenv("LYBRA_REAL_TARGETS", value)
+        assert declared_real_targets() == ()
+        assert allowed_outbound_addresses() == set()
+
+
+def test_declared_addresses_are_parsed_and_trimmed(monkeypatch):
+    monkeypatch.setenv("LYBRA_REAL_TARGETS", " 198.51.100.7 , 203.0.113.9 ")
+    assert declared_real_targets() == ("198.51.100.7", "203.0.113.9")
+    assert allowed_outbound_addresses() == {"198.51.100.7", "203.0.113.9"}
+
+
+def test_a_target_that_does_not_resolve_does_not_sink_the_rest(monkeypatch):
+    """Un nombre inválido no puede dejar sin lista blanca a los que sí lo son:
+    el banco reportará ese objetivo como inalcanzable cuando le toque, que es
+    donde se ve, en vez de hacer fallar la construcción del sello."""
+    monkeypatch.setenv("LYBRA_REAL_TARGETS", "198.51.100.7,no-existe.invalid")
+    assert "198.51.100.7" in allowed_outbound_addresses()


### PR DESCRIPTION
Avanza #277. **No lo cierra**, y el motivo está explicado abajo: falta un dato que sólo puedes aportar tú.

## Qué pide el issue y qué se puede hacer sin ti

El §9 del roadmap declara la paridad laboratorio/real **no negociable** para dar por cerradas las fases F (fingerprinting), T (transporte propio) y N (protocolos no-HTTP). Su argumento merece repetirse entero, porque es el que ordena el trabajo:

> *«eso no puede convertirse en la excusa de "el objetivo real es más difícil" cuando Nmap identifica con soltura servicios en hosts públicos reales. Si aparece un caso como "en localhost identificamos producto y versión, pero en un host público real sólo vemos puertos abiertos", no es un resultado aceptable por ser "un objetivo más duro": es una brecha concreta que hay que cerrar»*

Un contenedor Docker es un objetivo dócil: responde al instante, no tiene un CDN delante, ni un WAF que corte la conexión al tercer intento, ni una latencia que agote un timeout, ni un balanceador que conteste una cosa distinta en cada petición. Medir sólo ahí produce un número alto y poco informativo — y el banco de #276 acaba de enseñar que incluso en laboratorio el número real era 0,43, no el 1,00 que el roadmap anotaba.

El issue divide el trabajo en tres, y sólo el primero depende de ti:

1. **Ampliar el registro de objetivos autorizados** — tuyo, por definición.
2. **Automatizar la medición real con la misma forma que la de laboratorio**, para que repetirla sea un comando y no una sesión — esto es lo que trae este PR.
3. **Publicar la comparativa por familia** — también aquí, en cuanto haya objetivos.

## El banco

`tests/oracle/test_lybra_real_parity_bench.py` mide los mismos dos números que el banco de laboratorio, **con las mismas funciones**, que es lo que hace que los dos sean comparables:

- **Fase T** — concordancia de puertos: qué encuentra el connect scan propio frente a lo que encuentra Nmap sobre el mismo objetivo. Umbral del roadmap: 0,95.
- **Fases F y N** — concordancia de fingerprint: si el dissector que aplica a cada servicio descubierto identifica el mismo producto que Nmap. Umbral: 0,90.

Y publica la comparativa **por familia**, no sólo el promedio. Eso no es presentación: un número global alto puede esconder que HTTP va perfecto y que FTP no identifica nada, que es exactamente el caso que el §9 se niega a dar por bueno. Hay un test dedicado a ello (`test_no_family_is_left_behind`) que suspende si alguna familia con muestra suficiente se queda por debajo del umbral, aunque la media salga bien.

Un detalle del diseño que merece explicación: una familia con **menos de tres** servicios observados no se juzga. Sin muestra, suspender por ella mediría el catálogo de objetivos y no el motor.

## Escanear máquinas ajenas: cómo se decide, y quién lo decide

Este banco **no trae ninguna lista de objetivos**, y no es un descuido.

La lista la aporta quien ejecuta la suite, en `LYBRA_REAL_TARGETS`, y esa declaración **es** la afirmación de que tiene autorización sobre esos hosts. Sin la variable, el módulo entero se salta — que es lo que ocurre en CI y en cualquier máquina que no haya decidido lo contrario.

Tampoco se lee de ningún fichero del repositorio, y eso también es deliberado: las direcciones de un laboratorio real no tienen por qué publicarse, y una autorización de escaneo es de quien la tiene, no del repositorio.

```bash
LYBRA_REAL_TARGETS="host1.example,host2.example,..." pytest tests/oracle/test_lybra_real_parity_bench.py -m oracle -s
```

El `-s` no es opcional en la práctica: el entregable de este ítem es **el número**, y el informe por familia se imprime.

## El sello de red: una lista blanca, no un interruptor

La suite está sellada contra la red (`_no_outbound_sockets` en `tests/conftest.py`): cualquier conexión fuera de loopback recibe un `ConnectionRefusedError` instantáneo. Es lo que la mantiene en dos minutos y lo que garantiza que su resultado no dependa de lo que haya al otro lado.

Un banco que escanea hosts reales necesita justo lo contrario, así que la tentación es apagar el sello mientras corre. No se ha hecho eso. Lo que hay es una **lista blanca de direcciones concretas**: las de `LYBRA_REAL_TARGETS` se resuelven una vez, *antes* de instalar el sello, y sólo ésas pasan. Todo lo demás sigue exactamente igual de cortado — incluidos los tests de Lybra que dependen de que un socket a `10.0.0.5` falle al instante en vez de esperar ocho segundos.

La diferencia importa: con un interruptor, un test cualquiera que olvidara mockear una sonda saldría a la red durante esa sesión y nadie se enteraría hasta que la suite empezara a tardar diez minutos.

Como esa excepción es lógica condicional dentro de una defensa, lleva sus propios tests (`test_real_targets.py`): que sin la variable la lista sale **vacía**, que una variable vacía o con comas sueltas de una edición a medias no abre la red «un poco», que lo declarado entra y nada más, y que un objetivo que no resuelve no hunde a los demás. Todos sobre IPs literales, porque un test del sello de red que saliera a la red a resolver nombres sería una contradicción en sus propios términos. Van sin marcador `oracle`: corren en el CI por defecto, que es donde importa comprobar que la lista sale vacía.

## Un detalle de fontanería que costó un rato

El dato de los objetivos lo leen **dos** sitios que no pueden discrepar: el sello, que decide a dónde se puede salir, y el banco, que decide a dónde se escanea. Si cada uno releyera la variable por su cuenta, una diferencia tonta —un `strip` de más, otro separador— dejaría al banco intentando llegar a un sitio bloqueado, o al sello abriendo una dirección que nadie usa.

Vive por eso en un módulo propio, `tests/oracle/_real_targets.py`, que el conftest carga **por ruta y no por nombre**. El primer intento fue un `from conftest import ...` plano, y funcionaba al ejecutar el fichero suelto pero reventaba en la suite completa: `conftest` es un nombre ambiguo — hay otro en `tests/postgres/` — y cuál gana depende del orden de recolección.

## Lo que este PR no demuestra

Sé honesto con lo que está verificado y lo que no:

- **Verificado:** que sin objetivos el módulo se salta limpiamente; que la lista blanca parsea y resuelve lo que debe y sólo eso; que la suite completa sigue en verde y sellada. Las funciones de medición son las mismas que el banco de laboratorio ya ejercita contra contenedores reales.
- **No verificado:** ningún escaneo contra un objetivo real. No he declarado ninguno ni he escaneado nada de internet por mi cuenta — eso es tuyo, y es el punto entero del issue.

Por eso el issue **no se cierra** con este PR.

## Lo que hace falta para cerrarlo

El criterio pide **al menos diez objetivos reales, autorizados y variados**, y el issue nombra los ejes que deben cubrir:

- con y sin CDN/WAF por delante,
- con y sin TLS,
- con cabecera `Server` presente y suprimida,
- y —crítico para la Fase N— al menos uno con servicios **no-HTTP** expuestos legítimamente.

Ese último es el que más falta hace: el banco de laboratorio (#276) acaba de medir cuatro dissectors no-HTTP que no producen un producto comparable, y sin objetivos reales no sabemos si eso mejora o empeora fuera del laboratorio.

Hay un test dedicado a ello (`test_the_real_side_has_enough_targets`) que suspende con menos de diez, en vez de dejar que un N=3 produzca un número que parece una medición. El lado real llevaba en N=3 desde julio: con esa muestra, un solo objetivo raro mueve el resultado medio punto.

## Validación

- `pytest -q -m "not oracle"`: en verde, sin fallos, con la suite igual de sellada que antes.
- El banco de paridad se salta limpiamente sin `LYBRA_REAL_TARGETS`.
- Los tests de la lista blanca pasan con y sin la variable declarada.
- El README no necesita cambios: no se toca ningún endpoint, categoría de TaskQueue, clave de configuración ni perfil de Docker. `LYBRA_REAL_TARGETS` es una variable del arnés de pruebas, no de la aplicación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
