### PR TITLE
La reconciliación de arranque deja en paz a los escaneos que siguen vivos (#346)

### DIFF
--- a/API/src/modules/features/themis/managers/scan.py
+++ b/API/src/modules/features/themis/managers/scan.py
@@ -423,6 +423,24 @@ class ScanManager(TaskTrackingMixin, ABC):
         ``Scheduler`` vuelva a lanzar ese escaneo programado (ver
         ``scheduling.py``). Se llama una vez al arrancar la API.
 
+        Antes se conservaba el escaneo **solo** si su tarea estaba exactamente
+        en ``PENDING``, y ese criterio se comía trabajo vivo. Los workers son
+        procesos aparte y reiniciar la API no los para: un job ``RUNNING``
+        puede estar escaneando ahora mismo en otro proceso. El usuario veía el
+        escaneo como fallido y, minutos después, el worker terminaba y escribía
+        ``finished`` encima de esa misma fila — una contradicción que además
+        deja el informe de un escaneo "fallido".
+
+        La pregunta correcta no es "¿en qué estado está el job?" sino "¿queda
+        alguien que vaya a terminarlo?". La responde
+        ``TaskQueue.is_recoverable()``, que para un job en ejecución comprueba
+        además si el worker que lo tomó sigue vivo de verdad — necesario porque
+        la clave ``rq:worker:<name>`` sobrevive con su TTL completo a una
+        muerte abrupta, así que su mera existencia no prueba nada.
+
+        Mismo arreglo que Iris hizo en su reconciliación (#208); el defecto era
+        literalmente el mismo porque este método fue el espejo del que se copió.
+
         Returns:
             Número de escaneos marcados como FAILED.
         """
@@ -431,10 +449,13 @@ class ScanManager(TaskTrackingMixin, ABC):
         with UnitOfWork() as uow:
             repo = ScanRepository(uow)
             for scan in repo.get_active_scans():
+                # El prefijo sale de la clase, no escrito a mano. No se compone
+                # con ``external_id_for`` —que es lo que hace Iris— porque
+                # ``ScanManager`` es abstracta: este método se invoca sobre ella
+                # para barrer los escaneos de los cuatro escáneres a la vez, que
+                # comparten prefijo y categoría.
                 external_id = f"{cls.EXTERNAL_ID_PREFIX}{scan.id}"
-                task = task_queue.get_task_by_external_id(external_id, cls.TASK_CATEGORY)
-
-                if task is not None and task.status == TaskStatus.PENDING:
+                if task_queue.is_recoverable(external_id, cls.TASK_CATEGORY):
                     continue
                 repo.update_status(scan, ScanStatus.FAILED)
                 fixed += 1

--- a/API/tests/integration/test_themis_reconciliation.py
+++ b/API/tests/integration/test_themis_reconciliation.py
@@ -1,0 +1,190 @@
+"""La reconciliación de arranque no mata escaneos que siguen vivos.
+
+``ScanManager.reconcile_orphaned_scans()`` corre una vez al arrancar la API y
+existe para rescatar registros que quedaron colgados cuando el proceso murió a
+mitad: sin ella, un escaneo se queda en ``running`` para siempre y bloquea que
+el scheduler vuelva a lanzar ese escaneo programado.
+
+El criterio era demasiado agresivo. Conservaba el escaneo **solo** si su tarea
+estaba exactamente en ``PENDING`` y marcaba como fallido todo lo demás — pero
+los workers son procesos aparte, y reiniciar la API no los para. Un job
+``RUNNING`` puede estar escaneando ahora mismo en otro proceso.
+
+Lo que veía el usuario era una contradicción: el escaneo aparecía como fallido
+y, minutos más tarde, el worker terminaba y escribía ``finished`` encima de esa
+misma fila.
+
+Es el mismo defecto que Iris arregló en #208, y no por casualidad: esta
+reconciliación fue el original del que aquélla se copió. Estos tests son el
+espejo de ``test_iris_reconciliation.py``, con la diferencia de que aquí el
+método es un ``classmethod`` sobre una clase abstracta que barre los escaneos de
+los cuatro escáneres a la vez.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Callable, Optional
+from unittest import mock
+
+import pytest
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.system.taskqueue import Task, TaskStatus
+
+import src.modules.features.themis.managers.scan as scan_mod
+from src.modules.features.themis.managers import ScanManager
+from src.modules.features.themis.model import NmapScan, ScanStatus
+from src.modules.features.themis.repositories import ScanRepository
+
+pytestmark = pytest.mark.integration
+
+
+class _FakeQueue:
+    """Cola fake que responde lo que el test necesite por external_id.
+
+    ``recoverable`` modela la respuesta de ``is_recoverable()``, que en la
+    implementación real combina el estado del job con la comprobación de si el
+    worker que lo tomó sigue vivo. Aquí se declara directamente: lo que estos
+    tests fijan es qué hace la reconciliación con esa respuesta, no cómo la
+    calcula la cola.
+    """
+
+    def __init__(self, tasks_by_external_id: dict, recoverable: Optional[dict] = None):
+        self._tasks = tasks_by_external_id
+        self._recoverable = recoverable or {}
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None):
+        return self._tasks.get(external_id)
+
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool:
+        if external_id in self._recoverable:
+            return self._recoverable[external_id]
+        task = self._tasks.get(external_id)
+        return task is not None and task.status is TaskStatus.PENDING
+
+    def submit(self, func: Callable, **kwargs): raise NotImplementedError
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
+
+
+def _make_scan(app, user_id: int, status: str) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            scan = NmapScan(target="10.0.0.5", user_id=user_id,
+                            started_at=datetime.now(), status=status)
+            ScanRepository(uow).save(scan)
+            return scan.id
+
+
+def _reconcile(app, queue) -> int:
+    with app.app_context():
+        with mock.patch.object(scan_mod.TaskQueue, "get_instance", return_value=queue):
+            return ScanManager.reconcile_orphaned_scans()
+
+
+def _status_of(app, scan_id: int) -> str:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return ScanRepository(uow).get_by_id(scan_id).status
+
+
+def _task(external_id: str, status: TaskStatus) -> Task:
+    return Task(id="job1", name="job1", category="themis.scan",
+                external_id=external_id, status=status)
+
+
+def test_a_scan_without_any_task_is_marked_failed(app, admin_user):
+    """Sin tarea en la cola no queda nadie que vaya a terminar el escaneo.
+
+    Es el caso para el que la reconciliación existe: el proceso murió antes de
+    encolar, o el job caducó del historial.
+    """
+    scan_id = _make_scan(app, admin_user.id, ScanStatus.RUNNING.value)
+
+    assert _reconcile(app, _FakeQueue({})) == 1
+    assert _status_of(app, scan_id) == ScanStatus.FAILED.value
+
+
+def test_a_queued_scan_is_left_alone(app, admin_user):
+    """Un job en cola lo tomará el primer worker libre: no está huérfano."""
+    scan_id = _make_scan(app, admin_user.id, ScanStatus.PENDING.value)
+    external_id = f"scan:{scan_id}"
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.PENDING)})
+
+    assert _reconcile(app, queue) == 0
+    assert _status_of(app, scan_id) == ScanStatus.PENDING.value
+
+
+def test_a_running_scan_whose_worker_is_alive_is_left_alone(app, admin_user):
+    """El caso que motiva el arreglo.
+
+    El worker está escaneando ahora mismo en otro proceso. Con el criterio
+    viejo —conservar sólo si el estado es exactamente ``PENDING``— este escaneo
+    se marcaba ``failed``, el usuario lo veía fallido, y poco después el worker
+    escribía ``finished`` encima de la misma fila.
+    """
+    scan_id = _make_scan(app, admin_user.id, ScanStatus.RUNNING.value)
+    external_id = f"scan:{scan_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: True},   # su worker sigue vivo
+    )
+
+    assert _reconcile(app, queue) == 0
+    assert _status_of(app, scan_id) == ScanStatus.RUNNING.value
+
+
+def test_a_running_scan_whose_worker_died_is_marked_failed(app, admin_user):
+    """La otra mitad, y la razón de que no baste con mirar el estado del job.
+
+    Un job sigue figurando como ``RUNNING`` cuando su worker muere de golpe:
+    nadie está ahí para cambiarlo. Eso sí es un huérfano, y distinguirlo del
+    caso de arriba es justo lo que hace ``is_recoverable`` comprobando el PID
+    del worker.
+    """
+    scan_id = _make_scan(app, admin_user.id, ScanStatus.RUNNING.value)
+    external_id = f"scan:{scan_id}"
+    queue = _FakeQueue(
+        {external_id: _task(external_id, TaskStatus.RUNNING)},
+        recoverable={external_id: False},   # el worker ya no está
+    )
+
+    assert _reconcile(app, queue) == 1
+    assert _status_of(app, scan_id) == ScanStatus.FAILED.value
+
+
+def test_a_completed_job_over_a_still_active_scan_is_marked_failed(app, admin_user):
+    """Un job terminado sobre una fila que sigue activa es una fila colgada: el
+    worker acabó sin llegar a escribir el estado final."""
+    scan_id = _make_scan(app, admin_user.id, ScanStatus.RUNNING.value)
+    external_id = f"scan:{scan_id}"
+    queue = _FakeQueue({external_id: _task(external_id, TaskStatus.COMPLETED)})
+
+    assert _reconcile(app, queue) == 1
+    assert _status_of(app, scan_id) == ScanStatus.FAILED.value
+
+
+def test_scans_of_every_scanner_are_swept_together(app, admin_user):
+    """La reconciliación se invoca sobre ``ScanManager``, la clase abstracta, y
+    recorre los escaneos activos de los cuatro escáneres.
+
+    Funciona porque los cuatro heredan el mismo ``EXTERNAL_ID_PREFIX`` y la
+    misma ``TASK_CATEGORY``. Si algún escáner futuro declarase los suyos
+    propios, sus escaneos se marcarían como huérfanos aunque estuvieran vivos —
+    este test es donde eso se notaría.
+    """
+    from src.modules.features.themis.managers import (
+        NmapScanManager, NiktoScanManager, NucleiScanManager, LybraEngineManager,
+    )
+
+    prefixes = {manager.EXTERNAL_ID_PREFIX for manager in
+                (NmapScanManager, NiktoScanManager, NucleiScanManager, LybraEngineManager)}
+    categories = {manager.TASK_CATEGORY for manager in
+                  (NmapScanManager, NiktoScanManager, NucleiScanManager, LybraEngineManager)}
+
+    assert prefixes == {ScanManager.EXTERNAL_ID_PREFIX}
+    assert categories == {ScanManager.TASK_CATEGORY}


### PR DESCRIPTION
Cierra #346.

## El defecto

`ScanManager.reconcile_orphaned_scans()` corre una vez al arrancar la API. Existe para rescatar registros que quedaron colgados cuando el proceso murió a mitad: sin ella, un escaneo se queda en `running` para siempre y bloquea que el scheduler vuelva a lanzar ese escaneo programado.

El criterio era demasiado agresivo:

```python
if task is not None and task.status == TaskStatus.PENDING:
    continue
# ...todo lo demás -> failed
```

Conservaba el escaneo **sólo** si su tarea estaba exactamente en `PENDING`. Y eso se come trabajo vivo, porque **los workers son procesos aparte y reiniciar la API no los para**: un job en `RUNNING` puede estar escaneando ahora mismo en otro proceso.

Lo que veía el usuario era una contradicción: el escaneo aparecía como fallido y, minutos más tarde, el worker terminaba y escribía `finished` encima de esa misma fila. Con el efecto secundario de dejar un informe colgado de un escaneo que estuvo marcado como fallido.

## El arreglo

La pregunta correcta no es «¿en qué estado está el job?» sino **«¿queda alguien que vaya a terminarlo?»**. La responde `TaskQueue.is_recoverable()`, que ya existe: #208 la añadió al arreglar exactamente este mismo defecto en Iris.

Para un job en ejecución, esa función comprueba además si el worker que lo tomó **sigue vivo de verdad**, con la misma verificación de PID que usa `cancel()`. Ese detalle no es opcional: la clave `rq:worker:<name>` sobrevive con su TTL completo a una muerte abrupta, así que su mera existencia no prueba nada.

El cambio es sustituir la comprobación de estado por esa llamada. Nada más.

## Un detalle de implementación que difiere de Iris

Iris construye una instancia del manager para componer el `external_id` con `external_id_for`. Aquí no se puede: `reconcile_orphaned_scans` es un `classmethod` que se invoca sobre `ScanManager`, que es **abstracta**, para barrer de una pasada los escaneos activos de los cuatro escáneres.

Se compone con `cls.EXTERNAL_ID_PREFIX`, que es lo que ya hacía y que tampoco viola la regla de «no escribir el external_id a mano»: el prefijo sale de la clase, no de una cadena literal.

Eso funciona porque los cuatro escáneres heredan el mismo prefijo y la misma categoría. Como es una propiedad de la que depende la corrección y que nadie estaba vigilando, hay un test que la fija.

## Sobre «revisar si algún otro módulo reconcilia con el mismo criterio»

Comprobado: en todo `src/` sólo hay dos reconciliaciones, la de Themis y la de Iris, y las dos se invocan desde `run.py`. La de Iris ya estaba arreglada. No queda ninguna otra.

## Los tests

`test_themis_reconciliation.py` es nuevo, y su ausencia es parte de la explicación de por qué el defecto se arregló en Iris y no aquí: Themis fue el original del que Iris copió la reconciliación, pero Iris se llevó los tests y Themis se quedó sin ninguno.

Los casos cubren los cuatro estados que separan un escaneo huérfano de uno vivo:

- **Sin tarea** — nadie lo va a terminar. Es para lo que la reconciliación existe.
- **En cola** — lo tomará el primer worker libre; no está huérfano.
- **En ejecución con su worker vivo** — el caso que motiva el arreglo. Antes se marcaba fallido.
- **En ejecución con el worker muerto** — huérfano de verdad. Distinguir este del anterior es precisamente lo que hace `is_recoverable` mirando el PID.

Más el job ya terminado sobre una fila que sigue activa, que es una fila colgada, y el test estructural sobre prefijos y categorías.

El doble de cola declara directamente la respuesta de `is_recoverable` en vez de recalcularla: lo que estos tests fijan es **qué hace la reconciliación con esa respuesta**, no cómo la calcula la cola, que se prueba en su propio sitio. Es el mismo criterio que usa el fichero espejo de Iris.

## Validación

- `pytest tests/integration/test_themis_reconciliation.py`: los seis pasan.
- `pytest -q -m "not oracle"`: en verde.
- El README no necesita cambios: la reconciliación es comportamiento interno de arranque, no superficie pública.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
