### PR TITLE
Paridad laboratorio/real medida: la brecha existe, y destapó tres defectos (#277)

### DIFF
--- a/API/tests/oracle/_docker_helpers.py
+++ b/API/tests/oracle/_docker_helpers.py
@@ -21,12 +21,29 @@ from typing import Optional
 
 
 def _working_docker(path: str) -> bool:
+    """¿Es ``path`` un cliente Docker que además tiene demonio detrás?
+
+    Se capturan **dos** formas de no estarlo, y la segunda costó una tarde:
+
+    - ``OSError``: el binario no existe o no se puede ejecutar.
+    - ``subprocess.TimeoutExpired``: el binario responde pero el demonio está
+      **colgado**, no ausente. Es lo que hace Docker Desktop cuando su distro
+      WSL no llega a arrancar: ``docker version`` se queda esperando al pipe
+      hasta que alguien lo mata.
+
+    Sin capturar la segunda, la excepción sube por ``resolve_docker()`` —que se
+    llama al **importar** cada módulo del banco— y revienta la recolección de
+    pytest. Y como los marcadores se filtran *después* de importar, eso tumba
+    la suite entera, incluso corriendo con ``-m "not oracle"``: cinco errores de
+    colección en tests que ni siquiera se iban a ejecutar. Un Docker roto tiene
+    que traducirse en "los bancos se saltan", nunca en "no hay suite".
+    """
     try:
         return subprocess.run(
             [path, "version", "--format", "{{.Server.Version}}"],
             capture_output=True, timeout=10,
         ).returncode == 0
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return False
 
 

--- a/API/tests/oracle/_nmap_oracle.py
+++ b/API/tests/oracle/_nmap_oracle.py
@@ -21,6 +21,7 @@ Not a test module itself (no ``test_`` prefix) — pytest does not collect it.
 
 from __future__ import annotations
 
+import ipaddress
 import shutil
 import subprocess
 import xml.etree.ElementTree as ET
@@ -37,6 +38,27 @@ NMAP_IMAGE = "instrumentisto/nmap"
 # catálogo publican en el host. Docker Desktop resuelve este nombre; en un
 # runner Linux hace falta ``--add-host``, que es lo que añade _docker_args().
 _HOST_FROM_CONTAINER = "host.docker.internal"
+
+
+def _target_from_container(host: str) -> str:
+    """El nombre con el que el contenedor de Nmap alcanza ``host``.
+
+    Un objetivo publicado en el propio host —los contenedores del banco de
+    laboratorio, siempre en 127.0.0.1— no es alcanzable por su IP de loopback
+    desde dentro de otro contenedor: hay que rebotar por ``host.docker.internal``.
+
+    Un objetivo **externo** (el banco de paridad real, L48) se alcanza por su
+    nombre o IP tal cual: sustituirlo por ``host.docker.internal`` haría que el
+    oráculo escaneara la máquina Docker en vez del objetivo, midiendo algo que
+    no tiene nada que ver. Sólo se reescribe loopback.
+    """
+    try:
+        if ipaddress.ip_address(host).is_loopback:
+            return _HOST_FROM_CONTAINER
+    except ValueError:
+        if host in ("localhost", ""):
+            return _HOST_FROM_CONTAINER
+    return host
 
 
 @dataclass(frozen=True)
@@ -79,7 +101,7 @@ def run_nmap_sv(
     else:
         if not docker_path:
             raise RuntimeError("Ni nmap instalado ni Docker disponible para el oráculo")
-        command = [docker_path, "run", "--rm", NMAP_IMAGE, *flags, "-oX", "-", _HOST_FROM_CONTAINER]
+        command = [docker_path, "run", "--rm", NMAP_IMAGE, *flags, "-oX", "-", _target_from_container(host)]
 
     completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=True)
     return parse_nmap_xml(completed.stdout)

--- a/API/tests/oracle/test_lybra_real_parity_bench.py
+++ b/API/tests/oracle/test_lybra_real_parity_bench.py
@@ -157,16 +157,26 @@ def _by_family(results: List[dict]) -> Dict[str, List[Tuple]]:
     return families
 
 
+def _ascii(value) -> str:
+    """Un banner de un servidor real puede traer cualquier byte, y la consola de
+    Windows (cp1252) no codifica todo Unicode: un solo carácter raro en un
+    producto hacía reventar el ``print`` del informe y con él la medición
+    entera. El informe es el entregable de L48, así que no puede caerse por un
+    acento de más — cualquier carácter fuera de ASCII se sustituye."""
+    return str(value).encode("ascii", "replace").decode("ascii")
+
+
 def _print_report(results: List[dict]) -> None:
     """Imprime la comparativa. El entregable de L48 es el número, no un OK."""
-    print("\n=== Paridad real (L48) — objetivos declarados en LYBRA_REAL_TARGETS ===")
+    print("\n=== Paridad real (L48) - objetivos declarados en LYBRA_REAL_TARGETS ===")
     for result in results:
         print(f"  {result['target']}: puertos propios={result['own_ports']} "
               f"nmap={result['nmap_ports']} concordancia={result['ports_score']:.2f}")
         for product, version, nmap_product, nmap_version, label, port in result["pairs"]:
-            verdict = "=" if agrees_with_nmap(product, version, nmap_product, nmap_version) else "≠"
-            print(f"      {port:>5}/{label:<6} {verdict} propio={product} {version} "
-                  f"| nmap={nmap_product} {nmap_version}")
+            verdict = "==" if agrees_with_nmap(product, version, nmap_product, nmap_version) else "!="
+            print(f"      {port:>5}/{_ascii(label):<6} {verdict} "
+                  f"propio={_ascii(product)} {_ascii(version)} "
+                  f"| nmap={_ascii(nmap_product)} {_ascii(nmap_version)}")
     print("  --- por familia ---")
     for family, pairs in sorted(_by_family(results).items()):
         print(f"      {family:<8} n={len(pairs):<3} concordancia={concordance_rate(pairs):.2f}")

--- a/API/tests/oracle/test_lybra_real_parity_bench.py
+++ b/API/tests/oracle/test_lybra_real_parity_bench.py
@@ -138,12 +138,41 @@ def _measure(target: str, docker_path: Optional[str]) -> dict:
             "ports_score": ports_score, "pairs": pairs}
 
 
-def _fingerprint_pairs(results: List[dict]) -> List[Tuple]:
-    """Los pares de concordancia de todos los objetivos, sin la etiqueta."""
-    return [pair[:4] for result in results for pair in result["pairs"]]
+def _is_measurable(pair: Tuple) -> bool:
+    """¿Dice este par algo sobre el motor, o sólo sobre lo duro que es el objetivo?
+
+    ``agrees_with_nmap`` devuelve ``False`` cuando **ninguno de los dos** lados
+    identifica un producto, y contra objetivos reales ese caso no es marginal:
+    en la primera medición fueron 23 de 38 servicios. Son puertos que aceptan la
+    conexión TCP y luego no contestan a nadie —firewalls que hacen de tarpit, o
+    un middlebox del operador—, así que ni la sonda propia ni Nmap sacan nada.
+
+    Meterlos en el cociente hace que el número mida **la dificultad del
+    catálogo** en lugar del fingerprinting: bastaría con elegir objetivos más
+    dóciles para "mejorar" la concordancia sin tocar una línea del motor. Es la
+    misma distinción que el banco de laboratorio ya trataba aparte como punto
+    ciego simétrico, sólo que aquí domina la muestra.
+
+    Un par es medible si **al menos uno** de los dos identificó un producto:
+    entonces sí hay algo que comparar — acuerdo, desacuerdo, o uno que ve lo que
+    el otro no.
+    """
+    product, _version, nmap_product, _nmap_version = pair[:4]
+    return bool(product) or bool(nmap_product)
 
 
-def _by_family(results: List[dict]) -> Dict[str, List[Tuple]]:
+def _fingerprint_pairs(results: List[dict], measurable_only: bool = True) -> List[Tuple]:
+    """Los pares de concordancia de todos los objetivos, sin la etiqueta.
+
+    Por defecto sólo los medibles (ver :func:`_is_measurable`); con
+    ``measurable_only=False`` salen todos, que es lo que hace falta para poder
+    informar de cuántos se descartaron y por qué.
+    """
+    pairs = [pair[:4] for result in results for pair in result["pairs"]]
+    return [pair for pair in pairs if _is_measurable(pair)] if measurable_only else pairs
+
+
+def _by_family(results: List[dict], measurable_only: bool = True) -> Dict[str, List[Tuple]]:
     """Agrupa los pares por la familia del dissector que los produjo.
 
     La paridad se cierra **por familia**, no en promedio: un número global alto
@@ -153,6 +182,8 @@ def _by_family(results: List[dict]) -> Dict[str, List[Tuple]]:
     families: Dict[str, List[Tuple]] = defaultdict(list)
     for result in results:
         for pair in result["pairs"]:
+            if measurable_only and not _is_measurable(pair):
+                continue
             families[pair[4]].append(pair[:4])
     return families
 
@@ -177,13 +208,19 @@ def _print_report(results: List[dict]) -> None:
             print(f"      {port:>5}/{_ascii(label):<6} {verdict} "
                   f"propio={_ascii(product)} {_ascii(version)} "
                   f"| nmap={_ascii(nmap_product)} {_ascii(nmap_version)}")
-    print("  --- por familia ---")
+    print("  --- por familia (solo pares medibles) ---")
     for family, pairs in sorted(_by_family(results).items()):
         print(f"      {family:<8} n={len(pairs):<3} concordancia={concordance_rate(pairs):.2f}")
+
+    every_pair = _fingerprint_pairs(results, measurable_only=False)
+    measurable = _fingerprint_pairs(results)
+    blind = len(every_pair) - len(measurable)
     ports = [result["ports_score"] for result in results]
     print(f"  puertos (Fase T): {sum(ports) / len(ports):.2f} sobre {len(ports)} objetivos")
-    print(f"  fingerprint (F/N): {concordance_rate(_fingerprint_pairs(results)):.2f} "
-          f"sobre {len(_fingerprint_pairs(results))} servicios")
+    print(f"  fingerprint (F/N): {concordance_rate(measurable):.2f} "
+          f"sobre {len(measurable)} servicios medibles")
+    print(f"  descartados: {blind} de {len(every_pair)} servicios donde NINGUNO de los dos "
+          f"identifica producto (puertos que aceptan y no contestan)")
 
 
 # =========================================================================
@@ -202,6 +239,16 @@ def test_the_real_side_has_enough_targets():
     )
 
 
+@pytest.mark.xfail(strict=False, reason=(
+    "El resultado de este test es HOY inestable, y no por el objetivo: dos "
+    "ejecuciones del banco con 20 minutos de diferencia dieron 0,96 y 0,58. La "
+    "diferencia entera son cuatro IPs donde el descubrimiento propio devolvio "
+    "lista vacia mientras Nmap encontraba sus cuatro puertos y un socket crudo "
+    "conectaba sin problema (issue L48-c). Mientras ese defecto siga abierto, la "
+    "Fase T no se puede certificar: el numero mide cuando nos bloquearon, no lo "
+    "que el transporte sabe hacer. `strict=False` a proposito — un `strict=True` "
+    "seria tan falso como la asercion, porque a veces pasa."
+))
 def test_port_discovery_matches_nmap_on_real_targets(measurements):
     """Fase T contra objetivos reales: es donde aparecen el WAF que corta a la
     tercera conexión y el balanceador que responde distinto en cada intento."""
@@ -211,14 +258,38 @@ def test_port_discovery_matches_nmap_on_real_targets(measurements):
     assert average >= _PORT_THRESHOLD, f"concordancia de puertos real {average:.2f} — {detail}"
 
 
+@pytest.mark.xfail(strict=True, reason=(
+    "Medido el 2026-09-01 sobre 10 objetivos reales autorizados: concordancia de "
+    "fingerprint entre 0,33 y 0,36 segun la ejecucion, frente al 0,90 que pide el "
+    "roadmap. El laboratorio daba 1,00 en las mismas familias, asi que la brecha "
+    "laboratorio/real que el §9 declara no negociable existe y esta cuantificada. "
+    "Las causas van por familia como issues de Fase 2: FTP no identifica ProFTPD "
+    "(L48-a) y HTTP lee el proxy de delante y no el servidor de detras (L48-b). El "
+    "rango en vez de una cifra unica no es imprecision: el tamano de la muestra "
+    "varia porque el descubrimiento falla de forma intermitente (L48-c)."
+))
 def test_fingerprinting_matches_nmap_on_real_targets(measurements):
-    """Fases F y N contra objetivos reales."""
+    """Fases F y N contra objetivos reales.
+
+    Sólo entran los pares **medibles**: un servicio que ni la sonda propia ni
+    Nmap consiguen identificar no dice nada sobre el motor, sólo sobre lo duro
+    que es el objetivo (ver :func:`_is_measurable`). En esta medición fueron 23
+    de 38, así que contarlos habría hundido la cifra por un motivo equivocado.
+    """
     pairs = _fingerprint_pairs(measurements)
     assert pairs, "Ningún servicio identificable en los objetivos declarados"
     rate = concordance_rate(pairs)
-    assert rate >= _FINGERPRINT_THRESHOLD, f"concordancia de fingerprint real {rate:.2f}"
+    assert rate >= _FINGERPRINT_THRESHOLD, (
+        f"concordancia de fingerprint real {rate:.2f} sobre {len(pairs)} servicios medibles"
+    )
 
 
+@pytest.mark.xfail(strict=True, reason=(
+    "Medido el 2026-09-01: FTP 0,00 y HTTP entre 0,07 y 0,25 quedan por debajo del "
+    "umbral; SSH aguanta en 0,75. Cada familia tiene su issue de Fase 2 (L48-a "
+    "para FTP, L48-b para HTTP). Este test pasara a XPASS cuando la ultima se "
+    "cierre."
+))
 def test_no_family_is_left_behind(measurements):
     """La paridad se cierra por familia, no en promedio.
 

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -58,3 +58,30 @@ def test_a_target_that_does_not_resolve_does_not_sink_the_rest(monkeypatch):
     donde se ve, en vez de hacer fallar la construcción del sello."""
     monkeypatch.setenv("LYBRA_REAL_TARGETS", "198.51.100.7,no-existe.invalid")
     assert "198.51.100.7" in allowed_outbound_addresses()
+
+
+# --------------------------------------------------------------------------
+# El oráculo alcanza el objetivo correcto (L48, arreglo del banco de paridad)
+# --------------------------------------------------------------------------
+#
+# Estas dos comprueban la traducción de host que el contenedor de Nmap necesita.
+# Son puras (no lanzan Nmap ni Docker), así que corren en CI como el resto de
+# este fichero, sin marcador ``oracle``.
+
+from ._nmap_oracle import _target_from_container
+
+
+def test_loopback_is_reached_through_the_docker_host():
+    """Un puerto publicado en 127.0.0.1 no es alcanzable por su loopback desde
+    dentro de otro contenedor: hay que rebotar por ``host.docker.internal``."""
+    assert _target_from_container("127.0.0.1") == "host.docker.internal"
+    assert _target_from_container("localhost") == "host.docker.internal"
+
+
+def test_an_external_target_is_scanned_directly():
+    """El defecto que tenía el banco de paridad real: el contenedor de Nmap
+    escaneaba ``host.docker.internal`` —la máquina Docker— en vez del objetivo
+    externo, midiendo algo que no tenía nada que ver. Un host o IP que no es
+    loopback se pasa tal cual."""
+    assert _target_from_container("emesa.com") == "emesa.com"
+    assert _target_from_container("203.0.113.9") == "203.0.113.9"

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -85,3 +85,39 @@ def test_an_external_target_is_scanned_directly():
     loopback se pasa tal cual."""
     assert _target_from_container("emesa.com") == "emesa.com"
     assert _target_from_container("203.0.113.9") == "203.0.113.9"
+
+
+# --------------------------------------------------------------------------
+# Un Docker colgado no puede tumbar la suite
+# --------------------------------------------------------------------------
+
+import subprocess
+
+from ._docker_helpers import _working_docker
+
+
+def test_a_hung_docker_daemon_is_reported_as_unavailable(monkeypatch):
+    """Docker Desktop con su distro WSL caída deja ``docker version`` esperando
+    al pipe hasta que alguien lo mata: el binario existe y responde, pero no hay
+    demonio detrás.
+
+    Antes eso subía como ``TimeoutExpired`` desde ``resolve_docker()``, que se
+    llama al **importar** cada módulo del banco. Como los marcadores de pytest
+    se filtran después de importar, un Docker colgado producía cinco errores de
+    colección y tumbaba la suite entera — incluso con ``-m "not oracle"``, en
+    tests que ni siquiera iban a ejecutarse.
+    """
+    def _hangs(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="docker version", timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", _hangs)
+    assert _working_docker("/cualquier/ruta/docker") is False
+
+
+def test_a_missing_docker_binary_is_still_reported_as_unavailable(monkeypatch):
+    """La otra mitad, que ya funcionaba: el binario no existe o no se ejecuta."""
+    def _explodes(*args, **kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(subprocess, "run", _explodes)
+    assert _working_docker("/cualquier/ruta/docker") is False


### PR DESCRIPTION
Cierra #277.

El lado real de la paridad laboratorio/real llevaba desde julio en N=3, medido una vez a mano y anotado en el roadmap. Este PR trae la **primera medición reproducible** sobre 10 objetivos reales autorizados — y con ella, tres defectos que ninguna cantidad de laboratorio habría enseñado.

## El número

| | Laboratorio | Real |
|---|---|---|
| **Fase T** — puertos | 1,00 | **0,96 y 0,58** (inestable, ver abajo) |
| **Fases F/N** — fingerprint | 1,00 | **0,33–0,36** |

Por familia, sobre servicios medibles: **SSH 0,75** · **HTTP 0,07–0,25** · **FTP 0,00** · SMB muestra insuficiente.

La brecha que el §9 declaraba no negociable existe y está cuantificada.

## Primero, una corrección de la métrica — porque el 0,13 inicial mentía

La primera lectura bruta fue 0,13. No la publiqué porque no significaba lo que parecía.

De 38 servicios medidos, **23 eran «ninguno de los dos identifica»**: puertos que aceptan la conexión TCP y después no contestan a nadie —firewalls que hacen de tarpit, o un middlebox del operador—, donde ni la sonda propia ni Nmap sacan nada. `agrees_with_nmap` devuelve `False` en ese caso, así que los 23 entraban en el cociente como desacuerdos.

Eso hace que el número mida **la dureza del catálogo y no el motor**. Y tiene una consecuencia perversa: bastaría con elegir objetivos más dóciles para «mejorar» la concordancia sin tocar una línea del transporte. Una vara de medir que premia elegir bien los exámenes no es una vara de medir.

Ahora un par sólo entra en el cociente si **al menos uno** de los dos lados identificó un producto, y el informe publica cuántos se descartaron y por qué. Es la misma distinción que el banco de laboratorio ya hacía con el punto ciego simétrico; la diferencia es que contra objetivos reales ese caso domina la muestra en vez de ser una anécdota.

## Lo que la medición encontró

Tres issues de Fase 2, uno por brecha, como el §9 exige en lugar de promediarlas.

### #370 — El descubrimiento devuelve lista vacía cuando lo bloquean

**El más grave de los tres, y no estaba en ningún diagnóstico previo.**

Se destapó porque el banco corrió **dos veces**: 0,96 y 0,58 con veinte minutos de diferencia. Al comparar objetivo por objetivo, la diferencia entera eran cuatro IPs donde Lybra devolvió `[]` mientras Nmap encontraba sus cuatro puertos. Verificado en el mismo minuto:

```
socket crudo de Python  80/443/5060/8080: ABIERTOS (15 ms)
scan_ports_sync(host, DEFAULT_PORTS)    : []       (2,0 s)
```

Tres ejecuciones seguidas vacío; minutos después, los cuatro puertos otra vez. Es intermitente, y encaja con un bloqueo transitorio tras una ráfaga de conexiones.

Lo que lo hace grave no es que falle, sino que **el fallo es indistinguible del éxito**. Un `[]` se lee como «objetivo limpio». Y peor: `apply_lifecycle` compara con el escaneo anterior y marca como `fixed` lo que ya no aparece — o sea que un escaneo bloqueado no sólo oculta lo que hay, **le dice al usuario que sus vulnerabilidades fueron remediadas**.

El código ya había anticipado exactamente este riesgo: `_discover_ports` documenta que devolver `None` y no `[]` ante un fallo es crítico *precisamente* para no marcar cosas como corregidas. La defensa está puesta un nivel por encima. El problema es que `scan_ports_sync` no tiene forma de señalar «todo falló de manera sospechosa», así que la distinción que el manager quiere hacer es inaplicable porque la información no le llega.

### #368 — FTP no identifica ProFTPD

Dos hosts, mismo resultado: Nmap lee `ProFTPD` del saludo y Lybra no saca nada. El parser sólo entiende el formato de vsftpd — que es, exactamente, el único servidor FTP del banco de laboratorio.

Ese 1,00 de FTP en laboratorio no medía la calidad del dissector: medía la coincidencia entre el dissector y el contenedor elegido. Es la misma trampa que la Fase 0 documentó dos veces (#269, #270), una capa más arriba.

### #369 — HTTP lee el proxy de delante, no el servidor de detrás

Cinco servicios en tres hosts, siempre igual: Lybra dice `nginx`, Nmap dice `Apache httpd`. Hay un nginx de proxy inverso delante de un Apache.

Ninguno de los dos miente — describen capas distintas de la misma pila. Pero para resolver un CPE la diferencia es enorme: buscar CVEs de nginx en un host que corre Apache produce falsos negativos por un lado y falsos positivos por el otro. En laboratorio los contenedores están pelados, la cabecera `Server` coincide con el servidor real, y por eso daba 1,00.

## Los tres arreglos del arnés que hicieron falta para poder medir

Ninguno de estos era el trabajo, pero sin ellos no había medición:

- **El oráculo Nmap escaneaba la máquina Docker.** La sustitución por `host.docker.internal` —correcta para los contenedores del laboratorio, que publican en loopback— estaba escrita a fuego. Contra un objetivo externo, el oráculo medía la máquina equivocada. Ahora sólo se reescribe loopback.
- **El informe se caía por un carácter.** `_print_report` imprimía el veredicto con `≠` y volcaba tal cual los banners de servidores reales. En consola Windows (cp1252) eso reventaba el `print`, y como el informe se genera dentro de la fixture, la excepción tiraba la medición entera: diez objetivos escaneados, cero líneas de salida. Todo lo que viene de la red se sanea ahora antes de imprimirse.
- **Un Docker colgado tumbaba la suite entera.** `_working_docker` capturaba `OSError` pero no `TimeoutExpired`, que es lo que pasa cuando el demonio está colgado en vez de ausente. Como `resolve_docker()` se llama al **importar** cada módulo del banco, y los marcadores se filtran *después* de importar, eso producía cinco errores de colección y se llevaba por delante la suite completa — corriendo con `-m "not oracle"`, en tests que ni siquiera iban a ejecutarse.

Los tres llevan tests de regresión que corren en CI, sin Docker.

## Los tests

`EXIT=0`: 1 passed, 3 xfailed.

- **Pasa** el de «hay al menos diez objetivos».
- **`xfail(strict=True)`** los de fingerprint y familias, con el número registrado en la razón.
- **`xfail(strict=False)`** el de puertos, y esto merece explicación: su resultado es hoy genuinamente inestable (0,96 y 0,58). Un `strict=True` sería tan falso como la aserción, porque a veces pasa. Mientras #370 siga abierto, la Fase T no se puede certificar: el número mide cuándo nos bloquearon, no lo que el transporte sabe hacer.

## Sobre los objetivos

Los aportó el mantenedor, y esa declaración es la autorización. **Se excluyó `s3.eu-west-2.wasabisys.com`**: es el punto de acceso S3 compartido de Wasabi para toda una región, infraestructura de miles de clientes a la vez, y no es algo que un cliente pueda autorizar a escanear por su cuenta. Los otros diez son activos propios.

La lista no vive en el repositorio, a propósito: viaja en `LYBRA_REAL_TARGETS` y las direcciones de un laboratorio real no tienen por qué publicarse.

## Una nota de método que conviene no perder

Esto se descubrió porque el banco corrió **dos veces**. Con una sola ejecución habríamos publicado 0,96 para la Fase T, habríamos dado la fase por cerrada, y el defecto #370 —el que le dice al usuario que sus vulnerabilidades están corregidas cuando en realidad nos bloquearon— seguiría ahí.

La reproducibilidad no era un lujo del método. Fue el instrumento de detección.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
