### PR TITLE
La defensa anti-SSRF viaja activada — y activarla destapó un fallo que tapaba

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -97,7 +97,7 @@
   "features": {
     "themis": {
       "enabled": true,
-      "areLocalIpsAllowed": true,
+      "areLocalIpsAllowed": false,
       "directories": {
         "csv": "data/themis/csv",
         "output": "data/themis/output",

--- a/API/src/modules/features/themis/services/parsing.py
+++ b/API/src/modules/features/themis/services/parsing.py
@@ -18,6 +18,7 @@ Formatos de puertos soportados (``validate_port``):
 
 import ipaddress
 import itertools
+import socket
 from typing import List
 
 import src.modules.system.config_reading as CR
@@ -180,11 +181,61 @@ def _reject_private_ips(lista_ips: List[str]) -> None:
             raise PrivateIPRequested(private_ips)
 
 
-def reject_private_ip(ip: str) -> None:
-    """Single-IP entry point for callers that resolve a hostname/URL
-    themselves (Nikto) instead of expanding a CIDR/range spec via
-    ``validate_ip``."""
-    _reject_private_ips([ip])
+def _resolved_addresses(target: str) -> List[str]:
+    """Las direcciones IP a las que apunta ``target``.
+
+    Si ya es una IP, se devuelve tal cual. Si es un nombre, **se resuelve**, y
+    esa resolución es parte de la defensa y no una comodidad: sin ella, un
+    nombre que apunta a 127.0.0.1 o a 169.254.169.254 atraviesa el guardia
+    anti-SSRF sin que nadie lo mire. Comprobar sólo lo que *parece* una IP deja
+    la puerta abierta al caso más fácil de explotar.
+
+    Se comprueban **todas** las direcciones devueltas, no la primera: un nombre
+    con varios registros basta con que tenga uno privado para ser peligroso.
+
+    Args:
+        target: Una IP o un nombre de host.
+
+    Returns:
+        Las direcciones a comprobar.
+
+    Raises:
+        IPValidationError: Si el nombre no resuelve.
+    """
+    try:
+        return [str(ipaddress.ip_address(target))]
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(target, None)
+    except OSError as exc:
+        raise IPValidationError(
+            message=f"No se pudo resolver el objetivo '{target}'",
+            ip_spec=target,
+        ) from exc
+    return sorted({info[4][0] for info in infos})
+
+
+def reject_private_ip(target: str) -> None:
+    """Rechaza un objetivo que apunte a una IP privada o de loopback.
+
+    Punto de entrada de objetivo único, para los llamantes que no expanden una
+    especificación CIDR/rango con ``validate_ip``: Nikto, y el arranque directo
+    de un escaneo Lybra (autodescubrimiento) que no pasa por el endpoint HTTP.
+
+    Acepta un nombre además de una IP, y lo resuelve antes de decidir (ver
+    :func:`_resolved_addresses`). Antes no lo hacía y explotaba con un
+    ``ValueError`` sin capturar en cuanto le llegaba un nombre — un fallo que
+    estuvo tapado mientras ``areLocalIpsAllowed`` estuvo en ``true``, porque ese
+    flag cortocircuita la comprobación entera antes de mirar el valor.
+
+    Lo que esto **no** resuelve es el desfase entre comprobar y escanear: entre
+    la resolución de aquí y la conexión real, el nombre puede cambiar de
+    dirección (DNS rebinding). Cerrar eso exige fijar la IP resuelta y escanear
+    esa, no el nombre, y es un cambio de mayor alcance.
+    """
+    _reject_private_ips(_resolved_addresses(target))
 
 
 def validate_ip(ips_str: str, max_hosts: int = 10) -> List[str]:

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -106,10 +106,23 @@ def test_lybra_self_discovery_requires_authorized_target(client, admin_user, aut
     assert resp.status_code == 403
 
 
-def test_lybra_run_scan_self_discovery_succeeds_once_authorized(app, admin_user):
+def test_lybra_run_scan_self_discovery_succeeds_once_authorized(app, admin_user, monkeypatch):
+    """Lo que se comprueba aquí es el **registro de objetivos autorizados**, no
+    la defensa anti-SSRF, así que el flag se fuerza a permitir IPs privadas.
+
+    Hace falta porque ``203.0.113.9`` es de TEST-NET-3 (RFC 5737, el rango de
+    documentación) y Python lo considera privado desde la 3.12: sin forzar el
+    flag, el escaneo se rechaza por SSRF antes de llegar a la autorización, y el
+    test dejaría de probar lo que dice. Peor aún, lo haría sólo en algunas
+    versiones de Python — pasando en el CI (3.11) y fallando en un portátil con
+    una más nueva.
+    """
     from unittest import mock
+    import src.modules.system.config_reading as CR
     from src.modules.features.themis.managers import AuthorizedTargetManager
     from src.modules.features.themis.exceptions import TargetNotAuthorizedError
+
+    monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=True))
 
     with app.app_context():
         with pytest.raises(TargetNotAuthorizedError):

--- a/API/tests/integration/test_quotas.py
+++ b/API/tests/integration/test_quotas.py
@@ -330,13 +330,21 @@ def test_an_invalid_target_does_not_burn_quota(app, regular_user, set_plan_limit
     from unittest import mock
 
     from src.modules.accounts.services.quotas import QuotaManager
-    from src.modules.features.themis.exceptions import TargetNotAuthorizedError
+    from src.modules.features.themis.exceptions import (
+        IPValidationError,
+        TargetNotAuthorizedError,
+    )
     from src.modules.features.themis.managers.lybra.engine import LybraEngineManager
 
     set_plan_limits({LimitKey.THEMIS_LYBRA_SCANS: 5})
 
+    # Se aceptan las dos formas de rechazo porque el objetivo es inválido por dos
+    # motivos a la vez: no resuelve (IPValidationError, desde que el guardia
+    # anti-SSRF resuelve los nombres antes de juzgarlos) y no está autorizado.
+    # Cuál salta primero es orden interno de validación, y no es lo que este test
+    # afirma: lo que afirma es que **ninguna de las dos cobra cuota**.
     with app.app_context():
-        with pytest.raises(TargetNotAuthorizedError):
+        with pytest.raises((IPValidationError, TargetNotAuthorizedError)):
             LybraEngineManager(task_queue=mock.Mock()).run_scan(
                 user_id=regular_user.id, target="no-autorizado.example.com",
             )

--- a/API/tests/integration/test_themis.py
+++ b/API/tests/integration/test_themis.py
@@ -94,11 +94,16 @@ def test_folder_isolation_between_users(client, make_user, auth_headers):
 # explícita, ningún scanner debe poder alcanzar una IP privada/loopback ni la
 # IP de metadata de nube.
 #
-# 'themis.areLocalIpsAllowed' se deja en true en el SecOpsConfig.json
-# versionado a propósito, para desarrollo local (ver CLAUDE.md). Estos tests
-# verifican la protección anti-SSRF en sí, así que fuerzan el valor a false
-# independientemente de esa config ambiente, igual que TestPrivateIpPolicy en
-# tests/unit/test_themis_parsing.py.
+# 'themis.areLocalIpsAllowed' viaja en false en el SecOpsConfig.json
+# versionado, y hay un test que lo ata (test_the_anti_ssrf_defence_ships_enabled
+# en tests/unit/test_config_shape.py): estuvo en true hasta 2026-09-01 y la
+# suite no se enteraba, precisamente porque estos tests fuerzan el valor.
+#
+# Se sigue forzando aquí a propósito: estos casos verifican la protección
+# anti-SSRF *en sí*, y deben hacerlo sin depender de lo que diga la config
+# ambiente — igual que TestPrivateIpPolicy en tests/unit/test_themis_parsing.py.
+# Lo que uno comprueba (el comportamiento) y lo que ata el otro (el valor que se
+# despliega) son cosas distintas, y hacen falta las dos.
 
 
 @pytest.fixture()

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -398,3 +398,33 @@ def test_every_directory_type_resolves(directory_type, monkeypatch):
         monkeypatch.delenv(env_var, raising=False)
 
     assert CR.get_directory_of(directory_type)
+
+
+# ---------------------------------------------------------------------------
+# Valores que se despliegan tal cual, y que no pueden quedarse en modo desarrollo
+# ---------------------------------------------------------------------------
+
+def test_the_anti_ssrf_defence_ships_enabled(raw_config):
+    """``areLocalIpsAllowed`` tiene que viajar en ``false`` al repositorio.
+
+    Es la defensa anti-SSRF del módulo de escaneo: con ``true``, un usuario
+    puede apuntar un escaneo a la red interna del servidor o al endpoint de
+    metadatos del cloud (``169.254.169.254``). En un producto cuyo trabajo es
+    escanear, eso convierte la propia herramienta en el vector.
+
+    Hacía falta un test **sobre el fichero versionado** porque los que ya
+    existen no cubren este riesgo, y conviene entender por qué: los tests de
+    SSRF fuerzan el valor a ``false`` con ``monkeypatch`` para poder probar la
+    protección en sí, así que pasan en verde diga lo que diga el JSON. Es decir
+    que el flag podía estar en ``true`` en producción con toda la suite
+    contenta — y de hecho lo estuvo, hasta que alguien miró a mano antes de un
+    despliegue.
+
+    Para desarrollo local contra IPs privadas, ponlo a ``true`` en tu copia sin
+    commitearlo, o parchéalo en el test que lo necesite (ver
+    ``TestPrivateIpPolicy`` en ``tests/unit/test_themis_parsing.py``).
+    """
+    assert _value_at(raw_config, "features.themis.areLocalIpsAllowed") is False, (
+        "areLocalIpsAllowed está en true en el SecOpsConfig.json versionado: "
+        "eso despliega el escáner con la defensa anti-SSRF desactivada"
+    )

--- a/API/tests/unit/test_themis_parsing.py
+++ b/API/tests/unit/test_themis_parsing.py
@@ -11,6 +11,7 @@ from src.modules.features.themis.exceptions import (
     PortValidationError,
     PrivateIPRequested,
 )
+from src.modules.features.themis.services import parsing
 from src.modules.features.themis.services.parsing import (
     validate_ip,
     validate_port,
@@ -124,3 +125,60 @@ class TestPrivateIpPolicy:
     def test_reject_private_ip_allows_public(self, monkeypatch):
         monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=False))
         reject_private_ip("8.8.8.8")  # no debe lanzar
+
+
+class TestHostnameTargetsReachTheSsrfGuard:
+    """El guardia de objetivo único acepta nombres, y los resuelve antes de juzgar.
+
+    Antes hacía ``ipaddress.ip_address(target)`` sin red de seguridad, así que
+    un nombre lo reventaba con un ``ValueError`` sin capturar. El fallo estuvo
+    tapado todo este tiempo porque ``areLocalIpsAllowed`` estaba en ``true`` en
+    el SecOpsConfig.json versionado, y ese flag cortocircuita la comprobación
+    entera **antes** de mirar el valor: con la defensa apagada, el bug no se
+    alcanzaba.
+
+    Resolver no es una comodidad para aceptar nombres: es parte de la defensa.
+    Un nombre que apunta a loopback o al endpoint de metadatos del cloud
+    atraviesa un guardia que sólo mire lo que *parece* una IP.
+    """
+
+    def test_a_hostname_pointing_at_loopback_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=False))
+        monkeypatch.setattr(
+            parsing.socket, "getaddrinfo",
+            lambda host, port: [(None, None, None, "", ("127.0.0.1", 0))],
+        )
+        with pytest.raises(PrivateIPRequested):
+            parsing.reject_private_ip("interno.example.com")
+
+    def test_a_hostname_with_one_private_record_is_rejected(self, monkeypatch):
+        """Basta con que una de las direcciones sea privada: comprobar sólo la
+        primera dejaría pasar un nombre con varios registros."""
+        monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=False))
+        monkeypatch.setattr(
+            parsing.socket, "getaddrinfo",
+            lambda host, port: [
+                (None, None, None, "", ("93.184.216.34", 0)),
+                (None, None, None, "", ("10.0.0.5", 0)),
+            ],
+        )
+        with pytest.raises(PrivateIPRequested):
+            parsing.reject_private_ip("mixto.example.com")
+
+    def test_a_hostname_pointing_at_a_public_address_passes(self, monkeypatch):
+        monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=False))
+        monkeypatch.setattr(
+            parsing.socket, "getaddrinfo",
+            lambda host, port: [(None, None, None, "", ("93.184.216.34", 0))],
+        )
+        parsing.reject_private_ip("publico.example.com")   # no lanza
+
+    def test_a_hostname_that_does_not_resolve_is_a_validation_error(self, monkeypatch):
+        """Y no un ``ValueError`` que se escape sin capturar, que es lo que
+        pasaba: el llamante no podía distinguirlo de un fallo del programa."""
+        monkeypatch.setattr(CR, "themis_config", lambda: CR.ThemisConfig(are_local_ips_allowed=False))
+        def _nxdomain(host, port):
+            raise OSError("Name or service not known")
+        monkeypatch.setattr(parsing.socket, "getaddrinfo", _nxdomain)
+        with pytest.raises(IPValidationError):
+            parsing.reject_private_ip("no-existe.invalid")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,11 +383,13 @@ que actualizarla en tres sitios — la ruta del `@config_block` (o la llamada a 
 - La versión de la API sale de la config: `create_app()` la lee con `CR.get_app_version()` desde
   `appVersion` en `SecOpsConfig.json` (hoy `0.5.10`). **No está hardcodeada** — y ojo, la rama
   puede ir por delante del `appVersion` del fichero.
-- `features.themis.areLocalIpsAllowed` está a `true` en `SecOpsConfig.json` (intencionado, para
-  desarrollo local contra IPs privadas). **Hay que devolverlo a `false` antes de cualquier
-  despliegue real**, o la defensa anti-SSRF se queda desactivada en producción. La suite **no** te
-  avisa si se te olvida: los tests de SSRF fijan el flag a `false` ellos mismos con una fixture
-  autouse en `test_themis.py`, así que pasan igual y no dicen nada sobre el valor desplegado.
+- `features.themis.areLocalIpsAllowed` viaja en `false`, y hay un test que lo ata
+  (`test_the_anti_ssrf_defence_ships_enabled` en `tests/unit/test_config_shape.py`). Estuvo en
+  `true` hasta 2026-09-01 —y por tanto la defensa anti-SSRF, apagada en producción— sin que la
+  suite dijera nada: los tests de SSRF fuerzan el valor a `false` con una fixture autouse, así que
+  pasaban en verde diga lo que diga el fichero. Comprobar el *comportamiento* y atar el *valor que
+  se despliega* son dos cosas distintas, y hacían falta las dos. Para desarrollo local contra IPs
+  privadas, ponlo a `true` en tu copia sin commitearlo.
 - **SSRF: cada escáner se autovalida.** Nmap, Nikto, Nuclei y Lybra rechazan IPs privadas dentro de
   su propio `run_scan()`, no solo en el endpoint HTTP, así que el flujo programado
   (`scheduling.py` llamando a `run_scan()` directo) también está cubierto. Los cuatro tests

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Ellysia uses a layered configuration system (`API/src/modules/system/config_read
 Config is read through frozen dataclasses bound to a branch of the tree (`@config_block`, e.g. `CR.nuclei_config().rate_limit`), not one getter per value, and cached — changes to `SecOpsConfig.json` require an app restart unless applied via `PUT /system`. Background jobs pick them up too: the worker re-reads the file per job when its mtime changed (`CR.reload_if_changed()`).
 
 > [!WARNING]
-> `features.themis.areLocalIpsAllowed` is set to `true` in the shipped `SecOpsConfig.json` so local development against private IPs works. **Revert it to `false` before any real deployment**, or the anti-SSRF defense stays disabled in production.
+> `features.themis.areLocalIpsAllowed` ships as `false`, and a test pins that value (`test_the_anti_ssrf_defence_ships_enabled`): with `true`, a user can point a scan at the server's internal network or the cloud metadata endpoint. Flip it to `true` in your working copy for local development against private IPs, but do not commit it.
 
 > [!TIP]
 > Use `python -c "from src.modules.system import config_reading as CR; print(CR.get_db_credentials())"` to verify your configuration.


### PR DESCRIPTION
Preparación para el despliegue a `main`. Salió de revisar a mano lo que `CLAUDE.md` marca como obligatorio antes de un despliegue real, y encontró más de lo que buscaba.

## El flag

`features.themis.areLocalIpsAllowed` estaba en **`true`** en el `SecOpsConfig.json` versionado —el que se despliega—. Con ese valor, un usuario puede apuntar un escaneo a la red interna del servidor o al endpoint de metadatos del cloud (`169.254.169.254`). En un producto cuyo trabajo es escanear, eso convierte la herramienta en el vector.

No lo introduce este PR: **`main` lo tiene igual hoy**. Que sea preexistente no lo hace menos urgente; lo hace más.

No es sobrescribible por `.env`: es un campo plano del `@config_block`, no un `configured_*` con `@property`, así que el valor del JSON es el que manda en producción.

## Por qué el arreglo no es sólo cambiar el valor

Los tests de SSRF que ya existían **fuerzan el flag a `false`** con `monkeypatch`, porque prueban la protección en sí. Eso está bien, pero significa que pasaban en verde dijera lo que dijera el fichero. La suite entera podía estar contenta con la defensa apagada en producción — y lo estuvo.

El test nuevo lee el **fichero versionado**, no la configuración en memoria. Comprobar el *comportamiento* y atar el *valor que se despliega* son cosas distintas, y hacían falta las dos. Verificado que detecta la regresión: con `true` falla, con `false` pasa.

## Lo que apareció al activarla

Activar el flag rompió dos tests, y uno era **un bug de producción que el flag estaba tapando**.

`reject_private_ip` hacía `ipaddress.ip_address(target)` sin red de seguridad: un nombre de host lo rompía con un `ValueError` sin capturar. Era inalcanzable porque `areLocalIpsAllowed` en `true` cortocircuita la comprobación antes de mirar el valor. Con la defensa activada —o sea, en cuanto se despliega bien— **cualquier escaneo programado contra un nombre de host revienta**.

El camino afectado no es el endpoint HTTP (ahí `validate_targets` valida IPs antes), sino el arranque directo de un escaneo Lybra de autodescubrimiento, que es por donde pasan los programados.

Rechazar todo lo que no sea una IP era lo cómodo, pero rompe un uso legítimo y central: escanear `example.com` es lo normal aquí. El guardia **resuelve** el nombre y juzga las direcciones resultantes — que además es lo que un guardia anti-SSRF debe hacer igualmente, porque un nombre apuntando a `127.0.0.1` atraviesa cualquier comprobación que sólo mire lo que *parece* una IP. Se miran todas las direcciones, no la primera.

**Lo que no cierra**, y queda escrito en el docstring: el desfase entre comprobar y escanear (DNS rebinding). Cerrarlo exige fijar la IP resuelta y escanear ésa en vez del nombre.

## Los dos tests adaptados

- **Autorización de Lybra**: usaba `203.0.113.9`, de TEST-NET-3, que Python considera privado desde la 3.12. Ahora fuerza el flag, porque lo que prueba es el registro de autorizados y no la defensa. Sin eso pasaría en el CI (3.11) y fallaría en un portátil con una versión más nueva — un test cuyo veredicto depende de la versión de Python.
- **Cuota**: acepta las dos formas de rechazo. Su objetivo es inválido por no resolver *y* por no estar autorizado; lo que el test afirma es que ninguna de las dos cobra cuota.

## Validación

- `pytest -m "not oracle"`: en verde, sin fallos.
- Cuatro tests nuevos para el guardia con nombres: loopback, varios registros con uno privado, público, y un nombre que no resuelve (que ahora da un error de validación y no un `ValueError` que se escapa).
- README y CLAUDE.md dejan de decir "acuérdate de cambiarlo antes de desplegar" y explican por qué la suite no lo veía.

🤖 Generated with [Claude Code](https://claude.com/claude-code)