### PR TITLE
fix(themis): un barrido de puertos bloqueado deja de leerse como objetivo limpio

### DIFF
--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -175,7 +175,10 @@ from .adapters import (
 )
 from .transport import (
     AsyncConnectScanner,
+    PortOutcome,
+    PortSweep,
     scan_ports_sync,
+    sweep_ports_sync,
     scan_udp_ports_sync,
     services_from_discovered_ports,
     DEFAULT_PORTS,
@@ -299,7 +302,10 @@ __all__ = [
     "finding_to_json",
     "QOD_NUCLEI_MATCH",
     "AsyncConnectScanner",
+    "PortOutcome",
+    "PortSweep",
     "scan_ports_sync",
+    "sweep_ports_sync",
     "scan_udp_ports_sync",
     "services_from_discovered_ports",
     "DEFAULT_PORTS",

--- a/API/src/modules/features/themis/lybra/transport.py
+++ b/API/src/modules/features/themis/lybra/transport.py
@@ -29,6 +29,14 @@ The event loop is created and torn down entirely inside :func:`scan_ports_sync`
 — the "asyncio island". It lives within a single synchronous worker call and
 never touches the Flask process or an ORM session. The connection opener is
 injectable, so the scanner can be tested without opening real sockets.
+
+**Un barrido vacío y un barrido bloqueado no son lo mismo** (L48-c). Un
+objetivo que deja de contestar a mitad de camino —él mismo, o un cortafuegos
+por delante— produce un plazo agotado en cada puerto, y sumarlos daba una
+lista vacía indistinguible de un host genuinamente limpio. Por eso el barrido
+clasifica cada intento (:class:`PortOutcome`), lo reporta entero
+(:class:`PortSweep`) y ``scan_ports_sync`` devuelve ``None`` cuando nada
+contestó de ninguna forma.
 """
 
 from __future__ import annotations
@@ -36,7 +44,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
-from typing import Callable, Dict, Iterable, List, Optional
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from .engine import Service
 
@@ -67,6 +78,86 @@ DEFAULT_PORTS: tuple = tuple(sorted(WELL_KNOWN_PORTS)) + (
 )
 
 
+# Número mínimo de puertos que hace falta barrer para que "todos expiraron"
+# signifique algo. Con una lista de tres puertos, que los tres agoten el plazo
+# es perfectamente posible en una red lenta; con sesenta y cuatro, no lo es.
+# Por debajo de este umbral, un barrido mudo se reporta como vacío y no como
+# fallo — preferimos callar antes que inventar un fallo que no está.
+BLOCKED_SWEEP_MIN_PORTS = 8
+
+
+class PortOutcome(Enum):
+    """En qué terminó el intento de conexión a un puerto.
+
+    El escáner tenía un solo bit —abierto o no— y esa era exactamente la
+    información que le faltaba al motor. Un puerto *rechazado* (RST) y un
+    puerto que *no contesta* se cuentan igual de cerrados en el resultado
+    final, pero significan cosas opuestas sobre el objetivo: el primero
+    demuestra que el host está vivo y contestando, el segundo no demuestra
+    nada. Distinguirlos es lo que permite reconocer un barrido bloqueado (ver
+    :class:`PortSweep`).
+    """
+
+    OPEN = "open"
+    REFUSED = "refused"
+    TIMED_OUT = "timed_out"
+    UNREACHABLE = "unreachable"
+
+
+@dataclass(frozen=True)
+class PortSweep:
+    """El resultado completo de un barrido, no sólo los puertos abiertos.
+
+    ``scan_ports_sync`` devolvía una lista, y una lista vacía es una respuesta
+    legítima: "aquí no hay nada expuesto". El problema es que también es lo que
+    devuelve un barrido que el objetivo bloqueó a mitad de camino, y las dos
+    cosas llegan al motor indistinguibles. La consecuencia no es sólo un
+    informe incompleto: el ciclo de vida compara con el escaneo anterior y pasa
+    a ``fixed`` todo lo que estaba abierto y ya no aparece, así que un barrido
+    bloqueado le dice al usuario que sus vulnerabilidades fueron remediadas.
+
+    Este objeto lleva el detalle que permite hacer la distinción; quien la usa
+    es :attr:`is_blocked`.
+
+    Attributes:
+        open_ports: Los puertos que aceptaron la conexión.
+        refused_ports: Los que la rechazaron activamente (RST) — prueba de que
+            el host está vivo.
+        timed_out_ports: Los que agotaron el plazo sin contestar nada.
+        unreachable_ports: Los que fallaron por un error de red distinto de
+            los dos anteriores (host inalcanzable, red caída).
+        was_cancelled: Si el barrido se abandonó por cancelación, en cuyo caso
+            los puertos no probados no aparecen en ninguna lista y el barrido
+            nunca se considera bloqueado.
+    """
+
+    open_ports: Tuple[int, ...]
+    refused_ports: Tuple[int, ...]
+    timed_out_ports: Tuple[int, ...]
+    unreachable_ports: Tuple[int, ...]
+    was_cancelled: bool = False
+
+    @property
+    def is_blocked(self) -> bool:
+        """Si el barrido parece bloqueado en vez de limpio.
+
+        La firma de un bloqueo transitorio —el objetivo, o un dispositivo
+        intermedio, deja de contestar tras una ráfaga de conexiones— es que
+        **nada** contestó de ninguna forma: ni un puerto abierto, ni un solo
+        RST, sólo plazos agotados. Contra un host con latencia normal eso no
+        es un resultado plausible, y es justo la señal que el escáner tenía
+        delante y tiraba.
+
+        Un barrido cancelado nunca cuenta como bloqueado: se dejó a medias a
+        propósito.
+        """
+        if self.was_cancelled:
+            return False
+        if self.open_ports or self.refused_ports:
+            return False
+        return len(self.timed_out_ports) >= BLOCKED_SWEEP_MIN_PORTS
+
+
 class AsyncConnectScanner:
     """A concurrent, unprivileged TCP connect scanner.
 
@@ -93,6 +184,48 @@ class AsyncConnectScanner:
         self._timeout = timeout
         self._opener = opener or asyncio.open_connection
 
+    async def sweep(
+        self,
+        host: str,
+        ports: Iterable[int],
+        cancel_check: Optional[Callable[[], bool]] = None
+    ) -> PortSweep:
+        """Barrer los puertos de un host y clasificar cómo terminó cada intento.
+
+        Args:
+            host: El objetivo (IP o nombre).
+            ports: Los puertos a probar.
+            cancel_check: Callable opcional, consultado antes de cada sonda; si
+                devuelve ``True`` se omiten las restantes.
+
+        Returns:
+            El :class:`PortSweep` con cada puerto en la lista de su desenlace.
+        """
+        semaphore = asyncio.Semaphore(self._concurrency)
+        outcomes: Dict[int, PortOutcome] = {}
+        was_cancelled = False
+
+        async def probe(port: int) -> None:
+            nonlocal was_cancelled
+            if cancel_check and cancel_check():
+                was_cancelled = True
+                return
+            async with semaphore:
+                outcomes[port] = await self._probe_outcome(host, port)
+
+        await asyncio.gather(*(probe(port) for port in ports))
+
+        def ports_with(outcome: PortOutcome) -> Tuple[int, ...]:
+            return tuple(sorted(port for port, result in outcomes.items() if result is outcome))
+
+        return PortSweep(
+            open_ports=ports_with(PortOutcome.OPEN),
+            refused_ports=ports_with(PortOutcome.REFUSED),
+            timed_out_ports=ports_with(PortOutcome.TIMED_OUT),
+            unreachable_ports=ports_with(PortOutcome.UNREACHABLE),
+            was_cancelled=was_cancelled,
+        )
+
     async def scan(
         self,
         host: str,
@@ -100,6 +233,9 @@ class AsyncConnectScanner:
         cancel_check: Optional[Callable[[], bool]] = None
     ) -> List[int]:
         """Scan a host's ports and return which ones are open.
+
+        The thin view over :meth:`sweep` for callers that only want the open
+        ports and have no use for how the rest failed.
 
         Args:
             host: The target host (IP or hostname).
@@ -110,39 +246,70 @@ class AsyncConnectScanner:
         Returns:
             The open ports, sorted ascending.
         """
-        semaphore = asyncio.Semaphore(self._concurrency)
-        open_ports: List[int] = []
+        sweep = await self.sweep(host, ports, cancel_check=cancel_check)
+        return list(sweep.open_ports)
 
-        async def probe(port: int) -> None:
-            if cancel_check and cancel_check():
-                return
-            async with semaphore:
-                if await self._is_open(host, port):
-                    open_ports.append(port)
+    async def _probe_outcome(self, host: str, port: int) -> PortOutcome:
+        """Intentar una conexión y decir en qué terminó, cerrándola limpiamente.
 
-        await asyncio.gather(*(probe(port) for port in ports))
-        return sorted(open_ports)
-
-    async def _is_open(self, host: str, port: int) -> bool:
-        """Return whether a single port accepts a connection, closing it cleanly.
-
-        Any connection error or timeout is taken to mean "closed"; the socket is
-        always closed afterwards on a best-effort basis.
+        Los tres desenlaces se distinguen porque significan cosas distintas
+        sobre el objetivo, no sobre el puerto: ver :class:`PortOutcome`.
         """
         try:
             _, writer = await asyncio.wait_for(self._opener(host, port), self._timeout)
-        except (OSError, asyncio.TimeoutError):
-            return False
+        except asyncio.TimeoutError:
+            return PortOutcome.TIMED_OUT
+        except ConnectionRefusedError:
+            return PortOutcome.REFUSED
+        except OSError:
+            return PortOutcome.UNREACHABLE
         except Exception as err:  # noqa: BLE001 - unexpected opener error: treat as closed
             logger.debug("connect probe error for %s:%s: %s", host, port, err)
-            return False
+            return PortOutcome.UNREACHABLE
         finally:
             try:
                 writer.close()
                 await writer.wait_closed()
             except Exception:  # noqa: BLE001 - close is best-effort
                 pass
-        return True
+        return PortOutcome.OPEN
+
+    async def _is_open(self, host: str, port: int) -> bool:
+        """Return whether a single port accepts a connection.
+
+        Kept as the boolean view over :meth:`_probe_outcome` — any connection
+        error or timeout means "not open".
+        """
+        return await self._probe_outcome(host, port) is PortOutcome.OPEN
+
+
+def sweep_ports_sync(
+    host: str,
+    ports: Optional[Iterable[int]] = None,
+    concurrency: int = 200,
+    timeout: float = 2.0,
+    opener: Optional[Callable] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> PortSweep:
+    """Ejecutar un barrido completo síncronamente, en un bucle de eventos propio.
+
+    La frontera de la "isla asyncio", en su forma detallada: devuelve el
+    :class:`PortSweep` entero en vez de sólo los puertos abiertos.
+
+    Args:
+        host: El objetivo.
+        ports: Los puertos a probar; por defecto :data:`DEFAULT_PORTS`.
+        concurrency: Máximo de intentos de conexión simultáneos.
+        timeout: Plazo por puerto, en segundos.
+        opener: Abridor de conexión inyectable (ver :class:`AsyncConnectScanner`).
+        cancel_check: Callable de cancelación opcional.
+
+    Returns:
+        El :class:`PortSweep` del barrido.
+    """
+    port_list = list(ports) if ports is not None else list(DEFAULT_PORTS)
+    scanner = AsyncConnectScanner(concurrency=concurrency, timeout=timeout, opener=opener)
+    return asyncio.run(scanner.sweep(host, port_list, cancel_check=cancel_check))
 
 
 def scan_ports_sync(
@@ -151,12 +318,27 @@ def scan_ports_sync(
     concurrency: int = 200,
     timeout: float = 2.0,
     opener: Optional[Callable] = None,
-    cancel_check: Optional[Callable[[], bool]] = None
-) -> List[int]:
+    cancel_check: Optional[Callable[[], bool]] = None,
+    retries: int = 1,
+    retry_delay: float = 2.0,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> Optional[List[int]]:
     """Run a connect scan synchronously, on a fresh event loop of its own.
 
     This is the boundary of the "asyncio island": it wraps the async scanner in
     ``asyncio.run``, so it is safe to call from an ordinary synchronous worker.
+
+    Devuelve ``None`` —no ``[]``— cuando el barrido parece bloqueado en vez de
+    limpio (ver :attr:`PortSweep.is_blocked`). Esa distinción es la razón de
+    ser de esta firma: el llamante ya tenía puesta la defensa de tratar
+    ``None`` como fallo, pero nunca podía dispararla porque la única respuesta
+    posible era una lista. Una lista vacía significa ahora, y sólo ahora,
+    "el objetivo contestó y no tiene nada abierto".
+
+    Antes de concluir que hay bloqueo se reintenta el barrido entero: un
+    objetivo que deja de contestar a mitad de camino suele recuperarse en
+    segundos, y un reintento espaciado cuesta mucho menos que un escaneo
+    perdido.
 
     Args:
         host: The target host.
@@ -165,13 +347,34 @@ def scan_ports_sync(
         timeout: The per-port connect timeout, in seconds.
         opener: An injectable connection opener (see :class:`AsyncConnectScanner`).
         cancel_check: An optional cancellation callable.
+        retries: Reintentos adicionales tras un barrido que parece bloqueado.
+        retry_delay: Espera entre reintentos, en segundos.
+        sleeper: Espera inyectable, para que un test no tenga que dormirla.
 
     Returns:
-        The open ports, sorted ascending.
+        Los puertos abiertos, ascendentes, o ``None`` si el barrido parece
+        bloqueado incluso tras los reintentos.
     """
-    port_list = list(ports) if ports is not None else list(DEFAULT_PORTS)
-    scanner = AsyncConnectScanner(concurrency=concurrency, timeout=timeout, opener=opener)
-    return asyncio.run(scanner.scan(host, port_list, cancel_check=cancel_check))
+    sweep = sweep_ports_sync(host, ports, concurrency, timeout, opener, cancel_check)
+    attempts_left = max(0, retries)
+    while sweep.is_blocked and attempts_left > 0:
+        logger.warning(
+            "Barrido de %s sin una sola respuesta (%s puertos expirados): reintentando",
+            host, len(sweep.timed_out_ports),
+        )
+        if retry_delay > 0:
+            sleeper(retry_delay)
+        sweep = sweep_ports_sync(host, ports, concurrency, timeout, opener, cancel_check)
+        attempts_left -= 1
+
+    if sweep.is_blocked:
+        logger.error(
+            "Descubrimiento de %s bloqueado: los %s puertos expiraron y ninguno "
+            "rechazó la conexión; no es un objetivo limpio",
+            host, len(sweep.timed_out_ports),
+        )
+        return None
+    return list(sweep.open_ports)
 
 
 def services_from_discovered_ports(

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -297,12 +297,29 @@ class LybraEngineManager(ScanManager):
         must not conflate the two: treating a failed probe as "everything is
         closed" would falsely mark previously-open findings as fixed once
         lifecycle correlation runs.
+
+        Esa defensa estuvo puesta y sin poder dispararse: ``scan_ports_sync``
+        sólo sabía devolver una lista, así que un objetivo que bloqueaba el
+        barrido a mitad de camino llegaba aquí como ``[]`` —un informe
+        tranquilizador sobre un host con servicios abiertos, y peor aún, un
+        ciclo de vida que marcaba como corregidos los hallazgos anteriores—.
+        Desde L48-c el transporte distingue "todo cerrado" de "no me han
+        dejado mirar" y devuelve ``None`` en el segundo caso, que es lo que
+        este método siempre esperó recibir.
         """
         try:
-            return scan_ports_sync(target, discover_ports)
+            discovered = scan_ports_sync(target, discover_ports)
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
             return None
+        if discovered is None:
+            logger.error(
+                "Descubrimiento bloqueado para %s: el host respondió al chequeo de "
+                "alcanzabilidad y después ningún puerto contestó. El escaneo falla "
+                "en vez de reportar un objetivo limpio.",
+                target,
+            )
+        return discovered
 
     def _discover_udp_ports(self, target: str) -> list:
         """Discover open UDP ports via the curated probe table (Fase N/Ronda 1).

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -229,6 +229,49 @@ def test_lybra_self_discovery_probe_failure_fails_without_false_fixed(app, admin
     assert escan.status == ScanStatus.FAILED.value
 
 
+def test_lybra_blocked_discovery_never_marks_findings_fixed(app, admin_user, monkeypatch):
+    """L48-c, la mitad que de verdad duele.
+
+    Un objetivo que bloquea el barrido a mitad de camino producía una lista
+    vacía indistinguible de un host limpio, y el ciclo de vida pasaba entonces
+    a ``fixed`` todo lo que el escaneo anterior había encontrado abierto: no
+    sólo se ocultaba lo que hay, se le decía al usuario que sus
+    vulnerabilidades estaban remediadas.
+
+    El transporte ya distingue los dos casos (ver
+    ``tests/unit/test_lybra_transport.py``); aquí se comprueba la consecuencia
+    aguas abajo: con un descubrimiento bloqueado, el escaneo falla y ningún
+    hallazgo previo cambia de estado.
+    """
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
+    monkeypatch.setattr(LybraEngineManager, "_discover_ports",
+                        lambda self, target, ports: [80, 443])
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        first = mgr._create_scan_record(target="10.0.0.31", user_id=admin_user.id)
+        mgr._run_lybra(first.id)
+
+    # Segundo escaneo: el objetivo bloquea el barrido — el transporte lo
+    # reconoce y devuelve None en vez de una lista vacía.
+    monkeypatch.setattr(LybraEngineManager, "_discover_ports",
+                        lambda self, target, ports: None)
+    with app.app_context():
+        mgr = LybraEngineManager()
+        second = mgr._create_scan_record(target="10.0.0.31", user_id=admin_user.id)
+        mgr._run_lybra(second.id)
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            second_findings = repo.get_findings_by_scan(second.id)
+            first_findings = repo.get_findings_by_scan(first.id)
+            second = repo.get_by_id(second.id)
+
+    assert second.status == ScanStatus.FAILED.value
+    assert second_findings == []
+    assert not any(finding.state == "fixed" for finding in first_findings)
+
+
 def test_lybra_self_discovery_genuine_zero_ports_still_marks_fixed(app, admin_user, monkeypatch):
     """Discovery running cleanly and finding nothing IS legitimate evidence:
     a previously-open finding on this target should still be marked fixed."""

--- a/API/tests/unit/test_lybra_transport.py
+++ b/API/tests/unit/test_lybra_transport.py
@@ -4,10 +4,14 @@ The connect scanner runs on a real (test-thread) event loop but against an
 injected ``opener``, so no real sockets or privileges are involved.
 """
 
+import asyncio
+
 import pytest
 
 from src.modules.features.themis.lybra import (
+    PortSweep,
     scan_ports_sync,
+    sweep_ports_sync,
     scan_udp_ports_sync,
     services_from_discovered_ports,
     DEFAULT_PORTS,
@@ -69,6 +73,90 @@ def test_scan_defaults_to_curated_port_set():
     opener = _opener_for({80})
     assert scan_ports_sync("10.0.0.5", opener=opener) == [80]
     assert {22, 80, 443} <= set(DEFAULT_PORTS)
+
+
+# --------------------------------------------- barrido bloqueado vs vacío
+#
+# L48-c: un objetivo que bloquea el barrido a mitad de camino devolvía una
+# lista vacía, indistinguible de un host limpio — y el ciclo de vida marcaba
+# entonces como corregidos hallazgos que seguían abiertos.
+
+
+def _timing_out_opener():
+    """Abridor que nunca completa: toda sonda agota su plazo."""
+    async def opener(host, port):
+        await asyncio.sleep(3600)
+    return opener
+
+
+def test_sweep_classifies_each_outcome_apart():
+    async def opener(host, port):
+        if port == 80:
+            return None, _FakeWriter()
+        if port == 22:
+            raise ConnectionRefusedError("closed")
+        raise OSError("network unreachable")
+
+    sweep = sweep_ports_sync("10.0.0.5", [80, 22, 443], opener=opener)
+    assert sweep.open_ports == (80,)
+    assert sweep.refused_ports == (22,)
+    assert sweep.unreachable_ports == (443,)
+    assert sweep.timed_out_ports == ()
+    assert not sweep.is_blocked
+
+
+def test_sweep_where_every_port_times_out_is_blocked():
+    ports = list(range(1000, 1000 + 16))
+    sweep = sweep_ports_sync("10.0.0.5", ports, timeout=0.01,
+                             opener=_timing_out_opener())
+    assert sweep.timed_out_ports == tuple(ports)
+    assert sweep.is_blocked
+
+
+def test_scan_returns_none_when_the_sweep_looks_blocked():
+    # La distinción entera del issue: esto NO puede ser [], porque [] significa
+    # "objetivo limpio" y el ciclo de vida actuaría en consecuencia.
+    ports = list(range(1000, 1000 + 16))
+    waits = []
+    result = scan_ports_sync("10.0.0.5", ports, timeout=0.01,
+                             opener=_timing_out_opener(),
+                             retry_delay=0.5, sleeper=waits.append)
+    assert result is None
+    assert waits == [0.5]          # se reintentó una vez antes de rendirse
+
+
+def test_scan_recovers_when_the_retry_answers():
+    ports = list(range(1000, 1000 + 16))
+    attempts = {"count": 0}
+
+    async def opener(host, port):
+        if attempts["count"] == 0:
+            await asyncio.sleep(3600)
+        if port == 1000:
+            return None, _FakeWriter()
+        raise ConnectionRefusedError("closed")
+
+    def sleeper(_seconds):
+        attempts["count"] += 1
+
+    result = scan_ports_sync("10.0.0.5", ports, timeout=0.01, opener=opener,
+                             retry_delay=0.1, sleeper=sleeper)
+    assert result == [1000]
+
+
+def test_a_short_muted_sweep_is_not_called_blocked():
+    # Con tres puertos, que los tres expiren es plausible en una red lenta:
+    # preferimos callar antes que inventar un fallo que no está.
+    result = scan_ports_sync("10.0.0.5", [1, 2, 3], timeout=0.01,
+                             opener=_timing_out_opener(), retry_delay=0)
+    assert result == []
+
+
+def test_a_cancelled_sweep_is_never_blocked():
+    sweep = PortSweep(open_ports=(), refused_ports=(),
+                      timed_out_ports=tuple(range(20)), unreachable_ports=(),
+                      was_cancelled=True)
+    assert not sweep.is_blocked
 
 
 # ------------------------------------------------------- services + oracle


### PR DESCRIPTION
## Resumen

Cierra #370.

El motor Lybra tiene su propio descubrimiento de puertos: abre una conexión TCP a cada puerto de una lista y apunta los que aceptan. Hasta ahora esa función devolvía una lista de números, y ya está.

El problema es que **una lista vacía tiene dos significados que no se pueden separar**. Uno es "he mirado los sesenta y cuatro puertos y este host no tiene nada expuesto". El otro es "el objetivo dejó de contestarme a mitad del barrido y no he podido ver nada". Los dos llegan al motor exactamente igual: `[]`.

Esto no se descubrió razonando sobre el código. Se descubrió porque el banco de paridad real de #277 se ejecutó **dos veces** contra los mismos objetivos y los números no cuadraron: la concordancia de puertos dio 0,96 en una pasada y 0,58 en la otra, veinte minutos después. La diferencia entera eran cuatro IPs donde el escáner propio devolvió `[]` mientras Nmap encontraba cuatro puertos abiertos en las dos pasadas.

## Por qué es más grave que un fallo de fiabilidad

Un escáner que a veces no encuentra puertos sería un problema de calidad. Éste es peor por lo que pasa **después** del escaneo.

Cada vez que un escaneo termina, el motor compara sus hallazgos con los del escaneo anterior sobre el mismo objetivo (lo llamamos *correlación de ciclo de vida*). Lo que estaba abierto la vez pasada y ya no aparece se marca como `fixed` — corregido. Es un comportamiento correcto y deseable: así el usuario ve qué ha arreglado.

Pero alimentado con un barrido bloqueado, ese mismo mecanismo **le dice al usuario que sus vulnerabilidades fueron remediadas** cuando lo único que pasó es que el cortafuegos del objetivo se cansó de la ráfaga de conexiones.

## Lo interesante: la defensa ya estaba puesta, y no podía dispararse

El código ya había anticipado este riesgo. `LybraEngineManager._discover_ports` lo dice en su propio docstring:

> *Returns `None` (not `[]`) when discovery itself failed unexpectedly, as opposed to running cleanly and finding zero open ports. The caller must not conflate the two.*

La intención era correcta. El problema es que `scan_ports_sync` —la función del transporte a la que llama— **no tenía forma de expresar el fallo**: su tipo de retorno era una lista, y una lista vacía es una respuesta legítima. La distinción que el manager quería hacer era inaplicable porque la información nunca le llegaba.

## Qué cambia

La idea de fondo: *"todo cerrado"* y *"no me han dejado mirar"* tienen que ser respuestas distintas, y quien tiene la información para distinguirlas es el transporte.

**1. El barrido clasifica cada intento en vez de reducirlo a un booleano.** Un nuevo enum `PortOutcome` con cuatro desenlaces:

| Desenlace | Qué pasó | Qué demuestra sobre el objetivo |
|---|---|---|
| `OPEN` | La conexión se completó | El puerto está abierto |
| `REFUSED` | El objetivo contestó con un RST | **El host está vivo y contestando** |
| `TIMED_OUT` | Se agotó el plazo sin recibir nada | Nada en absoluto |
| `UNREACHABLE` | Otro error de red | Nada en absoluto |

La distinción que importa es la de las dos filas centrales. Un puerto *rechazado* y un puerto que *no contesta* cuentan igual de "cerrado" en el resultado final, pero significan cosas opuestas: el rechazo es una respuesta activa del objetivo, el silencio no es una respuesta.

**2. Un `PortSweep` que lleva el detalle**, con la propiedad que hace el juicio:

```python
@property
def is_blocked(self) -> bool:
    if self.was_cancelled:
        return False
    if self.open_ports or self.refused_ports:
        return False
    return len(self.timed_out_ports) >= BLOCKED_SWEEP_MIN_PORTS
```

El criterio es *"nada contestó de ninguna forma"*: ni un puerto abierto, ni un solo RST, sólo plazos agotados. Contra un host que acaba de responder al chequeo de alcanzabilidad con 15 ms de latencia, que las sesenta y cuatro conexiones expiren a la vez no es un resultado plausible.

**3. El umbral de ocho puertos** (`BLOCKED_SWEEP_MIN_PORTS`) evita el falso positivo simétrico: con una lista de tres puertos, que los tres expiren sí es plausible en una red lenta. Por debajo del umbral se reporta vacío y se calla, antes que inventar un fallo que no está.

**4. Se reintenta antes de concluir.** Un objetivo que se bloquea suele recuperarse en segundos —de hecho eso es exactamente lo que se observó en la medición: minutos después el mismo barrido funcionaba—. El reintento y su espera son parámetros, y la espera es inyectable para que un test no tenga que dormirla de verdad.

**5. `scan_ports_sync` devuelve `Optional[List[int]]`.** Ése es el cambio de contrato que hace utilizable la defensa que el manager ya tenía escrita. Una lista vacía significa ahora, y sólo ahora, "el objetivo contestó y no tiene nada abierto".

Para quien sólo quiera los puertos abiertos sin el detalle, `AsyncConnectScanner.scan` sigue existiendo con la misma firma de siempre; ahora es una vista fina sobre `sweep`.

## Validación

`pytest tests/unit/test_lybra_transport.py` (21 pasan) y los tests de descubrimiento de `tests/integration/test_lybra.py` (12 pasan). Sin `pylint` nuevo en los ficheros tocados.

Seis tests nuevos:

- `test_sweep_classifies_each_outcome_apart` — un abierto, un rechazado y un inalcanzable acaban cada uno en su lista, y el barrido no se considera bloqueado (algo contestó).
- `test_sweep_where_every_port_times_out_is_blocked` — dieciséis puertos, todos mudos: bloqueado.
- `test_scan_returns_none_when_the_sweep_looks_blocked` — la distinción entera del issue. El resultado **no puede** ser `[]`, porque `[]` significa "objetivo limpio". Comprueba además que se reintentó una vez antes de rendirse.
- `test_scan_recovers_when_the_retry_answers` — el caso que justifica el reintento: primera pasada muda, segunda con respuestas, resultado bueno.
- `test_a_short_muted_sweep_is_not_called_blocked` — el umbral, por el lado del falso positivo.
- `test_a_cancelled_sweep_is_never_blocked` — un barrido abandonado a propósito no es un bloqueo.

Y uno de integración, `test_lybra_blocked_discovery_never_marks_findings_fixed`, que comprueba la consecuencia aguas abajo —la que de verdad duele—: dos escaneos sobre el mismo objetivo, el segundo con el descubrimiento bloqueado. El escaneo acaba en `FAILED`, no persiste ningún hallazgo engañoso, y **ningún hallazgo del escaneo anterior pasa a `fixed`**.

## Notas

- Los tests `oracle` (contenedores Docker reales) no se han tocado ni ejecutado: siguen fuera del run por defecto de CI.
- Este arreglo explica la varianza que hizo imposible certificar el número de la Fase T en #277, pero no vuelve a medirlo: eso pertenece a una nueva ejecución del banco de paridad, no a este PR.
- El punto 3 del issue —registrar explícitamente la contradicción "el host respondió al chequeo de alcanzabilidad y después ningún puerto contestó"— se cubre con un `logger.error` en `_discover_ports`, que es donde se conocen las dos cosas a la vez.