### PR TITLE
fix(themis): el dissector FTP reconoce el producto cuando el saludo calla la versión

### DIFF
--- a/API/src/modules/features/themis/lybra/fingerprinting/ftp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/ftp.py
@@ -8,16 +8,26 @@ negotiation, no framing, just a banner ending in ``\\r\\n``. The well-known
 most recognisable "verified by an intentionally-vulnerable lab image" targets
 that exists, which makes this dissector unusually easy to validate.
 
-Two banner shapes cover the common daemons:
+Two banner shapes carry a version outright:
 
 - ``220 (vsFTPd 2.3.4)`` — product and version in parentheses (vsftpd).
 - ``220 ProFTPD 1.3.5 Server (Debian) [...]`` — bare ``Product Version``
   tokens before any parenthetical comment (ProFTPD, and similar daemons).
 
-A banner that carries no version at all — Pure-FTPd's default is the classic
-example, which suppresses its version for exactly the reason this dissector
-exists — yields no identification rather than a guess. That mirrors the
-project's rule everywhere else: no CPE that was not actually observed.
+**Y muchos despliegues reales no llevan ninguna de las dos** (L48-a). El
+saludo por defecto de ProFTPD en Debian es ``220 ProFTPD Server (Debian)
+[::ffff:...]``: nombra el producto y calla la versión, que es justo lo que
+recomienda cualquier guía de fortificación. Pure-FTPd hace lo mismo. Contra
+esos servidores el dissector no devolvía nada mientras Nmap leía el producto
+del mismo saludo — medido en dos hosts reales, concordancia 0,00 para la
+familia FTP frente al 1,00 de laboratorio, donde el único contenedor del
+banco era un vsftpd cuyo formato el parser sí conocía.
+
+De ahí :data:`KNOWN_DAEMONS`: una tabla de nombres de demonio conocidos que se
+buscan en el saludo cuando ningún patrón con versión ha casado. **Reconocer un
+producto nombrado no es inventarlo** — el nombre está literalmente en el
+banner—; lo que sigue prohibido es fabricar la versión que no se observó, y
+por eso este camino devuelve siempre ``(producto, None)``.
 """
 
 from __future__ import annotations
@@ -41,6 +51,49 @@ _PAREN_RE = re.compile(r"\(([A-Za-z][\w.\-]*)\s+([0-9][\w.\-]*)\)")
 # a version token, before any parenthetical comment.
 _BARE_RE = re.compile(r"^220[- ]+([A-Za-z][A-Za-z0-9_\-]*(?:\s[A-Za-z]+)?)\s+([0-9][\w.\-]*)")
 
+# Demonios FTP cuyo nombre basta para identificar el producto cuando el saludo
+# no trae versión. La clave es la aguja que se busca en el banner (en
+# minúsculas); el valor, el nombre canónico del producto tal y como debe
+# aparecer en el hallazgo y en la consulta de CPE.
+#
+# Es una tabla y no una heurística a propósito: un `split()` esperanzado sobre
+# la primera palabra del saludo convertiría cualquier mensaje de bienvenida
+# personalizado en un producto inventado. Aquí, si el nombre no está escrito,
+# no hay identificación.
+#
+# El orden importa donde un nombre contiene a otro: "Microsoft FTP Service" se
+# comprueba antes que "FTP", y "FileZilla Server" antes que "FileZilla".
+KNOWN_DAEMONS: Tuple[Tuple[str, str], ...] = (
+    ("microsoft ftp service", "Microsoft FTP Service"),
+    ("filezilla server", "FileZilla Server"),
+    ("pure-ftpd", "Pure-FTPd"),
+    ("proftpd", "ProFTPD"),
+    ("vsftpd", "vsFTPd"),
+    ("wu-ftpd", "WU-FTPD"),
+    ("serv-u", "Serv-U"),
+    ("crushftp", "CrushFTP"),
+    ("glftpd", "glFTPd"),
+    ("bftpd", "bftpd"),
+    ("titan ftp", "Titan FTP Server"),
+)
+
+
+def _named_daemon(banner: str) -> Optional[str]:
+    """Devuelve el producto nombrado en ``banner``, si es uno conocido.
+
+    Args:
+        banner: La línea de saludo completa.
+
+    Returns:
+        El nombre canónico del demonio, o ``None`` si el saludo no nombra
+        ninguno de los conocidos.
+    """
+    lowered = banner.lower()
+    for needle, product in KNOWN_DAEMONS:
+        if needle in lowered:
+            return product
+    return None
+
 
 @dataclass(frozen=True)
 class FtpFingerprint:
@@ -63,10 +116,11 @@ def parse_ftp_banner(banner: str) -> Tuple[Optional[str], Optional[str]]:
         banner: The banner line, e.g. ``"220 (vsFTPd 2.3.4)"``.
 
     Returns:
-        A ``(product, version)`` tuple. Both are ``None`` when the banner does
-        not carry a recognisable product/version pair — deliberately not a
-        guess, since a fabricated identification would go on to look up a
-        CPE that does not exist.
+        A ``(product, version)`` tuple. La versión es ``None`` cuando el saludo
+        nombra un demonio conocido pero suprime su versión —el caso por defecto
+        de ProFTPD y de Pure-FTPd—; ambos son ``None`` cuando no se reconoce
+        nada. Nunca se fabrica una versión que no se leyó: sin ella no hay CPE,
+        y un CPE inventado buscaría CVEs de un producto que no está ahí.
     """
     banner = (banner or "").strip()
     if not banner.startswith("220"):
@@ -77,7 +131,7 @@ def parse_ftp_banner(banner: str) -> Tuple[Optional[str], Optional[str]]:
     match = _BARE_RE.match(banner)
     if match:
         return match.group(1), match.group(2)
-    return None, None
+    return _named_daemon(banner), None
 
 
 def fingerprint_ftp(banner: str) -> FtpFingerprint:
@@ -90,7 +144,14 @@ def fingerprint_ftp(banner: str) -> FtpFingerprint:
         An :class:`FtpFingerprint`.
     """
     product, version = parse_ftp_banner(banner)
-    confidence = 0.9 if product and version else 0.0
+    if product and version:
+        confidence = 0.9
+    elif product:
+        # El producto se leyó del saludo; sólo falta la versión. Mismo escalón
+        # que usa fingerprint_http para un `Server` sin versión.
+        confidence = 0.6
+    else:
+        confidence = 0.0
     return FtpFingerprint(product=product, version=version, confidence=confidence)
 
 

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -79,7 +79,7 @@ _HOST = "127.0.0.1"
 # mapa de puertos conocidos haría en producción— el número de puerto no cambia
 # qué dissector se elige ni qué lee.
 _PORTS = {
-    "ftp": 12121, "smtp": 12525, "mysql": 13306, "smb": 14445,
+    "ftp": 12121, "proftpd": 12122, "smtp": 12525, "mysql": 13306, "smb": 14445,
     "vnc": 15900, "snmp": 16161, "redis": 16379,
 }
 
@@ -156,6 +156,35 @@ def ftp_target():
     try:
         _wait_for_greeting(port, b"220")
         yield Target("ftp", port, "ftp")
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture(scope="module")
+def proftpd_target():
+    """El segundo servidor FTP del catálogo, y la razón de que exista (L48-a).
+
+    La familia FTP daba concordancia 1,00 en laboratorio y 0,00 contra
+    objetivos reales. La explicación no era la red: el banco tenía **un solo**
+    servidor FTP, un vsftpd cuyo saludo (``220 (vsFTPd 3.0.5)``) es justo el
+    formato que el parser sabía leer. Ese 1,00 no medía la calidad del
+    dissector, medía la coincidencia entre el dissector y el contenedor
+    elegido — la misma trampa que la Fase 0 documentó en #269 y #270.
+
+    ProFTPD es el otro servidor FTP extendido y saluda de otra forma; en su
+    configuración por defecto de Debian, además, **omite la versión**. Con él
+    en el catálogo, la familia deja de medirse contra sí misma.
+    """
+    port, name = _PORTS["proftpd"], "lybra-concordance-proftpd"
+    _start(name, port, 21, "alpine:latest", "sh", "-c",
+           "apk add --no-cache proftpd >/dev/null 2>&1 && "
+           "printf '%s\n' 'ServerName \"lybra\"' 'ServerType standalone' "
+           "'Port 21' 'User proftpd' 'Group proftpd' "
+           "> /etc/proftpd/proftpd.conf && "
+           "proftpd --nodaemon --config /etc/proftpd/proftpd.conf")
+    try:
+        _wait_for_greeting(port, b"220")
+        yield Target("proftpd", port, "ftp")
     finally:
         docker_rm(_DOCKER, name)
 
@@ -284,6 +313,13 @@ def _assert_agrees(target: Target) -> None:
 
 def test_ftp_fingerprint_agrees_with_nmap(ftp_target):
     _assert_agrees(ftp_target)
+
+
+def test_proftpd_fingerprint_agrees_with_nmap(proftpd_target):
+    """El caso que la medición real destapó: un ProFTPD sin versión en el
+    saludo. Lybra y Nmap deben coincidir en el producto; que ninguno dé
+    versión no es un desacuerdo (ver ``agrees_with_nmap``)."""
+    _assert_agrees(proftpd_target)
 
 
 def test_redis_fingerprint_agrees_with_nmap(redis_target):

--- a/API/tests/oracle/test_lybra_real_parity_bench.py
+++ b/API/tests/oracle/test_lybra_real_parity_bench.py
@@ -286,9 +286,11 @@ def test_fingerprinting_matches_nmap_on_real_targets(measurements):
 
 @pytest.mark.xfail(strict=True, reason=(
     "Medido el 2026-09-01: FTP 0,00 y HTTP entre 0,07 y 0,25 quedan por debajo del "
-    "umbral; SSH aguanta en 0,75. Cada familia tiene su issue de Fase 2 (L48-a "
-    "para FTP, L48-b para HTTP). Este test pasara a XPASS cuando la ultima se "
-    "cierre."
+    "umbral; SSH aguanta en 0,75. La causa de FTP (L48-a) ya esta corregida —el "
+    "parser reconocia un solo formato de saludo, el de vsftpd, y los dos hosts "
+    "medidos servian ProFTPD sin version— pero el numero solo cambia cuando el "
+    "banco se vuelva a ejecutar contra objetivos reales. Queda HTTP (L48-b). Este "
+    "test pasara a XPASS cuando la ultima familia se cierre."
 ))
 def test_no_family_is_left_behind(measurements):
     """La paridad se cierra por familia, no en promedio.

--- a/API/tests/unit/test_lybra_fingerprint.py
+++ b/API/tests/unit/test_lybra_fingerprint.py
@@ -277,10 +277,38 @@ def test_parse_ftp_banner_filezilla_two_word_product():
     assert (product, version) == ("FileZilla Server", "0.9.60beta")
 
 
-def test_parse_ftp_banner_versionless_pureftpd_yields_nothing():
-    # Pure-FTPd's default banner deliberately omits the version — no CPE
-    # should be invented for what was never actually observed.
+def test_parse_ftp_banner_debian_proftpd_without_version():
+    """L48-a: el saludo por defecto de ProFTPD en Debian nombra el producto y
+    calla la versión. Es el caso que se midió en real y que daba `None`
+    mientras Nmap leía `ProFTPD` del mismo saludo."""
+    banner = "220 ProFTPD Server (Debian) [::ffff:203.0.113.10]"
+    assert parse_ftp_banner(banner) == ("ProFTPD", None)
+
+
+def test_parse_ftp_banner_versionless_pureftpd_names_the_product():
+    # Pure-FTPd suprime su versión por defecto. El producto sí está escrito en
+    # el saludo, así que reconocerlo no es inventarlo; la versión sigue sin
+    # fabricarse, que es lo que la regla del proyecto prohíbe.
     banner = "220---------- Welcome to Pure-FTPd [privsep] [TLS] ----------"
+    assert parse_ftp_banner(banner) == ("Pure-FTPd", None)
+
+
+def test_parse_ftp_banner_versionless_iis_names_the_product():
+    assert parse_ftp_banner("220 Microsoft FTP Service") == ("Microsoft FTP Service", None)
+
+
+def test_parse_ftp_banner_a_version_always_wins_over_the_name_table():
+    # El saludo nombra ProFTPD y además trae la versión: gana el patrón con
+    # versión, no la tabla de nombres.
+    banner = "220 ProFTPD 1.3.5 Server (Debian) [::ffff:10.0.0.1]"
+    assert parse_ftp_banner(banner) == ("ProFTPD", "1.3.5")
+
+
+def test_parse_ftp_banner_unknown_daemon_is_not_guessed():
+    # El caso importante de la tabla: un saludo personalizado que no nombra
+    # ningún demonio conocido no produce producto. Sin esto, la tabla sería
+    # una heurística disfrazada.
+    banner = "220 Bienvenido al servidor de ficheros de la empresa."
     assert parse_ftp_banner(banner) == (None, None)
 
 
@@ -292,6 +320,10 @@ def test_parse_ftp_banner_rejects_non_220_lines():
 def test_fingerprint_ftp_confidence_reflects_whether_a_version_was_found():
     hit = fingerprint_ftp("220 (vsFTPd 2.3.4)")
     assert hit.product == "vsFTPd" and hit.version == "2.3.4" and hit.confidence == 0.9
+
+    named_only = fingerprint_ftp("220 ProFTPD Server (Debian) [::ffff:10.0.0.1]")
+    assert named_only.product == "ProFTPD"
+    assert named_only.version is None and named_only.confidence == 0.6
 
     miss = fingerprint_ftp("220 Service ready.")
     assert miss.product is None and miss.confidence == 0.0


### PR DESCRIPTION
## Resumen

Cierra #368.

Un *dissector* es la pieza del motor Lybra que habla un protocolo concreto para averiguar qué producto y qué versión hay detrás de un puerto. El de FTP es el más simple de todos: el servidor manda una línea de bienvenida (el *saludo*, o *banner*) nada más aceptar la conexión, sin que haya que pedirle nada. Ahí suele venir escrito quién es.

Ese dato importa porque es el que arranca toda la cadena: producto + versión → CPE (el identificador estándar de un producto de software) → CVEs de la base de conocimiento local. Sin producto no hay CPE, y sin CPE no hay ni una vulnerabilidad reportada.

## El síntoma

En el banco de laboratorio, la familia FTP concordaba con Nmap **1,00**. Contra objetivos reales, **0,00**:

```
  emesagrupo.com     21/FTP  != propio=None None | nmap=ProFTPD None
  emesasoftware.com  21/FTP  != propio=None None | nmap=ProFTPD None
```

Nmap lee el producto del mismo saludo que Lybra recibe y tira. No es un problema de red, ni de timeout, ni de un servidor que se esconda: la información está ahí.

## La causa, y por qué el 1,00 de laboratorio no valía nada

El parser conocía dos formatos, ambos con la versión incluida:

- `220 (vsFTPd 3.0.5)` — producto y versión entre paréntesis.
- `220 ProFTPD 1.3.5 Server (Debian)` — producto y versión sueltos al principio.

Y si ninguno casaba, devolvía `(None, None)`.

El problema es que la configuración por defecto de ProFTPD en Debian **omite la versión**: saluda con `220 ProFTPD Server (Debian) [::ffff:...]`. Suprimir la versión del banner es, además, lo primero que recomienda cualquier guía de fortificación, así que no es un caso raro — es el caso normal en un servidor bien administrado. Pure-FTPd hace lo mismo por defecto.

Lo interesante es por qué el laboratorio no lo vio venir. **El banco tenía un solo servidor FTP: un vsftpd.** Y el saludo de vsftpd es exactamente el primero de los dos formatos que el parser sabía leer. Aquel 1,00 no medía la calidad del dissector: medía la coincidencia entre el dissector y el contenedor que alguien eligió para probarlo.

Es la misma trampa que la Fase 0 ya documentó dos veces (#269, #270): **una prueba escrita por quien escribió el parser demuestra que el parser es consistente consigo mismo**, no que funcione contra el mundo.

## Qué cambia

**1. Una tabla de demonios FTP conocidos** (`KNOWN_DAEMONS`), consultada *sólo* cuando ningún patrón con versión ha casado:

```python
KNOWN_DAEMONS = (
    ("microsoft ftp service", "Microsoft FTP Service"),
    ("filezilla server",      "FileZilla Server"),
    ("pure-ftpd",             "Pure-FTPd"),
    ("proftpd",               "ProFTPD"),
    ("vsftpd",                "vsFTPd"),
    ...
)
```

La clave es la aguja que se busca en el saludo, en minúsculas; el valor es el nombre canónico del producto. El orden importa donde un nombre contiene a otro: `"filezilla server"` va antes que cualquier `"filezilla"` suelto.

Conviene ser explícito sobre dónde está la línea que este PR **no** cruza. La regla del proyecto es «ningún CPE que no se haya observado de verdad», y sigue en pie: reconocer un producto **cuyo nombre está literalmente escrito en el banner** no es inventarlo. Lo que sigue prohibido es fabricar la versión que no se leyó, y por eso este camino devuelve siempre `(producto, None)`, nunca una versión adivinada.

Es una tabla y no una heurística por el mismo motivo. Un `split()` sobre la primera palabra del saludo convertiría cualquier mensaje de bienvenida personalizado —`220 Bienvenido al servidor de ficheros de la empresa`— en un producto inventado. Con la tabla, si el nombre no está escrito, no hay identificación; hay un test que lo fija.

**2. Un escalón de confianza intermedio.** `fingerprint_ftp` daba 0,9 con versión y 0,0 sin ella, sin nada en medio. Ahora un producto sin versión vale 0,6, que es el mismo escalón que `fingerprint_http` ya usaba para una cabecera `Server` sin versión.

**3. Un ProFTPD en el catálogo de laboratorio.** Esto es lo que impide que el arreglo se vuelva a comprobar contra sí mismo. Mientras el banco tenga un único servidor FTP, cualquier número que produzca la familia mide ese contenedor y no el dissector. El nuevo `proftpd_target` levanta un ProFTPD que además omite la versión, con su propio test de concordancia.

## Validación

`pytest tests/unit -k lybra` (356 pasan). `pylint` sin avisos nuevos en `ftp.py`.

Tests nuevos, uno por caso que la medición real destapó o que la tabla podría estropear:

- `test_parse_ftp_banner_debian_proftpd_without_version` — el caso medido en real. Da `("ProFTPD", None)` donde antes daba `(None, None)`.
- `test_parse_ftp_banner_versionless_pureftpd_names_the_product` — el mismo hueco en Pure-FTPd. Sustituye al test anterior, que fijaba el comportamiento viejo (`(None, None)`); el comentario explica por qué el producto sí se reconoce y la versión sigue sin fabricarse.
- `test_parse_ftp_banner_versionless_iis_names_the_product` — `220 Microsoft FTP Service`, un saludo que es sólo el nombre.
- `test_parse_ftp_banner_a_version_always_wins_over_the_name_table` — cuando el saludo trae versión, gana el patrón con versión y no la tabla.
- `test_parse_ftp_banner_unknown_daemon_is_not_guessed` — el test que sostiene todo lo demás: un saludo personalizado que no nombra ningún demonio conocido no produce producto. Sin él, la tabla sería una heurística disfrazada.

## Notas

- El `xfail(strict=True)` de `test_no_family_is_left_behind` **sigue en pie**, y a propósito. Cubre dos familias (L48-a FTP y L48-b HTTP) y sólo puede pasar a XPASS cuando las dos se cierren; HTTP es #369 y no entra aquí. Se ha actualizado su `reason` para dejar constancia de que la causa de FTP ya está corregida y de que el número sólo cambiará cuando el banco se vuelva a ejecutar contra objetivos reales.
- Los tests `oracle` (Docker) no se han ejecutado: el nuevo `proftpd_target` es una definición de contenedor que queda lista para la próxima pasada del banco.
- Este PR **no** vuelve a medir la paridad real. Corrige la causa; el número es otra ejecución del banco, no un cambio de código.