### PR TITLE
feat(themis): el fingerprint HTTP reconoce que un puerto puede tener dos capas

### DIFF
--- a/API/src/modules/features/themis/lybra/fingerprinting/dispatch.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/dispatch.py
@@ -38,11 +38,17 @@ class DissectorResult:
             todos los dissectors usaban y lo que sigue valiendo para los que
             leen una sola fuente. El de HTTP sí distingue —su versión puede
             venir de seis sitios de calidad muy distinta— y lo aprovecha (L18).
+        extra_layers: Las capas de servidor **adicionales** observadas en el
+            mismo puerto, como tuplas ``(producto, versión, rol)``. Vacía en el
+            caso normal, un elemento cuando hay un proxy inverso por delante de
+            un servidor distinto (L48-b). La primera capa no aparece aquí: ya
+            viaja en ``product``/``version``.
     """
     product: Optional[str]
     version: Optional[str]
     label: str
     qod: int = QOD_FINGERPRINT
+    extra_layers: tuple = ()
 
 
 class Dissector:

--- a/API/src/modules/features/themis/lybra/fingerprinting/http.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/http.py
@@ -767,7 +767,7 @@ def _resolve_identity(
     return product, None, 0.6, None
 
 
-def fingerprint_http(
+def fingerprint_http(  # pylint: disable=too-many-locals
     response: Response,
     favicon: Optional[bytes] = None,
     error_resp: Optional[Response] = None,
@@ -795,6 +795,11 @@ def fingerprint_http(
     Returns:
         An :class:`HttpFingerprint`.
     """
+    # Muchas variables locales, y a propósito: cada una es una lectura distinta
+    # de la misma respuesta, y sacarlas a funciones aparte obligaría a volver a
+    # pasarles la respuesta entera para no ganar nada. El trabajo pesado —la
+    # cascada y la elección— ya vive fuera, en _version_readings y
+    # _resolve_identity.
     title = _extract_title(response.body)
     evidence = _tech_evidence(response, title, error_resp)
     candidates = (_signature_hit(signature, evidence) for signature in _TECH_SIGNATURES)
@@ -811,7 +816,6 @@ def fingerprint_http(
     )
     layers = _detect_layers(response, readings, edge)
 
-    catalog_hash = favicon_hash_value(favicon) if favicon else None
     if not product:
         # Última red: el icono. Sólo se consulta cuando ninguna otra fuente ha
         # nombrado el producto — un favicon identifica producto y casi nunca
@@ -825,7 +829,8 @@ def fingerprint_http(
         product=product, version=version, title=title,
         favicon_hash=favicon_digest, technologies=technologies,
         confidence=confidence, version_source=version_source,
-        favicon_catalog_hash=catalog_hash, layers=layers,
+        favicon_catalog_hash=favicon_hash_value(favicon) if favicon else None,
+        layers=layers,
     )
 
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/http.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/http.py
@@ -69,6 +69,10 @@ class HttpFingerprint:  # pylint: disable=too-many-instance-attributes
             la convención pública), o ``None``. Es el que se busca en
             ``feeds/favicon_hashes.json``; ver ``fingerprinting/favicon.py``
             para por qué se guardan los dos.
+        layers: Todas las capas de servidor observadas en el puerto, no sólo la
+            que ``product`` reporta (ver :class:`ServiceLayer`). Tiene una sola
+            entrada en el caso normal y dos cuando hay un proxy inverso
+            delante de un servidor distinto.
         technologies: A tuple of technology names matched by signature.
         confidence: A 0.0-1.0 self-assessed confidence in the identification.
         version_source: De qué nivel de la cascada salió la versión (uno de
@@ -86,6 +90,40 @@ class HttpFingerprint:  # pylint: disable=too-many-instance-attributes
     confidence: float
     version_source: Optional[str] = None
     favicon_catalog_hash: Optional[int] = None
+    layers: Tuple[ServiceLayer, ...] = ()
+
+
+@dataclass(frozen=True)
+class ServiceLayer:
+    """Una de las capas de software que atienden un mismo puerto.
+
+    Un servicio HTTP no es siempre **un** programa. La topología más corriente
+    que existe —un nginx haciendo de proxy inverso por delante de un Apache— son
+    dos, y el modelo anterior (``product`` + ``version``, uno y sólo uno) no
+    podía expresarlo: se quedaba con lo que dijera la cabecera ``Server``, que
+    la pone el de delante.
+
+    Eso salió caro en la medición real (L48-b): cinco servicios en tres hosts,
+    siempre el mismo patrón — Lybra decía ``nginx``, Nmap decía ``Apache
+    httpd``. **Ninguno de los dos estaba equivocado**; describían capas
+    distintas de la misma pila. Pero para resolver un CPE y correlacionar CVEs
+    la diferencia es enorme: buscar vulnerabilidades de nginx en un host cuyo
+    servidor real es Apache produce falsos negativos por un lado y falsos
+    positivos por el otro.
+
+    Attributes:
+        product: El producto de esta capa.
+        version: Su versión, si se leyó.
+        role: ``"edge"`` para lo que contesta en el puerto (lo que la cabecera
+            ``Server`` nombra) y ``"origin"`` para lo que se deduce que hay
+            detrás. Es una descripción de dónde se observó, no una jerarquía de
+            importancia: las dos capas están expuestas y las dos tienen CVEs.
+        source: El nivel de la cascada del que salió (:data:`VERSION_SOURCES`).
+    """
+    product: str
+    version: Optional[str]
+    role: str
+    source: str
 
 
 @dataclass(frozen=True)
@@ -576,6 +614,125 @@ def _version_readings(
     return [reading for reading in readings if reading is not None]
 
 
+# Productos que son servidores HTTP, no aplicaciones. Sólo entre dos de éstos
+# tiene sentido hablar de "proxy delante de un origen": un WordPress detectado
+# junto a un nginx no son dos capas de servidor, son el servidor y lo que sirve.
+_SERVER_PRODUCTS = (
+    "nginx", "apache", "apache tomcat", "tomcat", "microsoft-iis", "iis",
+    "lighttpd", "openresty", "caddy", "jetty", "gunicorn", "cherokee",
+    "litespeed", "haproxy", "varnish", "envoy", "traefik", "squid",
+)
+
+# Cabeceras cuya sola presencia delata que hay un intermediario. No identifican
+# el origen —para eso hace falta una lectura de producto— pero sí confirman que
+# la respuesta ha pasado por más de una mano, y eso decide si dos lecturas
+# distintas son "dos capas" o "una lectura equivocada".
+_PROXY_EVIDENCE_HEADERS = (
+    "via", "x-cache", "x-cache-hits", "x-varnish", "x-proxy-cache",
+    "cf-ray", "x-served-by", "x-forwarded-server", "x-backend-server",
+)
+
+
+# Los productos de la lista anterior que además se despliegan habitualmente
+# **por delante** de otro servidor. Que el borde sea uno de éstos es, por sí
+# solo, evidencia de que puede haber algo detrás.
+_PROXY_PRODUCTS = ("nginx", "haproxy", "varnish", "envoy", "traefik",
+                   "squid", "openresty", "caddy")
+
+
+def _is_known_proxy(product: Optional[str]) -> bool:
+    """Si un producto se despliega habitualmente como proxy inverso."""
+    lowered = (product or "").lower()
+    return any(proxy in lowered for proxy in _PROXY_PRODUCTS)
+
+
+def _is_server_product(product: Optional[str]) -> bool:
+    """Si un nombre de producto es un servidor HTTP y no una aplicación."""
+    lowered = (product or "").lower()
+    return any(server in lowered for server in _SERVER_PRODUCTS)
+
+
+def _same_product(first: Optional[str], second: Optional[str]) -> bool:
+    """Si dos nombres se refieren al mismo producto.
+
+    Comparación por solapamiento de subcadena, igual que hace el arnés de
+    concordancia: "Apache" y "Apache Tomcat" no son lo mismo, pero "nginx" y
+    "nginx" escritos con distinta caja sí.
+    """
+    if not first or not second:
+        return False
+    first, second = first.lower(), second.lower()
+    return first in second or second in first
+
+
+def _detect_layers(
+    response: Response,
+    readings: List[VersionReading],
+    chosen: Optional[ServiceLayer],
+) -> Tuple[ServiceLayer, ...]:
+    """Reconoce las capas de servidor que atienden el puerto.
+
+    **El rol de una capa lo decide dónde se observó, no cuál gana la versión.**
+    La capa de borde es siempre la que nombra la cabecera ``Server``: es
+    literalmente quien ha escrito la respuesta. Lo que se deduce por cualquier
+    otra vía —una página de error sin personalizar, una cabecera de plataforma—
+    es el origen, aunque su lectura sea la más completa de las dos. Confundir
+    esto daría exactamente la vuelta al diagnóstico: diría que el Apache está
+    delante porque su versión se leyó mejor.
+
+    Una segunda capa se declara sólo cuando se cumplen las dos condiciones:
+
+    1. Alguna otra fuente nombra un **servidor** distinto. Una aplicación
+       identificada por firma no cuenta: un WordPress detrás de un nginx no son
+       dos capas de servidor, son el servidor y lo que sirve.
+    2. Hay evidencia de intermediario — o la cabecera ``Server`` nombra un
+       proxy conocido, o la respuesta trae alguna cabecera que sólo pone un
+       intermediario.
+
+    Sin la segunda condición esto degeneraría en declarar una capa nueva cada
+    vez que dos fuentes discrepan, que es justo el ruido que se quiere evitar.
+
+    Args:
+        response: La respuesta a ``GET /``.
+        readings: Las lecturas de la cascada.
+        chosen: La capa que ``_resolve_identity`` eligió reportar, si hay.
+
+    Returns:
+        Las capas observadas, la de borde primero. Vacía si no se identificó
+        ningún producto.
+    """
+    if chosen is None:
+        return ()
+
+    # Quien escribe la cabecera ``Server`` **es** el borde, se reconozca su
+    # nombre o no: un producto a medida sigue siendo lo que contesta en el
+    # puerto. La lista de servidores conocidos sólo filtra al candidato a
+    # origen, más abajo, donde sí hace falta distinguir un servidor de una
+    # aplicación.
+    edge = next(
+        (reading for reading in readings if reading.source == "server-header"),
+        None,
+    )
+    if edge is None:
+        return (chosen,)
+
+    origin = next(
+        (reading for reading in readings
+         if reading.source != "server-header"
+         and _is_server_product(reading.product)
+         and not _same_product(reading.product, edge.product)),
+        None,
+    )
+    has_proxy_header = any(response.headers.get(name) for name in _PROXY_EVIDENCE_HEADERS)
+    if origin is None or not (has_proxy_header or _is_known_proxy(edge.product)):
+        return (chosen,)
+
+    return (
+        ServiceLayer(edge.product, edge.version, "edge", edge.source),
+        ServiceLayer(origin.product, origin.version, "origin", origin.source),
+    )
+
+
 def _resolve_identity(
     readings: List[VersionReading],
     body: str,
@@ -645,9 +802,14 @@ def fingerprint_http(
     technologies = tuple(hit.name for hit in hits)
     favicon_digest = hashlib.sha256(favicon).hexdigest() if favicon else None
 
-    product, version, confidence, version_source = _resolve_identity(
-        _version_readings(response, hits, error_resp), response.body,
+    readings = _version_readings(response, hits, error_resp)
+    product, version, confidence, version_source = _resolve_identity(readings, response.body)
+
+    edge = (
+        ServiceLayer(product, version, "edge", version_source or "server-header")
+        if product else None
     )
+    layers = _detect_layers(response, readings, edge)
 
     catalog_hash = favicon_hash_value(favicon) if favicon else None
     if not product:
@@ -663,7 +825,7 @@ def fingerprint_http(
         product=product, version=version, title=title,
         favicon_hash=favicon_digest, technologies=technologies,
         confidence=confidence, version_source=version_source,
-        favicon_catalog_hash=catalog_hash,
+        favicon_catalog_hash=catalog_hash, layers=layers,
     )
 
 
@@ -721,4 +883,14 @@ class HttpDissector(Dissector):
             fingerprint.version,
             self.label,
             qod=VERSION_SOURCE_QOD.get(fingerprint.version_source or "", QOD_FINGERPRINT),
+            # Sólo las capas que product/version no está ya reportando. Cuál
+            # de las dos gana ese sitio lo decide la cascada de versión, no el
+            # rol: en la topología medida en real es el origen quien trae
+            # versión y el proxy quien no, así que la capa "sobrante" puede ser
+            # cualquiera de las dos.
+            extra_layers=tuple(
+                (layer.product, layer.version, layer.role)
+                for layer in fingerprint.layers
+                if not _same_product(layer.product, fingerprint.product)
+            ),
         )

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -30,6 +30,7 @@ from ...lybra import (
     finding_to_json,
     QOD_OPEN_PORT,
     default_dissectors,
+    DissectorResult,
     HostRateLimiter,
     kb_feed_version,
     load_checks,
@@ -444,11 +445,35 @@ class LybraEngineManager(ScanManager):
                 continue
 
             findings.append(self._fingerprint_finding(service, result))
+            findings.extend(self._layer_findings(service, result))
             if result.product and result.version:
                 service = replace(service, product=result.product, version=result.version)
             updated.append(service)
 
         return updated, findings
+
+    @classmethod
+    def _layer_findings(cls, service, result) -> list:
+        """Un hallazgo informativo por cada capa de servidor adicional (L48-b).
+
+        Un puerto HTTP no siempre lo atiende **un** programa: la topología más
+        corriente que existe —un nginx de proxy inverso por delante de un
+        Apache— son dos, y hasta ahora el motor sólo podía reportar uno. La
+        medición real lo destapó: cinco servicios en tres hosts donde Lybra
+        decía ``nginx`` y Nmap decía ``Apache httpd``, sin que ninguno de los
+        dos estuviera equivocado.
+
+        Reportar las dos capas es la respuesta honesta. Las dos están expuestas
+        y las dos tienen CVEs; elegir una en silencio produce falsos negativos
+        por un lado y falsos positivos por el otro.
+        """
+        return [
+            cls._fingerprint_finding(
+                service,
+                DissectorResult(product, version, f"{result.label} {role}", qod=result.qod),
+            )
+            for product, version, role in getattr(result, "extra_layers", ())
+        ]
 
     @staticmethod
     def _fingerprint_finding(service, result) -> dict:

--- a/API/tests/oracle/_concordance.py
+++ b/API/tests/oracle/_concordance.py
@@ -69,12 +69,56 @@ def agrees_with_nmap(
     """
     if not product or not nmap_product:
         return False
-    p, np = product.lower(), nmap_product.lower()
-    if p not in np and np not in p:
+    if not _products_agree(product, nmap_product):
         return False
     if version and nmap_version and not _versions_agree(version, nmap_version):
         return False
     return True
+
+
+def _products_agree(product: str, nmap_product: str) -> bool:
+    """Return whether two product names refer to the same software."""
+    product, nmap_product = product.lower(), nmap_product.lower()
+    return product in nmap_product or nmap_product in product
+
+
+def agrees_with_nmap_across_layers(
+    layers: Iterable[Tuple[Optional[str], Optional[str]]],
+    nmap_product: Optional[str], nmap_version: Optional[str],
+) -> bool:
+    """Decide whether **any** layer of our reading agrees with Nmap's.
+
+    Esta variante existe por un desacuerdo que resultó no serlo (L48-b). Contra
+    objetivos reales, cinco servicios en tres hosts daban siempre el mismo
+    patrón: Lybra decía ``nginx``, Nmap decía ``Apache httpd``. La lectura más
+    probable —y la que el catálogo de laboratorio ahora reproduce— es un nginx
+    haciendo de proxy inverso por delante de un Apache.
+
+    **Ninguna de las dos herramientas estaba equivocada.** Describían capas
+    distintas de la misma pila: Lybra leía la cabecera ``Server``, que la pone
+    el de delante; Nmap, con sus sondas adicionales, llegaba al de detrás.
+    Contarlo como fallo medía qué capa mira cada herramienta, no si el motor
+    identifica bien.
+
+    Ésta es la justificación escrita que el criterio de cierre del issue pide
+    para ajustar la métrica. Y el ajuste es acotado a propósito: **no** basta
+    con que una capa coincida en nombre si su versión contradice a la de Nmap,
+    porque entonces sí hay un desacuerdo real; y una capa sólo cuenta si Lybra
+    la observó de verdad, no si la lista se rellena por si acaso.
+
+    Args:
+        layers: Los pares ``(producto, versión)`` de cada capa que Lybra
+            identificó en el servicio, de borde a origen.
+        nmap_product: El producto que Nmap reporta para el mismo servicio.
+        nmap_version: Su versión.
+
+    Returns:
+        ``True`` si alguna capa concuerda con la lectura de Nmap.
+    """
+    return any(
+        agrees_with_nmap(product, version, nmap_product, nmap_version)
+        for product, version in layers
+    )
 
 
 def concordance_rate(pairs: Iterable[Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]]) -> float:

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -80,7 +80,7 @@ _HOST = "127.0.0.1"
 # qué dissector se elige ni qué lee.
 _PORTS = {
     "ftp": 12121, "proftpd": 12122, "smtp": 12525, "mysql": 13306, "smb": 14445,
-    "vnc": 15900, "snmp": 16161, "redis": 16379,
+    "vnc": 15900, "snmp": 16161, "redis": 16379, "reverse-proxy": 18080,
 }
 
 
@@ -95,6 +95,32 @@ class Target:
 
 def _docker(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run([_DOCKER, *args], capture_output=True, text=True, timeout=120, check=True)
+
+
+CRLF = bytes((13, 10))
+
+
+def _wait_for_http(port: int, timeout: float = 240.0) -> None:
+    """Esperar a que un puerto conteste a un ``GET /`` con una línea de estado.
+
+    HTTP no manda saludo: hay que preguntar. Por lo demás, el mismo cuidado que
+    :func:`_wait_for_greeting` — el proxy de Docker acepta la conexión mucho
+    antes de que el servidor de dentro exista.
+    """
+    deadline = time.monotonic() + timeout
+    last = "sin intentos"
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((_HOST, port), timeout=3.0) as sock:
+                sock.settimeout(3.0)
+                sock.sendall(b"GET / HTTP/1.0" + CRLF + b"Host: localhost" + CRLF + CRLF)
+                if sock.recv(64).startswith(b"HTTP/"):
+                    return
+            last = "respuesta que no es HTTP"
+        except OSError as exc:
+            last = str(exc)
+        time.sleep(1.0)
+    raise TimeoutError(f"{_HOST}:{port} no contestó HTTP en {timeout}s ({last})")
 
 
 def _wait_for_greeting(port: int, expect: bytes, timeout: float = 240.0) -> None:
@@ -178,13 +204,46 @@ def proftpd_target():
     port, name = _PORTS["proftpd"], "lybra-concordance-proftpd"
     _start(name, port, 21, "alpine:latest", "sh", "-c",
            "apk add --no-cache proftpd >/dev/null 2>&1 && "
-           "printf '%s\n' 'ServerName \"lybra\"' 'ServerType standalone' "
+           "printf '%s\\n' 'ServerName \"lybra\"' 'ServerType standalone' "
            "'Port 21' 'User proftpd' 'Group proftpd' "
            "> /etc/proftpd/proftpd.conf && "
            "proftpd --nodaemon --config /etc/proftpd/proftpd.conf")
     try:
         _wait_for_greeting(port, b"220")
         yield Target("proftpd", port, "ftp")
+    finally:
+        docker_rm(_DOCKER, name)
+
+
+@pytest.fixture(scope="module")
+def reverse_proxy_target():
+    """Un nginx de proxy inverso por delante de un Apache (L48-b).
+
+    Todos los demás objetivos HTTP del catálogo son **servidores pelados**: la
+    cabecera ``Server`` y el servidor real son la misma cosa, así que leerla
+    acierta siempre y la familia HTTP concordaba 1,00. En producción casi nada
+    está pelado, y contra objetivos reales la misma familia bajó a 0,08.
+
+    Este objetivo es esa brecha metida en el banco: nginx contesta en el puerto
+    y firma la respuesta, Apache atiende por detrás y firma su página de error.
+    Un fingerprint correcto tiene que ver **las dos** capas.
+
+    Se levanta con una sola imagen de Alpine que arranca los dos servidores
+    para no depender de una red de contenedores: el Apache escucha en el 8081
+    interno y el nginx en el 80, pasándole todo.
+    """
+    port, name = _PORTS["reverse-proxy"], "lybra-concordance-reverse-proxy"
+    _start(name, port, 80, "alpine:latest", "sh", "-c",
+           "apk add --no-cache apache2 nginx >/dev/null 2>&1 && "
+           "sed -i 's/^Listen 80$/Listen 8081/' /etc/apache2/httpd.conf && "
+           "httpd && "
+           "printf '%s\\n' 'events {}' 'http { server { listen 80; "
+           "location / { proxy_pass http://127.0.0.1:8081; } } }' "
+           "> /etc/nginx/nginx.conf && "
+           "nginx -g 'daemon off;'")
+    try:
+        _wait_for_http(port)
+        yield Target("http-proxied", port, "http")
     finally:
         docker_rm(_DOCKER, name)
 

--- a/API/tests/unit/test_lybra_fingerprint.py
+++ b/API/tests/unit/test_lybra_fingerprint.py
@@ -346,6 +346,112 @@ def test_every_declared_version_source_has_a_confidence_and_a_qod():
     assert set(VERSION_SOURCES) == set(VERSION_SOURCE_QOD)
 
 
+# ============================ capas de servidor: proxy y origen (L48-b)
+#
+# Contra objetivos reales, cinco servicios en tres hosts daban siempre el mismo
+# patrón: Lybra decía `nginx`, Nmap decía `Apache httpd`. Ninguno de los dos
+# estaba equivocado — describían capas distintas de la misma pila, y el modelo
+# de un solo `product` no podía expresarlo.
+
+_APACHE_ERROR_PAGE = "<address>Apache/2.4.57 (Debian) Server at x Port 80</address>"
+
+
+def test_a_plain_server_reports_a_single_layer():
+    """El caso normal no cambia: un servidor pelado es una sola capa."""
+    fp = fingerprint_http(Response(200, "<html></html>", {"server": "Apache/2.4.57"}))
+    assert len(fp.layers) == 1
+    assert (fp.layers[0].product, fp.layers[0].role) == ("Apache", "edge")
+
+
+def test_a_reverse_proxy_in_front_of_a_different_server_reports_two_layers():
+    home = Response(200, "<html>Hola</html>", {"server": "nginx"})
+    error = Response(404, _APACHE_ERROR_PAGE, {})
+    fp = fingerprint_http(home, error_resp=error)
+    assert [(layer.product, layer.role) for layer in fp.layers] == [
+        ("nginx", "edge"), ("Apache", "origin"),
+    ]
+
+
+def test_the_edge_is_whoever_wrote_the_server_header_not_whoever_had_a_version():
+    """El error que este modelo podría cometer y no comete.
+
+    En la topología medida, es el **origen** quien trae versión (la firma de su
+    página de error) y el proxy quien no. Si el rol se decidiera por quién gana
+    la cascada de versión, el diagnóstico saldría del revés: diría que el
+    Apache está delante porque su versión se leyó mejor.
+    """
+    home = Response(200, "<html>Hola</html>", {"server": "nginx"})
+    error = Response(404, _APACHE_ERROR_PAGE, {})
+    fp = fingerprint_http(home, error_resp=error)
+    assert fp.layers[0].product == "nginx" and fp.layers[0].version is None
+    assert fp.layers[1].product == "Apache" and fp.layers[1].version == "2.4.57"
+
+
+def test_a_proxy_header_is_enough_evidence_even_without_a_known_proxy_name():
+    home = Response(200, "<html>Hola</html>",
+                    {"server": "Bespoke-Server", "via": "1.1 varnish"})
+    error = Response(404, _APACHE_ERROR_PAGE, {})
+    fp = fingerprint_http(home, error_resp=error)
+    assert [layer.role for layer in fp.layers] == ["edge", "origin"]
+
+
+def test_an_application_behind_a_server_is_not_a_second_server_layer():
+    """La condición que evita el ruido: un WordPress detrás de un nginx no son
+    dos capas de servidor, son el servidor y lo que sirve."""
+    body = ('<html><head><meta name="generator" content="WordPress 6.4.2" /></head>'
+            "<body>wp-content</body></html>")
+    fp = fingerprint_http(Response(200, body, {"server": "nginx/1.24.0"}))
+    assert len(fp.layers) == 1
+    assert fp.layers[0].product == "nginx"
+    assert "WordPress" in fp.technologies
+
+
+def test_two_readings_of_the_same_server_are_one_layer():
+    home = Response(200, "<html></html>", {"server": "nginx/1.24.0"})
+    error = Response(404, "<center>nginx/1.24.0</center>", {})
+    fp = fingerprint_http(home, error_resp=error)
+    assert len(fp.layers) == 1
+
+
+def test_the_dissector_reports_the_layer_that_product_is_not_carrying():
+    """`product`/`version` sólo tiene sitio para una capa; la otra viaja aparte
+    para que el hallazgo la muestre y sus CVEs se busquen."""
+    class _Probe:
+        def fetch(self, host, port, method, path):
+            if "nonexistent" in path:
+                return Response(404, _APACHE_ERROR_PAGE, {})
+            return Response(200, "<html>Hola</html>", {"server": "nginx", "via": "1.1 v"})
+
+        def fetch_bytes(self, host, port, path):
+            return None
+
+    class _NullLimiter:
+        def acquire(self, host):
+            pass
+
+    from src.modules.features.themis.lybra.fingerprinting.http import HttpDissector
+
+    result = HttpDissector(probe=_Probe()).probe(
+        "10.0.0.5", Service(80, "tcp", "http"), _NullLimiter())
+    assert (result.product, result.version) == ("Apache", "2.4.57")
+    assert result.extra_layers == (("nginx", None, "edge"),)
+
+
+def test_the_manager_emits_one_finding_per_extra_layer():
+    service = Service(port=80, protocol="tcp", name="http", product="", version="")
+    result = DissectorResult("Apache", "2.4.57", "HTTP", qod=60,
+                             extra_layers=(("nginx", None, "edge"),))
+    findings = LybraEngineManager._layer_findings(service, result)
+    assert len(findings) == 1
+    assert findings[0]["title"] == "Fingerprint propio (HTTP edge): nginx"
+
+
+def test_a_single_layer_result_emits_no_extra_findings():
+    service = Service(port=80, protocol="tcp", name="http", product="", version="")
+    result = DissectorResult("Apache", "2.4.57", "HTTP")
+    assert LybraEngineManager._layer_findings(service, result) == []
+
+
 # ================================================================ SSH banner
 
 @pytest.mark.parametrize("banner,product,version", [


### PR DESCRIPTION
## Resumen

Cierra #369.

Contra objetivos reales, el dissector HTTP y Nmap identificaban **productos distintos en el mismo puerto**, de forma sistemática y reproducible:

```
  emesa.com          80/HTTP  != propio=nginx None | nmap=Apache httpd None
  emesagrupo.com     80/HTTP  != propio=nginx None | nmap=Apache httpd None
  emesagrupo.com    443/HTTP  != propio=nginx None | nmap=Apache httpd None
  emesasoftware.com  80/HTTP  != propio=nginx None | nmap=Apache httpd None
  emesasoftware.com 443/HTTP  != propio=nginx None | nmap=Apache httpd None
```

Cinco servicios, tres hosts, siempre el mismo patrón.

## Lo interesante: ninguno de los dos estaba equivocado

La lectura más probable es un **nginx haciendo de proxy inverso por delante de un Apache**, una topología completamente corriente. Lybra lee la cabecera `Server` de la respuesta —que la pone el proxy— y Nmap, con sus firmas y sus sondas adicionales, llega a identificar el servidor de detrás.

Los dos describen la pila correctamente; describen **capas distintas** de ella. El problema no es que uno mienta, es que el modelo del motor no podía expresar que hubiera dos.

Y para lo que el motor tiene que hacer después la diferencia es enorme. `product` + `version` alimentan la resolución de un CPE, y con él la correlación de CVEs: buscar vulnerabilidades de nginx en un host cuyo servidor real es Apache produce **falsos negativos por un lado y falsos positivos por el otro**.

### Lo que este caso enseña sobre el laboratorio

En el banco, la familia HTTP concordaba **1,00**. Ahí los contenedores son un nginx pelado o un Apache pelado: **no hay nada delante**. La cabecera `Server` y el servidor real son la misma cosa, así que leerla acierta siempre.

En producción casi nada está pelado. La brecha laboratorio/real que el §9 declaraba no negociable queda aquí cuantificada: **1,00 en laboratorio → 0,08 en real** para la misma familia. Y no se descubrió razonando sobre el código, sino apuntando el motor a un servidor de verdad.

## Qué cambia

### 1. `HttpFingerprint` gana `layers`

Un `ServiceLayer` por capa de servidor observada, con producto, versión, rol y la fuente de la cascada de la que salió. Tiene **una sola entrada en el caso normal** —un servidor pelado sigue siendo un servidor pelado— y dos cuando hay un proxy delante de un servidor distinto.

### 2. El rol lo decide dónde se observó, no quién ganó la versión

Ésta es la decisión de diseño que más fácil habría sido equivocar, y merece explicarse.

El borde es **siempre** quien escribe la cabecera `Server`: es literalmente quien ha redactado la respuesta. Lo que se deduce por cualquier otra vía —la firma de una página de error sin personalizar, una cabecera de plataforma— es el origen.

Lo tentador sería decidirlo por la lectura más completa, y saldría al revés. En la topología que se midió es **el origen quien trae versión** (el Apache firma su página de error con `Apache/2.4.57`) y el proxy quien no (`Server: nginx`, a secas). Un rol asignado por calidad de lectura diría que el Apache está delante porque su versión se leyó mejor. Hay un test dedicado a fijar esto.

### 3. Dos condiciones para declarar una segunda capa

Sin ellas, esto degeneraría en declarar una capa nueva cada vez que dos fuentes de la cascada discrepan — justo el ruido que se quiere evitar:

1. **Otra fuente nombra un servidor distinto.** Una aplicación identificada por firma no cuenta: un WordPress detrás de un nginx no son dos capas de servidor, son el servidor y lo que sirve.
2. **Hay evidencia de intermediario.** O la cabecera `Server` nombra un proxy conocido (nginx, HAProxy, Varnish, Envoy, Traefik, Squid...), o la respuesta trae alguna cabecera que sólo pone un intermediario (`Via`, `X-Cache`, `X-Varnish`, `CF-Ray`, `X-Served-By`...).

Un `Server` con un nombre que no reconocemos **sí** cuenta como borde: un servidor a medida sigue siendo lo que contesta en el puerto. La lista de servidores conocidos filtra al candidato a origen, no al borde.

### 4. La segunda capa llega al informe

`DissectorResult` gana `extra_layers`, y el manager emite un hallazgo informativo por cada una. Las dos capas están expuestas y las dos tienen CVEs; elegir una en silencio es lo que producía el problema.

`product`/`version` sigue teniendo sitio para una sola, y cuál se queda ahí lo decide la cascada de versión, no el rol — de nuevo porque en la topología real es el origen quien trae versión. En los casos medidos eso significa que Lybra pasa a reportar `Apache 2.4.57` donde antes reportaba `nginx` sin versión, que es a la vez lo que Nmap dice y lo que sirve para buscar CVEs.

### 5. La métrica de concordancia entiende pilas de varias capas

Es la segunda mitad del criterio de cierre del issue: *«o —si se decide que informar del proxy es la respuesta correcta— la métrica de concordancia se ajusta con una justificación escrita de por qué la lectura de Lybra no es un desacuerdo»*.

`agrees_with_nmap_across_layers` cuenta como acuerdo que **alguna** capa de Lybra case con la lectura de Nmap, y su docstring lleva escrita la justificación: contar como fallo un desacuerdo entre capas medía qué capa mira cada herramienta, no si el motor identifica bien.

El ajuste es acotado a propósito, y conviene decir qué **no** relaja: no basta con coincidir en nombre si la versión contradice a la de Nmap —ahí sí hay desacuerdo real—, y una capa sólo cuenta si Lybra la observó, no si la lista se rellena por si acaso.

### 6. Un objetivo con proxy inverso en el catálogo de laboratorio

`reverse_proxy_target`: nginx contestando en el puerto y firmando la respuesta, Apache atendiendo por detrás y firmando su página de error. Sin él, la familia HTTP seguiría midiéndose sólo contra servidores pelados y este arreglo no tendría contra qué comprobarse.

## Validación

`pytest tests/unit tests/integration -k "lybra or themis"` (579 pasan). `pylint` en 10,00/10 sobre `http.py`.

Nueve tests nuevos. Los tres que sostienen el diseño:

- `test_the_edge_is_whoever_wrote_the_server_header_not_whoever_had_a_version` — el error que el modelo podría cometer y no comete.
- `test_an_application_behind_a_server_is_not_a_second_server_layer` — la condición que evita el ruido, con el caso WordPress-tras-nginx.
- `test_a_plain_server_reports_a_single_layer` — el caso normal no cambia.

Más: dos lecturas del mismo servidor son una capa; una cabecera de proxy basta como evidencia aunque el nombre del borde no se reconozca; el dissector reporta la capa que `product` no lleva; el manager emite un hallazgo por capa adicional y ninguno cuando sólo hay una.

## Notas

- **Arreglo colateral**: la fixture `proftpd_target` que entró en #375 tenía un `\n` sin escapar en el comando del contenedor, lo que metía un salto de línea real en el `printf` del `sh -c` y habría roto el arranque. Se corrige aquí (un carácter) porque es el fichero que este PR ya está tocando. Es un test `oracle`, así que nunca llegó a ejecutarse en CI.
- Los tests `oracle` no se han ejecutado: `reverse_proxy_target` queda listo para la próxima pasada del banco, y el número real sólo cambia cuando el banco de paridad se vuelva a ejecutar contra objetivos reales.
- Con esto quedan cerradas las dos familias del `xfail(strict=True)` de `test_no_family_is_left_behind` (L48-a en #375, L48-b aquí). El marcador **no** se quita en este PR: sólo puede pasar a XPASS con una medición real nueva, y quitarlo antes sería afirmar un número que nadie ha medido.
