### PR TITLE
feat(themis): las APIs de administración sin autenticar pasan de informativo a CRITICAL

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-6"
+CHECKS_FEED_VERSION = "lybra-checks-7"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -93,10 +93,38 @@ _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
 # misma enfermedad —decidir por número de puerto— desde el otro lado.
 _TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986}
 
+# APIs de administración que hablan HTTP y publican su versión en un JSON sin
+# autenticar (L17). Cada familia tiene su propio predicado —y no uno común—
+# porque el runtime de checks selecciona los servicios por ese nombre: con un
+# único ``admin_api``, el check de Docker se ejecutaría también contra el 9200
+# de Elasticsearch, seis peticiones donde basta una.
+_DOCKER_SERVICE_NAMES = {"docker"}
+_DOCKER_PORTS = {2375, 2376}
+_ELASTICSEARCH_SERVICE_NAMES = {"elasticsearch"}
+_ELASTICSEARCH_PORTS = {9200}
+_KIBANA_SERVICE_NAMES = {"kibana"}
+_KIBANA_PORTS = {5601}
+_KUBERNETES_SERVICE_NAMES = {"kubernetes", "kube-apiserver"}
+_KUBERNETES_PORTS = {6443}
+_ETCD_SERVICE_NAMES = {"etcd"}
+_ETCD_PORTS = {2379}
+_CONSUL_SERVICE_NAMES = {"consul"}
+_CONSUL_PORTS = {8500}
+
+# La unión, para lo que sí es común: decidir si un puerto pertenece a esta
+# familia y, con ello, que entre en el conjunto HTTP.
+_ADMIN_API_PORTS = (
+    _DOCKER_PORTS | _ELASTICSEARCH_PORTS | _KIBANA_PORTS
+    | _KUBERNETES_PORTS | _ETCD_PORTS | _CONSUL_PORTS
+)
+
 # Puertos que se consideran servicio HTTP. Incluye los de TLS: un HTTPS en 9443
 # tampoco entraba por esta puerta, así que ampliar sólo la lista de TLS no
-# habría servido de nada.
-_HTTP_PORTS = {80, 8080, 8000, 8888, 8008} | _TLS_HYGIENE_PORTS
+# habría servido de nada. Y los de las APIs de administración: hablan HTTP, y
+# excluirlos dejaba fuera tanto los checks de exposición como los de higiene de
+# certificado sobre servicios que son de los más graves que se pueden encontrar
+# expuestos (L17).
+_HTTP_PORTS = {80, 8080, 8000, 8888, 8008} | _TLS_HYGIENE_PORTS | _ADMIN_API_PORTS
 # Service names and ports for FTP — Fase N's first ``type: "network"`` family.
 _FTP_SERVICE_NAMES = {"ftp"}
 _FTP_PORTS = {21}
@@ -476,6 +504,12 @@ CHECK_MODES = ("safe", "aggressive")
 # conoce.
 CHECK_CATEGORIES = (
     "exposed_path",
+    # Un servicio entero alcanzable sin credenciales, no un fichero suelto que
+    # se coló bajo la raíz web (L17). La distinción no es cosmética: un
+    # `exposed_path` es un descuido del despliegue, y un `exposed_service` es
+    # el propio servicio ofreciéndose sin puerta — una API de Docker en claro
+    # es ejecución remota de código como root sin exploit ninguno.
+    "exposed_service",
     "default_credentials",
     "security_header",
     "network_config",
@@ -683,6 +717,48 @@ def is_snmp_service(service: Service) -> bool:
     if (service.protocol or "tcp").lower() != "udp":
         return False
     return (service.name or "").lower() in _SNMP_SERVICE_NAMES or service.port in _SNMP_PORTS
+
+
+def is_admin_api_service(service: Service) -> bool:
+    """Si el servicio es una de las APIs de administración de :mod:`http_apis`.
+
+    Decide qué puertos reclama ``AdminApiDissector``. No es un predicado de
+    check —para eso están los seis de abajo, uno por producto— sino el que
+    separa esta familia de la sonda HTTP genérica.
+    """
+    return service.port in _ADMIN_API_PORTS
+
+
+def is_docker_service(service: Service) -> bool:
+    """Si el servicio es la API de Docker (2375 en claro, 2376 con TLS)."""
+    return (service.name or "").lower() in _DOCKER_SERVICE_NAMES or service.port in _DOCKER_PORTS
+
+
+def is_elasticsearch_service(service: Service) -> bool:
+    """Si el servicio es la API REST de Elasticsearch."""
+    return ((service.name or "").lower() in _ELASTICSEARCH_SERVICE_NAMES
+            or service.port in _ELASTICSEARCH_PORTS)
+
+
+def is_kibana_service(service: Service) -> bool:
+    """Si el servicio es Kibana."""
+    return (service.name or "").lower() in _KIBANA_SERVICE_NAMES or service.port in _KIBANA_PORTS
+
+
+def is_kubernetes_service(service: Service) -> bool:
+    """Si el servicio es el servidor de API de Kubernetes."""
+    return ((service.name or "").lower() in _KUBERNETES_SERVICE_NAMES
+            or service.port in _KUBERNETES_PORTS)
+
+
+def is_etcd_service(service: Service) -> bool:
+    """Si el servicio es etcd."""
+    return (service.name or "").lower() in _ETCD_SERVICE_NAMES or service.port in _ETCD_PORTS
+
+
+def is_consul_service(service: Service) -> bool:
+    """Si el servicio es el agente de Consul."""
+    return (service.name or "").lower() in _CONSUL_SERVICE_NAMES or service.port in _CONSUL_PORTS
 
 
 def _network_service_matchers() -> Dict[str, Callable[[Service], bool]]:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-6
+feedVersion: lybra-checks-7
 checks:
   - id: git-config-exposure
     version: 1
@@ -367,6 +367,88 @@ checks:
     mode: safe
     finding:
       title: 'SMB: firma de mensajes no requerida'
+      qod: 99
+      confirmed: true
+  # ------------------------------------------------------------------
+  # APIs de administracion expuestas sin autenticar (L17).
+  #
+  # Los tres checks de aqui abajo comparten una forma y una razon. La forma:
+  # un GET sin credenciales que exige un 200 con contenido reconocible del
+  # producto. La razon: en estos tres servicios, que la peticion conteste
+  # **es** el hallazgo, y de los graves.
+  #
+  # El 200 no es un adorno del matcher, es la mitad del check. Un 401 o un 403
+  # significan que el servicio esta ahi y pide credenciales — que es como debe
+  # estar — y por eso no producen hallazgo ninguno.
+  - id: docker-api-unauthenticated
+    version: 1
+    type: http
+    category: exposed_service
+    severity: CRITICAL
+    service: docker
+    mode: safe
+    requests:
+      - method: GET
+        path: /version
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - ApiVersion
+              - GoVersion
+    finding:
+      title: API de Docker expuesta sin autenticacion (ejecucion remota de codigo como root)
+      qod: 99
+      confirmed: true
+  - id: elasticsearch-unauthenticated
+    version: 1
+    type: http
+    category: exposed_service
+    severity: CRITICAL
+    service: elasticsearch
+    mode: safe
+    requests:
+      - method: GET
+        path: /_cluster/health
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - cluster_name
+              - number_of_nodes
+    finding:
+      title: Cluster de Elasticsearch accesible sin autenticacion (lectura y borrado de todos los indices)
+      qod: 99
+      confirmed: true
+  - id: kubernetes-anonymous-api
+    version: 1
+    type: http
+    category: exposed_service
+    severity: CRITICAL
+    service: kubernetes
+    mode: safe
+    requests:
+      - method: GET
+        path: /api/v1/namespaces
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - NamespaceList
+    finding:
+      title: API de Kubernetes accesible de forma anonima (inventario y control del cluster)
       qod: 99
       confirmed: true
   - id: snmp-default-community

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -4,6 +4,13 @@ Instead of trusting ``nmap -sV`` blindly, this package identifies a service's
 product and version on its own terms. One module per protocol, chosen for the
 best value-for-effort in the roadmap:
 
+``http_apis``
+    Las APIs de administración que hablan HTTP y publican su versión en un
+    JSON sin autenticar: Docker, Elasticsearch, Kibana, Kubernetes, etcd y
+    Consul. Se importa **antes** que ``http`` porque sus puertos entran ahora
+    en la familia HTTP y el motor se queda con el primer dissector que
+    reclame el servicio (ver ``registry``).
+
 ``http``
     Una cascada de seis fuentes para producto y versión —cabecera ``Server``,
     cabeceras ``X-Powered-By``/``X-AspNet-Version``, ``<meta generator>``,
@@ -88,6 +95,12 @@ from .favicon import (
     load_favicon_hashes,
     murmurhash3_x86_32,
     validate_favicon_hashes,
+)
+from .http_apis import (
+    ADMIN_APIS,
+    AdminApi,
+    AdminApiDissector,
+    fingerprint_admin_api,
 )
 from .http import (
     HttpFingerprint,
@@ -177,6 +190,10 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "ADMIN_APIS",
+    "AdminApi",
+    "AdminApiDissector",
+    "fingerprint_admin_api",
     "banner_readers",
     "blind_probers",
     "identify_unknown_service",

--- a/API/src/modules/features/themis/lybra/fingerprinting/http_apis.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/http_apis.py
@@ -1,0 +1,177 @@
+"""APIs de administración sin autenticar — el mejor valor por coste del backlog.
+
+Hay una familia de servicios que reúne las tres propiedades que la deja en
+cabeza de cualquier lista de coste/valor: **son HTTP** (el transporte ya existe
+y funciona), **anuncian su versión en un JSON sin autenticar** (identificación
+gratis) y **su exposición es en sí misma el hallazgo más grave que un escáner
+puede dar**.
+
+- **Docker en 2375** sin TLS ni autenticación es ejecución remota de código
+  como root, sin exploit ninguno: un ``POST /containers/create`` con el sistema
+  de ficheros del host montado y ya está. Es de las cosas más graves que se
+  pueden encontrar en una red interna.
+- **Elasticsearch en 9200** sin autenticación expone —y permite borrar— todos
+  los índices. Su ``GET /`` devuelve la versión exacta.
+- **Kubernetes en 6443**, **etcd en 2379**, **Consul en 8500** y **Kibana en
+  5601** siguen el mismo patrón.
+
+Hasta L17 el motor veía ``2375/tcp abierto — docker`` (el nombre salía de
+``WELL_KNOWN_PORTS``, así que hasta lo llamaba por su nombre) y emitía un
+informativo con ``qod=30``. La información para dar un CRITICAL confirmado
+estaba a un ``GET`` de distancia y no se pedía, porque ``is_http_service``
+rechazaba esos puertos y ni el dissector HTTP ni los checks los tocaban.
+
+**Todo lo que hay aquí son lecturas puras** (``GET``), así que caben en modo
+``safe`` sin discusión. Y la versión extraída entra en la maquinaria de
+detección por versión que ya funciona, y produce sus CVEs sola: escribir
+*ojos*, no checks, que es el apalancamiento que el roadmap describe.
+
+**Una respuesta 401 o 403 no es un hallazgo, es lo contrario.** Significa que
+el servicio está ahí y que exige credenciales, que es exactamente como debe
+estar. Este módulo no identifica producto en ese caso y no emite exposición
+ninguna; los checks del feed exigen un 200 con contenido reconocible.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from ..checks import HttpProbe, Response, is_admin_api_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AdminApi:
+    """Una API de administración: dónde escucha, qué se le pide y qué se lee.
+
+    Attributes:
+        product: El nombre del producto tal y como debe llegar al hallazgo.
+        path: La ruta que se pide, siempre un ``GET`` sin efectos.
+        version_path: La ruta dentro del JSON de respuesta donde vive la
+            versión, como secuencia de claves. ``("version", "number")``
+            significa ``respuesta["version"]["number"]``.
+    """
+    product: str
+    path: str
+    version_path: Tuple[str, ...]
+
+
+# Puerto → API que se espera encontrar ahí. Una fila por producto, y **una sola
+# petición por puerto**: el mapa evita probar las seis rutas contra los seis
+# puertos, que sería multiplicar por seis el coste para no aprender nada nuevo.
+#
+# El 8080 de Kubernetes (su puerto "inseguro" histórico) queda fuera a
+# propósito: es también el puerto HTTP alternativo más común que existe, y
+# reclamarlo aquí le quitaría a la sonda HTTP genérica un puerto que casi
+# siempre es un servidor web corriente.
+ADMIN_APIS: Dict[int, AdminApi] = {
+    2375: AdminApi("Docker", "/version", ("Version",)),
+    2376: AdminApi("Docker", "/version", ("Version",)),
+    9200: AdminApi("Elasticsearch", "/", ("version", "number")),
+    5601: AdminApi("Kibana", "/api/status", ("version", "number")),
+    6443: AdminApi("Kubernetes", "/version", ("gitVersion",)),
+    2379: AdminApi("etcd", "/version", ("etcdserver",)),
+    8500: AdminApi("Consul", "/v1/agent/self", ("Config", "Version")),
+}
+
+
+def _value_at(payload: Any, path: Tuple[str, ...]) -> Optional[str]:
+    """Lee un valor anidado de un JSON ya parseado, sin reventar por el camino.
+
+    Args:
+        payload: El JSON decodificado.
+        path: Las claves a recorrer, en orden.
+
+    Returns:
+        El valor como texto, o ``None`` si la ruta no existe o no es texto.
+    """
+    for key in path:
+        if not isinstance(payload, dict):
+            return None
+        payload = payload.get(key)
+    if isinstance(payload, (str, int, float)):
+        return str(payload)
+    return None
+
+
+def _clean_version(version: Optional[str]) -> Optional[str]:
+    """Normaliza la versión que estas APIs publican.
+
+    Kubernetes la da como ``"v1.28.4"`` y etcd como ``"3.5.9"``; la ``v`` de
+    delante sobra para buscar un CPE, y dejarla haría que ``1.28.4`` y
+    ``v1.28.4`` fueran dos versiones distintas para el matcher.
+    """
+    if not version:
+        return None
+    version = version.strip()
+    if version[:1].lower() == "v" and version[1:2].isdigit():
+        version = version[1:]
+    return version or None
+
+
+def fingerprint_admin_api(port: int, response: Optional[Response]) -> Optional[DissectorResult]:
+    """Identifica una API de administración a partir de su respuesta JSON.
+
+    Args:
+        port: El puerto sondado, que decide qué API se esperaba.
+        response: La respuesta HTTP, o ``None`` si la petición falló.
+
+    Returns:
+        La identificación, o ``None`` cuando el puerto no está en el mapa, la
+        petición falló, el servicio exigió credenciales (401/403) o el cuerpo
+        no es el JSON que ese producto publica.
+    """
+    api = ADMIN_APIS.get(port)
+    if api is None or response is None:
+        return None
+    if response.status != 200:
+        # 401/403 significa "existe y pide credenciales", que es como debe
+        # estar. No es un hallazgo, y tampoco una identificación: sin cuerpo
+        # legible no se ha observado ninguna versión.
+        logger.debug("API de administración en %s contestó %s", port, response.status)
+        return None
+    try:
+        payload = json.loads(response.body or "")
+    except (ValueError, TypeError):
+        return None
+    version = _clean_version(_value_at(payload, api.version_path))
+    if version is None:
+        return None
+    return DissectorResult(api.product, version, f"{api.product} API")
+
+
+@register_dissector
+class AdminApiDissector(Dissector):
+    """Un ``GET`` sin autenticar contra la API de administración de su puerto.
+
+    Se registra **antes** que :class:`~.http.HttpDissector` a propósito: los
+    puertos de esta familia también entran ahora en ``is_http_service`` —para
+    que los checks de exposición y de higiene TLS los alcancen— y el motor se
+    queda con el primer dissector que reclame el servicio. Sin esa precedencia,
+    la sonda HTTP genérica se llevaría el 2375 y leería una cabecera ``Server``
+    en vez de la versión que el JSON publica.
+    """
+
+    label = "Admin API"
+
+    def __init__(self, probe: Optional[HttpProbe] = None) -> None:
+        self._probe = probe or HttpProbe()
+
+    def applies(self, service) -> bool:
+        return is_admin_api_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        api = ADMIN_APIS.get(service.port)
+        if api is None:
+            return None
+        rate_limiter.acquire(target)
+        response = self._probe.fetch(target, service.port, "GET", api.path)
+        if response is None:
+            return None
+        return fingerprint_admin_api(service.port, response)

--- a/API/src/modules/features/themis/lybra/fingerprinting/registry.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/registry.py
@@ -22,8 +22,17 @@ _DissectorT = TypeVar("_DissectorT", bound=Type[Dissector])
 
 # Registration order follows import order (see __init__.py), which follows
 # the roadmap's own cost/value ranking — cheapest and most common protocols
-# first. Order only matters for readability: each dissector's ``applies``
-# predicate is protocol-specific and none overlap.
+# first.
+#
+# Y desde L17 el orden **importa de verdad** para un caso concreto, no sólo
+# para la legibilidad. Los predicados dejaron de ser disjuntos cuando los
+# puertos de las APIs de administración (2375, 9200, 6443...) entraron en la
+# familia HTTP para que los checks de exposición y de higiene TLS los
+# alcanzaran: ahora los reclaman dos dissectors, y
+# ``LybraEngineManager._fingerprint_services`` se queda con el primero que
+# aplique. ``http_apis`` va antes que ``http`` justamente por eso — si no, la
+# sonda genérica se llevaría el 2375 y leería una cabecera ``Server`` en vez de
+# la versión que el JSON publica.
 _REGISTERED_DISSECTORS: List[Type[Dissector]] = []
 
 

--- a/API/src/modules/features/themis/lybra/transport.py
+++ b/API/src/modules/features/themis/lybra/transport.py
@@ -62,9 +62,11 @@ WELL_KNOWN_PORTS = {
     110: "pop3", 111: "rpcbind", 135: "msrpc", 139: "netbios-ssn", 143: "imap",
     161: "snmp", 389: "ldap", 443: "https", 445: "microsoft-ds", 465: "smtps",
     587: "submission", 631: "ipp", 993: "imaps", 995: "pop3s", 1433: "ms-sql-s",
-    1521: "oracle", 2049: "nfs", 2375: "docker", 3306: "mysql", 3389: "ms-wbt-server",
-    5432: "postgresql", 5900: "vnc", 5985: "wsman", 6379: "redis", 8080: "http-proxy",
-    8443: "https-alt", 8888: "http-alt", 9200: "elasticsearch", 27017: "mongodb",
+    1521: "oracle", 2049: "nfs", 2375: "docker", 2376: "docker-tls",
+    2379: "etcd", 3306: "mysql", 3389: "ms-wbt-server",
+    5432: "postgresql", 5601: "kibana", 5900: "vnc", 5985: "wsman",
+    6379: "redis", 6443: "kubernetes", 8080: "http-proxy", 8443: "https-alt",
+    8500: "consul", 8888: "http-alt", 9200: "elasticsearch", 27017: "mongodb",
 }
 
 # The ports swept when the caller does not specify a list: the common,
@@ -73,7 +75,7 @@ WELL_KNOWN_PORTS = {
 # this module does not implement.
 DEFAULT_PORTS: tuple = tuple(sorted(WELL_KNOWN_PORTS)) + (
     20, 69, 123, 137, 138, 512, 513, 514, 873, 1080, 1723, 2181, 3000, 3268,
-    4444, 5000, 5060, 5601, 6667, 7001, 8000, 8008, 8081, 8088, 8181, 9000,
+    4444, 5000, 5060, 6667, 7001, 8000, 8008, 8081, 8088, 8181, 9000,
     9090, 9300, 11211,
 )
 

--- a/API/tests/unit/test_lybra_admin_apis.py
+++ b/API/tests/unit/test_lybra_admin_apis.py
@@ -1,0 +1,204 @@
+"""APIs de administración expuestas sin autenticar (L17).
+
+Docker en 2375, Elasticsearch en 9200, Kubernetes en 6443: servicios que hablan
+HTTP, publican su versión en un JSON sin credenciales, y cuya sola exposición
+es el hallazgo más grave que un escáner puede dar. El motor ya escaneaba esos
+puertos y hasta los llamaba por su nombre; lo que no hacía era preguntarles
+nada.
+"""
+
+import json
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    Response,
+    is_admin_api_service,
+    is_docker_service,
+    is_http_service,
+    load_checks,
+)
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting import default_dissectors
+from src.modules.features.themis.lybra.fingerprinting.http_apis import (
+    ADMIN_APIS,
+    AdminApiDissector,
+    fingerprint_admin_api,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _json_response(payload, status=200):
+    return Response(status, json.dumps(payload), {"content-type": "application/json"})
+
+
+# ================================================= extracción de versión
+
+
+def test_docker_version_endpoint():
+    body = {"Version": "24.0.7", "ApiVersion": "1.43", "GoVersion": "go1.20.10"}
+    result = fingerprint_admin_api(2375, _json_response(body))
+    assert (result.product, result.version) == ("Docker", "24.0.7")
+
+
+def test_elasticsearch_root_endpoint():
+    body = {"name": "node-1", "cluster_name": "docker-cluster",
+            "version": {"number": "8.11.3", "build_flavor": "default"}}
+    result = fingerprint_admin_api(9200, _json_response(body))
+    assert (result.product, result.version) == ("Elasticsearch", "8.11.3")
+
+
+def test_kibana_status_endpoint():
+    body = {"name": "kibana", "version": {"number": "8.11.3", "build_number": 12345}}
+    result = fingerprint_admin_api(5601, _json_response(body))
+    assert (result.product, result.version) == ("Kibana", "8.11.3")
+
+
+def test_kubernetes_version_endpoint_drops_the_leading_v():
+    """Kubernetes publica `v1.28.4`. La `v` sobra para buscar un CPE, y dejarla
+    haría que `1.28.4` y `v1.28.4` fueran dos versiones distintas."""
+    body = {"major": "1", "minor": "28", "gitVersion": "v1.28.4",
+            "platform": "linux/amd64"}
+    result = fingerprint_admin_api(6443, _json_response(body))
+    assert (result.product, result.version) == ("Kubernetes", "1.28.4")
+
+
+def test_etcd_version_endpoint():
+    body = {"etcdserver": "3.5.9", "etcdcluster": "3.5.0"}
+    result = fingerprint_admin_api(2379, _json_response(body))
+    assert (result.product, result.version) == ("etcd", "3.5.9")
+
+
+def test_consul_agent_endpoint():
+    body = {"Config": {"Datacenter": "dc1", "Version": "1.17.1"}}
+    result = fingerprint_admin_api(8500, _json_response(body))
+    assert (result.product, result.version) == ("Consul", "1.17.1")
+
+
+# ============================================ lo que NO debe identificar
+
+
+def test_an_authenticated_api_is_not_an_identification():
+    """El caso que separa un hallazgo de un servicio bien configurado. Un 401 o
+    un 403 significan que el servicio está ahí y pide credenciales — que es
+    como debe estar — así que no hay versión observada ni exposición ninguna."""
+    for status in (401, 403):
+        body = {"message": "missing authentication credentials"}
+        assert fingerprint_admin_api(9200, _json_response(body, status)) is None
+
+
+def test_a_body_that_is_not_json_is_not_guessed():
+    assert fingerprint_admin_api(2375, Response(200, "<html>hola</html>", {})) is None
+
+
+def test_a_json_without_the_expected_field_yields_nothing():
+    assert fingerprint_admin_api(9200, _json_response({"name": "node-1"})) is None
+
+
+def test_a_failed_request_yields_nothing():
+    assert fingerprint_admin_api(2375, None) is None
+
+
+def test_a_port_outside_the_map_yields_nothing():
+    assert fingerprint_admin_api(80, _json_response({"Version": "24.0.7"})) is None
+
+
+# ============================================== selección de dissector
+
+
+def test_the_admin_ports_are_now_part_of_the_http_family():
+    """Sin esto, `is_http_service` rechazaba el 2375 y el 9200, y ni los checks
+    de exposición ni los de higiene de certificado los tocaban."""
+    for port in ADMIN_APIS:
+        assert is_http_service(Service(port, "tcp", ""))
+
+
+def test_the_admin_api_dissector_is_asked_before_the_generic_http_one():
+    """El orden del registro importa desde que los predicados se solapan: el
+    motor se queda con el primero que aplique, y si ganara la sonda HTTP
+    genérica leería una cabecera `Server` en vez de la versión del JSON."""
+    labels = [dissector.label for dissector in default_dissectors()]
+    assert labels.index("Admin API") < labels.index("HTTP")
+
+
+def test_the_dissector_only_claims_the_ports_in_its_map():
+    dissector = AdminApiDissector()
+    assert dissector.applies(Service(2375, "tcp", ""))
+    assert dissector.applies(Service(9200, "tcp", ""))
+    assert not dissector.applies(Service(80, "tcp", "http"))
+    assert not dissector.applies(Service(8080, "tcp", "http-proxy"))
+
+
+def test_kubernetes_insecure_8080_is_left_to_the_generic_http_probe():
+    """El 8080 es también el puerto HTTP alternativo más común que existe.
+    Reclamarlo aquí le quitaría a la sonda genérica un puerto que casi siempre
+    es un servidor web corriente."""
+    assert not is_admin_api_service(Service(8080, "tcp", ""))
+
+
+def test_the_dissector_asks_one_path_per_port():
+    """Un mapa puerto→API, no seis rutas contra los seis puertos."""
+    asked = []
+
+    class _Probe:
+        def fetch(self, host, port, method, path):
+            asked.append((port, path))
+            return _json_response({"Version": "24.0.7"})
+
+    class _NullLimiter:
+        def acquire(self, host):
+            pass
+
+    result = AdminApiDissector(probe=_Probe()).probe(
+        "10.0.0.5", Service(2375, "tcp", "docker"), _NullLimiter())
+    assert asked == [(2375, "/version")]
+    assert (result.product, result.version) == ("Docker", "24.0.7")
+
+
+# ================================================ los checks del feed
+
+
+@pytest.fixture(scope="module")
+def feed():
+    return {check.id: check for check in load_checks()}
+
+
+@pytest.mark.parametrize("check_id, service", [
+    ("docker-api-unauthenticated", "docker"),
+    ("elasticsearch-unauthenticated", "elasticsearch"),
+    ("kubernetes-anonymous-api", "kubernetes"),
+])
+def test_the_exposure_checks_are_critical_safe_and_service_scoped(feed, check_id, service):
+    check = feed[check_id]
+    assert check.severity == "CRITICAL"
+    assert check.mode == "safe"          # todo son GET, lecturas puras
+    assert check.service == service      # una petición por producto, no seis
+    assert check.category == "exposed_service"
+
+
+@pytest.mark.parametrize("check_id", [
+    "docker-api-unauthenticated",
+    "elasticsearch-unauthenticated",
+    "kubernetes-anonymous-api",
+])
+def test_the_exposure_checks_require_a_200_so_a_401_never_fires(feed, check_id):
+    """La mitad del check que evita el falso positivo: sin exigir 200, un 401
+    con un cuerpo JSON que mencionara el producto dispararía un CRITICAL contra
+    un servicio correctamente autenticado."""
+    request = feed[check_id].requests[0]
+    status_matchers = [m for m in request.matchers if m.type == "status"]
+    assert status_matchers, f"{check_id} no exige código de estado"
+    assert all(200 in m.values for m in status_matchers)
+    assert request.method == "GET"
+
+
+def test_every_admin_api_has_a_service_predicate():
+    """Un check declara su protocolo como cadena y el runtime necesita el
+    predicado que decide si un servicio descubierto *es* ese protocolo. El mapa
+    se deriva de los nombres de función, así que basta con definirlas."""
+    from src.modules.features.themis.lybra.checks import _NETWORK_SERVICE_MATCHERS
+
+    assert {"docker", "elasticsearch", "kibana",
+            "kubernetes", "etcd", "consul"} <= set(_NETWORK_SERVICE_MATCHERS)
+    assert is_docker_service(Service(2375, "tcp", ""))


### PR DESCRIPTION
## Resumen

Cierra #281, que el propio epic señala como **el mejor valor por coste de todo el backlog**.

## Por qué esta familia va la primera

Hay un grupo de servicios que reúne tres propiedades a la vez, y esa combinación es lo que lo pone en cabeza de cualquier lista de coste/valor:

1. **Hablan HTTP.** El transporte ya existe, funciona y está probado. No hace falta ni un byte de protocolo nuevo.
2. **Publican su versión en un JSON sin autenticar.** Identificación gratis, con un `GET`.
3. **Su exposición es en sí misma el hallazgo más grave que un escáner puede dar.**

El tercer punto merece concretarse, porque no es retórica:

- **Docker en 2375** sin TLS ni autenticación es **ejecución remota de código como root, sin exploit ninguno**. Un `POST /containers/create` con el sistema de ficheros del host montado y ya está. Es de las cosas más graves que se pueden encontrar en una red interna.
- **Elasticsearch en 9200** sin autenticación permite leer y borrar todos los índices.
- **Kubernetes en 6443** con acceso anónimo entrega el inventario y el control del clúster.

## Lo que pasaba hasta ahora

El motor **ya escaneaba esos puertos y hasta los llamaba por su nombre**: `WELL_KNOWN_PORTS` incluía `2375: "docker"` y `9200: "elasticsearch"`. Un escaneo producía `Puerto 2375/tcp abierto — docker`, categoría `open_port`, `qod=30`, y ahí se acababa.

El motivo es una lista de siete números:

```python
_HTTP_PORTS = {80, 443, 8080, 8443, 8000, 8888, 8008}
```

`is_http_service` rechazaba el 2375 y el 9200, así que ni el dissector HTTP ni ningún check los tocaban. La información para dar un CRITICAL confirmado estaba a un `GET` de distancia y no se pedía.

## Qué cambia

### 1. Un dissector con un mapa puerto → API

`fingerprinting/http_apis.py`. Una fila por producto, y **una sola petición por puerto**:

| Puerto | Producto | Sonda | Campo del JSON |
|---|---|---|---|
| 2375, 2376 | Docker | `GET /version` | `Version` |
| 9200 | Elasticsearch | `GET /` | `version.number` |
| 5601 | Kibana | `GET /api/status` | `version.number` |
| 6443 | Kubernetes | `GET /version` | `gitVersion` |
| 2379 | etcd | `GET /version` | `etcdserver` |
| 8500 | Consul | `GET /v1/agent/self` | `Config.Version` |

El mapa evita probar las seis rutas contra los seis puertos, que sería multiplicar por seis el coste para no aprender nada nuevo.

**Todo son `GET`**, lecturas puras, así que caben en modo `safe` sin discusión. Y la versión extraída entra en la maquinaria de detección por versión que ya funciona y produce sus CVEs sola: escribir *ojos*, no checks, que es el apalancamiento que el roadmap describe.

Un detalle pequeño con consecuencias: Kubernetes publica `v1.28.4` y la `v` de delante se recorta. Dejarla haría que `1.28.4` y `v1.28.4` fueran dos versiones distintas para el matcher de CPE, y una de las dos no encontraría nada.

### 2. Un 401 no es un hallazgo: es lo contrario

Ésta es la mitad del trabajo que separa un escáner útil de uno que grita.

Una respuesta 401 o 403 significa que el servicio **está ahí y exige credenciales**, que es exactamente como debe estar. Así que:

- El dissector **no identifica producto** en ese caso: sin cuerpo legible no se ha observado ninguna versión, y no se va a inventar.
- Los checks del feed **exigen un 200** además del contenido reconocible. Sin ese requisito, un 401 cuyo cuerpo JSON mencionara el producto dispararía un CRITICAL contra un servicio correctamente configurado. Hay un test parametrizado que lo fija para los tres checks.

### 3. Los puertos entran en la familia HTTP, y eso hace que el orden importe

Añadir estos puertos a `_HTTP_PORTS` es necesario para que los checks de exposición y los de higiene de certificado los alcancen. Pero tiene un efecto de segundo orden que hay que nombrar: **los predicados de aplicabilidad dejaron de ser disjuntos**.

El comentario del registro decía, hasta ahora, que el orden sólo importaba para la legibilidad porque *«each dissector's applies predicate is protocol-specific and none overlap»*. Ya no es cierto: el 2375 lo reclaman dos dissectors, y `_fingerprint_services` se queda con el primero que aplique.

Por eso `http_apis` se importa **antes** que `http` — sin esa precedencia, la sonda HTTP genérica se llevaría el 2375 y leería una cabecera `Server` en vez de la versión que el JSON publica. El comentario del registro se ha actualizado para decirlo, y hay un test que fija la precedencia.

**El 8080 de Kubernetes queda fuera a propósito.** Es su puerto «inseguro» histórico, pero también el puerto HTTP alternativo más común que existe; reclamarlo aquí le quitaría a la sonda genérica un puerto que casi siempre es un servidor web corriente. Hay un test que documenta la decisión.

### 4. Un predicado por producto, no uno común

Los seis productos tienen su propio `is_*_service`, y no comparten un único `admin_api`. La razón es concreta: el runtime de checks selecciona los servicios por ese nombre, así que con un predicado común el check de Docker se ejecutaría también contra el 9200 de Elasticsearch — seis peticiones donde basta una.

El mapa `service` → predicado se deriva de los nombres de función (el arreglo de #272), así que definirlas es todo lo que hace falta para que `service: docker` funcione en el feed.

### 5. Una categoría de hallazgo nueva

`exposed_service`, junto a `exposed_path`. La distinción no es cosmética: un `exposed_path` es un descuido del despliegue —un `.git/config` que se coló bajo la raíz web—, y un `exposed_service` es el propio servicio ofreciéndose sin puerta.

Vale la pena señalar que **el validador del feed detectó la categoría nueva antes que ningún humano**: al añadir los checks, `validate_checks` los rechazó por categoría desconocida. Es exactamente el fallo silencioso que #L27 existía para convertir en fallo de CI — un hallazgo bajo una familia que ningún filtro conoce.

`feedVersion` sube a `lybra-checks-7`: el feed gana una familia nueva.

## Validación

`pytest tests/unit` completa: **0 fallos**. Los tests de integración de Lybra y Themis, también. `pylint` en 10,00/10 sobre `http_apis.py`, y sin avisos nuevos en `checks.py` respecto a la línea base (29 antes, 29 después).

`tests/unit/test_lybra_admin_apis.py`, 23 tests:

- **Extracción de versión**: uno por producto, con la respuesta JSON real de cada uno. El de Kubernetes comprueba además el recorte de la `v`.
- **Lo que no debe identificar**: un 401 y un 403 (el caso que separa un hallazgo de un servicio bien configurado), un cuerpo que no es JSON, un JSON sin el campo esperado, una petición fallida y un puerto fuera del mapa.
- **Selección de dissector**: los puertos están ahora en la familia HTTP, `Admin API` va antes que `HTTP` en el registro, el dissector sólo reclama los puertos de su mapa, el 8080 se deja a la sonda genérica, y una sonda real pide **una** ruta.
- **Los checks del feed**: los tres son CRITICAL, `safe`, con `service` propio y categoría `exposed_service`; los tres exigen un 200 con `GET`; y los seis productos tienen su predicado registrado.

## Notas

- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide contenedores `elasticsearch:8` con y sin `xpack.security` y un `docker:dind` con el socket TCP expuesto en una red aislada; eso pertenece a una pasada del banco, y montar un `dind` con la API abierta merece su propia revisión de aislamiento antes de entrar al repositorio.
- Kibana, etcd y Consul aportan fingerprint pero **no** check de exposición, siguiendo la tabla del issue: su acceso anónimo no es por sí solo el hallazgo grave que sí es en los otros tres.
- Este PR se apoya en #380 (la cascada de identificación), ya mergeado.
