### PR TITLE
feat(themis): dissector de PostgreSQL, y el check de un servidor que no pide contraseña

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-7"
+CHECKS_FEED_VERSION = "lybra-checks-8"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -140,6 +140,8 @@ _SMB_SERVICE_NAMES = {"microsoft-ds", "netbios-ssn"}
 _SMB_PORTS = {139, 445}
 _MYSQL_SERVICE_NAMES = {"mysql"}
 _MYSQL_PORTS = {3306}
+_POSTGRES_SERVICE_NAMES = {"postgresql", "postgres"}
+_POSTGRES_PORTS = {5432}
 _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
@@ -690,6 +692,12 @@ def is_smb_service(service: Service) -> bool:
 def is_mysql_service(service: Service) -> bool:
     """Return whether a service should be probed by the MySQL dissector."""
     return (service.name or "").lower() in _MYSQL_SERVICE_NAMES or service.port in _MYSQL_PORTS
+
+
+def is_postgres_service(service: Service) -> bool:
+    """Return whether a service should be probed by the PostgreSQL dissector."""
+    return ((service.name or "").lower() in _POSTGRES_SERVICE_NAMES
+            or service.port in _POSTGRES_PORTS)
 
 
 def is_redis_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-7
+feedVersion: lybra-checks-8
 checks:
   - id: git-config-exposure
     version: 1
@@ -449,6 +449,18 @@ checks:
               - NamespaceList
     finding:
       title: API de Kubernetes accesible de forma anonima (inventario y control del cluster)
+      qod: 99
+      confirmed: true
+  - id: postgres-trust-authentication
+    version: 1
+    type: script
+    script: postgres-trust-authentication
+    category: default_credentials
+    severity: CRITICAL
+    service: postgres
+    mode: safe
+    finding:
+      title: 'PostgreSQL: acepta conexiones de red sin contrasena (modo trust)'
       qod: 99
       confirmed: true
   - id: snmp-default-community

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -31,6 +31,13 @@ best value-for-effort in the roadmap:
     and expiry status of the certificate. Not JARM (full bit-exact
     *identification*, a separate and larger effort left for later).
 
+``postgres``
+    La primera base de datos que **negocia** en vez de ofrecer un banner: un
+    ``SSLRequest`` de ocho bytes y un ``StartupMessage`` con un usuario que no
+    existe, para leer si el servidor exige TLS y qué autenticación anuncia.
+    Ningún intento de login. PostgreSQL no regala su versión antes de
+    autenticar, y el módulo no la inventa.
+
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
     Fase N's non-HTTP protocols — each volunteers its identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
@@ -73,9 +80,7 @@ large and risky to ship without a live TLS lab to validate it against) and OS
 fingerprinting (which the roadmap itself rates low value). Both stay
 oracle-only — handled by Nmap — until picked up. RDP, LDAP, VNC's full
 protocol beyond its version banner, and RPC stay oracle-only too, per the
-roadmap's own priority-3 rating for that group; PostgreSQL/MSSQL/MongoDB
-(unlike MySQL/Redis) need a negotiated handshake rather than a volunteered
-banner and are deferred alongside them.
+roadmap's own priority-3 rating for that group.
 """
 
 from __future__ import annotations
@@ -154,6 +159,17 @@ from .smb import (
     SmbProbe,
     SmbDissector,
 )
+from .postgres import (
+    AUTH_METHODS,
+    PostgresDissector,
+    PostgresFingerprint,
+    PostgresProbe,
+    build_ssl_request,
+    build_startup_message,
+    fingerprint_postgres,
+    parse_ssl_response,
+    parse_startup_response,
+)
 from .mysql import (
     MysqlFingerprint,
     parse_mysql_handshake,
@@ -190,6 +206,15 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "AUTH_METHODS",
+    "PostgresDissector",
+    "PostgresFingerprint",
+    "PostgresProbe",
+    "build_ssl_request",
+    "build_startup_message",
+    "fingerprint_postgres",
+    "parse_ssl_response",
+    "parse_startup_response",
     "ADMIN_APIS",
     "AdminApi",
     "AdminApiDissector",

--- a/API/src/modules/features/themis/lybra/fingerprinting/postgres.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/postgres.py
@@ -1,0 +1,346 @@
+"""El dissector de PostgreSQL — el primero que negocia en vez de escuchar.
+
+PostgreSQL es una de las tres bases de datos que la Fase N dejó fuera con una
+justificación honesta: *"a diferencia de MySQL/Redis, exigen un handshake
+negociado en vez de un banner ofrecido, mayor coste/riesgo que valor añadido en
+esa ronda"*. El coste sigue siendo mayor; el valor también, porque un
+PostgreSQL expuesto es un hallazgo de primer orden y hasta ahora producía un
+``open_port`` informativo y nada más.
+
+**Conviene ser honesto sobre el techo: PostgreSQL no regala su versión antes de
+autenticar.** Ningún truco cambia eso. Lo que sí se puede observar sin
+credenciales, y ya es bastante, son tres cosas:
+
+- Si el servidor **exige o admite TLS**, preguntándoselo con un ``SSLRequest``
+  de ocho bytes al que contesta con una sola letra: ``S`` o ``N``.
+- Qué **método de autenticación** anuncia. Y aquí está el hallazgo: un
+  servidor en modo ``trust`` accesible por red es acceso total **sin
+  contraseña** — no una configuración débil, la ausencia completa de
+  autenticación.
+- El **mensaje de error** ante un usuario inexistente, que en algunas
+  configuraciones nombra la versión.
+
+Los dos intercambios son lecturas del protocolo de conexión: **no se intenta
+autenticar en ningún momento**, no se manda contraseña ninguna y no se prueba
+credencial alguna. Por eso caben en modo ``safe``. Un intento de login sería
+otra cosa —Fase D— y no está aquí.
+
+El formato de los mensajes viene de la documentación de PostgreSQL, "Frontend/
+Backend Protocol" §55.2.1 y §55.7. Todo se construye y se parsea a mano: traer
+``psycopg`` para leer dos respuestas sería la misma desproporción que traer
+``pysnmp`` para un solo GetRequest.
+
+Este módulo paga el diseño que :mod:`mssql` y :mod:`mongo` reutilizan.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from ..checks import is_postgres_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+# El código mágico que convierte los ocho bytes en una petición de TLS
+# (documentación de PostgreSQL §55.2.1). No es un número de versión de
+# protocolo: es un valor reservado que el servidor reconoce como "¿hablas
+# TLS?".
+SSL_REQUEST_CODE = 80877103
+
+# Versión 3.0 del protocolo, empaquetada como major<<16 | minor. Es la que
+# habla todo servidor desde PostgreSQL 7.4 (2003).
+PROTOCOL_VERSION_3 = 196608
+
+# Los métodos de autenticación que un ``AuthenticationRequest`` puede anunciar,
+# por su código. El 0 es el que importa: significa que el servidor ha dado la
+# conexión por buena **sin pedir nada**.
+AUTH_METHODS: Dict[int, str] = {
+    0: "trust",
+    2: "gss",
+    3: "password",
+    5: "md5",
+    6: "scm-credential",
+    7: "gss-continue",
+    9: "sspi",
+    10: "sasl",
+    12: "sasl-final",
+}
+
+# El método que es, por sí solo, un hallazgo crítico.
+NO_AUTHENTICATION = "trust"
+
+# "PostgreSQL 16.1 on x86_64-pc-linux-gnu" — la forma en que el servidor se
+# nombra a sí mismo cuando aparece en un mensaje de error.
+_VERSION_RE = re.compile(r"PostgreSQL\s+(?P<version>\d+(?:\.\d+)*)", re.IGNORECASE)
+
+_PRODUCT = "PostgreSQL"
+
+
+@dataclass(frozen=True)
+class PostgresFingerprint:
+    """Lo que se puede saber de un PostgreSQL sin autenticarse.
+
+    Attributes:
+        product: ``"PostgreSQL"`` si el servidor habló el protocolo, ``None``
+            si no se reconoció nada.
+        version: La versión, sólo cuando el servidor la nombró. Suele ser
+            ``None``, y eso es correcto: no se inventa lo que no se observó.
+        accepts_tls: ``True`` si el servidor acepta TLS, ``False`` si contestó
+            que no, ``None`` si no llegó a preguntarse.
+        auth_method: El método anunciado (:data:`AUTH_METHODS`), o ``None``.
+        sasl_mechanisms: Los mecanismos SASL ofrecidos, cuando el método es
+            ``sasl`` — es donde aparece ``SCRAM-SHA-256``.
+    """
+    product: Optional[str]
+    version: Optional[str]
+    accepts_tls: Optional[bool]
+    auth_method: Optional[str]
+    sasl_mechanisms: Tuple[str, ...] = ()
+
+    @property
+    def is_unauthenticated(self) -> bool:
+        """Si el servidor deja entrar sin credencial ninguna (modo ``trust``)."""
+        return self.auth_method == NO_AUTHENTICATION
+
+
+def build_ssl_request() -> bytes:
+    """Construye el ``SSLRequest``: ocho bytes, longitud y código mágico.
+
+    Returns:
+        El mensaje completo, listo para enviar nada más conectar.
+    """
+    return struct.pack("!ii", 8, SSL_REQUEST_CODE)
+
+
+def build_startup_message(user: str, database: Optional[str] = None) -> bytes:
+    """Construye un ``StartupMessage`` para el usuario indicado.
+
+    Se manda con un usuario que no existe **a propósito**: la respuesta dice
+    qué método de autenticación anuncia el servidor sin que haga falta acertar
+    con ningún nombre real, y sin intentar autenticarse.
+
+    Args:
+        user: El nombre de usuario a declarar.
+        database: La base de datos, si se quiere declarar una.
+
+    Returns:
+        El mensaje completo, con su longitud por delante.
+    """
+    parameters = b"user\x00" + user.encode("utf-8") + b"\x00"
+    if database:
+        parameters += b"database\x00" + database.encode("utf-8") + b"\x00"
+    body = struct.pack("!i", PROTOCOL_VERSION_3) + parameters + b"\x00"
+    return struct.pack("!i", len(body) + 4) + body
+
+
+def parse_ssl_response(data: bytes) -> Optional[bool]:
+    """Interpreta la respuesta de una sola letra al ``SSLRequest``.
+
+    Args:
+        data: Los bytes recibidos.
+
+    Returns:
+        ``True`` si el servidor acepta TLS (``S``), ``False`` si lo rechaza
+        (``N``), ``None`` si la respuesta no es ninguna de las dos — lo que
+        significa que al otro lado no hay un PostgreSQL.
+    """
+    if not data:
+        return None
+    if data[:1] == b"S":
+        return True
+    if data[:1] == b"N":
+        return False
+    return None
+
+
+def _parse_error_fields(body: bytes) -> Dict[str, str]:
+    """Descompone un ``ErrorResponse`` en sus campos etiquetados.
+
+    Cada campo es un byte de tipo (``S`` severidad, ``C`` código, ``M``
+    mensaje...) seguido de una cadena terminada en NUL; un byte cero suelto
+    cierra la lista.
+
+    Args:
+        body: El cuerpo del mensaje, sin el byte de tipo ni la longitud.
+
+    Returns:
+        Un mapa etiqueta → valor.
+    """
+    fields: Dict[str, str] = {}
+    offset = 0
+    while offset < len(body) and body[offset] != 0:
+        label = chr(body[offset])
+        end = body.find(b"\x00", offset + 1)
+        if end == -1:
+            break
+        fields[label] = body[offset + 1:end].decode("utf-8", "ignore")
+        offset = end + 1
+    return fields
+
+
+def parse_startup_response(data: bytes) -> Tuple[Optional[str], Optional[str], Tuple[str, ...]]:
+    """Interpreta la respuesta al ``StartupMessage``.
+
+    El servidor contesta con un ``AuthenticationRequest`` (``R``), que dice qué
+    método exige, o con un ``ErrorResponse`` (``E``), que a veces nombra la
+    versión.
+
+    Args:
+        data: Los bytes recibidos.
+
+    Returns:
+        Una tupla ``(método, versión, mecanismos SASL)``. El método es ``None``
+        cuando la respuesta es un error o no se reconoce; la versión, cuando el
+        servidor no la nombró.
+    """
+    if len(data) < 5:
+        return None, None, ()
+    kind = data[:1]
+    length = struct.unpack("!i", data[1:5])[0]
+    body = data[5:4 + length]
+
+    if kind == b"R":
+        if len(body) < 4:
+            return None, None, ()
+        code = struct.unpack("!i", body[:4])[0]
+        method = AUTH_METHODS.get(code)
+        mechanisms: Tuple[str, ...] = ()
+        if method == "sasl":
+            mechanisms = tuple(
+                name.decode("utf-8", "ignore")
+                for name in body[4:].split(b"\x00") if name
+            )
+        return method, None, mechanisms
+
+    if kind == b"E":
+        fields = _parse_error_fields(body)
+        text = " ".join(fields.values())
+        found = _VERSION_RE.search(text)
+        return None, (found.group("version") if found else None), ()
+
+    return None, None, ()
+
+
+def fingerprint_postgres(
+    ssl_reply: bytes,
+    startup_reply: bytes,
+) -> PostgresFingerprint:
+    """Construye el fingerprint a partir de las dos respuestas.
+
+    Args:
+        ssl_reply: La respuesta al ``SSLRequest``.
+        startup_reply: La respuesta al ``StartupMessage``.
+
+    Returns:
+        El :class:`PostgresFingerprint`. Sin producto cuando ninguna de las dos
+        respuestas es reconocible: un puerto que acepta la conexión y contesta
+        cualquier cosa no es un PostgreSQL.
+    """
+    accepts_tls = parse_ssl_response(ssl_reply)
+    method, version, mechanisms = parse_startup_response(startup_reply)
+    spoke_the_protocol = accepts_tls is not None or method is not None or version is not None
+    return PostgresFingerprint(
+        product=_PRODUCT if spoke_the_protocol else None,
+        version=version,
+        accepts_tls=accepts_tls,
+        auth_method=method,
+        sasl_mechanisms=mechanisms,
+    )
+
+
+# =========================================================================
+# SONDA (el borde de red: socket crudo, sin cliente de PostgreSQL)
+# =========================================================================
+
+# El usuario que se declara en el StartupMessage. Deliberadamente inexistente:
+# lo que se busca es la respuesta del servidor sobre su política, no entrar.
+PROBE_USER = "lybra-probe-nonexistent"
+
+
+class PostgresProbe:  # pylint: disable=too-few-public-methods
+    """Hace los dos intercambios y devuelve las dos respuestas crudas.
+
+    Son **dos conexiones y no una**: tras responder ``S`` o ``N`` al
+    ``SSLRequest``, el servidor espera o bien un handshake TLS o bien el
+    ``StartupMessage`` sobre la misma conexión, y encadenarlos obligaría a
+    negociar TLS aquí para el primer caso. Dos conexiones cortas cuestan menos
+    que meter una pila TLS en esta sonda, y cada una pide su turno al
+    limitador.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable, para que
+            un test use un socket falso.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def _exchange(self, host: str, port: int, payload: bytes) -> Optional[bytes]:
+        """Abre una conexión, manda ``payload`` y devuelve lo que llegue."""
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("PostgreSQL: conexión fallida a %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            sock.sendall(payload)
+            return sock.recv(4096)
+        except OSError as err:
+            logger.debug("PostgreSQL: intercambio fallido con %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+    def fetch(self, host: str, port: int = 5432) -> Optional[Tuple[bytes, bytes]]:
+        """Hace los dos intercambios contra ``host:port``.
+
+        Args:
+            host: El objetivo.
+            port: El puerto de PostgreSQL.
+
+        Returns:
+            Un par ``(respuesta al SSLRequest, respuesta al StartupMessage)``,
+            o ``None`` si el primer intercambio ni siquiera llegó a completarse.
+        """
+        ssl_reply = self._exchange(host, port, build_ssl_request())
+        if ssl_reply is None:
+            return None
+        startup_reply = self._exchange(host, port, build_startup_message(PROBE_USER)) or b""
+        return ssl_reply, startup_reply
+
+
+@register_dissector
+class PostgresDissector(Dissector):
+    """Dos lecturas del protocolo de conexión, ningún intento de login."""
+
+    label = "PostgreSQL"
+
+    def __init__(self, probe: Optional[PostgresProbe] = None) -> None:
+        self._probe = probe or PostgresProbe()
+
+    def applies(self, service) -> bool:
+        return is_postgres_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        rate_limiter.acquire(target)
+        replies = self._probe.fetch(target, service.port or 5432)
+        if replies is None:
+            return None
+        rate_limiter.acquire(target)
+        fingerprint = fingerprint_postgres(*replies)
+        if not fingerprint.product:
+            return None
+        return DissectorResult(fingerprint.product, fingerprint.version, self.label)

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -35,9 +35,16 @@ from __future__ import annotations
 import logging
 from typing import Dict, Optional
 
-from .checks import ScriptContext, ScriptPlugin, is_smb_service, is_snmp_service
+from .checks import (
+    ScriptContext,
+    ScriptPlugin,
+    is_postgres_service,
+    is_smb_service,
+    is_snmp_service,
+)
 from .engine import Service
 from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
+from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
 from .fingerprinting.snmp import SnmpProbe
 
 logger = logging.getLogger(__name__)
@@ -117,6 +124,45 @@ class SnmpDefaultCommunityPlugin(ScriptPlugin):
         return sysdescr is not None
 
 
+class PostgresTrustAuthenticationPlugin(ScriptPlugin):
+    """Detecta un PostgreSQL que acepta conexiones de red **sin contraseña**.
+
+    El modo ``trust`` de PostgreSQL no es una autenticación débil: es la
+    ausencia completa de autenticación. Un servidor con ``trust`` en su
+    ``pg_hba.conf`` para direcciones de red da acceso total a cualquiera que
+    alcance el puerto — sin exploit, sin fuerza bruta y sin credenciales.
+
+    La evidencia no se infiere: es el propio servidor contestando
+    ``AuthenticationOk`` a un ``StartupMessage`` con un usuario que **no
+    existe**. Por eso el hallazgo nace ``confirmed``, y por eso el plugin no
+    intenta autenticarse en ningún momento: no manda contraseña ninguna, sólo
+    lee la política que el servidor anuncia.
+
+    Comparte sonda con el dissector por el mismo criterio que el de SNMP: el
+    dato que responde a la pregunta es el mismo, y mandar dos veces el mismo
+    intercambio no lo haría más cierto.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "postgres-trust-authentication"
+
+    def __init__(self, probe: Optional[PostgresProbe] = None) -> None:
+        self._probe = probe or PostgresProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_postgres_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        replies = self._probe.fetch(context.target, context.service.port or 5432)
+        if replies is None:
+            # Sin intercambio no hay evidencia, y sin evidencia no hay hallazgo.
+            return False
+        return fingerprint_postgres(*replies).is_unauthenticated
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -124,5 +170,9 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         Un mapa ``plugin_id -> plugin``, que es lo que ``CheckRuntime`` espera
         recibir por inyección. Añadir un plugin es añadir una entrada aquí.
     """
-    plugins = (SmbSigningNotRequiredPlugin(), SnmpDefaultCommunityPlugin())
+    plugins = (
+        SmbSigningNotRequiredPlugin(),
+        SnmpDefaultCommunityPlugin(),
+        PostgresTrustAuthenticationPlugin(),
+    )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/tests/unit/test_lybra_feed_shape.py
+++ b/API/tests/unit/test_lybra_feed_shape.py
@@ -107,7 +107,11 @@ def test_a_network_service_without_predicate_is_reported(feed):
     """El caso de #272: un check ``network`` para un protocolo que ningún
     predicado reconoce. Aquel arreglo lo hizo fallar al cargar; esta validación
     lo encuentra además sobre un feed externo, que no pasa por ese camino."""
-    broken = replace(_first_of_type(feed, "network"), service="postgres")
+    # El nombre tiene que ser uno que ningún `is_*_service` reconozca. Aquí
+    # estuvo "postgres" hasta que L12 le dio su predicado, que es justo la
+    # forma en la que este test se mantiene honesto: el día que el protocolo
+    # inventado deja de estar inventado, hay que inventar otro.
+    broken = replace(_first_of_type(feed, "network"), service="protocolo-inventado")
     assert any("predicado" in problem for problem in validate_checks([broken]))
 
 

--- a/API/tests/unit/test_lybra_postgres.py
+++ b/API/tests/unit/test_lybra_postgres.py
@@ -1,0 +1,309 @@
+"""El dissector de PostgreSQL (L12).
+
+La primera base de datos del motor que **negocia** en vez de escuchar un banner
+ofrecido. Todo con socket falso: la sonda recibe su conector inyectado, igual
+que el resto del paquete.
+
+El techo del protocolo está asumido en los tests, no disimulado: PostgreSQL no
+regala su versión antes de autenticar, así que la mayoría de los casos
+comprueban producto sin versión — y comprueban que no se inventa ninguna.
+"""
+
+import struct
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import is_postgres_service
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.postgres import (
+    PROTOCOL_VERSION_3,
+    SSL_REQUEST_CODE,
+    PostgresDissector,
+    PostgresProbe,
+    build_ssl_request,
+    build_startup_message,
+    fingerprint_postgres,
+    parse_ssl_response,
+    parse_startup_response,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _auth_response(code: int, extra: bytes = b"") -> bytes:
+    """Un AuthenticationRequest con el código dado."""
+    body = struct.pack("!i", code) + extra
+    return b"R" + struct.pack("!i", len(body) + 4) + body
+
+
+def _error_response(**fields) -> bytes:
+    """Un ErrorResponse con los campos etiquetados dados."""
+    body = b""
+    for label, value in fields.items():
+        body += label.encode("ascii") + value.encode("utf-8") + b"\x00"
+    body += b"\x00"
+    return b"E" + struct.pack("!i", len(body) + 4) + body
+
+
+# ============================================= los mensajes que se construyen
+
+
+def test_the_ssl_request_is_the_eight_bytes_the_protocol_fixes():
+    """El único artefacto de este módulo verificable a ojo contra la
+    documentación: longitud 8 y el código mágico, nada más."""
+    request = build_ssl_request()
+    assert len(request) == 8
+    assert struct.unpack("!ii", request) == (8, SSL_REQUEST_CODE)
+
+
+def test_the_startup_message_declares_its_length_and_protocol():
+    message = build_startup_message("alguien")
+    length, version = struct.unpack("!ii", message[:8])
+    assert length == len(message)
+    assert version == PROTOCOL_VERSION_3
+    assert b"user\x00alguien\x00" in message
+    assert message.endswith(b"\x00")
+
+
+def test_the_startup_message_can_declare_a_database():
+    message = build_startup_message("alguien", "produccion")
+    assert b"database\x00produccion\x00" in message
+    assert struct.unpack("!i", message[:4])[0] == len(message)
+
+
+# ================================================== la respuesta al SSLRequest
+
+
+@pytest.mark.parametrize("reply, expected", [
+    (b"S", True),
+    (b"N", False),
+    (b"X", None),
+    (b"", None),
+])
+def test_the_ssl_reply_is_a_single_letter(reply, expected):
+    assert parse_ssl_response(reply) is expected
+
+
+# ============================================ la respuesta al StartupMessage
+
+
+@pytest.mark.parametrize("code, method", [
+    (0, "trust"),
+    (3, "password"),
+    (5, "md5"),
+    (10, "sasl"),
+])
+def test_each_authentication_code_names_its_method(code, method):
+    assert parse_startup_response(_auth_response(code))[0] == method
+
+
+def test_the_sasl_mechanisms_are_read_from_the_body():
+    """Es donde aparece SCRAM-SHA-256, que es lo que distingue un servidor
+    moderno de uno que sigue con md5."""
+    reply = _auth_response(10, b"SCRAM-SHA-256\x00SCRAM-SHA-256-PLUS\x00\x00")
+    method, _version, mechanisms = parse_startup_response(reply)
+    assert method == "sasl"
+    assert mechanisms == ("SCRAM-SHA-256", "SCRAM-SHA-256-PLUS")
+
+
+def test_an_unknown_authentication_code_names_no_method():
+    assert parse_startup_response(_auth_response(99))[0] is None
+
+
+def test_an_error_response_can_carry_the_version():
+    reply = _error_response(S="FATAL", C="28000",
+                            M='role "lybra-probe" does not exist on PostgreSQL 16.1')
+    method, version, _mechanisms = parse_startup_response(reply)
+    assert method is None
+    assert version == "16.1"
+
+
+def test_an_error_response_without_a_version_invents_none():
+    """El caso normal, y el que importa: PostgreSQL casi nunca se nombra en sus
+    errores. Producto sí, versión no."""
+    reply = _error_response(S="FATAL", C="28000", M='role "lybra-probe" does not exist')
+    assert parse_startup_response(reply)[1] is None
+
+
+@pytest.mark.parametrize("reply", [b"", b"R", b"R\x00\x00", b"Z\x00\x00\x00\x05I"])
+def test_a_truncated_or_unrelated_reply_yields_nothing(reply):
+    assert parse_startup_response(reply) == (None, None, ())
+
+
+# ======================================================== el fingerprint
+
+
+def test_a_server_requiring_scram_is_identified_without_a_version():
+    fingerprint = fingerprint_postgres(
+        b"S", _auth_response(10, b"SCRAM-SHA-256\x00\x00"))
+    assert fingerprint.product == "PostgreSQL"
+    assert fingerprint.version is None
+    assert fingerprint.accepts_tls is True
+    assert fingerprint.auth_method == "sasl"
+    assert not fingerprint.is_unauthenticated
+
+
+def test_a_server_in_trust_mode_is_flagged_as_unauthenticated():
+    """El hallazgo del issue. `trust` no es autenticación débil: es la ausencia
+    completa de autenticación, y el servidor lo dice él mismo contestando
+    AuthenticationOk a un usuario que no existe."""
+    fingerprint = fingerprint_postgres(b"N", _auth_response(0))
+    assert fingerprint.is_unauthenticated
+    assert fingerprint.auth_method == "trust"
+    assert fingerprint.accepts_tls is False
+
+
+def test_a_server_that_only_answers_the_ssl_request_is_still_identified():
+    fingerprint = fingerprint_postgres(b"S", b"")
+    assert fingerprint.product == "PostgreSQL"
+    assert fingerprint.accepts_tls is True
+    assert fingerprint.auth_method is None
+
+
+def test_something_that_is_not_postgres_is_not_identified():
+    """Un puerto que acepta la conexión y contesta cualquier cosa no es un
+    PostgreSQL, y no se va a etiquetar como tal."""
+    fingerprint = fingerprint_postgres(b"HTTP/1.1 400 Bad Request", b"<html>")
+    assert fingerprint.product is None
+
+
+# ============================================================ la sonda
+
+
+class _ScriptedSocket:
+    def __init__(self, reply, sent):
+        self._reply = reply
+        self._sent = sent
+
+    def settimeout(self, _timeout):
+        pass
+
+    def sendall(self, payload):
+        self._sent.append(payload)
+
+    def recv(self, _size):
+        return self._reply
+
+    def close(self):
+        pass
+
+
+def _probe_with(replies):
+    sent = []
+    pending = list(replies)
+
+    def connect(_address, _timeout):
+        return _ScriptedSocket(pending.pop(0), sent)
+
+    return PostgresProbe(connect=connect), sent
+
+
+def test_the_probe_makes_the_two_exchanges_in_order():
+    probe, sent = _probe_with([b"S", _auth_response(0)])
+    ssl_reply, startup_reply = probe.fetch("10.0.0.5")
+    assert ssl_reply == b"S"
+    assert startup_reply == _auth_response(0)
+    assert sent[0] == build_ssl_request()
+    assert sent[1].startswith(struct.pack("!i", len(sent[1])))
+
+
+def test_the_probe_never_sends_a_password():
+    """La garantía que permite que esto viva en modo `safe`: se leen las dos
+    respuestas del protocolo de conexión y no se intenta autenticar."""
+    probe, sent = _probe_with([b"S", _auth_response(5)])
+    probe.fetch("10.0.0.5")
+    assert len(sent) == 2                      # SSLRequest y StartupMessage
+    assert b"password" not in b"".join(sent).lower()
+
+
+def test_a_refused_connection_yields_nothing():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    assert PostgresProbe(connect=refuse).fetch("10.0.0.5") is None
+
+
+# ======================================================== el dissector
+
+
+def test_the_dissector_claims_its_port_and_its_name():
+    dissector = PostgresDissector()
+    assert dissector.applies(Service(5432, "tcp", "postgresql"))
+    assert dissector.applies(Service(5433, "tcp", "postgres"))
+    assert not dissector.applies(Service(3306, "tcp", "mysql"))
+    assert is_postgres_service(Service(5432, "tcp", ""))
+
+
+class _NullLimiter:
+    def acquire(self, _host):
+        pass
+
+
+def test_the_dissector_reports_the_product_it_observed():
+    probe, _sent = _probe_with([b"S", _auth_response(10, b"SCRAM-SHA-256\x00\x00")])
+    result = PostgresDissector(probe=probe).probe(
+        "10.0.0.5", Service(5432, "tcp", "postgresql"), _NullLimiter())
+    assert (result.product, result.version, result.label) == (
+        "PostgreSQL", None, "PostgreSQL")
+
+
+def test_the_dissector_stays_quiet_when_nothing_answered():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    result = PostgresDissector(probe=PostgresProbe(connect=refuse)).probe(
+        "10.0.0.5", Service(5432, "tcp", "postgresql"), _NullLimiter())
+    assert result is None
+
+
+# ================================== el check de trust (plugin de tipo script)
+
+
+def _trust_plugin(replies):
+    from src.modules.features.themis.lybra.script_checks import (
+        PostgresTrustAuthenticationPlugin,
+    )
+    probe, _sent = _probe_with(replies)
+    return PostgresTrustAuthenticationPlugin(probe=probe)
+
+
+class _Context:
+    def __init__(self, port=5432):
+        self.target = "10.0.0.5"
+        self.service = Service(port, "tcp", "postgresql")
+
+    def acquire(self):
+        pass
+
+
+def test_the_trust_check_fires_only_when_the_server_asks_for_nothing():
+    assert _trust_plugin([b"N", _auth_response(0)]).run(_Context()) is True
+
+
+@pytest.mark.parametrize("code", [3, 5, 10])
+def test_the_trust_check_stays_quiet_for_a_server_that_authenticates(code):
+    assert _trust_plugin([b"S", _auth_response(code)]).run(_Context()) is False
+
+
+def test_the_trust_check_stays_quiet_without_evidence():
+    """Sin intercambio no hay evidencia, y sin evidencia no hay hallazgo — el
+    mismo criterio que los otros dos plugins de primera parte."""
+    from src.modules.features.themis.lybra.script_checks import (
+        PostgresTrustAuthenticationPlugin,
+    )
+
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    plugin = PostgresTrustAuthenticationPlugin(probe=PostgresProbe(connect=refuse))
+    assert plugin.run(_Context()) is False
+
+
+def test_the_trust_check_is_registered_and_wired_to_its_feed_entry():
+    from src.modules.features.themis.lybra.checks import load_checks
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    check = next(c for c in load_checks() if c.id == "postgres-trust-authentication")
+    assert check.severity == "CRITICAL" and check.mode == "safe"
+    assert check.service == "postgres"
+    assert check.script in default_script_plugins()


### PR DESCRIPTION
## Resumen

Cierra #285.

PostgreSQL es una de las tres bases de datos que la Fase N dejó fuera, con una justificación que sigue siendo honesta: *«a diferencia de MySQL/Redis, exigen un handshake negociado en vez de un banner ofrecido, mayor coste/riesgo que valor añadido en esa ronda»*.

La diferencia importa. Los ocho dissectors que ya existían **escuchan**: se conectan y el servicio se presenta solo, sin que haya que pedirle nada. PostgreSQL no dice ni una palabra hasta que se le habla en su protocolo. Éste es el primer dissector del motor que negocia.

El coste sigue siendo mayor, pero el valor también: un PostgreSQL expuesto es un hallazgo de primer orden, y hasta ahora producía un `open_port` informativo y se acababa ahí.

## El techo, dicho antes de nada

**PostgreSQL no regala su versión antes de autenticar.** Ningún truco cambia eso, y este PR no pretende lo contrario. Lo normal, contra un servidor real, va a ser producto sin versión — y el módulo no inventa una. Los tests lo asumen explícitamente en vez de disimularlo.

Lo que sí se puede observar sin credenciales, y ya es bastante:

- **Si el servidor admite o exige TLS.** Se le pregunta con un `SSLRequest` de ocho bytes y contesta con una sola letra: `S` o `N`. Es un hecho observado, no una inferencia a partir del puerto.
- **Qué método de autenticación anuncia** — `trust`, `password`, `md5`, `scram-sha-256`. Aquí está el hallazgo.
- **El mensaje de error** ante un usuario inexistente, que en algunas configuraciones nombra la versión.

## El hallazgo: `trust` no es autenticación débil

Merece decirse con claridad porque es fácil leerlo como una configuración floja más. El modo `trust` de PostgreSQL, aplicado a direcciones de red en `pg_hba.conf`, **es la ausencia completa de autenticación**: cualquiera que alcance el puerto entra, con el usuario que quiera, sin contraseña, sin exploit y sin fuerza bruta.

Y la evidencia no se infiere de nada. Es el propio servidor contestando `AuthenticationOk` a un `StartupMessage` con un usuario que **no existe**. Por eso el hallazgo nace `confirmed`, con severidad CRITICAL.

## Por qué esto cabe en modo `safe`

La pregunta es legítima: mandar un `StartupMessage` se parece a intentar entrar. No lo es, y la distinción es la que separa este PR de la Fase D:

- **No se manda ninguna contraseña.** Hay un test que lo comprueba sobre los bytes que salen por el socket.
- **No se prueba ninguna credencial.** El usuario declarado es deliberadamente inexistente (`lybra-probe-nonexistent`); lo que se busca no es entrar, es que el servidor diga qué política tiene.
- **Los dos intercambios son lecturas del protocolo de conexión**, la parte que ocurre *antes* de cualquier autenticación.

Un intento de login sí sería otra cosa, sería Fase D, y no está aquí.

## Qué se ha construido

**`fingerprinting/postgres.py`**, todo a mano contra la documentación oficial («Frontend/Backend Protocol», §55.2.1 y §55.7). Traer `psycopg` para leer dos respuestas sería la misma desproporción que llevó a construir SNMP sin `pysnmp`.

- `build_ssl_request()` — ocho bytes: la longitud y el código mágico `80877103`. Es el único artefacto del módulo verificable a ojo contra la documentación, y tiene su test dorado.
- `build_startup_message(user, database)` — longitud, versión de protocolo 3.0, y los parámetros terminados en NUL.
- `parse_ssl_response()` — `S`, `N`, o `None` si no es ninguna de las dos, lo que significa que al otro lado no hay un PostgreSQL.
- `parse_startup_response()` — distingue un `AuthenticationRequest` (`R`, que trae el código del método y, para SASL, la lista de mecanismos donde aparece `SCRAM-SHA-256`) de un `ErrorResponse` (`E`, cuyos campos etiquetados a veces nombran la versión).

**Dos conexiones y no una**, y conviene explicar por qué. Tras contestar `S` o `N` al `SSLRequest`, el servidor espera sobre esa misma conexión o bien un handshake TLS o bien el `StartupMessage`. Encadenarlos obligaría a meter una pila TLS en esta sonda para cubrir el primer caso. Dos conexiones cortas cuestan bastante menos, y cada una pide su turno al limitador de ritmo.

**`PostgresTrustAuthenticationPlugin`**, un check de tipo `script`. Comparte sonda con el dissector por el mismo criterio que el de SNMP: el dato que responde a la pregunta es el mismo, y mandar dos veces el mismo intercambio no lo haría más cierto.

`feedVersion` sube a `lybra-checks-8`.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa). `pylint` en 10,00/10 sobre `postgres.py` y `script_checks.py`.

`tests/unit/test_lybra_postgres.py`, 35 tests:

- **Los mensajes que se construyen**: el `SSLRequest` de ocho bytes exactos, y que el `StartupMessage` declare bien su longitud, su versión de protocolo y sus parámetros.
- **La respuesta al `SSLRequest`**: `S`, `N`, una letra cualquiera y una respuesta vacía.
- **La respuesta al `StartupMessage`**: cada código de autenticación con su método, la lista de mecanismos SASL, un código desconocido que no nombra método, un `ErrorResponse` con versión y —el caso normal, y el que importa— uno **sin** versión, que no inventa ninguna. Más cuatro respuestas truncadas o de otro protocolo.
- **El fingerprint**: un servidor con SCRAM identificado sin versión; uno en `trust` marcado como sin autenticar; uno que sólo contesta al `SSLRequest` igualmente identificado; y una respuesta HTTP que **no** se etiqueta como PostgreSQL.
- **La sonda**: los dos intercambios en orden, que no se manda ninguna contraseña, y que una conexión rechazada no produce nada.
- **El dissector**: reclama su puerto y su nombre (incluido un `postgres` en el 5433, gracias a la cascada de #380), reporta lo que observó, y se calla cuando no contestó nadie.
- **El check**: dispara sólo con `trust`, se calla con `password`/`md5`/`sasl`, se calla sin evidencia, y está registrado y conectado con su entrada del feed.

## Notas

- **Un test existente ha cambiado de dato, no de intención.** `test_a_network_service_without_predicate_is_reported` usaba `service="postgres"` precisamente porque era un protocolo que ningún predicado reconocía; ahora sí lo reconoce. Se ha sustituido por `"protocolo-inventado"`, con un comentario que explica que ése es el modo en que el test se mantiene honesto: el día que el protocolo inventado deja de estar inventado, hay que inventar otro.
- El docstring del paquete de fingerprinting ya no declara PostgreSQL/MSSQL/MongoDB como diferidos: MSSQL (#286) y MongoDB (#287) van en sus propios PR y reutilizan el diseño que éste paga.
- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un `postgres:16` con `scram-sha-256` y otro con `trust`; eso pertenece a una pasada del banco.
