### PR TITLE
feat(themis): dissector de SQL Server desde el PRELOGIN de TDS

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -142,6 +142,8 @@ _MYSQL_SERVICE_NAMES = {"mysql"}
 _MYSQL_PORTS = {3306}
 _POSTGRES_SERVICE_NAMES = {"postgresql", "postgres"}
 _POSTGRES_PORTS = {5432}
+_MSSQL_SERVICE_NAMES = {"ms-sql-s", "mssql", "sqlserver"}
+_MSSQL_PORTS = {1433}
 _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
@@ -698,6 +700,12 @@ def is_postgres_service(service: Service) -> bool:
     """Return whether a service should be probed by the PostgreSQL dissector."""
     return ((service.name or "").lower() in _POSTGRES_SERVICE_NAMES
             or service.port in _POSTGRES_PORTS)
+
+
+def is_mssql_service(service: Service) -> bool:
+    """Return whether a service should be probed by the SQL Server dissector."""
+    return ((service.name or "").lower() in _MSSQL_SERVICE_NAMES
+            or service.port in _MSSQL_PORTS)
 
 
 def is_redis_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/feeds/product_aliases.json
+++ b/API/src/modules/features/themis/lybra/feeds/product_aliases.json
@@ -1,5 +1,5 @@
 {
-  "feedVersion": "lybra-aliases-3",
+  "feedVersion": "lybra-aliases-4",
   "aliases": [
     { "match": "apache httpd",        "vendor": "apache",             "product": "http_server" },
     { "match": "apache",              "vendor": "apache",             "product": "http_server" },
@@ -14,6 +14,8 @@
     { "match": "dovecot imapd",       "vendor": "dovecot",            "product": "dovecot" },
     { "match": "pure ftpd",           "vendor": "pureftpd",           "product": "pure-ftpd" },
     { "match": "exim smtpd",          "vendor": "exim",               "product": "exim" },
+    { "match": "microsoft sql server", "vendor": "microsoft",         "product": "sql_server" },
+    { "match": "postgresql",          "vendor": "postgresql",         "product": "postgresql" },
 
     { "match": "git",                 "vendor": "git-scm",            "product": "git" },
     { "match": "vlc media player",    "vendor": "videolan",           "product": "vlc_media_player" },

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -38,6 +38,11 @@ best value-for-effort in the roadmap:
     Ningún intento de login. PostgreSQL no regala su versión antes de
     autenticar, y el módulo no la inventa.
 
+``mssql``
+    El más generoso de los tres: un ``PRELOGIN`` de TDS devuelve major, minor
+    y build en un campo binario de tamaño fijo, sin autenticar, más el modo de
+    cifrado que el servidor exige.
+
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
     Fase N's non-HTTP protocols — each volunteers its identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
@@ -159,6 +164,15 @@ from .smb import (
     SmbProbe,
     SmbDissector,
 )
+from .mssql import (
+    ENCRYPTION_MODES,
+    MssqlDissector,
+    MssqlFingerprint,
+    MssqlProbe,
+    build_prelogin_request,
+    fingerprint_mssql,
+    parse_prelogin_response,
+)
 from .postgres import (
     AUTH_METHODS,
     PostgresDissector,
@@ -206,6 +220,13 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "ENCRYPTION_MODES",
+    "MssqlDissector",
+    "MssqlFingerprint",
+    "MssqlProbe",
+    "build_prelogin_request",
+    "fingerprint_mssql",
+    "parse_prelogin_response",
     "AUTH_METHODS",
     "PostgresDissector",
     "PostgresFingerprint",

--- a/API/src/modules/features/themis/lybra/fingerprinting/mssql.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mssql.py
@@ -1,0 +1,270 @@
+"""El dissector de SQL Server — el más generoso de los tres pendientes.
+
+De las tres bases de datos que la Fase N dejó fuera, SQL Server es la que más
+se identifica sola: el paquete ``PRELOGIN`` del protocolo TDS devuelve la
+versión del servidor —major, minor y build— en un campo binario de tamaño
+fijo, **sin autenticar y sin negociar nada más**.
+
+Esa versión mapea directo a un producto de NVD (``microsoft:sql_server``) con
+historial de CVEs abundante, así que es el caso limpio del apalancamiento que
+el roadmap describe: se escriben *ojos*, no checks, y la correlación de
+vulnerabilidades sale sola de la base de conocimiento local.
+
+El ``PRELOGIN`` dice además si el servidor **exige cifrado**, en cuatro estados
+(:data:`ENCRYPTION_MODES`), lo que es un hecho de configuración por sí mismo en
+cuanto el puerto está expuesto.
+
+**Formato del intercambio** (MS-TDS §2.2.6.5). Un paquete TDS son ocho bytes de
+cabecera y un cuerpo. El cuerpo de un ``PRELOGIN`` es una tabla de opciones:
+cada fila son cinco bytes —un identificador, y el desplazamiento y la longitud
+de su dato dentro del mismo cuerpo—, un ``0xFF`` cierra la tabla, y detrás
+vienen los datos a los que las filas apuntan. Los desplazamientos son
+**relativos al principio del cuerpo**, no del paquete; equivocarse en eso es el
+error clásico al parsear esto a mano, y de ahí que el módulo lo diga aquí.
+
+Todo se construye y se parsea a mano, sin librería de TDS, por el mismo
+criterio que llevó a hacer SNMP sin ``pysnmp``: dos mensajes no justifican una
+dependencia.
+
+Comparte diseño con :mod:`postgres` y :mod:`mongo`.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from ..checks import is_mssql_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+# Tipo de paquete TDS para PRELOGIN, y el estado "este es el último paquete
+# del mensaje" (MS-TDS §2.2.3.1.2).
+PACKET_TYPE_PRELOGIN = 0x12
+STATUS_END_OF_MESSAGE = 0x01
+TDS_HEADER_SIZE = 8
+
+# Identificadores de opción dentro del cuerpo del PRELOGIN. Sólo se piden y se
+# leen los dos que aportan algo sin autenticar.
+OPTION_VERSION = 0x00
+OPTION_ENCRYPTION = 0x01
+OPTION_TERMINATOR = 0xFF
+
+# Qué dice el servidor sobre el cifrado del canal. ``REQ`` y ``ON`` son la
+# postura correcta; ``NOT_SUP`` significa que las credenciales de cualquier
+# cliente van a viajar en claro.
+ENCRYPTION_MODES: Dict[int, str] = {
+    0x00: "off",
+    0x01: "on",
+    0x02: "not-supported",
+    0x03: "required",
+}
+
+_PRODUCT = "Microsoft SQL Server"
+
+# Familia comercial por versión mayor, para que el hallazgo diga algo legible
+# además del número. No sustituye a la versión —el CPE se resuelve con
+# ``major.minor.build``, que es lo que NVD indexa— sino que la acompaña.
+RELEASE_NAMES: Dict[int, str] = {
+    8: "2000", 9: "2005", 10: "2008", 11: "2012", 12: "2014",
+    13: "2016", 14: "2017", 15: "2019", 16: "2022",
+}
+
+
+@dataclass(frozen=True)
+class MssqlFingerprint:
+    """Lo que el ``PRELOGIN`` cuenta de un SQL Server.
+
+    Attributes:
+        product: ``"Microsoft SQL Server"``, o ``None`` si la respuesta no era
+            un ``PRELOGIN``.
+        version: ``"major.minor.build"``, la forma en que NVD indexa este
+            producto.
+        release_name: La familia comercial (``"2019"``), cuando la versión
+            mayor es conocida. Acompaña a la versión, no la sustituye.
+        encryption: El modo de cifrado anunciado
+            (:data:`ENCRYPTION_MODES`), o ``None``.
+    """
+    product: Optional[str]
+    version: Optional[str]
+    release_name: Optional[str]
+    encryption: Optional[str]
+
+    @property
+    def is_encryption_unsupported(self) -> bool:
+        """Si el servidor declara que no admite cifrar el canal."""
+        return self.encryption == "not-supported"
+
+
+def build_prelogin_request() -> bytes:
+    """Construye un paquete ``PRELOGIN`` mínimo con las dos opciones que se leen.
+
+    Se declara ``ENCRYPTION = off`` como postura del *cliente*: es lo que dice
+    "yo no voy a cifrar", y sirve para que el servidor conteste con su propia
+    postura sin que haya que negociar TLS aquí. No cambia nada de lo que el
+    servidor exija.
+
+    Returns:
+        El paquete completo, cabecera incluida.
+    """
+    # Tabla de opciones: dos filas de cinco bytes más el terminador.
+    table_size = 5 * 2 + 1
+    version_data = b"\x00" * 6
+    encryption_data = b"\x00"
+    body = (
+        struct.pack("!BHH", OPTION_VERSION, table_size, len(version_data))
+        + struct.pack("!BHH", OPTION_ENCRYPTION,
+                      table_size + len(version_data), len(encryption_data))
+        + bytes((OPTION_TERMINATOR,))
+        + version_data
+        + encryption_data
+    )
+    header = struct.pack(
+        "!BBHHBB",
+        PACKET_TYPE_PRELOGIN, STATUS_END_OF_MESSAGE,
+        TDS_HEADER_SIZE + len(body),
+        0,      # SPID
+        0,      # PacketID
+        0,      # Window
+    )
+    return header + body
+
+
+def _option_table(body: bytes) -> Dict[int, Tuple[int, int]]:
+    """Lee la tabla de opciones del cuerpo de un ``PRELOGIN``.
+
+    Args:
+        body: El cuerpo del paquete, ya sin la cabecera TDS.
+
+    Returns:
+        Un mapa ``identificador -> (desplazamiento, longitud)``. Los
+        desplazamientos son relativos al principio de ``body``.
+    """
+    options: Dict[int, Tuple[int, int]] = {}
+    offset = 0
+    while offset < len(body) and body[offset] != OPTION_TERMINATOR:
+        if offset + 5 > len(body):
+            break
+        token = body[offset]
+        data_offset, data_length = struct.unpack("!HH", body[offset + 1:offset + 5])
+        options[token] = (data_offset, data_length)
+        offset += 5
+    return options
+
+
+def parse_prelogin_response(data: bytes) -> MssqlFingerprint:
+    """Interpreta la respuesta ``PRELOGIN`` de un SQL Server.
+
+    Args:
+        data: El paquete completo recibido, con su cabecera.
+
+    Returns:
+        El :class:`MssqlFingerprint`. Sin producto cuando el paquete está
+        truncado, no es TDS o no trae la opción de versión: un puerto que
+        contesta cualquier cosa no es un SQL Server.
+    """
+    empty = MssqlFingerprint(None, None, None, None)
+    if len(data) <= TDS_HEADER_SIZE:
+        return empty
+
+    body = data[TDS_HEADER_SIZE:]
+    options = _option_table(body)
+
+    version_offset, version_length = options.get(OPTION_VERSION, (0, 0))
+    if version_length < 6 or version_offset + 6 > len(body):
+        return empty
+    major, minor, build = struct.unpack("!BBH", body[version_offset:version_offset + 4])
+
+    encryption = None
+    encryption_offset, encryption_length = options.get(OPTION_ENCRYPTION, (0, 0))
+    if encryption_length >= 1 and encryption_offset < len(body):
+        encryption = ENCRYPTION_MODES.get(body[encryption_offset])
+
+    return MssqlFingerprint(
+        product=_PRODUCT,
+        version=f"{major}.{minor}.{build}",
+        release_name=RELEASE_NAMES.get(major),
+        encryption=encryption,
+    )
+
+
+def fingerprint_mssql(data: bytes) -> MssqlFingerprint:
+    """Fingerprint de un SQL Server desde su respuesta ``PRELOGIN``."""
+    return parse_prelogin_response(data)
+
+
+# =========================================================================
+# SONDA (el borde de red: socket crudo, sin librería de TDS)
+# =========================================================================
+
+class MssqlProbe:  # pylint: disable=too-few-public-methods
+    """Manda un ``PRELOGIN`` y devuelve la respuesta cruda.
+
+    Un solo intercambio, a diferencia de :class:`~.postgres.PostgresProbe`: el
+    ``PRELOGIN`` trae la versión y el modo de cifrado en la misma respuesta.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def fetch(self, host: str, port: int = 1433) -> Optional[bytes]:
+        """Hace el intercambio contra ``host:port``.
+
+        Args:
+            host: El objetivo.
+            port: El puerto de SQL Server.
+
+        Returns:
+            El paquete de respuesta, o ``None`` si la conexión o la lectura
+            fallan.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("MSSQL: conexión fallida a %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            sock.sendall(build_prelogin_request())
+            return sock.recv(4096) or None
+        except OSError as err:
+            logger.debug("MSSQL: intercambio fallido con %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+@register_dissector
+class MssqlDissector(Dissector):
+    """Un ``PRELOGIN`` y ya: versión exacta y modo de cifrado, sin autenticar."""
+
+    label = "MSSQL"
+
+    def __init__(self, probe: Optional[MssqlProbe] = None) -> None:
+        self._probe = probe or MssqlProbe()
+
+    def applies(self, service) -> bool:
+        return is_mssql_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        rate_limiter.acquire(target)
+        response = self._probe.fetch(target, service.port or 1433)
+        if response is None:
+            return None
+        fingerprint = fingerprint_mssql(response)
+        if not fingerprint.product:
+            return None
+        return DissectorResult(fingerprint.product, fingerprint.version, self.label)

--- a/API/tests/unit/test_lybra_mssql.py
+++ b/API/tests/unit/test_lybra_mssql.py
@@ -1,0 +1,233 @@
+"""El dissector de SQL Server (L13).
+
+El más generoso de los tres pendientes de la Fase N: el ``PRELOGIN`` de TDS
+devuelve major, minor y build en un campo binario de tamaño fijo, sin
+autenticar y sin negociar nada más.
+
+Los desplazamientos de la tabla de opciones son **relativos al principio del
+cuerpo**, no del paquete. Es el error clásico al parsear esto a mano, y varios
+tests de aquí existen para que no vuelva.
+"""
+
+import struct
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import is_mssql_service
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.mssql import (
+    OPTION_ENCRYPTION,
+    OPTION_TERMINATOR,
+    OPTION_VERSION,
+    PACKET_TYPE_PRELOGIN,
+    TDS_HEADER_SIZE,
+    MssqlDissector,
+    MssqlProbe,
+    build_prelogin_request,
+    fingerprint_mssql,
+    parse_prelogin_response,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _prelogin_response(major=15, minor=0, build=2000, encryption=0x03,
+                       with_encryption=True):
+    """Construye una respuesta PRELOGIN como la que manda un servidor real."""
+    table_size = 5 * (2 if with_encryption else 1) + 1
+    version_data = struct.pack("!BBHH", major, minor, build, 0)
+    body = struct.pack("!BHH", OPTION_VERSION, table_size, len(version_data))
+    if with_encryption:
+        body += struct.pack("!BHH", OPTION_ENCRYPTION,
+                            table_size + len(version_data), 1)
+    body += bytes((OPTION_TERMINATOR,)) + version_data
+    if with_encryption:
+        body += bytes((encryption,))
+    header = struct.pack("!BBHHBB", 0x04, 0x01, TDS_HEADER_SIZE + len(body), 0, 0, 0)
+    return header + body
+
+
+# ================================================= el paquete que se construye
+
+
+def test_the_prelogin_request_declares_its_own_length():
+    """La cabecera TDS lleva la longitud total del paquete. Un servidor real
+    espera exactamente esos bytes, así que si la longitud miente la conexión se
+    queda colgada en vez de fallar."""
+    request = build_prelogin_request()
+    kind, _status, length = struct.unpack("!BBH", request[:4])
+    assert kind == PACKET_TYPE_PRELOGIN
+    assert length == len(request)
+
+
+def test_the_prelogin_request_offsets_point_inside_its_own_body():
+    """El error clásico: los desplazamientos son relativos al cuerpo, no al
+    paquete. Si se contara desde la cabecera, apuntarían ocho bytes más allá."""
+    body = build_prelogin_request()[TDS_HEADER_SIZE:]
+    version_offset, version_length = struct.unpack("!HH", body[1:5])
+    assert version_offset + version_length <= len(body)
+    assert body[version_offset - 1] == OPTION_TERMINATOR
+
+
+# ============================================================ el parseo
+
+
+def test_a_real_shaped_response_yields_version_and_encryption():
+    fingerprint = fingerprint_mssql(_prelogin_response(15, 0, 2000, 0x03))
+    assert fingerprint.product == "Microsoft SQL Server"
+    assert fingerprint.version == "15.0.2000"
+    assert fingerprint.release_name == "2019"
+    assert fingerprint.encryption == "required"
+
+
+@pytest.mark.parametrize("code, mode", [
+    (0x00, "off"),
+    (0x01, "on"),
+    (0x02, "not-supported"),
+    (0x03, "required"),
+])
+def test_every_encryption_mode_is_named(code, mode):
+    assert fingerprint_mssql(_prelogin_response(encryption=code)).encryption == mode
+
+
+def test_a_server_that_cannot_encrypt_is_flagged():
+    """Un `not-supported` significa que las credenciales de cualquier cliente
+    van a viajar en claro: es un hecho de configuración por sí mismo en cuanto
+    el puerto está expuesto."""
+    assert fingerprint_mssql(_prelogin_response(encryption=0x02)).is_encryption_unsupported
+    assert not fingerprint_mssql(_prelogin_response(encryption=0x03)).is_encryption_unsupported
+
+
+@pytest.mark.parametrize("major, release", [
+    (8, "2000"), (10, "2008"), (13, "2016"), (16, "2022"),
+])
+def test_the_major_version_names_its_commercial_release(major, release):
+    assert fingerprint_mssql(_prelogin_response(major=major)).release_name == release
+
+
+def test_an_unknown_major_version_still_reports_the_number():
+    """La familia comercial acompaña a la versión, no la sustituye: el CPE se
+    resuelve con `major.minor.build`, que es lo que NVD indexa."""
+    fingerprint = fingerprint_mssql(_prelogin_response(major=99, minor=1, build=7))
+    assert fingerprint.version == "99.1.7"
+    assert fingerprint.release_name is None
+    assert fingerprint.product == "Microsoft SQL Server"
+
+
+def test_a_response_without_the_encryption_option_still_gives_the_version():
+    fingerprint = fingerprint_mssql(_prelogin_response(with_encryption=False))
+    assert fingerprint.version == "15.0.2000"
+    assert fingerprint.encryption is None
+
+
+# ==================================================== lo que no identifica
+
+
+@pytest.mark.parametrize("data", [
+    b"",
+    b"\x04\x01\x00\x08\x00\x00\x00\x00",                 # cabecera sin cuerpo
+    b"HTTP/1.1 400 Bad Request\r\n\r\n",                 # otro protocolo
+    b"+OK POP3 ready\r\n",                               # un banner de texto
+])
+def test_something_that_is_not_a_prelogin_is_not_identified(data):
+    assert fingerprint_mssql(data).product is None
+
+
+def test_a_truncated_version_field_is_not_guessed():
+    """Un desplazamiento que apunta fuera del cuerpo no se lee "hasta donde
+    llegue": no hay versión, y sin versión no hay producto."""
+    body = struct.pack("!BHH", OPTION_VERSION, 200, 6) + bytes((OPTION_TERMINATOR,))
+    packet = struct.pack("!BBHHBB", 0x04, 0x01, TDS_HEADER_SIZE + len(body), 0, 0, 0) + body
+    assert parse_prelogin_response(packet).product is None
+
+
+def test_an_option_table_without_a_terminator_does_not_loop():
+    body = struct.pack("!BHH", OPTION_VERSION, 11, 6) * 3
+    packet = struct.pack("!BBHHBB", 0x04, 0x01, TDS_HEADER_SIZE + len(body), 0, 0, 0) + body
+    parse_prelogin_response(packet)          # no cuelga ni revienta
+
+
+# ============================================================== la sonda
+
+
+class _ScriptedSocket:
+    def __init__(self, reply, sent):
+        self._reply = reply
+        self._sent = sent
+
+    def settimeout(self, _timeout):
+        pass
+
+    def sendall(self, payload):
+        self._sent.append(payload)
+
+    def recv(self, _size):
+        return self._reply
+
+    def close(self):
+        pass
+
+
+def _probe_with(reply):
+    sent = []
+    return MssqlProbe(connect=lambda _a, _t: _ScriptedSocket(reply, sent)), sent
+
+
+def test_the_probe_sends_one_prelogin_and_returns_the_answer():
+    """Un solo intercambio, a diferencia de PostgreSQL: el PRELOGIN trae la
+    versión y el cifrado en la misma respuesta."""
+    reply = _prelogin_response()
+    probe, sent = _probe_with(reply)
+    assert probe.fetch("10.0.0.5") == reply
+    assert sent == [build_prelogin_request()]
+
+
+def test_a_refused_connection_yields_nothing():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    assert MssqlProbe(connect=refuse).fetch("10.0.0.5") is None
+
+
+# =========================================================== el dissector
+
+
+class _NullLimiter:
+    def acquire(self, _host):
+        pass
+
+
+def test_the_dissector_claims_its_port_and_its_names():
+    dissector = MssqlDissector()
+    assert dissector.applies(Service(1433, "tcp", "ms-sql-s"))
+    assert dissector.applies(Service(14330, "tcp", "mssql"))
+    assert not dissector.applies(Service(5432, "tcp", "postgresql"))
+    assert is_mssql_service(Service(1433, "tcp", ""))
+
+
+def test_the_dissector_reports_product_and_version():
+    probe, _sent = _probe_with(_prelogin_response(15, 0, 2000))
+    result = MssqlDissector(probe=probe).probe(
+        "10.0.0.5", Service(1433, "tcp", "ms-sql-s"), _NullLimiter())
+    assert (result.product, result.version, result.label) == (
+        "Microsoft SQL Server", "15.0.2000", "MSSQL")
+
+
+def test_the_dissector_stays_quiet_for_a_port_that_is_not_sql_server():
+    probe, _sent = _probe_with(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+    result = MssqlDissector(probe=probe).probe(
+        "10.0.0.5", Service(1433, "tcp", "ms-sql-s"), _NullLimiter())
+    assert result is None
+
+
+def test_the_product_name_has_an_alias_to_its_nvd_identity():
+    """Sin el alias, `Microsoft SQL Server` no encontraría nada en la base de
+    conocimiento: NVD lo indexa como `microsoft:sql_server`."""
+    import json
+    from pathlib import Path
+
+    feed = Path(__file__).resolve().parents[2] / (
+        "src/modules/features/themis/lybra/feeds/product_aliases.json")
+    aliases = json.loads(feed.read_text(encoding="utf-8"))["aliases"]
+    entry = next(a for a in aliases if a["match"] == "microsoft sql server")
+    assert (entry["vendor"], entry["product"]) == ("microsoft", "sql_server")


### PR DESCRIPTION
## Resumen

Cierra #286.

De las tres bases de datos que la Fase N dejó fuera, SQL Server es la que **más generosamente se identifica**. No hace falta ninguna astucia: el paquete `PRELOGIN` del protocolo TDS devuelve la versión del servidor —major, minor y build— en un campo binario de tamaño fijo, **sin autenticar y sin negociar nada más**.

Y esa versión mapea directo a un producto de NVD (`microsoft:sql_server`) con historial de CVEs abundante. Es el caso limpio del apalancamiento que el roadmap describe: se escriben **ojos**, no checks, y la correlación de vulnerabilidades sale sola de la base de conocimiento local. Un dissector de treinta líneas de parseo produce las vulnerabilidades de veinte años de SQL Server sin escribir ni una regla.

Hasta ahora, un 1433 abierto producía `Puerto 1433/tcp abierto — ms-sql-s`, `qod=30`, y nada más.

## Qué se lee, además de la versión

El mismo `PRELOGIN` dice si el servidor **exige cifrado**, en cuatro estados: `off`, `on`, `not-supported` y `required`. El interesante es `not-supported`: significa que las credenciales de cualquier cliente que se conecte van a viajar en claro por la red, y eso es un hecho de configuración por sí mismo en cuanto el puerto está expuesto.

## El formato, y el error clásico

Conviene explicarlo porque es la parte del PR donde una transcripción a mano se rompe.

Un paquete TDS son **ocho bytes de cabecera y un cuerpo**. El cuerpo de un `PRELOGIN` no lleva los datos seguidos: lleva primero una **tabla de opciones**, donde cada fila son cinco bytes —un identificador, y el desplazamiento y la longitud de su dato—, un `0xFF` cierra la tabla, y detrás vienen los datos a los que las filas apuntan.

**Los desplazamientos son relativos al principio del cuerpo, no del paquete.** Contarlos desde la cabecera los desplaza ocho bytes y hace que se lea basura — que es el error clásico al parsear esto sin librería. Va dicho en el docstring del módulo, y hay dos tests que lo fijan: uno comprueba que los desplazamientos del paquete que construimos caen dentro de nuestro propio cuerpo, y otro que un desplazamiento que apunta fuera **no** se lee «hasta donde llegue» sino que produce «sin versión».

Todo se construye y se parsea a mano, sin librería de TDS, por el mismo criterio que llevó a hacer SNMP sin `pysnmp`: dos mensajes no justifican una dependencia.

## Un detalle sobre el nombre de la versión

`RELEASE_NAMES` traduce la versión mayor a su familia comercial: `15` → `2019`, `13` → `2016`, `10` → `2008`. Sirve para que el hallazgo diga algo legible en el informe.

Pero **acompaña a la versión, no la sustituye**: el CPE se resuelve con `major.minor.build`, que es lo que NVD indexa. Una versión mayor desconocida sigue produciendo el número completo y el producto; sólo se queda sin nombre comercial. Hay un test para eso.

## Los alias de producto

Se añaden dos entradas a `product_aliases.json`: `microsoft sql server` → `microsoft:sql_server` y `postgresql` → `postgresql:postgresql` (esta segunda, para el dissector de #382, ya mergeado).

No es un detalle menor. **Sin el alias, `Microsoft SQL Server` no encontraría un solo CVE** por mucho que la versión fuera exacta, porque NVD no lo llama así. Un dissector perfecto y un alias ausente producen exactamente el mismo resultado que no tener dissector, y con la misma cara de éxito. Hay un test que ata la entrada.

`feedVersion` del feed de alias sube a `lybra-aliases-4`.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa). `pylint` en 10,00/10 sobre `mssql.py`.

`tests/unit/test_lybra_mssql.py`, 26 tests:

- **El paquete que se construye**: que la cabecera declare la longitud real (si miente, un servidor real deja la conexión colgada en vez de fallar) y que los desplazamientos caigan dentro del propio cuerpo.
- **El parseo**: una respuesta con la forma real da versión, familia comercial y cifrado; los cuatro modos de cifrado tienen nombre; un servidor sin soporte de cifrado queda marcado; cuatro versiones mayores dan su familia; una desconocida sigue dando el número; y una respuesta sin la opción de cifrado sigue dando la versión.
- **Lo que no identifica**: un paquete vacío, una cabecera sin cuerpo, una respuesta HTTP, un banner de POP3, un campo de versión truncado, y una tabla de opciones sin terminador (que no debe colgar el parser).
- **La sonda**: manda **un** `PRELOGIN` y devuelve la respuesta; una conexión rechazada no produce nada.
- **El dissector**: reclama su puerto y sus nombres (incluido un `mssql` en el 14330, gracias a la cascada de #380), reporta producto y versión, y se calla ante un puerto que no es SQL Server.
- **El alias**: la entrada de NVD existe y apunta donde debe.

## Notas

- **La sonda UDP de 1434** (SQL Server Browser, que devuelve nombre de instancia y versión en texto plano y es aún más barata que el TDS) **no entra aquí**: depende de la ampliación de `UDP_PROBES`, que es #292 y va en su propio PR. Se hará allí, junto al resto de la superficie UDP.
- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un `mcr.microsoft.com/mssql/server:2022-latest`; eso pertenece a una pasada del banco.
- Comparte diseño con #382 (PostgreSQL, ya mergeado) y con #287 (MongoDB), que va en su propio PR.
