### PR TITLE
feat(themis): dissector de MongoDB, y el check que distingue contestar de dejar entrar

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-8"
+CHECKS_FEED_VERSION = "lybra-checks-9"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -144,6 +144,8 @@ _POSTGRES_SERVICE_NAMES = {"postgresql", "postgres"}
 _POSTGRES_PORTS = {5432}
 _MSSQL_SERVICE_NAMES = {"ms-sql-s", "mssql", "sqlserver"}
 _MSSQL_PORTS = {1433}
+_MONGODB_SERVICE_NAMES = {"mongodb", "mongo"}
+_MONGODB_PORTS = {27017, 27018, 27019}
 _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
@@ -706,6 +708,17 @@ def is_mssql_service(service: Service) -> bool:
     """Return whether a service should be probed by the SQL Server dissector."""
     return ((service.name or "").lower() in _MSSQL_SERVICE_NAMES
             or service.port in _MSSQL_PORTS)
+
+
+def is_mongodb_service(service: Service) -> bool:
+    """Return whether a service should be probed by the MongoDB dissector.
+
+    27018 y 27019 entran junto al 27017: son los puertos por defecto de un
+    ``mongos`` y de un servidor de configuración en un despliegue fragmentado,
+    y ahí es donde vive el catálogo entero del clúster.
+    """
+    return ((service.name or "").lower() in _MONGODB_SERVICE_NAMES
+            or service.port in _MONGODB_PORTS)
 
 
 def is_redis_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-8
+feedVersion: lybra-checks-9
 checks:
   - id: git-config-exposure
     version: 1
@@ -461,6 +461,18 @@ checks:
     mode: safe
     finding:
       title: 'PostgreSQL: acepta conexiones de red sin contrasena (modo trust)'
+      qod: 99
+      confirmed: true
+  - id: mongodb-unauthenticated-access
+    version: 1
+    type: script
+    script: mongodb-unauthenticated-access
+    category: exposed_service
+    severity: CRITICAL
+    service: mongodb
+    mode: safe
+    finding:
+      title: 'MongoDB: catalogo accesible sin autenticacion'
       qod: 99
       confirmed: true
   - id: snmp-default-community

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -43,6 +43,11 @@ best value-for-effort in the roadmap:
     y build en un campo binario de tamaño fijo, sin autenticar, más el modo de
     cifrado que el servidor exige.
 
+``mongo``
+    ``hello`` para la versión —que contesta siempre, con autenticación y sin
+    ella— y ``listDatabases`` para saber si el servidor deja entrar sin
+    credenciales. Parseo de BSON mínimo, sin ``pymongo``.
+
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
     Fase N's non-HTTP protocols — each volunteers its identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
@@ -164,6 +169,17 @@ from .smb import (
     SmbProbe,
     SmbDissector,
 )
+from .mongo import (
+    HELLO_COMMAND,
+    LIST_DATABASES_COMMAND,
+    MongoDissector,
+    MongoFingerprint,
+    MongoProbe,
+    build_op_msg,
+    fingerprint_mongo,
+    parse_bson_document,
+    parse_op_msg,
+)
 from .mssql import (
     ENCRYPTION_MODES,
     MssqlDissector,
@@ -220,6 +236,15 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "HELLO_COMMAND",
+    "LIST_DATABASES_COMMAND",
+    "MongoDissector",
+    "MongoFingerprint",
+    "MongoProbe",
+    "build_op_msg",
+    "fingerprint_mongo",
+    "parse_bson_document",
+    "parse_op_msg",
     "ENCRYPTION_MODES",
     "MssqlDissector",
     "MssqlFingerprint",

--- a/API/src/modules/features/themis/lybra/fingerprinting/mongo.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mongo.py
@@ -1,0 +1,345 @@
+"""El dissector de MongoDB — y el hallazgo más famoso de la lista.
+
+MongoDB cierra el trío de bases de datos que la Fase N dejó fuera, y es el que
+tiene asociado el incidente más conocido: durante años, las instalaciones por
+defecto escuchaban en todas las interfaces **sin autenticación**, y eso produjo
+una de las mayores oleadas de fuga de datos y de ransomware de bases de datos
+que se recuerdan. Sigue apareciendo.
+
+**Una corrección al planteamiento original, porque cambia el diseño.** El issue
+daba por hecho que un ``hello`` sin autenticar sólo contesta si el servidor no
+exige credenciales, y que por tanto su respuesta *es* la evidencia de la
+exposición. No es así: ``hello`` (antes ``isMaster``) es el comando de
+*handshake* del protocolo y **siempre** contesta, con ``--auth`` y sin él —
+tiene que hacerlo, porque el cliente necesita saber con quién habla antes de
+poder autenticarse. Un check construido sobre esa premisa habría marcado como
+expuesto **todo** MongoDB alcanzable, incluidos los correctamente cerrados.
+
+Así que el módulo separa las dos preguntas, que resultan ser distintas:
+
+- ``hello`` responde *"¿qué versión eres?"* — y contesta siempre, así que
+  sirve para el fingerprint y para nada más.
+- ``listDatabases`` responde *"¿me dejas entrar?"* — sin credenciales
+  devuelve la lista de bases de datos; con ``--auth`` devuelve
+  ``ok: 0`` y el código 13 (*Unauthorized*). **Ahí** está la evidencia.
+
+El parseo de BSON necesario es mínimo —leer un documento y sacar unos pocos
+campos—, así que no hace falta traer ``pymongo`` sólo para esto: mismo criterio
+que llevó a construir SNMP sin ``pysnmp`` y el ``PRELOGIN`` de TDS a mano.
+
+Comparte diseño con :mod:`postgres` y :mod:`mssql`.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ..checks import is_mongodb_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+# El opcode del único mensaje que este módulo habla. OP_MSG sustituyó en
+# MongoDB 3.6 a la familia de opcodes antiguos, y es el que entiende cualquier
+# servidor que siga en soporte.
+OP_MSG = 2013
+MESSAGE_HEADER_SIZE = 16
+
+# El código de error que MongoDB devuelve cuando un comando exige credenciales
+# y no se han dado. Es el que distingue un servidor cerrado de uno abierto.
+UNAUTHORIZED_CODE = 13
+
+_PRODUCT = "MongoDB"
+
+
+# =========================================================================
+# BSON — lo justo para leer un documento de respuesta
+# =========================================================================
+
+def _read_cstring(data: bytes, offset: int) -> Tuple[str, int]:
+    """Lee una cadena terminada en NUL y devuelve dónde sigue el documento."""
+    end = data.find(b"\x00", offset)
+    if end == -1:
+        raise ValueError("cadena BSON sin terminador")
+    return data[offset:end].decode("utf-8", "ignore"), end + 1
+
+
+def _read_value(  # pylint: disable=too-many-return-statements
+    data: bytes, offset: int, element_type: int,
+) -> Tuple[Any, int]:
+    """Lee un valor BSON del tipo indicado.
+
+    Un ``return`` por tipo, y a propósito: la alternativa —una tabla de
+    tamaños— tendría que llevar además, para la mitad de los tipos, la regla
+    de cómo se calcula ese tamaño a partir del propio dato. Diez ramas
+    explícitas de dos líneas se leen mejor que una tabla con excepciones.
+
+    Sólo se implementan los tipos que aparecen en las respuestas que este
+    módulo consume. Un tipo no soportado corta la lectura en vez de avanzar a
+    ciegas: seguir adelante con un desplazamiento equivocado produce basura que
+    *parece* datos, que es peor que no leer nada.
+
+    Args:
+        data: El documento completo.
+        offset: Dónde empieza el valor.
+        element_type: El byte de tipo BSON.
+
+    Returns:
+        Un par ``(valor, siguiente desplazamiento)``.
+
+    Raises:
+        ValueError: Si el tipo no está soportado o el documento está truncado.
+    """
+    if element_type == 0x01:                                   # double
+        return struct.unpack_from("<d", data, offset)[0], offset + 8
+    if element_type == 0x02:                                   # string
+        length = struct.unpack_from("<i", data, offset)[0]
+        text = data[offset + 4:offset + 4 + length - 1].decode("utf-8", "ignore")
+        return text, offset + 4 + length
+    if element_type in (0x03, 0x04):                           # documento / array
+        length = struct.unpack_from("<i", data, offset)[0]
+        return parse_bson_document(data[offset:offset + length]), offset + length
+    if element_type == 0x05:                                   # binario
+        length = struct.unpack_from("<i", data, offset)[0]
+        return data[offset + 5:offset + 5 + length], offset + 5 + length
+    if element_type == 0x07:                                   # ObjectId
+        return data[offset:offset + 12], offset + 12
+    if element_type == 0x08:                                   # booleano
+        return bool(data[offset]), offset + 1
+    if element_type == 0x0A:                                   # null
+        return None, offset
+    if element_type == 0x10:                                   # int32
+        return struct.unpack_from("<i", data, offset)[0], offset + 4
+    if element_type in (0x09, 0x11, 0x12):                     # datetime, ts, int64
+        return struct.unpack_from("<q", data, offset)[0], offset + 8
+    raise ValueError(f"tipo BSON no soportado: {element_type:#04x}")
+
+
+def parse_bson_document(data: bytes) -> Dict[str, Any]:
+    """Descompone un documento BSON en un diccionario.
+
+    Args:
+        data: El documento completo, empezando por su longitud de cuatro bytes.
+
+    Returns:
+        El documento como diccionario. Vacío si está truncado o trae un tipo
+        que este lector no conoce — se prefiere no devolver nada a devolver una
+        lectura parcial que nadie distinguiría de una completa.
+    """
+    if len(data) < 5:
+        return {}
+    document: Dict[str, Any] = {}
+    offset = 4
+    try:
+        while offset < len(data) and data[offset] != 0x00:
+            element_type = data[offset]
+            name, offset = _read_cstring(data, offset + 1)
+            document[name], offset = _read_value(data, offset, element_type)
+    except (ValueError, struct.error, IndexError):
+        return {}
+    return document
+
+
+def build_bson_document(fields: List[Tuple[str, Any]]) -> bytes:
+    """Serializa los pocos tipos que hacen falta para pedir un comando.
+
+    Args:
+        fields: Los campos, en orden. MongoDB exige que el nombre del comando
+            sea **el primero** del documento, de ahí que sea una lista de pares
+            y no un diccionario.
+
+    Returns:
+        El documento BSON completo.
+    """
+    body = b""
+    for name, value in fields:
+        key = name.encode("utf-8") + b"\x00"
+        if isinstance(value, bool):
+            body += b"\x08" + key + bytes((1 if value else 0,))
+        elif isinstance(value, int):
+            body += b"\x10" + key + struct.pack("<i", value)
+        else:
+            encoded = str(value).encode("utf-8") + b"\x00"
+            body += b"\x02" + key + struct.pack("<i", len(encoded)) + encoded
+    return struct.pack("<i", len(body) + 5) + body + b"\x00"
+
+
+# =========================================================================
+# OP_MSG
+# =========================================================================
+
+def build_op_msg(command: List[Tuple[str, Any]], request_id: int = 1) -> bytes:
+    """Envuelve un comando en un ``OP_MSG`` mínimo.
+
+    Args:
+        command: Los campos del comando, con su nombre el primero.
+        request_id: El identificador de la petición.
+
+    Returns:
+        El mensaje completo, con su cabecera de dieciséis bytes.
+    """
+    # flagBits = 0, y una sola sección de tipo 0 (el documento del comando).
+    body = struct.pack("<I", 0) + b"\x00" + build_bson_document(command)
+    header = struct.pack("<iiii", MESSAGE_HEADER_SIZE + len(body), request_id, 0, OP_MSG)
+    return header + body
+
+
+def parse_op_msg(data: bytes) -> Dict[str, Any]:
+    """Extrae el documento de respuesta de un ``OP_MSG``.
+
+    Args:
+        data: El mensaje recibido, con su cabecera.
+
+    Returns:
+        El documento, o un diccionario vacío si la respuesta no es un
+        ``OP_MSG`` reconocible.
+    """
+    if len(data) < MESSAGE_HEADER_SIZE + 5:
+        return {}
+    opcode = struct.unpack_from("<i", data, 12)[0]
+    if opcode != OP_MSG:
+        return {}
+    # flagBits (4) + tipo de sección (1) por delante del documento.
+    return parse_bson_document(data[MESSAGE_HEADER_SIZE + 5:])
+
+
+HELLO_COMMAND: List[Tuple[str, Any]] = [("hello", 1), ("$db", "admin")]
+LIST_DATABASES_COMMAND: List[Tuple[str, Any]] = [("listDatabases", 1), ("$db", "admin")]
+
+
+@dataclass(frozen=True)
+class MongoFingerprint:
+    """Lo que MongoDB cuenta de sí mismo, y si deja entrar sin credenciales.
+
+    Attributes:
+        product: ``"MongoDB"``, o ``None`` si no contestó el protocolo.
+        version: La versión exacta que ``hello`` publica.
+        max_wire_version: La versión del protocolo de cable, que acota la
+            familia del servidor incluso si ``version`` no viniera.
+        allows_unauthenticated_access: Si un comando que exige permisos
+            funcionó **sin credenciales**. Es el hallazgo, y es un hecho
+            observado: el servidor devolvió los datos.
+    """
+    product: Optional[str]
+    version: Optional[str]
+    max_wire_version: Optional[int]
+    allows_unauthenticated_access: bool = False
+
+
+def fingerprint_mongo(hello_reply: bytes, list_reply: bytes = b"") -> MongoFingerprint:
+    """Construye el fingerprint a partir de las dos respuestas.
+
+    Args:
+        hello_reply: La respuesta a ``hello``, que contesta siempre.
+        list_reply: La respuesta a ``listDatabases``, que sólo trae datos
+            cuando el servidor no exige credenciales.
+
+    Returns:
+        El :class:`MongoFingerprint`.
+    """
+    hello = parse_op_msg(hello_reply)
+    if not hello or "maxWireVersion" not in hello:
+        return MongoFingerprint(None, None, None)
+
+    listing = parse_op_msg(list_reply) if list_reply else {}
+    # `ok: 1` **y** la lista presente: un servidor con --auth contesta `ok: 0`
+    # con el código 13, y uno que no entiende el comando no trae `databases`.
+    is_open = bool(listing.get("ok")) and "databases" in listing
+
+    version = hello.get("version")
+    return MongoFingerprint(
+        product=_PRODUCT,
+        version=str(version) if version else None,
+        max_wire_version=hello.get("maxWireVersion"),
+        allows_unauthenticated_access=is_open,
+    )
+
+
+# =========================================================================
+# SONDA (el borde de red: socket crudo, sin pymongo)
+# =========================================================================
+
+class MongoProbe:  # pylint: disable=too-few-public-methods
+    """Manda ``hello`` y ``listDatabases`` sobre la misma conexión.
+
+    Las dos preguntas van juntas porque son dos secciones del mismo diálogo y
+    el servidor no cierra entre una y otra: a diferencia de PostgreSQL, aquí no
+    hay ninguna negociación de transporte en medio que obligue a reconectar.
+
+    **Ninguno de los dos comandos escribe nada.** ``listDatabases`` es una
+    lectura de catálogo; se manda sin credenciales y su fracaso es tan
+    informativo como su éxito.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def fetch(self, host: str, port: int = 27017) -> Optional[Tuple[bytes, bytes]]:
+        """Hace los dos intercambios contra ``host:port``.
+
+        Args:
+            host: El objetivo.
+            port: El puerto de MongoDB.
+
+        Returns:
+            Un par ``(respuesta a hello, respuesta a listDatabases)``, o
+            ``None`` si ni siquiera el primero llegó a completarse.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("MongoDB: conexión fallida a %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            sock.sendall(build_op_msg(HELLO_COMMAND, request_id=1))
+            hello_reply = sock.recv(8192)
+            if not hello_reply:
+                return None
+            sock.sendall(build_op_msg(LIST_DATABASES_COMMAND, request_id=2))
+            try:
+                list_reply = sock.recv(8192)
+            except OSError:
+                list_reply = b""
+            return hello_reply, list_reply
+        except OSError as err:
+            logger.debug("MongoDB: intercambio fallido con %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+@register_dissector
+class MongoDissector(Dissector):
+    """``hello`` para la versión, ``listDatabases`` para saber si hay puerta."""
+
+    label = "MongoDB"
+
+    def __init__(self, probe: Optional[MongoProbe] = None) -> None:
+        self._probe = probe or MongoProbe()
+
+    def applies(self, service) -> bool:
+        return is_mongodb_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        rate_limiter.acquire(target)
+        replies = self._probe.fetch(target, service.port or 27017)
+        if replies is None:
+            return None
+        fingerprint = fingerprint_mongo(*replies)
+        if not fingerprint.product:
+            return None
+        return DissectorResult(fingerprint.product, fingerprint.version, self.label)

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -38,12 +38,14 @@ from typing import Dict, Optional
 from .checks import (
     ScriptContext,
     ScriptPlugin,
+    is_mongodb_service,
     is_postgres_service,
     is_smb_service,
     is_snmp_service,
 )
 from .engine import Service
 from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
+from .fingerprinting.mongo import MongoProbe, fingerprint_mongo
 from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
 from .fingerprinting.snmp import SnmpProbe
 
@@ -163,6 +165,41 @@ class PostgresTrustAuthenticationPlugin(ScriptPlugin):
         return fingerprint_postgres(*replies).is_unauthenticated
 
 
+class MongoUnauthenticatedAccessPlugin(ScriptPlugin):
+    """Detecta un MongoDB que sirve su catálogo **sin credenciales**.
+
+    Es el hallazgo clásico del producto: durante años las instalaciones por
+    defecto escuchaban en todas las interfaces sin autenticación, y de ahí
+    salió una de las mayores oleadas de fuga de datos y de ransomware de bases
+    de datos que se recuerdan.
+
+    **La evidencia no es que el servidor conteste.** El comando ``hello``
+    responde siempre, con ``--auth`` y sin él —es el handshake del protocolo, y
+    tiene que hacerlo para que el cliente sepa con quién habla—, así que un
+    check construido sobre "ha contestado" marcaría como expuesto todo MongoDB
+    alcanzable. La evidencia es que ``listDatabases``, que sí exige permisos,
+    devuelva la lista: un servidor cerrado responde ``ok: 0`` con el código 13.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "mongodb-unauthenticated-access"
+
+    def __init__(self, probe: Optional[MongoProbe] = None) -> None:
+        self._probe = probe or MongoProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_mongodb_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        replies = self._probe.fetch(context.target, context.service.port or 27017)
+        if replies is None:
+            return False
+        return fingerprint_mongo(*replies).allows_unauthenticated_access
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -174,5 +211,6 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         SmbSigningNotRequiredPlugin(),
         SnmpDefaultCommunityPlugin(),
         PostgresTrustAuthenticationPlugin(),
+        MongoUnauthenticatedAccessPlugin(),
     )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/tests/unit/test_lybra_mongo.py
+++ b/API/tests/unit/test_lybra_mongo.py
@@ -1,0 +1,278 @@
+"""El dissector de MongoDB (L14).
+
+Cierra el trío de bases de datos de la Fase N, y trae el hallazgo más famoso de
+la lista: durante años las instalaciones por defecto escuchaban en todas las
+interfaces sin autenticación.
+
+El bloque que más importa aquí es el que distingue **contestar** de **dejar
+entrar**. Ver el docstring del módulo: `hello` responde siempre, así que un
+check construido sobre "ha contestado" marcaría como expuesto todo MongoDB
+alcanzable, incluidos los correctamente cerrados.
+"""
+
+import struct
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import is_mongodb_service
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.mongo import (
+    HELLO_COMMAND,
+    LIST_DATABASES_COMMAND,
+    MESSAGE_HEADER_SIZE,
+    OP_MSG,
+    MongoDissector,
+    MongoProbe,
+    build_bson_document,
+    build_op_msg,
+    fingerprint_mongo,
+    parse_bson_document,
+    parse_op_msg,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _op_msg_reply(fields):
+    """Una respuesta OP_MSG con el documento dado."""
+    document = build_bson_document(fields)
+    body = struct.pack("<I", 0) + b"\x00" + document
+    return struct.pack("<iiii", MESSAGE_HEADER_SIZE + len(body), 1, 1, OP_MSG) + body
+
+
+HELLO_REPLY = _op_msg_reply([
+    ("helloOk", True), ("maxWireVersion", 21), ("version", "7.0.5"), ("ok", 1),
+])
+OPEN_LISTING = _op_msg_reply([("databases", "admin,config,local"), ("ok", 1)])
+DENIED_LISTING = _op_msg_reply([
+    ("ok", 0),
+    ("errmsg", "command listDatabases requires authentication"),
+    ("code", 13),
+])
+
+
+# ==================================================================== BSON
+
+
+def test_a_document_survives_the_round_trip():
+    document = build_bson_document([("hello", 1), ("$db", "admin")])
+    assert parse_bson_document(document) == {"hello": 1, "$db": "admin"}
+
+
+def test_the_command_name_stays_first():
+    """MongoDB exige que el nombre del comando sea el primer campo del
+    documento. De ahí que se serialice una lista de pares y no un diccionario:
+    el orden es parte del protocolo, no una preferencia."""
+    document = build_bson_document(HELLO_COMMAND)
+    assert document[4] == 0x10                      # tipo int32
+    assert document[5:5 + 6] == b"hello\x00"
+
+
+@pytest.mark.parametrize("data", [b"", b"\x05\x00", b"\x05\x00\x00\x00"])
+def test_a_truncated_document_reads_as_empty(data):
+    assert parse_bson_document(data) == {}
+
+
+def test_an_unsupported_type_yields_nothing_rather_than_a_partial_read():
+    """Avanzar a ciegas con un desplazamiento equivocado produce basura que
+    *parece* datos, y eso es peor que no leer nada."""
+    body = b"\x7f" + b"raro\x00" + b"\x01\x02"
+    document = struct.pack("<i", len(body) + 5) + body + b"\x00"
+    assert parse_bson_document(document) == {}
+
+
+# ================================================================== OP_MSG
+
+
+def test_the_message_declares_its_own_length_and_opcode():
+    message = build_op_msg(HELLO_COMMAND)
+    length, _request, _response, opcode = struct.unpack_from("<iiii", message, 0)
+    assert length == len(message)
+    assert opcode == OP_MSG
+
+
+def test_a_reply_with_another_opcode_is_ignored():
+    body = struct.pack("<I", 0) + b"\x00" + build_bson_document([("ok", 1)])
+    other = struct.pack("<iiii", MESSAGE_HEADER_SIZE + len(body), 1, 1, 2012) + body
+    assert parse_op_msg(other) == {}
+
+
+@pytest.mark.parametrize("data", [b"", b"\x00" * 16, b"HTTP/1.1 400 Bad Request"])
+def test_a_reply_that_is_not_op_msg_reads_as_empty(data):
+    assert parse_op_msg(data) == {}
+
+
+# ============================================ contestar no es dejar entrar
+
+
+def test_hello_alone_identifies_the_product_and_its_version():
+    fingerprint = fingerprint_mongo(HELLO_REPLY)
+    assert fingerprint.product == "MongoDB"
+    assert fingerprint.version == "7.0.5"
+    assert fingerprint.max_wire_version == 21
+
+
+def test_a_server_that_serves_its_catalogue_without_credentials_is_flagged():
+    fingerprint = fingerprint_mongo(HELLO_REPLY, OPEN_LISTING)
+    assert fingerprint.allows_unauthenticated_access
+
+
+def test_a_server_with_auth_answers_hello_but_is_not_flagged():
+    """**El test central de este módulo.**
+
+    `hello` es el handshake del protocolo y contesta siempre, con `--auth` y
+    sin él — tiene que hacerlo, porque el cliente necesita saber con quién
+    habla antes de poder autenticarse. Si la evidencia de exposición fuera "ha
+    contestado", este caso —un servidor correctamente cerrado— saldría marcado
+    como CRITICAL.
+    """
+    fingerprint = fingerprint_mongo(HELLO_REPLY, DENIED_LISTING)
+    assert fingerprint.product == "MongoDB"          # identificado igualmente
+    assert fingerprint.version == "7.0.5"
+    assert not fingerprint.allows_unauthenticated_access
+
+
+def test_no_listing_reply_at_all_is_not_taken_as_open():
+    """Sin respuesta al segundo comando no hay evidencia, y sin evidencia no
+    hay hallazgo — nunca al revés."""
+    assert not fingerprint_mongo(HELLO_REPLY, b"").allows_unauthenticated_access
+
+
+def test_an_ok_reply_without_the_database_list_is_not_taken_as_open():
+    partial = _op_msg_reply([("ok", 1)])
+    assert not fingerprint_mongo(HELLO_REPLY, partial).allows_unauthenticated_access
+
+
+def test_something_that_is_not_mongodb_is_not_identified():
+    assert fingerprint_mongo(b"+OK POP3 ready\r\n").product is None
+    assert fingerprint_mongo(_op_msg_reply([("ok", 1)])).product is None
+
+
+# ============================================================== la sonda
+
+
+class _ScriptedSocket:
+    def __init__(self, replies, sent):
+        self._replies = list(replies)
+        self._sent = sent
+
+    def settimeout(self, _timeout):
+        pass
+
+    def sendall(self, payload):
+        self._sent.append(payload)
+
+    def recv(self, _size):
+        return self._replies.pop(0) if self._replies else b""
+
+    def close(self):
+        pass
+
+
+def _probe_with(replies):
+    sent = []
+    return MongoProbe(connect=lambda _a, _t: _ScriptedSocket(replies, sent)), sent
+
+
+def test_the_probe_asks_both_commands_over_one_connection():
+    probe, sent = _probe_with([HELLO_REPLY, OPEN_LISTING])
+    hello_reply, list_reply = probe.fetch("10.0.0.5")
+    assert hello_reply == HELLO_REPLY and list_reply == OPEN_LISTING
+    assert sent == [build_op_msg(HELLO_COMMAND, request_id=1),
+                    build_op_msg(LIST_DATABASES_COMMAND, request_id=2)]
+
+
+def test_the_probe_never_writes_anything():
+    """Los dos comandos son lecturas: `hello` es el handshake y
+    `listDatabases` una consulta de catálogo."""
+    probe, sent = _probe_with([HELLO_REPLY, OPEN_LISTING])
+    probe.fetch("10.0.0.5")
+    combined = b"".join(sent).lower()
+    for writing_command in (b"insert", b"update", b"delete", b"drop"):
+        assert writing_command not in combined
+
+
+def test_a_server_that_says_nothing_yields_nothing():
+    probe, _sent = _probe_with([b""])
+    assert probe.fetch("10.0.0.5") is None
+
+
+def test_a_refused_connection_yields_nothing():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    assert MongoProbe(connect=refuse).fetch("10.0.0.5") is None
+
+
+# =========================================================== el dissector
+
+
+class _NullLimiter:
+    def acquire(self, _host):
+        pass
+
+
+def test_the_dissector_claims_the_sharded_ports_too():
+    """27018 y 27019 son los puertos de un `mongos` y de un servidor de
+    configuración: ahí vive el catálogo entero del clúster."""
+    dissector = MongoDissector()
+    for port in (27017, 27018, 27019):
+        assert dissector.applies(Service(port, "tcp", ""))
+    assert dissector.applies(Service(37017, "tcp", "mongodb"))
+    assert not dissector.applies(Service(5432, "tcp", "postgresql"))
+    assert is_mongodb_service(Service(27017, "tcp", ""))
+
+
+def test_the_dissector_reports_product_and_version():
+    probe, _sent = _probe_with([HELLO_REPLY, DENIED_LISTING])
+    result = MongoDissector(probe=probe).probe(
+        "10.0.0.5", Service(27017, "tcp", "mongodb"), _NullLimiter())
+    assert (result.product, result.version, result.label) == ("MongoDB", "7.0.5", "MongoDB")
+
+
+# ============================================ el check y su registro
+
+
+class _Context:
+    def __init__(self, port=27017):
+        self.target = "10.0.0.5"
+        self.service = Service(port, "tcp", "mongodb")
+
+    def acquire(self):
+        pass
+
+
+def _plugin(replies):
+    from src.modules.features.themis.lybra.script_checks import (
+        MongoUnauthenticatedAccessPlugin,
+    )
+    probe, _sent = _probe_with(replies)
+    return MongoUnauthenticatedAccessPlugin(probe=probe)
+
+
+def test_the_check_fires_only_for_a_server_that_hands_over_its_catalogue():
+    assert _plugin([HELLO_REPLY, OPEN_LISTING]).run(_Context()) is True
+    assert _plugin([HELLO_REPLY, DENIED_LISTING]).run(_Context()) is False
+
+
+def test_the_check_stays_quiet_without_evidence():
+    from src.modules.features.themis.lybra.script_checks import (
+        MongoUnauthenticatedAccessPlugin,
+    )
+
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    plugin = MongoUnauthenticatedAccessPlugin(probe=MongoProbe(connect=refuse))
+    assert plugin.run(_Context()) is False
+
+
+def test_the_check_is_registered_and_wired_to_its_feed_entry():
+    from src.modules.features.themis.lybra.checks import load_checks
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    check = next(c for c in load_checks() if c.id == "mongodb-unauthenticated-access")
+    assert check.severity == "CRITICAL" and check.mode == "safe"
+    assert check.service == "mongodb"
+    assert check.category == "exposed_service"
+    assert check.script in default_script_plugins()


### PR DESCRIPTION
## Resumen

Cierra #287. Con esto quedan los tres dissectors de base de datos que la Fase N había dejado fuera: PostgreSQL (#382), SQL Server (#383) y MongoDB.

MongoDB es el que tiene asociado el incidente más conocido: durante años, las instalaciones por defecto escuchaban en todas las interfaces **sin autenticación**, y de ahí salió una de las mayores oleadas de fuga de datos y de ransomware de bases de datos que se recuerdan. Sigue apareciendo.

## Una corrección al planteamiento del issue, y cambia el diseño

Merece explicarse antes que nada porque es la decisión de fondo de este PR.

El issue daba por hecho lo siguiente: *«un comando `isMaster` / `hello` sin autenticar devuelve la versión exacta si el servidor no exige credenciales. Que responda **es** la evidencia del hallazgo»*.

**No es así.** `hello` (antes `isMaster`) es el comando de *handshake* del protocolo de MongoDB, y contesta **siempre**: con `--auth` activado y sin él. Tiene que hacerlo, porque el cliente necesita saber con quién está hablando —qué versión, qué topología, qué mecanismos de autenticación— antes de poder autenticarse siquiera.

Un check construido sobre esa premisa habría marcado como CRITICAL **todo MongoDB alcanzable por red**, incluidos los correctamente cerrados. Sería un falso positivo del 100 % sobre los servidores bien configurados, y de los que no se detectan mirando el código: el check «funciona», dispara, y el hallazgo tiene una pinta perfectamente creíble.

Así que el módulo separa dos preguntas que resultan ser distintas:

| Comando | Pregunta | Con `--auth` | Sin `--auth` |
|---|---|---|---|
| `hello` | ¿Qué versión eres? | Contesta | Contesta |
| `listDatabases` | ¿Me dejas entrar? | `ok: 0`, código 13 (*Unauthorized*) | Devuelve la lista |

El fingerprint sale del primero. **La evidencia de exposición sale del segundo**, y es un hecho observado: el servidor entregó su catálogo a quien no se identificó.

Hay un test dedicado a esto —`test_a_server_with_auth_answers_hello_but_is_not_flagged`— que es el más importante del fichero: un servidor correctamente cerrado se identifica igual de bien y **no** se marca.

## Qué se ha construido

**`fingerprinting/mongo.py`**, con BSON y `OP_MSG` a mano. El parseo necesario es mínimo —leer un documento y sacar unos pocos campos—, así que no hace falta traer `pymongo` sólo para esto: mismo criterio que llevó a construir SNMP sin `pysnmp` y el `PRELOGIN` de TDS a mano.

Dos detalles del lector de BSON que son decisiones y no descuidos:

- **Un tipo BSON no soportado corta la lectura** en vez de avanzar saltándoselo. Seguir adelante con un desplazamiento equivocado produce basura que *parece* datos, y eso es peor que no leer nada — un documento a medias no se distingue de uno completo cuando llega al que lo consume.
- **Los campos se serializan como lista de pares, no como diccionario.** MongoDB exige que el nombre del comando sea el primer campo del documento: el orden es parte del protocolo, no una preferencia de estilo. Hay un test que lo fija.

**`MongoUnauthenticatedAccessPlugin`**, un check de tipo `script` con severidad CRITICAL y categoría `exposed_service` (la que #381 introdujo). Comparte sonda con el dissector, igual que los de SNMP y PostgreSQL: el mismo diálogo responde a las dos preguntas, y repetirlo no lo haría más cierto.

**Los puertos 27018 y 27019** entran junto al 27017. Son los puertos por defecto de un `mongos` y de un servidor de configuración en un despliegue fragmentado, y ahí es justamente donde vive el catálogo entero del clúster.

`feedVersion` sube a `lybra-checks-9`.

## Sobre el modo `safe`

Los dos comandos son lecturas. `hello` es el handshake; `listDatabases` es una consulta de catálogo. No se escribe nada, no se prueba ninguna credencial, y el fracaso del segundo comando es tan informativo como su éxito. Hay un test que comprueba sobre los bytes que salen por el socket que no aparece ningún comando de escritura.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa). `pylint` en 10,00/10 sobre `mongo.py` y `script_checks.py`.

`tests/unit/test_lybra_mongo.py`, 26 tests:

- **BSON**: un documento sobrevive el viaje de ida y vuelta; el nombre del comando se queda el primero; tres documentos truncados leen vacío; y un tipo no soportado produce **nada** en vez de una lectura parcial.
- **OP_MSG**: el mensaje declara su propia longitud y su opcode; una respuesta con otro opcode se ignora; y tres respuestas que no son OP_MSG leen vacío.
- **Contestar no es dejar entrar** (el bloque central): `hello` solo identifica producto y versión; un servidor que entrega su catálogo queda marcado; **un servidor con `--auth` contesta `hello` y no queda marcado**; sin respuesta al segundo comando no hay hallazgo; un `ok: 1` sin la lista tampoco cuenta; y un banner de POP3 no se identifica como MongoDB.
- **La sonda**: los dos comandos sobre una conexión, en orden y con sus identificadores de petición; ningún comando de escritura sale por el socket; un servidor mudo y una conexión rechazada no producen nada.
- **El dissector**: reclama los tres puertos del despliegue fragmentado y un `mongodb` en el 37017 (gracias a la cascada de #380), y reporta producto y versión.
- **El check**: dispara sólo con el catálogo servido, se calla con `--auth`, se calla sin evidencia, y está registrado y conectado con su entrada del feed.

## Notas

- El issue mencionaba que el check dependía de #272 (el mapa `service` → predicado escrito a mano). Ese arreglo ya está: el mapa se deriva de los nombres de función, así que definir `is_mongodb_service` es todo lo que hace falta para que `service: mongodb` funcione en el feed.
- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un `mongo:7` con y sin `--auth`; eso pertenece a una pasada del banco — y es justamente el par de contenedores que confirmaría contra un servidor real la corrección de premisa que este PR hace sobre `hello`.
