### PR TITLE
feat(themis): dissector de LDAP por rootDSE, y sus dos checks de configuración

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-9"
+CHECKS_FEED_VERSION = "lybra-checks-10"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -91,7 +91,7 @@ _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
 # se sondea igual de bien (el esquema se observa), pero no recibe los checks de
 # certificado. Ampliarla es gratis; hacerla innecesaria es #283, que ataca la
 # misma enfermedad —decidir por número de puerto— desde el otro lado.
-_TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986}
+_TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986, 636, 3269}
 
 # APIs de administración que hablan HTTP y publican su versión en un JSON sin
 # autenticar (L17). Cada familia tiene su propio predicado —y no uno común—
@@ -146,6 +146,14 @@ _MSSQL_SERVICE_NAMES = {"ms-sql-s", "mssql", "sqlserver"}
 _MSSQL_PORTS = {1433}
 _MONGODB_SERVICE_NAMES = {"mongodb", "mongo"}
 _MONGODB_PORTS = {27017, 27018, 27019}
+# 3268 es el Catálogo Global de Active Directory: mismo protocolo, y sirve el
+# bosque entero en vez de un solo dominio. 636 y 3269 son sus variantes sobre
+# TLS, que hablan LDAP igual una vez levantado el canal.
+_LDAP_SERVICE_NAMES = {"ldap", "ldaps", "ldapssl", "globalcatldap", "globalcatldapssl"}
+_LDAP_PORTS = {389, 636, 3268, 3269}
+# El subconjunto que va cifrado, para la comprobación de "389 en claro
+# conviviendo con un 636".
+LDAPS_PORTS = {636, 3269}
 _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
@@ -721,6 +729,11 @@ def is_mongodb_service(service: Service) -> bool:
             or service.port in _MONGODB_PORTS)
 
 
+def is_ldap_service(service: Service) -> bool:
+    """Return whether a service should be probed by the LDAP dissector."""
+    return (service.name or "").lower() in _LDAP_SERVICE_NAMES or service.port in _LDAP_PORTS
+
+
 def is_redis_service(service: Service) -> bool:
     """Return whether a service should be probed by the Redis dissector or
     ``type: "network"`` checks (Fase N)."""
@@ -856,11 +869,20 @@ class ScriptContext:
             network exchange, exactly as the dissectors do.
         mode: ``"safe"`` or ``"aggressive"`` — the mode the runtime already
             authorised this check under, in case a plugin wants to adapt.
+        sibling_services: Los demás servicios descubiertos en el **mismo host**.
+            Hay hallazgos que no son propiedad de un servicio sino de la
+            relación entre dos: un LDAP en claro en el 389 no dice nada por sí
+            solo, y dice bastante si el mismo host publica además un 636. El
+            runtime ya tiene la lista completa mientras itera, así que dársela
+            al plugin no cuesta ninguna petición de red — y sin ella, el plugin
+            tendría que descubrir puertos por su cuenta, que es justo lo que
+            esta clase existe para impedir.
     """
     target: str
     service: Service
     rate_limiter: Optional["HostRateLimiter"] = None
     mode: str = "safe"
+    sibling_services: tuple = ()
 
     def acquire(self) -> None:
         """Respect the host's rate limit before touching the network."""
@@ -1013,6 +1035,13 @@ class CheckRuntime:
         # objetivo ha podido cambiar — que es justo lo que un escáner mide.
         self._responses: Dict[tuple, Optional[Response]] = {}
         self._handshakes: Dict[tuple, object] = {}
+
+        services = tuple(services)
+        # Los plugins de tipo ``script`` pueden necesitar ver los servicios
+        # hermanos del mismo host (ver ``ScriptContext.sibling_services``). La
+        # lista ya está aquí; guardarla evita que un plugin tenga que
+        # redescubrirla por su cuenta.
+        self._services = services
 
         findings: List[dict] = []
         for service in services:
@@ -1203,6 +1232,7 @@ class CheckRuntime:
             service=service,
             rate_limiter=self._rl,
             mode=self._mode,
+            sibling_services=self._services,
         )
         try:
             fired = plugin.run(context)

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-9
+feedVersion: lybra-checks-10
 checks:
   - id: git-config-exposure
     version: 1
@@ -473,6 +473,30 @@ checks:
     mode: safe
     finding:
       title: 'MongoDB: catalogo accesible sin autenticacion'
+      qod: 99
+      confirmed: true
+  - id: ldap-anonymous-bind
+    version: 1
+    type: script
+    script: ldap-anonymous-bind
+    category: network_config
+    severity: MEDIUM
+    service: ldap
+    mode: safe
+    finding:
+      title: 'LDAP: bind anonimo permitido (el directorio es publico)'
+      qod: 99
+      confirmed: true
+  - id: ldap-cleartext-with-ldaps
+    version: 1
+    type: script
+    script: ldap-cleartext-with-ldaps
+    category: network_config
+    severity: MEDIUM
+    service: ldap
+    mode: safe
+    finding:
+      title: 'LDAP: puerto en claro abierto habiendo LDAPS en el mismo host'
       qod: 99
       confirmed: true
   - id: snmp-default-community

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -48,6 +48,12 @@ best value-for-effort in the roadmap:
     ella— y ``listDatabases`` para saber si el servidor deja entrar sin
     credenciales. Parseo de BSON mínimo, sin ``pymongo``.
 
+``ldap``
+    El rootDSE, la consulta anónima que la RFC 4512 define para que un cliente
+    sepa con quién habla: vendor, versión y los dominios que el servidor sirve.
+    BER a mano, con lectura de longitudes en forma larga — la mitad que el
+    codificador de SNMP no necesitaba.
+
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
     Fase N's non-HTTP protocols — each volunteers its identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
@@ -88,9 +94,9 @@ confidence beyond what the matcher already assigns any version-based guess.
 Two techniques are deliberately left for later: full JARM fingerprinting (too
 large and risky to ship without a live TLS lab to validate it against) and OS
 fingerprinting (which the roadmap itself rates low value). Both stay
-oracle-only — handled by Nmap — until picked up. RDP, LDAP, VNC's full
-protocol beyond its version banner, and RPC stay oracle-only too, per the
-roadmap's own priority-3 rating for that group.
+oracle-only — handled by Nmap — until picked up. RDP, VNC's full protocol beyond
+its version banner, and RPC stay oracle-only too, per the roadmap's own
+priority-3 rating for that group.
 """
 
 from __future__ import annotations
@@ -169,6 +175,17 @@ from .smb import (
     SmbProbe,
     SmbDissector,
 )
+from .ldap import (
+    ROOTDSE_ATTRIBUTES,
+    LdapDissector,
+    LdapFingerprint,
+    LdapProbe,
+    build_anonymous_bind,
+    build_rootdse_search,
+    fingerprint_ldap,
+    parse_bind_response,
+    parse_search_entry,
+)
 from .mongo import (
     HELLO_COMMAND,
     LIST_DATABASES_COMMAND,
@@ -236,6 +253,15 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "ROOTDSE_ATTRIBUTES",
+    "LdapDissector",
+    "LdapFingerprint",
+    "LdapProbe",
+    "build_anonymous_bind",
+    "build_rootdse_search",
+    "fingerprint_ldap",
+    "parse_bind_response",
+    "parse_search_entry",
     "HELLO_COMMAND",
     "LIST_DATABASES_COMMAND",
     "MongoDissector",

--- a/API/src/modules/features/themis/lybra/fingerprinting/ldap.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/ldap.py
@@ -1,0 +1,430 @@
+"""El dissector de LDAP — el servicio que más cuenta sobre una organización.
+
+LDAP estaba en la prioridad-3 de la tabla de la Fase N —*"banner y capacidades
+básicas, bajo coste cada uno, poca frecuencia"*— y esa valoración de
+**frecuencia** merecía revisarse: en una red corporativa con Active Directory,
+el 389 está abierto **siempre**.
+
+Y a diferencia de casi todo lo demás, LDAP tiene una consulta estándar y
+anónima diseñada precisamente para esto: el **rootDSE**, la entrada raíz que
+todo servidor publica para que un cliente sepa con qué está hablando antes de
+autenticarse. Devuelve ``vendorName``, ``vendorVersion``, los
+``namingContexts`` (los dominios que sirve) y los ``supportedSASLMechanisms``.
+
+Dos hallazgos vienen de regalo con la misma sonda:
+
+- **Bind anónimo permitido.** Si el rootDSE contesta sin credenciales, la
+  información del directorio es pública. Es un hallazgo de configuración
+  clásico, de los que OpenVAS detectaba y este motor no.
+- **LDAP en claro conviviendo con LDAPS.** Un 389 abierto en un host que
+  también publica el 636 significa que hay credenciales de directorio
+  viajando sin cifrar por decisión de cada cliente.
+
+El ``namingContexts`` merece mención aparte: da el nombre de dominio de la
+organización, que es el mejor identificador de activo que puede aparecer en un
+informe. Una IP no dice de quién es una máquina; ``DC=empresa,DC=local`` sí.
+
+**La codificación es BER**, la misma familia que el SNMP que ya se construyó a
+mano en ``transport.py``, así que hay precedente y experiencia en casa. La
+diferencia práctica es que aquí hay que **leer** longitudes en forma larga
+—una lista de atributos pasa de 127 bytes con facilidad—, no sólo escribirlas
+en forma corta.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from ..checks import is_ldap_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+# Etiquetas BER de los mensajes LDAP que este módulo construye o lee
+# (RFC 4511 §4.1.1 y siguientes). Las de aplicación llevan el bit 0x60 porque
+# son constructed + application class.
+TAG_SEQUENCE = 0x30
+TAG_INTEGER = 0x02
+TAG_ENUMERATED = 0x0A
+TAG_OCTET_STRING = 0x04
+TAG_BOOLEAN = 0x01
+TAG_BIND_REQUEST = 0x60
+TAG_BIND_RESPONSE = 0x61
+TAG_SEARCH_REQUEST = 0x63
+TAG_SEARCH_ENTRY = 0x64
+TAG_SEARCH_DONE = 0x65
+TAG_SIMPLE_AUTH = 0x80          # [0] contexto: contraseña simple
+TAG_FILTER_PRESENT = 0x87       # [7] contexto: filtro "el atributo existe"
+
+# Códigos de resultado que importan (RFC 4511 §4.1.9).
+RESULT_SUCCESS = 0
+RESULT_INAPPROPRIATE_AUTHENTICATION = 48
+RESULT_STRONGER_AUTH_REQUIRED = 8
+
+# Los atributos del rootDSE que se piden. Ni uno más: cada uno tiene un
+# consumidor concreto abajo, y pedir el directorio entero sería una consulta
+# muy distinta en coste y en intención.
+ROOTDSE_ATTRIBUTES: Tuple[str, ...] = (
+    "vendorName",
+    "vendorVersion",
+    "namingContexts",
+    "supportedLDAPVersion",
+    "supportedSASLMechanisms",
+)
+
+_PRODUCT_FALLBACK = "LDAP"
+
+
+# =========================================================================
+# BER — escribir y, sobre todo, leer
+# =========================================================================
+
+def encode_length(length: int) -> bytes:
+    """Codifica una longitud BER, en forma corta o larga según haga falta.
+
+    Args:
+        length: La longitud a codificar.
+
+    Returns:
+        Los bytes de longitud. Hasta 127 es un solo byte; a partir de ahí, un
+        byte con el bit alto y el número de bytes que siguen.
+    """
+    if length < 0x80:
+        return bytes((length,))
+    body = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes((0x80 | len(body),)) + body
+
+
+def ber(tag: int, value: bytes) -> bytes:
+    """Envuelve ``value`` en un TLV BER con la etiqueta dada."""
+    return bytes((tag,)) + encode_length(len(value)) + value
+
+
+def read_length(data: bytes, offset: int) -> Tuple[int, int]:
+    """Lee una longitud BER, en cualquiera de sus dos formas.
+
+    Ésta es la mitad que ``transport.py`` no necesitaba: al escribir, ningún
+    campo del GetRequest de SNMP se acerca a 128 bytes, pero al leer una
+    respuesta LDAP con varios atributos la forma larga es la norma.
+
+    Args:
+        data: Los bytes del mensaje.
+        offset: Dónde empieza la longitud (justo tras la etiqueta).
+
+    Returns:
+        Un par ``(longitud, siguiente desplazamiento)``.
+
+    Raises:
+        ValueError: Si el mensaje está truncado.
+    """
+    if offset >= len(data):
+        raise ValueError("longitud BER truncada")
+    first = data[offset]
+    if first < 0x80:
+        return first, offset + 1
+    count = first & 0x7F
+    if count == 0 or offset + 1 + count > len(data):
+        raise ValueError("longitud BER indefinida o truncada")
+    return int.from_bytes(data[offset + 1:offset + 1 + count], "big"), offset + 1 + count
+
+
+def read_tlv(data: bytes, offset: int) -> Tuple[int, bytes, int]:
+    """Lee un TLV completo.
+
+    Args:
+        data: Los bytes del mensaje.
+        offset: Dónde empieza la etiqueta.
+
+    Returns:
+        Una tupla ``(etiqueta, valor, siguiente desplazamiento)``.
+
+    Raises:
+        ValueError: Si el mensaje está truncado.
+    """
+    if offset >= len(data):
+        raise ValueError("TLV truncado")
+    tag = data[offset]
+    length, value_offset = read_length(data, offset + 1)
+    end = value_offset + length
+    if end > len(data):
+        raise ValueError("valor BER truncado")
+    return tag, data[value_offset:end], end
+
+
+# =========================================================================
+# Los mensajes que se envían
+# =========================================================================
+
+def build_anonymous_bind(message_id: int = 1) -> bytes:
+    """Construye un ``BindRequest`` anónimo: LDAPv3, sin nombre y sin contraseña.
+
+    Un bind anónimo no es un intento de adivinar credenciales: es la forma que
+    el propio protocolo define para preguntar sin identificarse, y lo que se
+    observa es **si el servidor la acepta**. No se prueba ninguna contraseña.
+
+    Args:
+        message_id: El identificador del mensaje.
+
+    Returns:
+        El mensaje LDAP completo.
+    """
+    request = ber(TAG_BIND_REQUEST, (
+        ber(TAG_INTEGER, bytes((3,)))       # versión 3
+        + ber(TAG_OCTET_STRING, b"")        # nombre vacío
+        + ber(TAG_SIMPLE_AUTH, b"")         # contraseña vacía
+    ))
+    return ber(TAG_SEQUENCE, ber(TAG_INTEGER, bytes((message_id,))) + request)
+
+
+def build_rootdse_search(message_id: int = 2) -> bytes:
+    """Construye el ``SearchRequest`` del rootDSE.
+
+    Base vacía, ámbito ``baseObject`` y filtro ``(objectClass=*)``: la consulta
+    exacta que la RFC 4512 §5.1 define para preguntarle a un servidor qué es,
+    sin recorrer ni una entrada del directorio.
+
+    Args:
+        message_id: El identificador del mensaje.
+
+    Returns:
+        El mensaje LDAP completo.
+    """
+    attributes = b"".join(
+        ber(TAG_OCTET_STRING, name.encode("ascii")) for name in ROOTDSE_ATTRIBUTES
+    )
+    request = ber(TAG_SEARCH_REQUEST, (
+        ber(TAG_OCTET_STRING, b"")               # baseObject: la raíz
+        + ber(TAG_ENUMERATED, bytes((0,)))       # scope: baseObject
+        + ber(TAG_ENUMERATED, bytes((0,)))       # derefAliases: never
+        + ber(TAG_INTEGER, bytes((0,)))          # sizeLimit: sin límite
+        + ber(TAG_INTEGER, bytes((0,)))          # timeLimit: sin límite
+        + ber(TAG_BOOLEAN, bytes((0,)))          # typesOnly: falso
+        + ber(TAG_FILTER_PRESENT, b"objectClass")
+        + ber(TAG_SEQUENCE, attributes)
+    ))
+    return ber(TAG_SEQUENCE, ber(TAG_INTEGER, bytes((message_id,))) + request)
+
+
+# =========================================================================
+# Lo que se recibe
+# =========================================================================
+
+def _protocol_ops(data: bytes) -> List[Tuple[int, bytes]]:
+    """Extrae los ``protocolOp`` de todos los ``LDAPMessage`` de un buffer.
+
+    Un servidor contesta a un ``SearchRequest`` con varios mensajes seguidos
+    —una o más entradas y un ``SearchResultDone``— y pueden llegar en la misma
+    lectura del socket.
+
+    Args:
+        data: Los bytes recibidos.
+
+    Returns:
+        Los pares ``(etiqueta, cuerpo)`` que se hayan podido leer enteros. Un
+        mensaje truncado al final corta el recorrido sin perder los anteriores.
+    """
+    operations: List[Tuple[int, bytes]] = []
+    offset = 0
+    try:
+        while offset < len(data):
+            tag, body, offset = read_tlv(data, offset)
+            if tag != TAG_SEQUENCE:
+                break
+            _id_tag, _id_value, inner = read_tlv(body, 0)
+            operation_tag, operation_body, _end = read_tlv(body, inner)
+            operations.append((operation_tag, operation_body))
+    except ValueError:
+        pass
+    return operations
+
+
+def parse_bind_response(data: bytes) -> Optional[int]:
+    """Lee el código de resultado de un ``BindResponse``.
+
+    Args:
+        data: Los bytes recibidos.
+
+    Returns:
+        El código, o ``None`` si no hay ningún ``BindResponse`` legible.
+    """
+    for tag, body in _protocol_ops(data):
+        if tag != TAG_BIND_RESPONSE:
+            continue
+        try:
+            _tag, value, _end = read_tlv(body, 0)
+        except ValueError:
+            return None
+        return int.from_bytes(value, "big") if value else None
+    return None
+
+
+def parse_search_entry(data: bytes) -> Dict[str, List[str]]:  # pylint: disable=too-many-locals
+    """Lee los atributos de un ``SearchResultEntry``.
+
+    Muchas variables locales porque BER se lee así: cada nivel de anidamiento
+    —la entrada, la lista de atributos, cada atributo, cada valor— produce su
+    etiqueta, su contenido y su desplazamiento, y nombrarlos es lo que hace
+    legible un recorrido que si no sería aritmética de índices.
+
+    Args:
+        data: Los bytes recibidos.
+
+    Returns:
+        Un mapa atributo → valores. Vacío si no hay ninguna entrada legible.
+    """
+    attributes: Dict[str, List[str]] = {}
+    for tag, body in _protocol_ops(data):
+        if tag != TAG_SEARCH_ENTRY:
+            continue
+        try:
+            _name_tag, _object_name, offset = read_tlv(body, 0)
+            _list_tag, attribute_list, _end = read_tlv(body, offset)
+            inner = 0
+            while inner < len(attribute_list):
+                _attr_tag, attribute, inner = read_tlv(attribute_list, inner)
+                _type_tag, attribute_type, values_offset = read_tlv(attribute, 0)
+                _values_tag, values, _values_end = read_tlv(attribute, values_offset)
+                name = attribute_type.decode("utf-8", "ignore")
+                collected: List[str] = []
+                value_offset = 0
+                while value_offset < len(values):
+                    _value_tag, value, value_offset = read_tlv(values, value_offset)
+                    collected.append(value.decode("utf-8", "ignore"))
+                attributes[name] = collected
+        except ValueError:
+            continue
+    return attributes
+
+
+@dataclass(frozen=True)
+class LdapFingerprint:
+    """Lo que el rootDSE cuenta de un servidor de directorio.
+
+    Attributes:
+        product: El ``vendorName`` publicado, o ``"LDAP"`` cuando el servidor
+            contesta pero no se nombra — que es el caso de Active Directory,
+            que no publica ``vendorName``.
+        version: El ``vendorVersion``, cuando lo hay.
+        naming_contexts: Los dominios que el servidor sirve. El mejor
+            identificador de activo que puede aparecer en un informe.
+        sasl_mechanisms: Los mecanismos SASL ofrecidos.
+        allows_anonymous_bind: Si el servidor aceptó el bind anónimo.
+    """
+    product: Optional[str]
+    version: Optional[str]
+    naming_contexts: Tuple[str, ...] = ()
+    sasl_mechanisms: Tuple[str, ...] = ()
+    allows_anonymous_bind: bool = False
+
+
+def fingerprint_ldap(bind_reply: bytes, search_reply: bytes) -> LdapFingerprint:
+    """Construye el fingerprint a partir de las dos respuestas.
+
+    Args:
+        bind_reply: La respuesta al ``BindRequest`` anónimo.
+        search_reply: La respuesta al ``SearchRequest`` del rootDSE.
+
+    Returns:
+        El :class:`LdapFingerprint`. Sin producto cuando ninguna de las dos
+        respuestas es LDAP legible.
+    """
+    result_code = parse_bind_response(bind_reply)
+    attributes = parse_search_entry(search_reply)
+    allows_anonymous = result_code == RESULT_SUCCESS
+
+    if result_code is None and not attributes:
+        return LdapFingerprint(None, None)
+
+    vendor = attributes.get("vendorName") or []
+    version = attributes.get("vendorVersion") or []
+    return LdapFingerprint(
+        product=vendor[0] if vendor else _PRODUCT_FALLBACK,
+        version=version[0] if version else None,
+        naming_contexts=tuple(attributes.get("namingContexts") or ()),
+        sasl_mechanisms=tuple(attributes.get("supportedSASLMechanisms") or ()),
+        allows_anonymous_bind=allows_anonymous,
+    )
+
+
+# =========================================================================
+# SONDA (el borde de red: socket crudo, sin cliente LDAP)
+# =========================================================================
+
+class LdapProbe:  # pylint: disable=too-few-public-methods
+    """Hace el bind anónimo y la consulta del rootDSE sobre una conexión.
+
+    Las dos van juntas porque el protocolo lo pide: un ``SearchRequest`` sólo
+    tiene sentido sobre una sesión ya vinculada, aunque sea anónimamente.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def fetch(self, host: str, port: int = 389) -> Optional[Tuple[bytes, bytes]]:
+        """Hace los dos intercambios contra ``host:port``.
+
+        Args:
+            host: El objetivo.
+            port: El puerto de LDAP.
+
+        Returns:
+            Un par ``(respuesta al bind, respuesta a la búsqueda)``, o ``None``
+            si ni siquiera el bind llegó a contestarse.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("LDAP: conexión fallida a %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            sock.sendall(build_anonymous_bind())
+            bind_reply = sock.recv(8192)
+            if not bind_reply:
+                return None
+            sock.sendall(build_rootdse_search())
+            try:
+                search_reply = sock.recv(16384)
+            except OSError:
+                search_reply = b""
+            return bind_reply, search_reply
+        except OSError as err:
+            logger.debug("LDAP: intercambio fallido con %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+@register_dissector
+class LdapDissector(Dissector):
+    """Bind anónimo y rootDSE: vendor, versión y los dominios que sirve."""
+
+    label = "LDAP"
+
+    def __init__(self, probe: Optional[LdapProbe] = None) -> None:
+        self._probe = probe or LdapProbe()
+
+    def applies(self, service) -> bool:
+        return is_ldap_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        rate_limiter.acquire(target)
+        replies = self._probe.fetch(target, service.port or 389)
+        if replies is None:
+            return None
+        fingerprint = fingerprint_ldap(*replies)
+        if not fingerprint.product:
+            return None
+        return DissectorResult(fingerprint.product, fingerprint.version, self.label)

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -38,6 +38,8 @@ from typing import Dict, Optional
 from .checks import (
     ScriptContext,
     ScriptPlugin,
+    LDAPS_PORTS,
+    is_ldap_service,
     is_mongodb_service,
     is_postgres_service,
     is_smb_service,
@@ -45,6 +47,7 @@ from .checks import (
 )
 from .engine import Service
 from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
+from .fingerprinting.ldap import LdapProbe, fingerprint_ldap
 from .fingerprinting.mongo import MongoProbe, fingerprint_mongo
 from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
 from .fingerprinting.snmp import SnmpProbe
@@ -200,6 +203,65 @@ class MongoUnauthenticatedAccessPlugin(ScriptPlugin):
         return fingerprint_mongo(*replies).allows_unauthenticated_access
 
 
+class LdapAnonymousBindPlugin(ScriptPlugin):
+    """Detecta un servidor de directorio que acepta un bind **anónimo**.
+
+    Si el rootDSE contesta sin credenciales, la información del directorio es
+    pública: quién sirve qué dominio, qué mecanismos de autenticación admite y,
+    en muchos despliegues, bastante más si la consulta se amplía.
+
+    Un bind anónimo no es un intento de adivinar credenciales: es la forma que
+    el propio protocolo define para preguntar sin identificarse (RFC 4511
+    §4.2), y lo que se observa es si el servidor **la acepta**. No se prueba
+    ninguna contraseña.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "ldap-anonymous-bind"
+
+    def __init__(self, probe: Optional[LdapProbe] = None) -> None:
+        self._probe = probe or LdapProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_ldap_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        replies = self._probe.fetch(context.target, context.service.port or 389)
+        if replies is None:
+            return False
+        return fingerprint_ldap(*replies).allows_anonymous_bind
+
+
+class LdapCleartextWithLdapsPlugin(ScriptPlugin):
+    """Detecta un LDAP en claro conviviendo con un LDAPS en el mismo host.
+
+    Éste es el primer check del motor que **no es propiedad de un servicio sino
+    de la relación entre dos**. Un 389 abierto no dice gran cosa por sí solo:
+    hay despliegues donde es la única opción y el cifrado se resuelve con
+    STARTTLS. Pero un 389 en un host que además publica el 636 significa que la
+    versión cifrada existe, funciona, y aun así el puerto en claro sigue
+    aceptando binds — así que basta con que un cliente esté mal configurado
+    para que unas credenciales de directorio viajen legibles por la red.
+
+    No hace ninguna petición: la evidencia son dos puertos que el
+    descubrimiento ya encontró (ver ``ScriptContext.sibling_services``).
+    """
+
+    plugin_id = "ldap-cleartext-with-ldaps"
+
+    def applies(self, service: Service) -> bool:
+        return is_ldap_service(service) and service.port not in LDAPS_PORTS
+
+    def run(self, context: ScriptContext) -> bool:
+        return any(
+            sibling.port in LDAPS_PORTS
+            for sibling in context.sibling_services
+        )
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -212,5 +274,7 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         SnmpDefaultCommunityPlugin(),
         PostgresTrustAuthenticationPlugin(),
         MongoUnauthenticatedAccessPlugin(),
+        LdapAnonymousBindPlugin(),
+        LdapCleartextWithLdapsPlugin(),
     )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/src/modules/features/themis/lybra/transport.py
+++ b/API/src/modules/features/themis/lybra/transport.py
@@ -61,9 +61,11 @@ WELL_KNOWN_PORTS = {
     21: "ftp", 22: "ssh", 23: "telnet", 25: "smtp", 53: "domain", 80: "http",
     110: "pop3", 111: "rpcbind", 135: "msrpc", 139: "netbios-ssn", 143: "imap",
     161: "snmp", 389: "ldap", 443: "https", 445: "microsoft-ds", 465: "smtps",
+    636: "ldaps",
     587: "submission", 631: "ipp", 993: "imaps", 995: "pop3s", 1433: "ms-sql-s",
     1521: "oracle", 2049: "nfs", 2375: "docker", 2376: "docker-tls",
     2379: "etcd", 3306: "mysql", 3389: "ms-wbt-server",
+    3268: "globalcatldap", 3269: "globalcatldapssl",
     5432: "postgresql", 5601: "kibana", 5900: "vnc", 5985: "wsman",
     6379: "redis", 6443: "kubernetes", 8080: "http-proxy", 8443: "https-alt",
     8500: "consul", 8888: "http-alt", 9200: "elasticsearch", 27017: "mongodb",
@@ -74,7 +76,7 @@ WELL_KNOWN_PORTS = {
 # full 1-65535 range — sweeping everything belongs to the raw fast-path, which
 # this module does not implement.
 DEFAULT_PORTS: tuple = tuple(sorted(WELL_KNOWN_PORTS)) + (
-    20, 69, 123, 137, 138, 512, 513, 514, 873, 1080, 1723, 2181, 3000, 3268,
+    20, 69, 123, 137, 138, 512, 513, 514, 873, 1080, 1723, 2181, 3000,
     4444, 5000, 5060, 6667, 7001, 8000, 8008, 8081, 8088, 8181, 9000,
     9090, 9300, 11211,
 )

--- a/API/tests/unit/test_lybra_ldap.py
+++ b/API/tests/unit/test_lybra_ldap.py
@@ -1,0 +1,359 @@
+"""El dissector de LDAP (L16).
+
+En una red corporativa con Active Directory el 389 está abierto siempre, y
+LDAP tiene una consulta estándar y anónima diseñada para esto: el rootDSE.
+
+La codificación es BER, la misma familia que el GetRequest de SNMP que ya se
+construyó a mano. La diferencia práctica —y la que más tests tiene aquí— es
+que hay que **leer** longitudes en forma larga, no sólo escribirlas en forma
+corta: una lista de atributos pasa de 127 bytes con facilidad.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import LDAPS_PORTS, is_ldap_service
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.ldap import (
+    RESULT_INAPPROPRIATE_AUTHENTICATION,
+    RESULT_SUCCESS,
+    ROOTDSE_ATTRIBUTES,
+    TAG_BIND_RESPONSE,
+    TAG_SEARCH_ENTRY,
+    LdapDissector,
+    LdapProbe,
+    ber,
+    build_anonymous_bind,
+    build_rootdse_search,
+    encode_length,
+    fingerprint_ldap,
+    parse_bind_response,
+    parse_search_entry,
+    read_length,
+    read_tlv,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _message(message_id, operation_tag, operation_body):
+    return ber(0x30, ber(0x02, bytes((message_id,))) + ber(operation_tag, operation_body))
+
+
+def _bind_reply(result_code):
+    body = ber(0x0A, bytes((result_code,))) + ber(0x04, b"") + ber(0x04, b"")
+    return _message(1, TAG_BIND_RESPONSE, body)
+
+
+def _attribute(name, values):
+    return ber(0x30, ber(0x04, name.encode()) + ber(
+        0x31, b"".join(ber(0x04, value.encode()) for value in values)))
+
+
+def _search_reply(attributes):
+    body = ber(0x04, b"") + ber(0x30, b"".join(
+        _attribute(name, values) for name, values in attributes.items()))
+    return _message(2, TAG_SEARCH_ENTRY, body)
+
+
+OPENLDAP_ROOTDSE = _search_reply({
+    "vendorName": ["Apache Software Foundation"],
+    "vendorVersion": ["2.0.0"],
+    "namingContexts": ["DC=empresa,DC=local"],
+    "supportedSASLMechanisms": ["GSSAPI", "DIGEST-MD5"],
+})
+
+# Active Directory no publica vendorName ni vendorVersion: se identifica por
+# sus contextos de nombres y por sus mecanismos.
+ACTIVE_DIRECTORY_ROOTDSE = _search_reply({
+    "namingContexts": ["DC=corp,DC=empresa,DC=com",
+                       "CN=Configuration,DC=corp,DC=empresa,DC=com"],
+    "supportedSASLMechanisms": ["GSSAPI", "GSS-SPNEGO", "EXTERNAL", "DIGEST-MD5"],
+    "supportedLDAPVersion": ["3", "2"],
+})
+
+
+# ====================================================================== BER
+
+
+@pytest.mark.parametrize("length, encoded", [
+    (0, b"\x00"),
+    (127, b"\x7f"),
+    (128, b"\x81\x80"),
+    (255, b"\x81\xff"),
+    (256, b"\x82\x01\x00"),
+])
+def test_lengths_use_the_short_form_up_to_127_and_the_long_form_after(length, encoded):
+    assert encode_length(length) == encoded
+
+
+@pytest.mark.parametrize("length", [0, 1, 127, 128, 300, 70000])
+def test_a_written_length_reads_back_the_same(length):
+    encoded = encode_length(length)
+    assert read_length(encoded, 0) == (length, len(encoded))
+
+
+def test_a_long_form_value_survives_the_round_trip():
+    """El caso que obliga a implementar la forma larga: un valor de más de 127
+    bytes, que es lo normal en una respuesta de rootDSE."""
+    payload = b"x" * 500
+    tag, value, end = read_tlv(ber(0x04, payload), 0)
+    assert (tag, value) == (0x04, payload)
+    assert end == len(ber(0x04, payload))
+
+
+@pytest.mark.parametrize("data", [
+    b"",
+    b"\x04",                       # etiqueta sin longitud
+    b"\x04\x05ab",                 # valor truncado
+    b"\x04\x82\x01",               # forma larga truncada
+    b"\x04\x80",                   # longitud indefinida, no permitida en LDAP
+])
+def test_a_truncated_tlv_raises_instead_of_returning_garbage(data):
+    with pytest.raises(ValueError):
+        read_tlv(data, 0)
+
+
+# ================================================ los mensajes que se envían
+
+
+def test_the_anonymous_bind_is_the_exact_message_the_rfc_fixes():
+    """El artefacto verificable a ojo de este módulo: un bind LDAPv3 anónimo
+    son catorce bytes y no admite variantes."""
+    assert build_anonymous_bind().hex() == "300c020101600702010304008000"
+
+
+def test_the_anonymous_bind_carries_no_password():
+    """No es un intento de adivinar credenciales: es la forma que el protocolo
+    define para preguntar sin identificarse (RFC 4511 §4.2), y lo que se
+    observa es si el servidor la acepta."""
+    request = build_anonymous_bind()
+    assert request.endswith(b"\x04\x00\x80\x00")     # nombre vacío, clave vacía
+
+
+def test_the_rootdse_search_asks_only_for_the_attributes_it_consumes():
+    request = build_rootdse_search()
+    for name in ROOTDSE_ATTRIBUTES:
+        assert name.encode() in request
+    # Base vacía y ámbito baseObject: no se recorre ni una entrada del
+    # directorio, sólo se pregunta por la raíz.
+    assert b"objectClass" in request
+
+
+def test_the_rootdse_search_needs_the_long_form_and_declares_it_right():
+    """Con cinco atributos el mensaje pasa de 127 bytes, así que este mensaje
+    es el que ejercita la forma larga al escribir."""
+    request = build_rootdse_search()
+    assert len(request) > 127
+    tag, value, end = read_tlv(request, 0)
+    assert tag == 0x30 and end == len(request) and value
+
+
+# ========================================================== las respuestas
+
+
+def test_a_successful_bind_is_read_as_success():
+    assert parse_bind_response(_bind_reply(RESULT_SUCCESS)) == RESULT_SUCCESS
+
+
+def test_a_rejected_bind_is_read_as_its_own_code():
+    reply = _bind_reply(RESULT_INAPPROPRIATE_AUTHENTICATION)
+    assert parse_bind_response(reply) == RESULT_INAPPROPRIATE_AUTHENTICATION
+
+
+@pytest.mark.parametrize("data", [b"", b"\x30\x00", b"no es LDAP"])
+def test_an_unreadable_bind_reply_yields_nothing(data):
+    assert parse_bind_response(data) is None
+
+
+def test_the_rootdse_attributes_are_read_with_all_their_values():
+    attributes = parse_search_entry(ACTIVE_DIRECTORY_ROOTDSE)
+    assert attributes["namingContexts"] == [
+        "DC=corp,DC=empresa,DC=com", "CN=Configuration,DC=corp,DC=empresa,DC=com"]
+    assert "GSSAPI" in attributes["supportedSASLMechanisms"]
+
+
+def test_a_search_reply_that_is_not_ldap_yields_no_attributes():
+    assert parse_search_entry(b"HTTP/1.1 400 Bad Request") == {}
+
+
+# ========================================================== el fingerprint
+
+
+def test_an_openldap_style_server_names_itself():
+    fingerprint = fingerprint_ldap(_bind_reply(RESULT_SUCCESS), OPENLDAP_ROOTDSE)
+    assert fingerprint.product == "Apache Software Foundation"
+    assert fingerprint.version == "2.0.0"
+    assert fingerprint.naming_contexts == ("DC=empresa,DC=local",)
+    assert fingerprint.allows_anonymous_bind
+
+
+def test_active_directory_is_identified_even_without_a_vendor_name():
+    """AD no publica `vendorName` ni `vendorVersion`. Se le reconoce igual como
+    servicio LDAP, y lo que aporta —el nombre de dominio— es el mejor
+    identificador de activo que puede llegar a un informe."""
+    fingerprint = fingerprint_ldap(_bind_reply(RESULT_SUCCESS), ACTIVE_DIRECTORY_ROOTDSE)
+    assert fingerprint.product == "LDAP"
+    assert fingerprint.version is None
+    assert fingerprint.naming_contexts[0] == "DC=corp,DC=empresa,DC=com"
+
+
+def test_a_server_that_rejects_the_anonymous_bind_is_not_flagged():
+    reply = _bind_reply(RESULT_INAPPROPRIATE_AUTHENTICATION)
+    fingerprint = fingerprint_ldap(reply, b"")
+    assert fingerprint.product == "LDAP"          # contestó LDAP, se identifica
+    assert not fingerprint.allows_anonymous_bind  # pero no deja mirar
+
+
+def test_something_that_is_not_ldap_is_not_identified():
+    assert fingerprint_ldap(b"+OK POP3 ready\r\n", b"<html>").product is None
+
+
+# ================================================================ la sonda
+
+
+class _ScriptedSocket:
+    def __init__(self, replies, sent):
+        self._replies = list(replies)
+        self._sent = sent
+
+    def settimeout(self, _timeout):
+        pass
+
+    def sendall(self, payload):
+        self._sent.append(payload)
+
+    def recv(self, _size):
+        return self._replies.pop(0) if self._replies else b""
+
+    def close(self):
+        pass
+
+
+def _probe_with(replies):
+    sent = []
+    return LdapProbe(connect=lambda _a, _t: _ScriptedSocket(replies, sent)), sent
+
+
+def test_the_probe_binds_before_searching():
+    """Un SearchRequest sólo tiene sentido sobre una sesión ya vinculada,
+    aunque sea anónimamente: el orden lo pide el protocolo."""
+    probe, sent = _probe_with([_bind_reply(RESULT_SUCCESS), OPENLDAP_ROOTDSE])
+    probe.fetch("10.0.0.5")
+    assert sent == [build_anonymous_bind(), build_rootdse_search()]
+
+
+def test_a_server_that_says_nothing_yields_nothing():
+    probe, _sent = _probe_with([b""])
+    assert probe.fetch("10.0.0.5") is None
+
+
+def test_a_refused_connection_yields_nothing():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    assert LdapProbe(connect=refuse).fetch("10.0.0.5") is None
+
+
+# ============================================================ el dissector
+
+
+class _NullLimiter:
+    def acquire(self, _host):
+        pass
+
+
+def test_the_dissector_claims_the_directory_ports():
+    dissector = LdapDissector()
+    for port in (389, 636, 3268, 3269):
+        assert dissector.applies(Service(port, "tcp", ""))
+    assert dissector.applies(Service(1389, "tcp", "ldap"))
+    assert not dissector.applies(Service(80, "tcp", "http"))
+    assert is_ldap_service(Service(389, "tcp", ""))
+
+
+def test_the_dissector_reports_what_the_rootdse_published():
+    probe, _sent = _probe_with([_bind_reply(RESULT_SUCCESS), OPENLDAP_ROOTDSE])
+    result = LdapDissector(probe=probe).probe(
+        "10.0.0.5", Service(389, "tcp", "ldap"), _NullLimiter())
+    assert (result.product, result.version, result.label) == (
+        "Apache Software Foundation", "2.0.0", "LDAP")
+
+
+# ================================================================ los checks
+
+
+class _Context:
+    def __init__(self, port=389, siblings=()):
+        self.target = "10.0.0.5"
+        self.service = Service(port, "tcp", "ldap")
+        self.sibling_services = siblings
+
+    def acquire(self):
+        pass
+
+
+def _anonymous_plugin(replies):
+    from src.modules.features.themis.lybra.script_checks import LdapAnonymousBindPlugin
+    probe, _sent = _probe_with(replies)
+    return LdapAnonymousBindPlugin(probe=probe)
+
+
+def test_the_anonymous_bind_check_follows_the_servers_answer():
+    accepted = [_bind_reply(RESULT_SUCCESS), OPENLDAP_ROOTDSE]
+    rejected = [_bind_reply(RESULT_INAPPROPRIATE_AUTHENTICATION), b""]
+    assert _anonymous_plugin(accepted).run(_Context()) is True
+    assert _anonymous_plugin(rejected).run(_Context()) is False
+
+
+def test_the_anonymous_bind_check_stays_quiet_without_evidence():
+    from src.modules.features.themis.lybra.script_checks import LdapAnonymousBindPlugin
+
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    plugin = LdapAnonymousBindPlugin(probe=LdapProbe(connect=refuse))
+    assert plugin.run(_Context()) is False
+
+
+def _cleartext_plugin():
+    from src.modules.features.themis.lybra.script_checks import (
+        LdapCleartextWithLdapsPlugin,
+    )
+    return LdapCleartextWithLdapsPlugin()
+
+
+def test_the_cleartext_check_needs_an_ldaps_sibling_to_fire():
+    """El primer check del motor que no es propiedad de un servicio sino de la
+    relación entre dos. Un 389 solo no dice gran cosa; un 389 junto a un 636
+    dice que la versión cifrada existe y que la de claro sigue abierta."""
+    plugin = _cleartext_plugin()
+    alone = _Context(389, siblings=(Service(389, "tcp", "ldap"),))
+    with_ldaps = _Context(389, siblings=(Service(389, "tcp", "ldap"),
+                                         Service(636, "tcp", "ldaps")))
+    assert plugin.run(alone) is False
+    assert plugin.run(with_ldaps) is True
+
+
+def test_the_cleartext_check_never_applies_to_the_encrypted_port_itself():
+    plugin = _cleartext_plugin()
+    for port in LDAPS_PORTS:
+        assert not plugin.applies(Service(port, "tcp", "ldaps"))
+    assert plugin.applies(Service(389, "tcp", "ldap"))
+
+
+def test_the_cleartext_check_makes_no_network_request():
+    """La evidencia son dos puertos que el descubrimiento ya encontró: no hay
+    ninguna petición que hacer, y por eso el plugin no recibe sonda."""
+    plugin = _cleartext_plugin()
+    assert not hasattr(plugin, "_probe")
+
+
+def test_both_ldap_checks_are_registered_and_wired_to_their_feed_entries():
+    from src.modules.features.themis.lybra.checks import load_checks
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    plugins = default_script_plugins()
+    for check_id in ("ldap-anonymous-bind", "ldap-cleartext-with-ldaps"):
+        check = next(c for c in load_checks() if c.id == check_id)
+        assert check.service == "ldap" and check.mode == "safe"
+        assert check.script in plugins


### PR DESCRIPTION
## Resumen

Cierra #288.

LDAP estaba en la prioridad-3 de la tabla de la Fase N —*«banner y capacidades básicas, bajo coste cada uno, poca frecuencia»*— y esa valoración de **frecuencia** merecía revisarse. En una red corporativa con Active Directory, el 389 no está abierto a veces: está abierto **siempre**. Y es de los servicios que más cuenta sobre la organización que hay detrás.

## La consulta que LDAP regala

A diferencia de casi todo lo demás, LDAP tiene una consulta **estándar y anónima diseñada precisamente para esto**: el **rootDSE**.

Es la entrada raíz que todo servidor de directorio publica para que un cliente sepa con qué está hablando *antes* de autenticarse — qué versiones del protocolo entiende, qué mecanismos de autenticación admite, qué dominios sirve. No es un agujero ni un descuido: es parte del diseño del protocolo (RFC 4512 §5.1), y por eso consultarla es tan barato y tan seguro.

De ahí salen `vendorName`, `vendorVersion`, `namingContexts` y `supportedSASLMechanisms`.

El **`namingContexts` merece mención aparte**. Da el nombre de dominio de la organización, y ése es el mejor identificador de activo que puede aparecer en un informe: una IP no dice de quién es una máquina, `DC=empresa,DC=local` sí.

## BER, y la mitad que faltaba

La codificación de LDAP es **BER**, la misma familia que el `GetRequest` de SNMP que ya se construyó a mano en `transport.py`. Hay precedente y experiencia en casa.

La diferencia práctica es concreta: aquel codificador sólo escribía longitudes en **forma corta**, y podía permitírselo porque ningún campo de un `GetRequest` se acerca a 128 bytes. Aquí hace falta la **forma larga** en los dos sentidos —al leer, porque una respuesta de rootDSE con varios atributos la usa siempre; y al escribir, porque la propia consulta con sus cinco atributos ocupa 129 bytes—.

La forma larga es un byte con el bit alto puesto que dice cuántos bytes de longitud vienen detrás. Hay tests parametrizados en los dos lados del límite (127 y 128) y un caso de ida y vuelta sobre 500 bytes.

El `BindRequest` anónimo tiene además su test dorado: son catorce bytes, `300c020101600702010304008000`, y no admite variantes. Es el artefacto de este módulo verificable a ojo contra la RFC.

## Los dos checks

### Bind anónimo permitido — `MEDIUM`

Si el rootDSE contesta sin credenciales, la información del directorio es pública.

Conviene ser preciso sobre qué se hace aquí, porque «bind anónimo» suena a intento de entrada y no lo es. Un bind anónimo es **la forma que el propio protocolo define para preguntar sin identificarse** (RFC 4511 §4.2): versión 3, nombre vacío, contraseña vacía. No se prueba ninguna contraseña, no se adivina ningún usuario. Lo que se observa es si el servidor **la acepta**, que es una decisión de configuración suya. Hay un test que comprueba sobre los bytes que el mensaje no lleva credencial ninguna.

### LDAP en claro conviviendo con LDAPS — `MEDIUM`

**Éste es el primer check del motor que no es propiedad de un servicio sino de la relación entre dos**, y merece explicarse porque es un tipo de hallazgo nuevo aquí.

Un 389 abierto no dice gran cosa por sí solo: hay despliegues donde es la única opción y el cifrado se resuelve con STARTTLS. Pero un 389 en un host que **además** publica el 636 significa que la versión cifrada existe, funciona, y aun así el puerto en claro sigue aceptando binds — así que basta con que un cliente esté mal configurado para que unas credenciales de directorio viajen legibles por la red.

Para poder mirar eso, `ScriptContext` gana `sibling_services`: los demás servicios descubiertos en el mismo host. Es una adición pequeña y bien acotada — **el runtime ya tenía la lista completa mientras iteraba**, así que dársela al plugin no cuesta ni una petición de red. Y es la alternativa correcta a que el plugin descubra puertos por su cuenta, que es justo lo que `ScriptContext` existe para impedir (*«un plugin nunca abre sus propias conexiones a su propio ritmo»*).

Este check, de hecho, **no hace ninguna petición**: la evidencia son dos puertos que el descubrimiento ya encontró. Hay un test que lo fija.

## Puertos

- **636 (LDAPS) entra en `WELL_KNOWN_PORTS`**, donde no estaba. Y en los puertos de higiene TLS, junto a 3269: un certificado caducado en el LDAPS de una empresa es tan hallazgo como en su web.
- **3268 y 3269** (Catálogo Global de Active Directory) pasan de ser números sueltos en `DEFAULT_PORTS` a tener nombre. Hablan el mismo protocolo y sirven el bosque entero en vez de un solo dominio.

`feedVersion` sube a `lybra-checks-10`.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa) y los tests de integración de Lybra y Themis. `pylint` en 10,00/10 sobre `ldap.py` y `script_checks.py`.

`tests/unit/test_lybra_ldap.py`, 43 tests:

- **BER**: las dos formas de longitud en los dos lados del límite; ida y vuelta para seis longitudes; un valor de 500 bytes; y cinco TLV truncados que **lanzan** en vez de devolver basura — incluida la longitud indefinida, que BER admite y LDAP prohíbe.
- **Los mensajes que se envían**: el bind anónimo byte a byte contra la RFC; que no lleva contraseña; que la consulta pide sólo los atributos que se consumen; y que pasa de 127 bytes, que es lo que ejercita la forma larga al escribir.
- **Las respuestas**: un bind aceptado y uno rechazado con su código; tres respuestas ilegibles; los atributos con todos sus valores; y una respuesta HTTP que no produce atributos.
- **El fingerprint**: un servidor estilo OpenLDAP que se nombra; **Active Directory, que no publica `vendorName` ni `vendorVersion`** y aun así se identifica y aporta su dominio; un servidor que rechaza el bind, que se identifica igual pero no queda marcado; y un banner de POP3 que no se confunde con LDAP.
- **La sonda**: el bind va antes que la búsqueda (el orden lo pide el protocolo); un servidor mudo y una conexión rechazada no producen nada.
- **El dissector**: reclama los cuatro puertos de directorio y un `ldap` en el 1389 (gracias a la cascada de #380).
- **Los checks**: el de bind sigue la respuesta del servidor y se calla sin evidencia; el de claro necesita el hermano cifrado para dispararse, nunca aplica al puerto cifrado, y no hace ninguna petición; los dos están registrados y conectados con sus entradas del feed.

## Notas

- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un `osixia/openldap` con y sin bind anónimo; eso pertenece a una pasada del banco.
- El docstring del paquete de fingerprinting ya no lista LDAP como *oracle-only*.
