### PR TITLE
feat(themis): dissector de RDP, y el check de NLA no exigido

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-10"
+CHECKS_FEED_VERSION = "lybra-checks-11"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -149,6 +149,8 @@ _MONGODB_PORTS = {27017, 27018, 27019}
 # 3268 es el Catálogo Global de Active Directory: mismo protocolo, y sirve el
 # bosque entero en vez de un solo dominio. 636 y 3269 son sus variantes sobre
 # TLS, que hablan LDAP igual una vez levantado el canal.
+_RDP_SERVICE_NAMES = {"ms-wbt-server", "rdp", "msrdp", "terminal-server"}
+_RDP_PORTS = {3389}
 _LDAP_SERVICE_NAMES = {"ldap", "ldaps", "ldapssl", "globalcatldap", "globalcatldapssl"}
 _LDAP_PORTS = {389, 636, 3268, 3269}
 # El subconjunto que va cifrado, para la comprobación de "389 en claro
@@ -732,6 +734,11 @@ def is_mongodb_service(service: Service) -> bool:
 def is_ldap_service(service: Service) -> bool:
     """Return whether a service should be probed by the LDAP dissector."""
     return (service.name or "").lower() in _LDAP_SERVICE_NAMES or service.port in _LDAP_PORTS
+
+
+def is_rdp_service(service: Service) -> bool:
+    """Return whether a service should be probed by the RDP dissector."""
+    return (service.name or "").lower() in _RDP_SERVICE_NAMES or service.port in _RDP_PORTS
 
 
 def is_redis_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-10
+feedVersion: lybra-checks-11
 checks:
   - id: git-config-exposure
     version: 1
@@ -497,6 +497,18 @@ checks:
     mode: safe
     finding:
       title: 'LDAP: puerto en claro abierto habiendo LDAPS en el mismo host'
+      qod: 99
+      confirmed: true
+  - id: rdp-nla-not-required
+    version: 1
+    type: script
+    script: rdp-nla-not-required
+    category: network_config
+    severity: HIGH
+    service: rdp
+    mode: safe
+    finding:
+      title: 'RDP: no exige autenticacion a nivel de red (NLA)'
       qod: 99
       confirmed: true
   - id: snmp-default-community

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -54,6 +54,11 @@ best value-for-effort in the roadmap:
     BER a mano, con lectura de longitudes en forma larga — la mitad que el
     codificador de SNMP no necesitaba.
 
+``rdp``
+    La negociación de ``X.224``: qué protocolo de seguridad elige el servidor
+    y, con ello, si exige NLA. Resultado binario y sin ambigüedad, que es lo
+    contrario de un banner de texto libre. No da versión, y no se inventa una.
+
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
     Fase N's non-HTTP protocols — each volunteers its identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
@@ -94,8 +99,8 @@ confidence beyond what the matcher already assigns any version-based guess.
 Two techniques are deliberately left for later: full JARM fingerprinting (too
 large and risky to ship without a live TLS lab to validate it against) and OS
 fingerprinting (which the roadmap itself rates low value). Both stay
-oracle-only — handled by Nmap — until picked up. RDP, VNC's full protocol beyond
-its version banner, and RPC stay oracle-only too, per the roadmap's own
+oracle-only — handled by Nmap — until picked up. VNC's full protocol beyond its
+version banner, and RPC, stay oracle-only too, per the roadmap's own
 priority-3 rating for that group.
 """
 
@@ -175,6 +180,16 @@ from .smb import (
     SmbProbe,
     SmbDissector,
 )
+from .rdp import (
+    FAILURE_CODES,
+    PROTOCOL_NAMES,
+    RdpDissector,
+    RdpFingerprint,
+    RdpProbe,
+    build_connection_request,
+    fingerprint_rdp,
+    parse_connection_confirm,
+)
 from .ldap import (
     ROOTDSE_ATTRIBUTES,
     LdapDissector,
@@ -253,6 +268,14 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "FAILURE_CODES",
+    "PROTOCOL_NAMES",
+    "RdpDissector",
+    "RdpFingerprint",
+    "RdpProbe",
+    "build_connection_request",
+    "fingerprint_rdp",
+    "parse_connection_confirm",
     "ROOTDSE_ATTRIBUTES",
     "LdapDissector",
     "LdapFingerprint",

--- a/API/src/modules/features/themis/lybra/fingerprinting/rdp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/rdp.py
@@ -1,0 +1,280 @@
+"""El dissector de RDP — el hallazgo que puede acabar en una llamada de teléfono.
+
+RDP figura en la tabla de la Fase N como prioridad 3 con coste "medio-alto".
+Por impacto real merece estar más arriba: es el vector de entrada de la mayoría
+de los incidentes de ransomware que empiezan por acceso remoto, y **BlueKeep**
+(CVE-2019-0708) sigue apareciendo en redes reales siete años después.
+
+**RDP sin NLA es el hallazgo.** NLA (*Network Level Authentication*) obliga a
+autenticarse **antes** de que se cree la sesión gráfica. Sin él, cualquiera que
+alcance el puerto llega a la pantalla de login, lo que habilita fuerza bruta y
+toda la familia de vulnerabilidades pre-autenticación de la que BlueKeep es el
+ejemplo canónico. Un RDP expuesto a internet sin NLA es, por sí solo, un
+hallazgo que justifica un informe entero.
+
+**Cómo se observa.** Un ``X.224 Connection Request`` con un ``RDP_NEG_REQ``
+anuncia qué protocolos de seguridad soporta el cliente, y el servidor contesta
+**cuál ha elegido** — o por qué no elige ninguno. Es la sonda más compleja del
+backlog en construcción (``TPKT`` + ``X.224`` + negociación), pero su resultado
+es binario y sin ambigüedad, que es justo lo contrario de un banner de texto
+libre: no hay nada que interpretar, el servidor dice un número.
+
+============================== ==========================================
+Protocolo elegido              Qué significa
+============================== ==========================================
+``HYBRID`` / ``HYBRID_EX``     NLA exigido. Es la postura correcta.
+``SSL``                        TLS, pero **sin** NLA.
+``RDP``                        Seguridad RDP estándar, sin TLS siquiera.
+============================== ==========================================
+
+Un ``RDP_NEG_FAILURE`` tampoco es un callejón sin salida: sus códigos
+(:data:`FAILURE_CODES`) dicen igual de bien qué exige el servidor —
+``HYBRID_REQUIRED_BY_SERVER`` es, de hecho, la mejor noticia posible.
+
+**Sobre la versión: este intercambio no la da, y no se inventa.** La
+negociación de X.224 ocurre antes de cualquier intercambio de capacidades, así
+que el dissector reporta producto sin versión. Cuando el servidor negocia TLS,
+el certificado que presenta suele traer el nombre del equipo — pero eso es un
+handshake TLS aparte, y se deja fuera de esta sonda a propósito.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+from ..checks import is_rdp_service
+from .dispatch import Dissector, DissectorResult
+from .registry import register_dissector
+
+logger = logging.getLogger(__name__)
+
+# TPKT (RFC 1006): versión 3, un byte reservado y la longitud total en 16 bits
+# big-endian. Es el sobre que lleva un TPDU de X.224 sobre TCP.
+TPKT_VERSION = 0x03
+TPKT_HEADER_SIZE = 4
+
+# Códigos de TPDU de X.224 que aparecen aquí, en el nibble alto del byte.
+TPDU_CONNECTION_REQUEST = 0xE0
+TPDU_CONNECTION_CONFIRM = 0xD0
+
+# Tipos de mensaje de la negociación de RDP (MS-RDPBCGR §2.2.1.1.1 y §2.2.1.2.1).
+NEG_REQUEST = 0x01
+NEG_RESPONSE = 0x02
+NEG_FAILURE = 0x03
+
+# Protocolos de seguridad, como máscara de bits. Se anuncian todos los que el
+# motor sabe reconocer para que el servidor elija el que de verdad prefiere:
+# pedir sólo uno mediría la petición, no la política del servidor.
+PROTOCOL_RDP = 0x00000000
+PROTOCOL_SSL = 0x00000001
+PROTOCOL_HYBRID = 0x00000002
+PROTOCOL_HYBRID_EX = 0x00000008
+REQUESTED_PROTOCOLS = PROTOCOL_SSL | PROTOCOL_HYBRID | PROTOCOL_HYBRID_EX
+
+# Nombre legible de cada protocolo elegido.
+PROTOCOL_NAMES: Dict[int, str] = {
+    PROTOCOL_RDP: "rdp",
+    PROTOCOL_SSL: "ssl",
+    PROTOCOL_HYBRID: "hybrid",
+    PROTOCOL_HYBRID_EX: "hybrid-ex",
+}
+
+# Los dos que implican NLA: la autenticación ocurre antes de que exista la
+# sesión gráfica.
+PROTOCOLS_WITH_NLA = {PROTOCOL_HYBRID, PROTOCOL_HYBRID_EX}
+
+# Códigos de fallo de la negociación (MS-RDPBCGR §2.2.1.2.2). Un fallo informa
+# tanto como un éxito: dice qué exige el servidor.
+FAILURE_CODES: Dict[int, str] = {
+    0x00000001: "ssl-required-by-server",
+    0x00000002: "ssl-not-allowed-by-server",
+    0x00000003: "ssl-cert-not-on-server",
+    0x00000004: "inconsistent-flags",
+    0x00000005: "hybrid-required-by-server",
+    0x00000006: "ssl-with-user-auth-required-by-server",
+}
+
+# El fallo que significa que el servidor exige NLA — es decir, la postura
+# correcta expresada como rechazo.
+FAILURE_MEANING_NLA_REQUIRED = "hybrid-required-by-server"
+
+_PRODUCT = "Microsoft Terminal Services"
+
+
+@dataclass(frozen=True)
+class RdpFingerprint:
+    """Lo que la negociación de X.224 cuenta de un servicio RDP.
+
+    Attributes:
+        product: El producto, o ``None`` si la respuesta no era RDP.
+        version: Siempre ``None``. La negociación ocurre antes de cualquier
+            intercambio de capacidades, así que este intercambio no da versión
+            — y no se inventa una.
+        selected_protocol: El nombre del protocolo que el servidor eligió
+            (:data:`PROTOCOL_NAMES`), o ``None`` si la negociación falló.
+        failure: El código de fallo legible (:data:`FAILURE_CODES`), cuando el
+            servidor rechazó la negociación.
+    """
+    product: Optional[str]
+    version: Optional[str] = None
+    selected_protocol: Optional[str] = None
+    failure: Optional[str] = None
+
+    @property
+    def requires_network_level_authentication(self) -> Optional[bool]:
+        """Si el servidor exige NLA.
+
+        ``None`` cuando la respuesta no permite decidirlo — y eso es distinto
+        de ``False``. Un servidor cuyo modo no se ha podido leer **no** debe
+        producir el hallazgo: sería afirmar una configuración insegura sin
+        haberla observado.
+        """
+        if self.failure == FAILURE_MEANING_NLA_REQUIRED:
+            return True
+        if self.selected_protocol is None:
+            return None
+        return self.selected_protocol in {"hybrid", "hybrid-ex"}
+
+
+def build_connection_request(protocols: int = REQUESTED_PROTOCOLS) -> bytes:
+    """Construye el ``X.224 Connection Request`` con su ``RDP_NEG_REQ``.
+
+    Args:
+        protocols: La máscara de protocolos de seguridad que el cliente
+            anuncia soportar.
+
+    Returns:
+        El paquete completo, con su sobre TPKT.
+
+    Nota sobre el endianness, que es donde esto se rompe si se transcribe mal:
+    la longitud de TPKT va en **big-endian** (viene de OSI) y los campos de
+    ``RDP_NEG_REQ`` en **little-endian** (vienen de Windows). Conviven en el
+    mismo paquete.
+    """
+    negotiation = struct.pack("<BBHI", NEG_REQUEST, 0x00, 8, protocols)
+    # LI cuenta los bytes del TPDU que van *después* del propio LI.
+    tpdu = struct.pack(
+        "!BBHHB",
+        6 + len(negotiation),          # length indicator
+        TPDU_CONNECTION_REQUEST,
+        0,                             # dst-ref
+        0,                             # src-ref
+        0,                             # class option
+    ) + negotiation
+    return struct.pack("!BBH", TPKT_VERSION, 0, TPKT_HEADER_SIZE + len(tpdu)) + tpdu
+
+
+def parse_connection_confirm(data: bytes) -> RdpFingerprint:
+    """Interpreta la respuesta del servidor a la petición de conexión.
+
+    Args:
+        data: El paquete completo recibido.
+
+    Returns:
+        El :class:`RdpFingerprint`. Sin producto cuando la respuesta no es un
+        ``Connection Confirm`` sobre TPKT: un puerto que contesta cualquier
+        cosa no es un RDP.
+    """
+    empty = RdpFingerprint(None)
+    if len(data) < TPKT_HEADER_SIZE + 7 or data[0] != TPKT_VERSION:
+        return empty
+    if data[TPKT_HEADER_SIZE + 1] & 0xF0 != TPDU_CONNECTION_CONFIRM:
+        return empty
+
+    # El servidor ha hablado RDP: eso ya identifica el servicio, incluso si no
+    # adjunta bloque de negociación (los servidores muy antiguos no lo hacen,
+    # y esa ausencia significa seguridad RDP estándar).
+    negotiation = data[TPKT_HEADER_SIZE + 7:]
+    if len(negotiation) < 8:
+        return RdpFingerprint(_PRODUCT, selected_protocol=PROTOCOL_NAMES[PROTOCOL_RDP])
+
+    kind, _flags, _length, value = struct.unpack("<BBHI", negotiation[:8])
+    if kind == NEG_RESPONSE:
+        return RdpFingerprint(_PRODUCT, selected_protocol=PROTOCOL_NAMES.get(value))
+    if kind == NEG_FAILURE:
+        return RdpFingerprint(_PRODUCT, failure=FAILURE_CODES.get(value))
+    return RdpFingerprint(_PRODUCT)
+
+
+def fingerprint_rdp(data: bytes) -> RdpFingerprint:
+    """Fingerprint de un servicio RDP desde su respuesta de negociación."""
+    return parse_connection_confirm(data)
+
+
+# =========================================================================
+# SONDA (el borde de red: socket crudo, sin cliente RDP)
+# =========================================================================
+
+class RdpProbe:  # pylint: disable=too-few-public-methods
+    """Manda la petición de conexión y devuelve la respuesta cruda.
+
+    Un solo intercambio: la negociación de seguridad es lo primero que ocurre
+    en una sesión RDP, y es todo lo que hace falta observar. **La sesión no se
+    llega a establecer** — la conexión se cierra en cuanto el servidor dice qué
+    protocolo prefiere, así que no se abre ninguna sesión gráfica ni se toca la
+    pantalla de login.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def fetch(self, host: str, port: int = 3389) -> Optional[bytes]:
+        """Hace el intercambio contra ``host:port``.
+
+        Args:
+            host: El objetivo.
+            port: El puerto de RDP.
+
+        Returns:
+            El paquete de respuesta, o ``None`` si la conexión o la lectura
+            fallan.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("RDP: conexión fallida a %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            sock.sendall(build_connection_request())
+            return sock.recv(4096) or None
+        except OSError as err:
+            logger.debug("RDP: intercambio fallido con %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
+@register_dissector
+class RdpDissector(Dissector):
+    """Una negociación de X.224 y ya: qué seguridad exige el servidor."""
+
+    label = "RDP"
+
+    def __init__(self, probe: Optional[RdpProbe] = None) -> None:
+        self._probe = probe or RdpProbe()
+
+    def applies(self, service) -> bool:
+        return is_rdp_service(service)
+
+    def probe(self, target, service, rate_limiter):
+        rate_limiter.acquire(target)
+        response = self._probe.fetch(target, service.port or 3389)
+        if response is None:
+            return None
+        fingerprint = fingerprint_rdp(response)
+        if not fingerprint.product:
+            return None
+        return DissectorResult(fingerprint.product, fingerprint.version, self.label)

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -41,6 +41,7 @@ from .checks import (
     LDAPS_PORTS,
     is_ldap_service,
     is_mongodb_service,
+    is_rdp_service,
     is_postgres_service,
     is_smb_service,
     is_snmp_service,
@@ -50,6 +51,7 @@ from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
 from .fingerprinting.ldap import LdapProbe, fingerprint_ldap
 from .fingerprinting.mongo import MongoProbe, fingerprint_mongo
 from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
+from .fingerprinting.rdp import RdpProbe, fingerprint_rdp
 from .fingerprinting.snmp import SnmpProbe
 
 logger = logging.getLogger(__name__)
@@ -262,6 +264,45 @@ class LdapCleartextWithLdapsPlugin(ScriptPlugin):
         )
 
 
+class RdpNlaNotRequiredPlugin(ScriptPlugin):
+    """Detecta un RDP que **no** exige autenticación a nivel de red.
+
+    NLA obliga a autenticarse antes de que exista la sesión gráfica. Sin él,
+    cualquiera que alcance el puerto llega a la pantalla de login — lo que
+    habilita la fuerza bruta y toda la familia de vulnerabilidades
+    pre-autenticación de la que BlueKeep (CVE-2019-0708) es el ejemplo
+    canónico. RDP es, además, el vector de entrada de la mayoría de los
+    incidentes de ransomware que empiezan por acceso remoto.
+
+    El dato no se infiere: es el protocolo de seguridad que el propio servidor
+    **elige** en la negociación de X.224, así que el hallazgo nace
+    ``confirmed``.
+
+    **Un servidor cuyo modo no se ha podido leer no dispara el check.** La
+    propiedad que se consulta distingue "no exige NLA" de "no se sabe"
+    (``None``), y sólo la primera es un hallazgo: afirmar una configuración
+    insegura sin haberla observado sería inventarla.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "rdp-nla-not-required"
+
+    def __init__(self, probe: Optional[RdpProbe] = None) -> None:
+        self._probe = probe or RdpProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_rdp_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        response = self._probe.fetch(context.target, context.service.port or 3389)
+        if response is None:
+            return False
+        return fingerprint_rdp(response).requires_network_level_authentication is False
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -276,5 +317,6 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         MongoUnauthenticatedAccessPlugin(),
         LdapAnonymousBindPlugin(),
         LdapCleartextWithLdapsPlugin(),
+        RdpNlaNotRequiredPlugin(),
     )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/tests/unit/test_lybra_rdp.py
+++ b/API/tests/unit/test_lybra_rdp.py
@@ -1,0 +1,294 @@
+"""El dissector de RDP (L15).
+
+RDP es el vector de entrada de la mayoría de los incidentes de ransomware que
+empiezan por acceso remoto, y BlueKeep (CVE-2019-0708) sigue apareciendo en
+redes reales. El hallazgo es **RDP sin NLA**: sin autenticación a nivel de red,
+cualquiera que alcance el puerto llega a la pantalla de login.
+
+La sonda es la más compleja del backlog en construcción, pero su resultado es
+binario: el servidor dice un número. Lo que estos tests protegen es el paso de
+ese número al veredicto — y, sobre todo, el caso en el que **no hay número**.
+"""
+
+import struct
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import is_rdp_service
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.rdp import (
+    NEG_FAILURE,
+    NEG_RESPONSE,
+    PROTOCOL_HYBRID,
+    PROTOCOL_HYBRID_EX,
+    PROTOCOL_RDP,
+    PROTOCOL_SSL,
+    REQUESTED_PROTOCOLS,
+    TPDU_CONNECTION_REQUEST,
+    TPKT_HEADER_SIZE,
+    TPKT_VERSION,
+    RdpDissector,
+    RdpProbe,
+    build_connection_request,
+    fingerprint_rdp,
+    parse_connection_confirm,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _confirm(negotiation=b""):
+    """Un Connection Confirm con el bloque de negociación dado."""
+    tpdu = struct.pack("!BBHHB", 6 + len(negotiation), 0xD0, 0, 0, 0) + negotiation
+    return struct.pack("!BBH", TPKT_VERSION, 0, TPKT_HEADER_SIZE + len(tpdu)) + tpdu
+
+
+def _selected(protocol):
+    return _confirm(struct.pack("<BBHI", NEG_RESPONSE, 0, 8, protocol))
+
+
+def _failed(code):
+    return _confirm(struct.pack("<BBHI", NEG_FAILURE, 0, 8, code))
+
+
+# =============================================== el paquete que se construye
+
+
+def test_the_connection_request_is_nineteen_bytes_with_a_matching_tpkt_length():
+    """TPKT lleva la longitud total del paquete; si miente, el servidor se
+    queda esperando bytes que no llegan en vez de contestar."""
+    request = build_connection_request()
+    version, _reserved, length = struct.unpack("!BBH", request[:4])
+    assert version == TPKT_VERSION
+    assert length == len(request) == 19
+
+
+def test_the_length_indicator_counts_the_bytes_after_itself():
+    """El LI de X.224 no cuenta el propio LI, que es la trampa de este campo."""
+    request = build_connection_request()
+    length_indicator = request[TPKT_HEADER_SIZE]
+    assert length_indicator == len(request) - TPKT_HEADER_SIZE - 1
+    assert request[TPKT_HEADER_SIZE + 1] == TPDU_CONNECTION_REQUEST
+
+
+def test_the_two_endiannesses_coexist_in_the_same_packet():
+    """TPKT viene de OSI y va en big-endian; RDP_NEG_REQ viene de Windows y va
+    en little-endian. Conviven en el mismo paquete, y transcribir uno con el
+    orden del otro es donde esto se rompe."""
+    request = build_connection_request()
+    assert struct.unpack("!H", request[2:4])[0] == 19            # TPKT: big-endian
+    kind, _flags, length, protocols = struct.unpack("<BBHI", request[11:19])
+    assert (kind, length, protocols) == (0x01, 8, REQUESTED_PROTOCOLS)
+
+
+def test_all_supported_protocols_are_announced():
+    """Pedir sólo uno mediría la petición, no la política del servidor: hay que
+    dejarle elegir entre todos los que sabemos reconocer."""
+    assert REQUESTED_PROTOCOLS & PROTOCOL_SSL
+    assert REQUESTED_PROTOCOLS & PROTOCOL_HYBRID
+    assert REQUESTED_PROTOCOLS & PROTOCOL_HYBRID_EX
+
+
+# ================================================== el protocolo negociado
+
+
+@pytest.mark.parametrize("protocol, name, has_nla", [
+    (PROTOCOL_HYBRID, "hybrid", True),
+    (PROTOCOL_HYBRID_EX, "hybrid-ex", True),
+    (PROTOCOL_SSL, "ssl", False),
+    (PROTOCOL_RDP, "rdp", False),
+])
+def test_each_selected_protocol_decides_whether_nla_is_required(protocol, name, has_nla):
+    fingerprint = fingerprint_rdp(_selected(protocol))
+    assert fingerprint.product == "Microsoft Terminal Services"
+    assert fingerprint.selected_protocol == name
+    assert fingerprint.requires_network_level_authentication is has_nla
+
+
+def test_the_dissector_never_claims_a_version():
+    """La negociación de X.224 ocurre antes de cualquier intercambio de
+    capacidades. Este intercambio no da versión, y no se inventa una."""
+    assert fingerprint_rdp(_selected(PROTOCOL_HYBRID)).version is None
+
+
+def test_a_server_without_a_negotiation_block_means_plain_rdp_security():
+    """Los servidores muy antiguos no adjuntan bloque de negociación, y esa
+    ausencia significa seguridad RDP estándar — sin TLS siquiera."""
+    fingerprint = fingerprint_rdp(_confirm())
+    assert fingerprint.selected_protocol == "rdp"
+    assert fingerprint.requires_network_level_authentication is False
+
+
+# ==================================================== la negociación fallida
+
+
+def test_a_failure_that_demands_nla_counts_as_nla_required():
+    """Un rechazo informa tanto como un éxito: `hybrid-required-by-server` es,
+    de hecho, la mejor noticia posible."""
+    fingerprint = fingerprint_rdp(_failed(0x00000005))
+    assert fingerprint.failure == "hybrid-required-by-server"
+    assert fingerprint.requires_network_level_authentication is True
+
+
+@pytest.mark.parametrize("code, name", [
+    (0x00000001, "ssl-required-by-server"),
+    (0x00000002, "ssl-not-allowed-by-server"),
+    (0x00000004, "inconsistent-flags"),
+])
+def test_other_failures_are_named_but_decide_nothing_about_nla(code, name):
+    """**El caso que hay que no equivocar.** Un fallo que no habla de NLA deja
+    la pregunta sin respuesta, y eso es `None`, no `False`: afirmar que un
+    servidor no exige NLA sin haberlo observado sería inventarlo."""
+    fingerprint = fingerprint_rdp(_failed(code))
+    assert fingerprint.failure == name
+    assert fingerprint.requires_network_level_authentication is None
+
+
+def test_an_unknown_failure_code_still_identifies_the_service():
+    fingerprint = fingerprint_rdp(_failed(0x000000FF))
+    assert fingerprint.product == "Microsoft Terminal Services"
+    assert fingerprint.failure is None
+    assert fingerprint.requires_network_level_authentication is None
+
+
+# ==================================================== lo que no identifica
+
+
+@pytest.mark.parametrize("data", [
+    b"",
+    b"\x03\x00\x00\x04",                             # TPKT sin TPDU
+    b"HTTP/1.1 400 Bad Request\r\n\r\n",
+    b"SSH-2.0-OpenSSH_8.9p1\r\n",
+])
+def test_something_that_is_not_rdp_is_not_identified(data):
+    assert parse_connection_confirm(data).product is None
+
+
+def test_a_tpdu_that_is_not_a_connection_confirm_is_not_identified():
+    tpdu = struct.pack("!BBHHB", 6, 0x80, 0, 0, 0)   # Disconnect Request
+    packet = struct.pack("!BBH", TPKT_VERSION, 0, TPKT_HEADER_SIZE + len(tpdu)) + tpdu
+    assert parse_connection_confirm(packet).product is None
+
+
+# ================================================================ la sonda
+
+
+class _ScriptedSocket:
+    def __init__(self, reply, sent):
+        self._reply = reply
+        self._sent = sent
+
+    def settimeout(self, _timeout):
+        pass
+
+    def sendall(self, payload):
+        self._sent.append(payload)
+
+    def recv(self, _size):
+        return self._reply
+
+    def close(self):
+        pass
+
+
+def _probe_with(reply):
+    sent = []
+    return RdpProbe(connect=lambda _a, _t: _ScriptedSocket(reply, sent)), sent
+
+
+def test_the_probe_sends_one_request_and_stops_there():
+    """La sesión no se llega a establecer: la conexión se cierra en cuanto el
+    servidor dice qué protocolo prefiere, así que no se abre ninguna sesión
+    gráfica ni se toca la pantalla de login."""
+    probe, sent = _probe_with(_selected(PROTOCOL_HYBRID))
+    probe.fetch("10.0.0.5")
+    assert sent == [build_connection_request()]
+
+
+def test_a_refused_connection_yields_nothing():
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    assert RdpProbe(connect=refuse).fetch("10.0.0.5") is None
+
+
+# =========================================================== el dissector
+
+
+class _NullLimiter:
+    def acquire(self, _host):
+        pass
+
+
+def test_the_dissector_claims_its_port_and_its_names():
+    dissector = RdpDissector()
+    assert dissector.applies(Service(3389, "tcp", "ms-wbt-server"))
+    assert dissector.applies(Service(33890, "tcp", "rdp"))
+    assert not dissector.applies(Service(22, "tcp", "ssh"))
+    assert is_rdp_service(Service(3389, "tcp", ""))
+
+
+def test_the_dissector_reports_the_product_without_a_version():
+    probe, _sent = _probe_with(_selected(PROTOCOL_HYBRID))
+    result = RdpDissector(probe=probe).probe(
+        "10.0.0.5", Service(3389, "tcp", "ms-wbt-server"), _NullLimiter())
+    assert (result.product, result.version, result.label) == (
+        "Microsoft Terminal Services", None, "RDP")
+
+
+# ================================================================ el check
+
+
+class _Context:
+    def __init__(self, port=3389):
+        self.target = "10.0.0.5"
+        self.service = Service(port, "tcp", "ms-wbt-server")
+        self.sibling_services = ()
+
+    def acquire(self):
+        pass
+
+
+def _plugin(reply):
+    from src.modules.features.themis.lybra.script_checks import RdpNlaNotRequiredPlugin
+    probe, _sent = _probe_with(reply)
+    return RdpNlaNotRequiredPlugin(probe=probe)
+
+
+@pytest.mark.parametrize("reply, fires", [
+    (_selected(PROTOCOL_SSL), True),        # TLS pero sin NLA
+    (_selected(PROTOCOL_RDP), True),        # ni TLS
+    (_selected(PROTOCOL_HYBRID), False),    # NLA exigido
+    (_selected(PROTOCOL_HYBRID_EX), False),
+    (_failed(0x00000005), False),           # NLA exigido, dicho como rechazo
+])
+def test_the_check_follows_the_protocol_the_server_chose(reply, fires):
+    assert _plugin(reply).run(_Context()) is fires
+
+
+def test_the_check_stays_quiet_when_the_mode_could_not_be_read():
+    """`None` no es `False`. Un servidor cuyo modo no se ha podido leer no
+    produce el hallazgo: sería afirmar una configuración insegura sin haberla
+    observado."""
+    assert _plugin(_failed(0x00000004)).run(_Context()) is False
+    assert _plugin(b"HTTP/1.1 400 Bad Request").run(_Context()) is False
+
+
+def test_the_check_stays_quiet_without_evidence():
+    from src.modules.features.themis.lybra.script_checks import RdpNlaNotRequiredPlugin
+
+    def refuse(_address, _timeout):
+        raise ConnectionRefusedError("cerrado")
+
+    plugin = RdpNlaNotRequiredPlugin(probe=RdpProbe(connect=refuse))
+    assert plugin.run(_Context()) is False
+
+
+def test_the_check_is_registered_and_wired_to_its_feed_entry():
+    from src.modules.features.themis.lybra.checks import load_checks
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    check = next(c for c in load_checks() if c.id == "rdp-nla-not-required")
+    assert check.severity == "HIGH" and check.mode == "safe"
+    assert check.service == "rdp"
+    assert check.script in default_script_plugins()


### PR DESCRIPTION
## Resumen

Cierra #293.

RDP figura en la tabla de la Fase N como prioridad 3 con coste «medio-alto». Por impacto real merece estar bastante más arriba: es el vector de entrada de la mayoría de los incidentes de ransomware que empiezan por acceso remoto, y **BlueKeep** (CVE-2019-0708) sigue apareciendo en redes reales siete años después.

Hasta ahora, un 3389 abierto producía exactamente esto: `Puerto 3389/tcp abierto — ms-wbt-server`, `qod=30`. Nada más.

## El hallazgo: RDP sin NLA

**NLA** (*Network Level Authentication*) obliga a autenticarse **antes** de que se cree la sesión gráfica. Es la diferencia entre «para intentar nada tienes que tener credenciales válidas» y «cualquiera que alcance el puerto llega a la pantalla de login».

Sin NLA se habilitan dos cosas a la vez: la fuerza bruta contra el login, y toda la familia de vulnerabilidades **pre-autenticación** —las que se explotan antes de identificarse— de la que BlueKeep es el ejemplo canónico. Un RDP expuesto a internet sin NLA es, por sí solo, un hallazgo que justifica un informe entero.

## Cómo se observa

Un `X.224 Connection Request` con un bloque `RDP_NEG_REQ` anuncia qué protocolos de seguridad soporta el cliente, y el servidor contesta **cuál ha elegido**:

| Protocolo elegido | Qué significa |
|---|---|
| `HYBRID` / `HYBRID_EX` | NLA exigido. La postura correcta. |
| `SSL` | TLS, pero **sin** NLA. |
| `RDP` | Seguridad RDP estándar, sin TLS siquiera. |

Es la sonda más compleja de las construidas hasta ahora —`TPKT` + `X.224` + negociación—, pero su resultado es **binario y sin ambigüedad**, que es exactamente lo contrario de un banner de texto libre: el servidor dice un número, y no hay nada que interpretar.

Un `RDP_NEG_FAILURE` tampoco es un callejón sin salida. Sus códigos dicen igual de bien qué exige el servidor, y `HYBRID_REQUIRED_BY_SERVER` es de hecho la mejor noticia posible: el servidor rechazó la negociación *porque* exige NLA.

## Los dos sitios donde esto se rompe si se transcribe mal

Van explícitos en el módulo y con test propio, porque son errores silenciosos: el paquete sale mal formado y el servidor simplemente no contesta, sin que nada indique por qué.

**Los dos endianness conviven en el mismo paquete.** TPKT viene del mundo OSI y lleva su longitud en **big-endian**; `RDP_NEG_REQ` viene de Windows y lleva los suyos en **little-endian**. Están a once bytes de distancia.

**El *length indicator* de X.224 no se cuenta a sí mismo.** Cuenta los bytes del TPDU que van *después* de él. Es la trampa clásica de ese campo, y el test la fija por relación (`LI == len(paquete) - 4 - 1`) y no por constante, para que siga valiendo si el paquete cambia.

## La decisión que más importa: `None` no es `False`

`requires_network_level_authentication` devuelve **tres** valores, no dos:

- `True` — el servidor eligió `HYBRID`/`HYBRID_EX`, o rechazó pidiendo NLA.
- `False` — el servidor eligió `SSL` o `RDP`. **Esto es el hallazgo.**
- `None` — la respuesta no permite decidirlo.

El tercero es el que hace segura la detección. Un servidor que devolvió un código de fallo que no habla de NLA (`inconsistent-flags`, `ssl-cert-not-on-server`), o cuya respuesta no se entendió, deja la pregunta **sin respuesta**. Y el check sólo dispara con `False` explícito: afirmar que un servidor no exige NLA sin haberlo observado sería inventar una configuración insegura, que es el peor tipo de falso positivo — el que suena creíble y manda a alguien a revisar una máquina que estaba bien.

## Sobre la versión, y sobre no tocar la pantalla de login

**Este intercambio no da versión.** La negociación de X.224 ocurre antes de cualquier intercambio de capacidades, así que el dissector reporta producto sin versión, y no se inventa una. Hay un test que lo fija.

El issue mencionaba que, cuando el servidor negocia TLS, el certificado suele traer el nombre del equipo. Es cierto y es valioso, pero es **un handshake TLS aparte**; se deja fuera de esta sonda a propósito para no mezclar dos intercambios de coste y de naturaleza distintos.

Y sobre el alcance de lo que se toca: **la sesión no se llega a establecer**. La conexión se cierra en cuanto el servidor dice qué protocolo prefiere, así que no se abre ninguna sesión gráfica, no se toca la pantalla de login y no se prueba ninguna credencial. Por eso cabe en modo `safe`. Hay un test que comprueba que se manda **una** petición y ahí acaba.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa). `pylint` en 10,00/10 sobre `rdp.py` y `script_checks.py`.

`tests/unit/test_lybra_rdp.py`, 32 tests:

- **El paquete**: los diecinueve bytes con su longitud TPKT coherente; el LI contado por relación; los dos endianness verificados en el mismo paquete; y que se anuncian todos los protocolos que sabemos reconocer (pedir sólo uno mediría la petición, no la política del servidor).
- **El protocolo negociado**: los cuatro casos con su veredicto de NLA; que nunca se reclama versión; y que un servidor sin bloque de negociación —los muy antiguos no lo adjuntan— significa seguridad RDP estándar.
- **La negociación fallida**: el fallo que exige NLA cuenta como NLA exigido; **tres fallos que no hablan de NLA dejan la pregunta en `None`**; y un código desconocido sigue identificando el servicio.
- **Lo que no identifica**: cuatro respuestas de otro protocolo o truncadas, y un TPDU que es un *Disconnect Request* en vez de un *Connection Confirm*.
- **La sonda**: una petición y para; una conexión rechazada no produce nada.
- **El dissector**: reclama su puerto y sus nombres, incluido un `rdp` en el 33890 (gracias a la cascada de #380).
- **El check**: parametrizado sobre los cinco desenlaces; se calla cuando el modo no se ha podido leer (los dos casos); se calla sin evidencia; y está registrado y conectado con su entrada del feed.

## Notas

- `feedVersion` sube a `lybra-checks-11`.
- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un `xrdp` con y sin NLA y fixtures capturados de un servidor real; eso pertenece a una pasada del banco. Los fixtures de estos tests se construyen contra MS-RDPBCGR §2.2.1.1.1 y §2.2.1.2, no contra una captura.
- El docstring del paquete de fingerprinting ya no lista RDP como *oracle-only*.
