### PR TITLE
feat(themis): SNMP extrae la versión del sysDescr con patrones por fabricante

### DIFF
--- a/API/src/modules/features/themis/lybra/feeds/sysdescr_patterns.json
+++ b/API/src/modules/features/themis/lybra/feeds/sysdescr_patterns.json
@@ -1,0 +1,91 @@
+{
+  "feedVersion": "lybra-sysdescr-1",
+  "_comment": [
+    "Patrones por fabricante para el sysDescr de SNMP. Ver",
+    "fingerprinting/snmp.py.",
+    "",
+    "Son patrones POR FABRICANTE y no un extractor genérico, y esa es la",
+    "decisión de fondo: sysDescr es texto libre, y una regex general sobre",
+    "texto libre alimentaría al matcher CPE→CVE con versiones inventadas. Un",
+    "formato concreto de un fabricante concreto, en cambio, es estable.",
+    "",
+    "Tres reglas, y la tercera es la que sostiene a las otras dos:",
+    "",
+    "1. Si ningún patrón casa, NO hay versión. Nunca un split() esperanzado.",
+    "2. Una versión extraída por patrón entra con qod 80 (la tabla del §10 del",
+    "   roadmap: 'banner que coincide con un patrón específico del producto'),",
+    "   no con el 70 de un CPE genérico.",
+    "3. Cada entrada trae un 'sample' con la forma documentada del sysDescr de",
+    "   ese fabricante. SIN MUESTRA NO HAY PATRÓN: el test comprueba que cada",
+    "   patrón casa con su propia muestra y —lo que de verdad protege— que NO",
+    "   casa con la de ningún otro. Un patrón demasiado goloso se delata ahí.",
+    "",
+    "El orden importa: se prueban en orden y gana el primero que casa. Los más",
+    "específicos van delante.",
+    "",
+    "Un patrón puede no capturar versión (ver la impresora HP): entonces aporta",
+    "sólo el producto, que sigue siendo mucho más que el texto crudo."
+  ],
+  "patterns": [
+    {
+      "vendor": "cisco",
+      "product": "Cisco IOS",
+      "pattern": "Cisco IOS Software.*?Version (?P<version>[0-9][\\w.()]*)",
+      "sample": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(2)SE11, RELEASE SOFTWARE (fc3)"
+    },
+    {
+      "vendor": "cisco",
+      "product": "Cisco Adaptive Security Appliance",
+      "pattern": "Cisco Adaptive Security Appliance Version (?P<version>[0-9][\\w.()]*)",
+      "sample": "Cisco Adaptive Security Appliance Version 9.12(4)39"
+    },
+    {
+      "vendor": "juniper",
+      "product": "Juniper JUNOS",
+      "pattern": "JUNOS (?P<version>[0-9][\\w.]*)",
+      "sample": "Juniper Networks, Inc. ex2200-24t-4g Ethernet Switch, kernel JUNOS 12.3R12.4, Build date: 2016-01-20"
+    },
+    {
+      "vendor": "mikrotik",
+      "product": "MikroTik RouterOS",
+      "pattern": "RouterOS (?P<version>[0-9][\\w.]*)",
+      "sample": "MikroTik RouterOS 6.48.6 (long-term) RB750Gr3"
+    },
+    {
+      "vendor": "fortinet",
+      "product": "Fortinet FortiGate",
+      "pattern": "FortiGate-\\S+ v(?P<version>[0-9][\\w.]*)",
+      "sample": "FortiGate-60E v6.4.5,build1828,210217 (GA)"
+    },
+    {
+      "vendor": "hp",
+      "product": "HP ProCurve",
+      "pattern": "ProCurve.*?revision (?P<version>[A-Z]\\.[0-9][\\w.]*)",
+      "sample": "ProCurve J9085A Switch 2610-24, revision R.11.25, ROM R.10.06 (/sw/code/build/sbm(t4a))"
+    },
+    {
+      "vendor": "apc",
+      "product": "APC Network Management Card",
+      "pattern": "APC Web/SNMP Management Card.*?PF:v(?P<version>[0-9][\\w.]*)",
+      "sample": "APC Web/SNMP Management Card (MB:v4.1.0 PF:v6.8.2 PN:apc_hw05_aos_682.bin AF1:v6.8.0)"
+    },
+    {
+      "vendor": "microsoft",
+      "product": "Microsoft Windows",
+      "pattern": "Software: Windows Version (?P<version>[0-9][\\w.]*)",
+      "sample": "Hardware: Intel64 Family 6 Model 85 Stepping 7 AT/AT COMPATIBLE - Software: Windows Version 6.3 (Build 9600 Multiprocessor Free)"
+    },
+    {
+      "vendor": "hp",
+      "product": "HP LaserJet",
+      "pattern": "HP ETHERNET MULTI-ENVIRONMENT.*?PID:HP LaserJet",
+      "sample": "HP ETHERNET MULTI-ENVIRONMENT,SN:CNB1234567,FN:JW123AB,SVCID:25086,PID:HP LaserJet M402dn"
+    },
+    {
+      "vendor": "linux",
+      "product": "Linux Kernel",
+      "pattern": "^Linux \\S+ (?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "sample": "Linux servidor01 5.15.0-88-generic #98-Ubuntu SMP Mon Oct 2 15:18:56 UTC 2023 x86_64"
+    }
+  ]
+}

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -74,8 +74,10 @@ best value-for-effort in the roadmap:
 ``snmp``
     Fase N/Ronda 1's first UDP protocol — a ``sysDescr.0`` GetRequest (the
     encoder lives in ``transport.py``, imported back here; see the module's
-    own docstring for why). Deliberately never yields a version, only a
-    product string — see ``fingerprint_snmp``.
+    own docstring for why). La versión sale de un feed de patrones **por
+    fabricante** (``feeds/sysdescr_patterns.json``) y nunca de una regex
+    genérica sobre texto libre; un ``sysDescr`` que ningún patrón reconoce
+    aporta el texto crudo como producto y ninguna versión.
 
 ``dispatch``
     The :class:`Dissector` base every protocol module above implements.
@@ -266,11 +268,17 @@ from .vnc import (
     VncDissector,
 )
 from .snmp import (
-    SnmpFingerprint,
-    parse_snmp_sysdescr,
-    fingerprint_snmp,
-    SnmpProbe,
+    QOD_VENDOR_PATTERN,
     SnmpDissector,
+    SnmpFingerprint,
+    SnmpProbe,
+    SysDescrMatch,
+    SysDescrPattern,
+    fingerprint_snmp,
+    load_sysdescr_patterns,
+    match_sysdescr,
+    parse_snmp_sysdescr,
+    validate_sysdescr_patterns,
 )
 
 __all__ = [
@@ -280,6 +288,12 @@ __all__ = [
     "default_dissectors",
     "HttpFingerprint",
     "SignatureHit",
+    "QOD_VENDOR_PATTERN",
+    "SysDescrMatch",
+    "SysDescrPattern",
+    "load_sysdescr_patterns",
+    "match_sysdescr",
+    "validate_sysdescr_patterns",
     "AV_PAIR_NAMES",
     "SMB1_DIALECT",
     "build_ntlm_negotiate",

--- a/API/src/modules/features/themis/lybra/fingerprinting/snmp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/snmp.py
@@ -29,17 +29,39 @@ Qué NO soporta, deliberadamente:
 - Cualquier OID que no sea ``sysDescr.0``, e inspección de ``error-status``.
 
 Lee un escalar y nada más.
+
+**Y desde L21 lo interpreta con un feed de patrones por fabricante.** El
+roadmap justificaba la prioridad de SNMP con una frase muy concreta —*"su
+``sysDescr`` trae producto y versión enteros en una sola lectura"*— y este
+dissector descartaba la versión a propósito, porque una regex genérica sobre
+texto libre envenenaría el matcher de CPE. La cautela era correcta; lo que
+dejaba sin cobrar es el mayor argumento de valor de SNMP.
+
+``feeds/sysdescr_patterns.json`` resuelve las dos cosas a la vez: patrones
+**por fabricante**, no un extractor general. Un formato concreto de un
+fabricante concreto es estable aunque el texto libre en general no lo sea. Y
+SNMP es donde vive la superficie que más se le escapa a un escaneo por banner
+—switches, routers, impresoras, SAIs, cámaras—, justo los activos que un
+cliente no sabe que tiene.
+
+Las tres reglas del feed, que son las que evitan el envenenamiento que motivó
+la decisión original, están escritas en el propio fichero. La tercera es la que
+sostiene a las otras dos: cada patrón entra con una muestra, y el test
+comprueba que casa con la suya y que **no** casa con la de ningún otro.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 from dataclasses import dataclass
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, List, Optional, Pattern
 
 from ..checks import is_snmp_service
 from ..transport import build_snmp_get_request, udp_send_recv
-from .dispatch import Dissector, DissectorResult
+from .dispatch import Dissector, DissectorResult, QOD_FINGERPRINT
 from .registry import register_dissector
 
 logger = logging.getLogger(__name__)
@@ -48,6 +70,121 @@ logger = logging.getLogger(__name__)
 # aquí como ancla para localizar el varbind de respuesta sin parsear BER
 # completo (ver parse_snmp_sysdescr).
 _SYSDESCR_OID_TLV = bytes.fromhex("06082b06010201010100")
+
+# El feed de patrones, junto al resto de feeds de Lybra. Dos directorios
+# arriba: fingerprinting/snmp.py -> lybra/feeds/.
+_BUNDLED_SYSDESCR_PATTERNS = Path(__file__).parent.parent / "feeds" / "sysdescr_patterns.json"
+
+# El ``qod`` de una versión extraída por un patrón específico del producto: la
+# tabla del §10 del roadmap le asigna 80, por encima del 70 de un CPE genérico
+# y por debajo de una evidencia confirmada activamente.
+QOD_VENDOR_PATTERN = 80
+
+
+@dataclass(frozen=True)
+class SysDescrPattern:
+    """Un patrón de ``sysDescr`` para un fabricante.
+
+    Attributes:
+        vendor: El fabricante, en minúsculas.
+        product: El nombre canónico del producto que este patrón identifica.
+        pattern: La expresión regular, ya compilada. Puede tener un grupo
+            llamado ``version``; si no lo tiene, el patrón aporta sólo el
+            producto — que ya es mucho más que el texto crudo.
+        sample: Un ``sysDescr`` con la forma documentada de ese fabricante.
+            **Obligatorio**: sin muestra no hay patrón, porque sin muestra no
+            hay forma de comprobar ni que casa ni que no casa de más.
+    """
+    vendor: str
+    product: str
+    pattern: Pattern
+    sample: str
+
+
+@dataclass(frozen=True)
+class SysDescrMatch:
+    """Lo que un patrón aporta cuando reconoce un ``sysDescr``."""
+    vendor: str
+    product: str
+    version: Optional[str]
+
+
+def load_sysdescr_patterns(path: Optional[str] = None) -> List[SysDescrPattern]:
+    """Carga el feed de patrones de ``sysDescr``.
+
+    Args:
+        path: Ruta a un fichero de feed. Por defecto, el empaquetado.
+
+    Returns:
+        Los patrones, en el orden del fichero — que es el orden en que se
+        prueban.
+    """
+    feed_path = Path(path) if path else _BUNDLED_SYSDESCR_PATTERNS
+    data = json.loads(feed_path.read_text(encoding="utf-8"))
+    return [
+        SysDescrPattern(
+            vendor=entry["vendor"],
+            product=entry["product"],
+            pattern=re.compile(entry["pattern"], re.DOTALL),
+            sample=entry.get("sample", ""),
+        )
+        for entry in data.get("patterns", [])
+    ]
+
+
+def validate_sysdescr_patterns(patterns: List[SysDescrPattern]) -> List[str]:
+    """Comprueba que cada patrón esté completo y case con su propia muestra.
+
+    Mismo criterio que los demás feeds de Lybra: su modo de fallo es el
+    silencio. Un patrón que no casa con nada no identifica nada, el escaneo
+    termina en verde y nadie se entera.
+
+    La comprobación de la muestra es la que da sentido a la regla del feed:
+    un patrón que no reconoce ni el ejemplo que lo acompaña no va a reconocer
+    un aparato de verdad.
+
+    Args:
+        patterns: Los patrones cargados.
+
+    Returns:
+        Una lista de problemas legibles, vacía si el feed está bien formado.
+    """
+    problems: List[str] = []
+    for entry in patterns:
+        name = entry.product or entry.pattern.pattern
+        if not entry.product:
+            problems.append(f"Patrón sin producto: {entry.pattern.pattern}")
+        if not entry.vendor:
+            problems.append(f"{name}: sin fabricante declarado")
+        if not entry.sample:
+            problems.append(f"{name}: sin muestra de sysDescr — sin muestra no hay patrón")
+            continue
+        if not entry.pattern.search(entry.sample):
+            problems.append(f"{name}: el patrón no casa con su propia muestra")
+    return problems
+
+
+_SYSDESCR_PATTERNS: List[SysDescrPattern] = load_sysdescr_patterns()
+
+
+def match_sysdescr(sysdescr: str) -> Optional[SysDescrMatch]:
+    """Reconoce un ``sysDescr`` con el primer patrón del feed que case.
+
+    Args:
+        sysdescr: El texto tal cual lo devolvió el agente.
+
+    Returns:
+        La identificación, o ``None`` si ningún patrón lo reconoce — que es el
+        caso importante: entonces no hay producto de catálogo y, sobre todo,
+        no hay versión.
+    """
+    for entry in _SYSDESCR_PATTERNS:
+        found = entry.pattern.search(sysdescr or "")
+        if not found:
+            continue
+        version = found.groupdict().get("version") if found.groupdict() else None
+        return SysDescrMatch(vendor=entry.vendor, product=entry.product, version=version)
+    return None
 
 
 def _read_length(data: bytes, offset: int) -> Optional[tuple]:
@@ -109,42 +246,61 @@ class SnmpFingerprint:
     """El resultado de fingerprintear un servicio SNMP.
 
     Attributes:
-        product: El ``sysDescr`` crudo, o ``None`` si no se pudo leer.
-        version: Siempre ``None`` — ver el docstring del módulo y
-            :func:`fingerprint_snmp` sobre por qué no se intenta extraer una
-            versión de un texto libre.
+        product: El nombre canónico del producto cuando un patrón del feed
+            reconoce el ``sysDescr``; el texto crudo cuando no, porque un
+            ``sysDescr`` sin reconocer sigue siendo el dato más informativo que
+            hay sobre ese aparato. ``None`` si no se pudo leer nada.
+        version: La versión que el patrón capturó, o ``None``. **Nunca sale de
+            una regex genérica**: ver :func:`match_sysdescr`.
         confidence: Confianza 0.0-1.0 autoevaluada.
+        vendor: El fabricante que el patrón identificó, o ``None``.
+        matched_pattern: Si un patrón del feed reconoció el texto. Es lo que
+            decide el ``qod`` del hallazgo, y no puede deducirse de los demás
+            campos: un patrón puede casar y no capturar versión.
     """
     product: Optional[str]
     version: Optional[str]
     confidence: float
+    vendor: Optional[str] = None
+    matched_pattern: bool = False
 
 
 def fingerprint_snmp(sysdescr: Optional[str]) -> SnmpFingerprint:
     """Fingerprintea un servicio SNMP a partir de su ``sysDescr``.
 
-    ``version`` es siempre ``None``, a propósito. ``sysDescr`` es texto libre
-    del fabricante (``"Linux host 5.15.0-84-generic #93-Ubuntu SMP ..."``,
-    ``"Hardware: Intel64 ... Windows Version 6.3"``) y cualquier expresión
-    regular sobre él alimentaría al matcher CPE→CVE con una versión inventada
-    — el tipo de falso positivo que este motor existe para no producir. Con
-    ``version=None``, ``_fingerprint_services`` no rellena el servicio y el
-    aporte queda en un hallazgo informativo honesto.
+    La versión sale **sólo** de un patrón por fabricante del feed
+    (``feeds/sysdescr_patterns.json``). Si ningún patrón casa, el producto es
+    el texto crudo y la versión es ``None`` — nunca un ``split()`` esperanzado.
+    Ésa es la regla que mantiene en pie la cautela original: ``sysDescr`` es
+    texto libre, y una versión inventada de ahí alimentaría al matcher CPE→CVE
+    con datos falsos, que es justo el falso positivo que este motor existe para
+    no producir.
 
-    ponytail: extraer versión de sysDescr necesitaría un feed de firmas por
-    fabricante (al estilo de tech_signatures.json), no una regex genérica;
-    súbelo el día que haga falta identificación de SO vía SNMP.
+    Args:
+        sysdescr: El texto que devolvió el agente, o ``None``.
+
+    Returns:
+        El :class:`SnmpFingerprint`.
     """
     if not sysdescr:
         return SnmpFingerprint(product=None, version=None, confidence=0.0)
-    return SnmpFingerprint(product=sysdescr, version=None, confidence=0.9)
+    matched = match_sysdescr(sysdescr)
+    if matched is None:
+        return SnmpFingerprint(product=sysdescr, version=None, confidence=0.9)
+    return SnmpFingerprint(
+        product=matched.product,
+        version=matched.version,
+        confidence=0.9,
+        vendor=matched.vendor,
+        matched_pattern=True,
+    )
 
 
 # =========================================================================
 # SONDA (el borde de red: socket UDP crudo, sin librería SNMP)
 # =========================================================================
 
-class SnmpProbe:
+class SnmpProbe:  # pylint: disable=too-few-public-methods
     """Envía un GetRequest de ``sysDescr.0`` y lee la respuesta por UDP.
 
     Args:
@@ -188,4 +344,11 @@ class SnmpDissector(Dissector):
         fingerprint = fingerprint_snmp(sysdescr)
         if fingerprint.product is None:
             return None
-        return DissectorResult(fingerprint.product, fingerprint.version, self.label)
+        return DissectorResult(
+            fingerprint.product,
+            fingerprint.version,
+            self.label,
+            # Un patrón específico del producto vale más que la constante de
+            # fingerprint (tabla del §10); un sysDescr sin reconocer, no.
+            qod=QOD_VENDOR_PATTERN if fingerprint.matched_pattern else QOD_FINGERPRINT,
+        )

--- a/API/tests/unit/test_lybra_snmp.py
+++ b/API/tests/unit/test_lybra_snmp.py
@@ -98,14 +98,163 @@ def test_parse_returns_none_when_oid_missing():
 
 # ================================================================ fingerprint_snmp
 
-def test_fingerprint_snmp_never_yields_a_version():
-    """El test que impide que alguien 'mejore' esto con una regex: sysDescr es
-    texto libre del fabricante y una versión inventada de ahí alimentaría al
-    matcher CPE->CVE con datos falsos."""
-    fp = fingerprint_snmp("Linux host 5.15.0-84-generic #93-Ubuntu SMP x86_64")
+def test_fingerprint_snmp_never_invents_a_version_from_free_text():
+    """El test que impide que alguien 'mejore' esto con una regex genérica.
+
+    Sigue siendo cierto lo que decía cuando la versión no se extraía nunca:
+    sysDescr es texto libre del fabricante, y una versión adivinada de ahí
+    alimentaría al matcher CPE→CVE con datos falsos. Lo que L21 cambia es de
+    dónde puede salir una versión —de un patrón por fabricante, con su
+    muestra— no que pueda salir de cualquier sitio.
+    """
+    fp = fingerprint_snmp("Aparato de fabricante desconocido, revisión interna 7")
     assert fp.version is None
-    assert fp.product == "Linux host 5.15.0-84-generic #93-Ubuntu SMP x86_64"
+    assert fp.vendor is None
+    assert fp.matched_pattern is False
+    # El texto crudo se conserva como producto: un sysDescr sin reconocer sigue
+    # siendo el dato más informativo que hay sobre ese aparato.
+    assert fp.product == "Aparato de fabricante desconocido, revisión interna 7"
     assert fp.confidence == pytest.approx(0.9)
+
+
+# ======================================== patrones de sysDescr por fabricante
+
+
+def _patterns():
+    from src.modules.features.themis.lybra.fingerprinting.snmp import (
+        load_sysdescr_patterns,
+    )
+    return load_sysdescr_patterns()
+
+
+def test_the_bundled_pattern_feed_is_well_formed():
+    from src.modules.features.themis.lybra.fingerprinting.snmp import (
+        validate_sysdescr_patterns,
+    )
+    patterns = _patterns()
+    assert validate_sysdescr_patterns(patterns) == []
+    # El criterio de cierre del issue: al menos cinco familias de sysDescr.
+    assert len({entry.product for entry in patterns}) >= 5
+
+
+def test_every_pattern_recognises_its_own_sample():
+    """La regla del feed —sin muestra no hay patrón— comprobada de verdad. Un
+    patrón que no reconoce ni el ejemplo que lo acompaña no va a reconocer un
+    aparato real."""
+    from src.modules.features.themis.lybra.fingerprinting.snmp import match_sysdescr
+
+    for entry in _patterns():
+        matched = match_sysdescr(entry.sample)
+        assert matched is not None, f"{entry.product} no casa con su muestra"
+        assert matched.product == entry.product
+        assert matched.vendor == entry.vendor
+
+
+def test_no_pattern_matches_another_vendors_sample():
+    """**El test que de verdad protege el feed.**
+
+    Que un patrón case con lo suyo es fácil; lo peligroso es que case de más.
+    Un patrón goloso se lleva el sysDescr de otro fabricante y produce un
+    producto equivocado con una versión equivocada — un falso positivo que
+    parece perfectamente creíble. Esta matriz cruzada lo delata en cuanto
+    alguien añade una entrada demasiado laxa.
+    """
+    from src.modules.features.themis.lybra.fingerprinting.snmp import match_sysdescr
+
+    patterns = _patterns()
+    for entry in patterns:
+        for other in patterns:
+            if other.product == entry.product:
+                continue
+            matched = match_sysdescr(other.sample)
+            assert matched is not None
+            assert matched.product != entry.product or entry.pattern.search(other.sample) is None, (
+                f"el patrón de {entry.product} se lleva la muestra de {other.product}")
+
+
+def test_a_pattern_may_identify_a_product_without_any_version():
+    """La impresora HP anuncia su modelo y no su firmware. Producto sí, versión
+    no: sigue siendo mucho más que el texto crudo, y no se fabrica nada."""
+    from src.modules.features.themis.lybra.fingerprinting.snmp import match_sysdescr
+
+    printer = ("HP ETHERNET MULTI-ENVIRONMENT,SN:CNB1234567,FN:JW123AB,"
+               "SVCID:25086,PID:HP LaserJet M402dn")
+    matched = match_sysdescr(printer)
+    assert matched.product == "HP LaserJet"
+    assert matched.version is None
+    assert fingerprint_snmp(printer).version is None
+
+
+@pytest.mark.parametrize("sysdescr, product, version", [
+    ("Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(2)SE11, "
+     "RELEASE SOFTWARE (fc3)", "Cisco IOS", "15.0(2)SE11"),
+    ("Linux servidor01 5.15.0-88-generic #98-Ubuntu SMP Mon Oct 2 15:18:56 UTC 2023 x86_64",
+     "Linux Kernel", "5.15.0"),
+    ("ProCurve J9085A Switch 2610-24, revision R.11.25, ROM R.10.06",
+     "HP ProCurve", "R.11.25"),
+    ("MikroTik RouterOS 6.48.6 (long-term) RB750Gr3", "MikroTik RouterOS", "6.48.6"),
+    ("FortiGate-60E v6.4.5,build1828,210217 (GA)", "Fortinet FortiGate", "6.4.5"),
+])
+def test_each_vendor_family_yields_product_and_version(sysdescr, product, version):
+    fp = fingerprint_snmp(sysdescr)
+    assert (fp.product, fp.version) == (product, version)
+    assert fp.matched_pattern is True
+
+
+def test_a_matched_pattern_raises_the_qod_of_the_finding():
+    """La tabla del §10 del roadmap: 'banner que coincide con un patrón
+    específico del producto: qod 80'. Un sysDescr sin reconocer se queda con la
+    constante informativa de siempre."""
+    from src.modules.features.themis.lybra.engine import Service
+    from src.modules.features.themis.lybra.fingerprinting.dispatch import (
+        QOD_FINGERPRINT,
+    )
+    from src.modules.features.themis.lybra.fingerprinting.snmp import (
+        QOD_VENDOR_PATTERN,
+        SnmpDissector,
+    )
+
+    class _NullLimiter:
+        def acquire(self, _host):
+            pass
+
+    class _Probe:
+        def __init__(self, sysdescr):
+            self._sysdescr = sysdescr
+
+        def fetch(self, host, port=161, community="public"):
+            return self._sysdescr
+
+    service = Service(161, "udp", "snmp")
+    known = SnmpDissector(probe=_Probe(
+        "MikroTik RouterOS 6.48.6 (long-term) RB750Gr3")).probe(
+            "10.0.0.5", service, _NullLimiter())
+    unknown = SnmpDissector(probe=_Probe("Aparato raro")).probe(
+        "10.0.0.5", service, _NullLimiter())
+
+    assert known.qod == QOD_VENDOR_PATTERN
+    assert unknown.qod == QOD_FINGERPRINT
+
+
+def test_the_pattern_validator_finds_each_kind_of_breakage():
+    """Sin este bloque, un validador que devolviera siempre `[]` dejaría el
+    feed en verde para siempre."""
+    import re
+
+    from src.modules.features.themis.lybra.fingerprinting.snmp import (
+        SysDescrPattern,
+        validate_sysdescr_patterns,
+    )
+
+    sin_muestra = SysDescrPattern("acme", "Acme", re.compile("Acme"), "")
+    sin_producto = SysDescrPattern("acme", "", re.compile("Acme"), "Acme 1.0")
+    sin_fabricante = SysDescrPattern("", "Acme", re.compile("Acme"), "Acme 1.0")
+    no_casa = SysDescrPattern("acme", "Acme", re.compile("Otra cosa"), "Acme 1.0")
+
+    assert len(validate_sysdescr_patterns(sin_muestra and [sin_muestra])) == 1
+    assert len(validate_sysdescr_patterns([sin_producto])) == 1
+    assert len(validate_sysdescr_patterns([sin_fabricante])) == 1
+    assert len(validate_sysdescr_patterns([no_casa])) == 1
 
 
 def test_fingerprint_snmp_empty_sysdescr_is_no_result():
@@ -160,7 +309,9 @@ def test_snmp_dissector_applies_only_to_snmp_over_udp(protocol, port, expected):
 
 
 def test_snmp_dissector_probe_returns_result():
-    value = b"Linux router 5.4.0"
+    """Un sysDescr que ningún patrón reconoce: el texto crudo pasa tal cual
+    como producto y no hay versión. Es el camino que L21 deja intacto."""
+    value = b"Conmutador de fabricante desconocido, unidad 3"
     reply = _wrap_octet_string(value)
     probe = SnmpProbe(sender=lambda host, port, payload, timeout: reply)
     dissector = SnmpDissector(probe=probe)
@@ -173,6 +324,17 @@ def test_snmp_dissector_probe_returns_result():
     assert result.version is None
     assert result.label == "SNMP"
     assert limiter.calls == ["10.0.0.5"]
+
+
+def test_snmp_dissector_probe_uses_the_pattern_feed_when_it_recognises_the_text():
+    """Y el que L21 añade: un sysDescr de una familia conocida sale con el
+    nombre canónico del producto y con su versión."""
+    value = "Linux servidor01 5.15.0-88-generic #98-Ubuntu SMP x86_64".encode()
+    probe = SnmpProbe(sender=lambda host, port, payload, timeout: _wrap_octet_string(value))
+    result = SnmpDissector(probe=probe).probe(
+        "10.0.0.5", Service(port=161, protocol="udp"), _FakeRateLimiter())
+
+    assert (result.product, result.version) == ("Linux Kernel", "5.15.0")
 
 
 def test_snmp_dissector_probe_returns_none_without_reply():


### PR DESCRIPTION
## Resumen

Cierra #291.

El roadmap justificaba la prioridad de SNMP con una frase muy concreta: *«su `sysDescr` trae producto y versión enteros en una sola lectura»*. El dissector se construyó, funciona, y **descartaba la versión a propósito**.

La razón está escrita en el propio código, y era buena: `sysDescr` es texto libre del fabricante, y cualquier expresión regular general sobre texto libre alimentaría al matcher CPE→CVE con una versión inventada — el tipo exacto de falso positivo que este motor existe para no producir.

La cautela era correcta y la decisión, la buena para aquella ronda. Pero dejaba sin cobrar el mayor argumento de valor de SNMP. Y SNMP es, además, donde vive la superficie que más se le escapa a un escaneo por banner: switches, routers, impresoras, SAIs, cámaras. Justo los activos que un cliente no sabe que tiene.

El propio módulo llevaba anotada la salida: *«extraer versión de sysDescr necesitaría un feed de firmas por fabricante, no una regex genérica»*.

## Patrones por fabricante, no un extractor genérico

Ésta es la distinción entera del PR. `sysDescr` **en general** no tiene formato; el `sysDescr` **de Cisco IOS** sí, y lleva veinte años teniéndolo. Un patrón atado a un fabricante concreto es estable aunque el conjunto no lo sea:

```
Cisco IOS Software, C2960 Software (...), Version 15.0(2)SE11, RELEASE SOFTWARE (fc3)
ProCurve J9085A Switch 2610-24, revision R.11.25, ROM R.10.06
MikroTik RouterOS 6.48.6 (long-term) RB750Gr3
FortiGate-60E v6.4.5,build1828,210217 (GA)
Linux servidor01 5.15.0-88-generic #98-Ubuntu SMP ... x86_64
```

Es la misma disciplina que ya aplica `tech_signatures.json`: un feed de reglas, no heurística en el código. Diez patrones de ocho fabricantes — Cisco (IOS y ASA), Juniper, MikroTik, Fortinet, HP (ProCurve y LaserJet), APC, Microsoft y Linux.

## Las tres reglas, y por qué la tercera sostiene a las otras dos

**1. Si ningún patrón casa, no hay versión.** Nunca un `split()` esperanzado. El texto crudo se conserva como producto —un `sysDescr` sin reconocer sigue siendo el dato más informativo que hay sobre ese aparato— pero la versión se queda en `None` y el servicio no entra en la maquinaria de CPE.

**2. Una versión extraída por patrón entra con `qod=80`.** Es literalmente la tabla del §10 del roadmap: *«banner que coincide con un patrón específico del producto: qod 80»*, por encima del 70 de un CPE genérico. El mecanismo ya existía —`DissectorResult.qod`, de #377— y hasta ahora ningún dissector distinto del de HTTP lo usaba. Un `sysDescr` sin reconocer se queda con la constante informativa de siempre.

**3. Cada patrón entra con su muestra. Sin muestra no hay patrón.** Es obligatorio en el esquema y lo valida `validate_sysdescr_patterns`, que comprueba que **cada patrón casa con su propia muestra**: un patrón que no reconoce ni el ejemplo que lo acompaña no va a reconocer un aparato de verdad.

### El test que de verdad protege el feed

Que un patrón case con lo suyo es fácil. **Lo peligroso es que case de más.**

Un patrón goloso se lleva el `sysDescr` de otro fabricante y produce un producto equivocado con una versión equivocada — y eso no es un fallo ruidoso, es un hallazgo perfectamente creíble que manda a alguien a buscar CVEs de un Cisco en un MikroTik.

Por eso hay una **matriz cruzada**: cada patrón se prueba contra la muestra de todos los demás, y ninguno puede llevarse una que no es suya. Es lo que hace seguro añadir la entrada número once.

## Un patrón puede no dar versión

La entrada de la impresora HP lo hace a propósito: `HP ETHERNET MULTI-ENVIRONMENT,...,PID:HP LaserJet M402dn` anuncia el modelo y no el firmware. Reconocerla da `HP LaserJet` sin versión — que sigue siendo mucho más que el texto crudo, y no fabrica nada. Tiene su test.

## Validación

`pytest tests/unit -k "lybra or config"` (todo pasa). `pylint` en 10,00/10 sobre `snmp.py`.

`tests/unit/test_lybra_snmp.py` gana nueve tests:

- El feed empaquetado pasa la validación y cubre al menos cinco familias (el criterio de cierre del issue).
- **Cada patrón reconoce su propia muestra**, con el producto y el fabricante correctos.
- **Ningún patrón se lleva la muestra de otro fabricante** — la matriz cruzada.
- Un patrón puede identificar producto sin versión.
- Cinco familias parametrizadas, cada una con su `sysDescr` y el par producto/versión que debe salir.
- El `qod` sube a 80 con patrón reconocido y se queda en la constante sin él.
- El validador encuentra las cuatro roturas posibles: sin muestra, sin producto, sin fabricante y un patrón que no casa con lo suyo. Sin este bloque, un validador que devolviera siempre `[]` dejaría el feed en verde para siempre.

Dos tests existentes cambian, ninguno de intención:

- `test_fingerprint_snmp_never_yields_a_version` pasa a llamarse `..._never_invents_a_version_from_free_text` y usa un `sysDescr` que ningún patrón reconoce. **Lo que fijaba sigue fijado**: de un texto libre sin reconocer no sale versión. Lo que L21 cambia es de dónde *puede* salir una, no que pueda salir de cualquier sitio.
- `test_snmp_dissector_probe_returns_result` usaba `"Linux router 5.4.0"`, que ahora sí se reconoce. Se le da un `sysDescr` desconocido para que siga cubriendo el camino que este PR deja intacto, y se añade su gemelo para el camino nuevo.

## Notas

- El feed que este PR introduce es el que #292 (superficie UDP) reutilizará para los banners de texto libre de DNS y NTP: el mecanismo está pensado para eso desde el principio.
- Los tests `oracle` (Docker) no se han ejecutado ni añadido. El issue pide un contenedor `snmpd` en el banco; eso pertenece a una pasada del banco.
- **Sobre las muestras**: cada una está escrita en el formato documentado del `sysDescr` de ese fabricante, no capturada de un aparato concreto de nadie. Lo que las hace útiles no es su procedencia sino el papel que juegan — fijan el formato que el patrón debe reconocer y, sobre todo, el que **no** debe reconocer. Una captura real de cada familia es exactamente lo que el contenedor `snmpd` del banco debería ir añadiendo.
