### PR TITLE
perf(themis): el fingerprinting y los checks activos dejan la fila india

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -199,6 +199,7 @@
             "white": "#f3f8ee"
           },
           "fingerprintingEnabled": true,
+          "hostPoolSize": 8,
           "ingest": {
             "enabled": false,
             "minSeverity": "MEDIUM",

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1054,6 +1054,7 @@ class CheckRuntime:
         tls_fetch: Optional[Callable[[str, int], object]] = None,
         network_open: Optional[Callable[[str, int], Optional["NetworkSession"]]] = None,
         script_plugins: Optional[Dict[str, object]] = None,
+        mapper: Optional[Callable] = None,
     ) -> None:
         self._checks = list(checks)
         self._fetch = fetch
@@ -1062,6 +1063,16 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
+        # Cómo se recorren los servicios. Por defecto, el ``map`` de siempre:
+        # uno detrás de otro. El manager inyecta aquí un pool acotado por host
+        # (L23), igual que ya inyecta las sondas — este módulo no conoce la
+        # configuración ni monta hilos por su cuenta.
+        self._mapper: Callable = mapper or map
+        # El host y sus servicios de la ejecución en curso: los rellena
+        # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
+        # pueda ver los servicios hermanos sin descubrirlos por su cuenta.
+        self._host = ''
+        self._services: Tuple[Service, ...] = ()
         # Sondas compartidas dentro de una ejecución; :meth:`run` las vacía al
         # empezar. Aquí sólo para que el objeto esté completo desde que nace.
         self._responses: Dict[tuple, Optional[Response]] = {}
@@ -1097,6 +1108,14 @@ class CheckRuntime:
         :meth:`_probe_response` for why that is a property of this loop and not
         a caching layer.
 
+        Los servicios se evalúan **a la vez** dentro de un pool acotado (L23),
+        no en fila india: estos checks son espera de red casi entera, y un
+        servicio que no contesta retrasaba a todos los que venían detrás. El
+        ritmo por host lo sigue marcando el limitador, que es seguro entre
+        hilos; el pool sólo decide cuántas sondas pueden estar esperando a la
+        vez. El orden de los hallazgos no cambia — ver
+        :meth:`_run_for_service`.
+
         Args:
             host: The target host.
             services: The host's discovered services (non-applicable ones are
@@ -1117,18 +1136,37 @@ class CheckRuntime:
         # lista ya está aquí; guardarla evita que un plugin tenga que
         # redescubrirla por su cuenta.
         self._services = services
+        self._host = host
 
+        per_service = self._mapper(self._run_for_service, services)
+        return [finding for group in per_service for finding in group]
+
+    def _run_for_service(self, service: Service) -> List[dict]:
+        """Ejecuta todos los checks aplicables a **un** servicio.
+
+        Es la unidad de trabajo del pool (L23), y la razón de que el pool sea
+        seguro sin candados: las cachés de respuesta y de handshake se indexan
+        por ``(host, puerto, ...)``, así que **cada hilo toca sólo las claves de
+        su propio servicio**. Dos checks del mismo servicio siguen compartiendo
+        una petición, que es para lo que la caché existe; dos servicios distintos
+        no compiten por ninguna entrada.
+
+        Args:
+            service: El servicio a evaluar.
+
+        Returns:
+            Los hallazgos de ese servicio, en el orden del feed.
+        """
         findings: List[dict] = []
-        for service in services:
-            for family in self._families:
-                if not family.applies_to_service(service):
+        for family in self._families:
+            if not family.applies_to_service(service):
+                continue
+            for check in self._checks:
+                if not family.check_matches(check, service):
                     continue
-                for check in self._checks:
-                    if not family.check_matches(check, service):
-                        continue
-                    finding = family.run_check(check, host, service)
-                    if finding is not None:
-                        findings.append(finding)
+                finding = family.run_check(check, self._host, service)
+                if finding is not None:
+                    findings.append(finding)
         return findings
 
     def _applies(self, check: Check) -> bool:

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -1,6 +1,7 @@
 """LybraEngineManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from typing import List, Optional
 import src.modules.system.config_reading as CR
@@ -355,6 +356,11 @@ class LybraEngineManager(ScanManager):
                 tls_fetch=TlsProbe().fetch,
                 network_open=NetworkProbe().open,
                 script_plugins=default_script_plugins(),
+                # El mismo pool acotado por host que usa el fingerprinting: los
+                # checks activos tienen exactamente la misma forma —espera de
+                # red servicio a servicio— y el mismo motivo para no hacerla en
+                # fila india.
+                mapper=self._in_host_pool,
             )
             return runtime.run(target, services)
         except Exception:
@@ -430,11 +436,15 @@ class LybraEngineManager(ScanManager):
         """
         dissectors = default_dissectors()
         rate_limiter = HostRateLimiter()
-        findings = []
-        updated: list = []
-
         cascade_config = CR.lybra_config()
-        for service in services:
+
+        def identify(service):
+            """Sonda un servicio y devuelve ``(servicio, resultado)``.
+
+            Se define dentro para que cada llamada comparta los ``dissectors`` y
+            el ``rate_limiter`` de **esta** ejecución: el limitador es lo que
+            mantiene el ritmo por host cuando varias sondas van a la vez, así que
+            compartirlo es justo el punto."""
             dissector = next((dissector for dissector in dissectors if dissector.applies(service)), None)
             result = None
             if dissector is not None:
@@ -460,7 +470,16 @@ class LybraEngineManager(ScanManager):
                     )
                 except Exception:
                     logger.debug("Cascade failed for %s:%s", target, service.port, exc_info=True)
+            return service, result
 
+        findings: list = []
+        updated: list = []
+        # El orden de ``services`` se conserva —``map`` devuelve en el orden de
+        # entrada, no en el de terminación—, así que el resultado de un escaneo no
+        # depende de cuál de los servicios contestó antes. Un escáner cuyos
+        # hallazgos cambian de orden entre ejecuciones hace ruido en cualquier
+        # comparación posterior, empezando por el ciclo de vida.
+        for service, result in self._in_host_pool(identify, services):
             if result is None:
                 updated.append(service)
                 continue
@@ -472,6 +491,45 @@ class LybraEngineManager(ScanManager):
             updated.append(service)
 
         return updated, findings
+
+    @staticmethod
+    def _in_host_pool(work, items):
+        """Ejecuta ``work`` sobre cada elemento con un pool acotado por host.
+
+        El fingerprinting y los checks activos son entrada/salida pura: casi todo
+        su tiempo es esperar a que un servicio conteste o a que se agote su plazo.
+        En fila india, **un servicio mudo retrasa a todos los que vienen detrás**,
+        y la fase más lenta de un escaneo acababa siendo la que menos trabajo hace.
+
+        Tres cosas que este pool **no** cambia, y que son las condiciones que lo
+        hacen aceptable:
+
+        - Los dissectors siguen siendo síncronos y sin estado compartido. El
+          paralelismo vive aquí, en el manager, y no dentro de cada protocolo:
+          migrar ocho módulos a asyncio costaría mucho más y daría lo mismo,
+          porque el trabajo es espera de red.
+        - El ritmo por host lo sigue marcando ``HostRateLimiter``, que es seguro
+          entre hilos y reserva el turno antes de dormir. El pool decide cuántas
+          sondas pueden estar **esperando** a la vez, no a qué ritmo salen.
+        - El aislamiento de fallos se mantiene: cada unidad de trabajo captura lo
+          suyo, así que un protocolo que revienta sigue costando su servicio y
+          nada más.
+
+        Args:
+            work: La función a aplicar a cada elemento.
+            items: Los elementos.
+
+        Returns:
+            Los resultados, **en el orden de entrada**.
+        """
+        items = list(items)
+        if not items:
+            return []
+        workers = max(1, min(CR.lybra_config().host_pool_size, len(items)))
+        if workers == 1:
+            return [work(item) for item in items]
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            return list(pool.map(work, items))
 
     @classmethod
     def _layer_findings(cls, service, result) -> list:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -833,6 +833,19 @@ class LybraConfig:
     Agotarlo **no** marca nada como cerrado: los puertos que aún no han
     contestado simplemente se dan por no observados, que es lo que ya eran."""
 
+    host_pool_size: int = 8
+
+"""Cuántos servicios del **mismo host** se sondan a la vez.
+
+    El fingerprinting y los checks activos son entrada/salida pura: casi todo
+    su tiempo es esperar a que un servicio conteste o a que se agote su plazo.
+    En fila india, un servicio mudo retrasa a todos los que vienen detrás.
+
+    El pool va acotado **por host** y no es un número grande a propósito: el
+    límite no es la máquina que escanea, es la cortesía con el objetivo. El
+    limitador de ritmo sigue mandando por encima de esto — el pool decide
+    cuántas sondas pueden estar esperando a la vez, no a qué ritmo salen."""
+
 
 @config_block("features.themis.scanners.lybra.ingest")
 @dataclass(frozen=True)

--- a/API/tests/unit/test_lybra_host_pool.py
+++ b/API/tests/unit/test_lybra_host_pool.py
@@ -1,0 +1,219 @@
+"""El pool acotado por host: fingerprinting y checks dejan la fila india (L23).
+
+``_fingerprint_services`` recorría los servicios en un ``for`` y sondaba cada
+uno hasta terminar antes de pasar al siguiente. Sobre un host con veinte
+puertos abiertos, y con dissectors que hacen varias peticiones cada uno, eso es
+una fila india de decenas de intercambios con sus plazos — y **un servicio mudo
+retrasa a todos los que vienen detrás**. La fase más lenta de un escaneo Lybra
+acababa siendo la que menos trabajo hace.
+
+Lo que estos tests protegen no es la velocidad, que es difícil de afirmar en un
+test: son las **cuatro garantías** que hacen aceptable el pool. Que las sondas
+van de verdad a la vez, que el tope se respeta, que el orden del resultado no
+depende de quién conteste antes, y que un dissector que revienta sigue costando
+sólo su servicio.
+"""
+
+import threading
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import Response
+from src.modules.features.themis.lybra.engine import Service
+from src.modules.features.themis.lybra.fingerprinting.dispatch import (
+    Dissector,
+    DissectorResult,
+)
+from src.modules.features.themis.managers import LybraEngineManager
+
+pytestmark = pytest.mark.unit
+
+
+def _services(count, first_port=8000):
+    return [Service(first_port + index, "tcp", "http") for index in range(count)]
+
+
+class _RecordingDissector(Dissector):
+    """Dissector falso que apunta cuándo entra y cuándo sale de cada sonda."""
+
+    label = "FALSO"
+
+    def __init__(self, on_probe=None):
+        self.ports = []
+        self._on_probe = on_probe
+
+    def applies(self, service):
+        return True
+
+    def probe(self, target, service, rate_limiter):
+        self.ports.append(service.port)
+        if self._on_probe is not None:
+            self._on_probe(service)
+        return DissectorResult("Falso", "1.0", self.label)
+
+
+def _run_fingerprint(monkeypatch, dissector, services, pool_size=8):
+    """Ejecuta ``_fingerprint_services`` con un dissector y un tope inyectados."""
+    from src.modules.features.themis.managers.lybra import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "default_dissectors", lambda: [dissector])
+    monkeypatch.setattr(
+        engine_module.CR, "lybra_config",
+        lambda: type("_Config", (), {
+            "host_pool_size": pool_size, "banner_timeout": 0.1, "max_blind_probes": 0,
+        })(),
+    )
+    return LybraEngineManager()._fingerprint_services("10.0.0.5", services)
+
+
+# ============================================== las sondas van de verdad a la vez
+
+
+def test_the_services_are_probed_concurrently(monkeypatch):
+    """Una barrera que sólo se abre cuando han llegado todos: si las sondas
+    fueran en fila india, la primera se quedaría esperando a las demás y el
+    test agotaría su plazo."""
+    services = _services(6)
+    barrier = threading.Barrier(len(services), timeout=5.0)
+    dissector = _RecordingDissector(on_probe=lambda _service: barrier.wait())
+
+    updated, findings = _run_fingerprint(monkeypatch, dissector, services)
+
+    assert len(updated) == len(services)
+    assert len(findings) == len(services)
+
+
+def test_the_pool_never_exceeds_its_bound(monkeypatch):
+    """El tope no es una sugerencia: el límite no es la máquina que escanea,
+    es la cortesía con el objetivo."""
+    services = _services(12)
+    in_flight = 0
+    peak = 0
+    lock = threading.Lock()
+    release = threading.Event()
+
+    def on_probe(_service):
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        release.wait(timeout=0.05)
+        with lock:
+            in_flight -= 1
+
+    _run_fingerprint(monkeypatch, _RecordingDissector(on_probe), services, pool_size=4)
+    assert peak <= 4
+
+
+def test_a_pool_of_one_still_works(monkeypatch):
+    """El tope a uno vuelve al comportamiento de antes, sin montar hilos: es la
+    salida de emergencia si el paralelismo diera problemas contra algún
+    objetivo."""
+    services = _services(3)
+    dissector = _RecordingDissector()
+    updated, _findings = _run_fingerprint(monkeypatch, dissector, services, pool_size=1)
+    assert dissector.ports == [8000, 8001, 8002]
+    assert len(updated) == 3
+
+
+# ================================================ el orden no depende de la carrera
+
+
+def test_the_result_keeps_the_order_of_the_input(monkeypatch):
+    """Un escáner cuyos hallazgos cambian de orden entre ejecuciones hace ruido
+    en cualquier comparación posterior, empezando por el ciclo de vida. El
+    orden lo fija la lista de entrada, no quién conteste antes."""
+    import time
+
+    services = _services(8)
+
+    def on_probe(service):
+        # Los puertos altos contestan antes: si el resultado siguiera el orden
+        # de terminación, saldría del revés.
+        time.sleep((8100 - service.port) / 1000)
+
+    updated, findings = _run_fingerprint(monkeypatch, _RecordingDissector(on_probe),
+                                         services)
+    assert [service.port for service in updated] == [service.port for service in services]
+    assert [finding["port"] for finding in findings] == [
+        service.port for service in services]
+
+
+# ============================================ el aislamiento de fallos se mantiene
+
+
+def test_a_dissector_that_raises_costs_only_its_own_service(monkeypatch):
+    """La garantía que ya existía antes del pool y que no se pierde con él."""
+    services = _services(5)
+
+    class _Exploding(_RecordingDissector):
+        def probe(self, target, service, rate_limiter):
+            if service.port == 8002:
+                raise RuntimeError("boom")
+            return super().probe(target, service, rate_limiter)
+
+    updated, findings = _run_fingerprint(monkeypatch, _Exploding(), services)
+
+    assert len(updated) == 5                       # ningún servicio se pierde
+    assert len(findings) == 4                      # el que reventó no aporta
+    assert 8002 not in [finding["port"] for finding in findings]
+
+
+# ================================================= el runtime de checks, igual
+
+
+def test_the_check_runtime_walks_services_with_the_injected_mapper():
+    """``CheckRuntime`` no monta hilos por su cuenta ni conoce la
+    configuración: recibe el recorrido igual que ya recibe las sondas."""
+    from src.modules.features.themis.lybra.checks import CheckRuntime, load_checks
+
+    calls = []
+
+    def mapper(work, items):
+        calls.append(len(list(items)))
+        return [work(item) for item in items]
+
+    runtime = CheckRuntime(
+        load_checks(),
+        lambda *_args: Response(404, "", {}),
+        mode="safe",
+        mapper=mapper,
+    )
+    runtime.run("10.0.0.5", _services(3))
+    assert calls == [3]
+
+
+def test_the_check_runtime_defaults_to_walking_them_one_by_one():
+    """Sin mapper inyectado se comporta como siempre. El paralelismo es una
+    decisión del manager, no del runtime."""
+    from src.modules.features.themis.lybra.checks import CheckRuntime, load_checks
+
+    runtime = CheckRuntime(load_checks(), lambda *_args: Response(404, "", {}))
+    assert runtime.run("10.0.0.5", _services(2)) == []
+
+
+def test_the_response_cache_is_keyed_per_service_so_threads_never_collide():
+    """La razón de que el pool sea seguro sin candados.
+
+    Las cachés de respuesta y de handshake se indexan por ``(host, puerto,
+    ...)``, así que cada hilo toca sólo las claves de su propio servicio. Dos
+    checks del mismo servicio siguen compartiendo una petición —que es para lo
+    que la caché existe— y dos servicios distintos no compiten por ninguna
+    entrada.
+    """
+    from src.modules.features.themis.lybra.checks import CheckRuntime, load_checks
+
+    requested = []
+
+    def fetch(_host, port, method, path):
+        requested.append((port, method, path))
+        return Response(404, "", {})
+
+    runtime = CheckRuntime(load_checks(), fetch, mode="safe")
+    runtime.run("10.0.0.5", _services(2))
+
+    ports = {port for port, _method, _path in requested}
+    assert ports == {8000, 8001}
+    # Ninguna combinación (puerto, método, ruta) se pide dos veces: la caché
+    # sigue haciendo su trabajo dentro de cada servicio.
+    assert len(requested) == len(set(requested))


### PR DESCRIPTION
## Resumen

Cierra #294.

`_fingerprint_services` recorría los servicios en un `for` y sondaba cada uno hasta terminar antes de pasar al siguiente. Sobre un host con veinte puertos abiertos, y con dissectors que hacen varias peticiones cada uno —el de HTTP hace tres—, eso es una fila india de decenas de intercambios de red con sus plazos.

El resultado práctico tiene su punto de ironía: **la fase más lenta de un escaneo Lybra era la que menos trabajo hace**. El descubrimiento de puertos ya usaba asyncio con concurrencia de 200 y barría cientos de puertos en el tiempo que el fingerprinting tardaba en mirar tres. Y un servicio mudo —uno que acepta la conexión y no contesta— retrasaba a todos los que venían detrás.

## Un pool de hilos, no una migración a asyncio

Reescribir ocho módulos de protocolo para que hablen asyncio costaría mucho más y daría lo mismo: **el trabajo es espera de red pura**, y ahí un `ThreadPoolExecutor` da exactamente lo que un bucle de eventos daría.

## Las tres condiciones del roadmap, cumplidas

El §9 ponía tres, y las tres son la razón de que esto sea aceptable y no simplemente rápido:

**1. El limitador de ritmo tenía que arreglarse antes**, o serializaría los hilos igual que antes y no se ganaría nada. Ya está: `HostRateLimiter` es seguro entre hilos y —lo que de verdad importa— **espera fuera del candado**, reservando el turno escribiendo la marca futura antes de dormir. Con el sueño dentro del candado, un hilo esperando su turno para el host A bloqueaba a todos los que iban al host B.

Así que el pool no esquiva el limitador: **decide cuántas sondas pueden estar esperando a la vez, no a qué ritmo salen**.

**2. Pool acotado por host**, con el tamaño en configuración (`hostPoolSize`, 8 por defecto). Y no es un número grande a propósito: el límite no es la máquina que escanea, es la cortesía con el objetivo.

**3. Los dissectors siguen siendo síncronos y sin estado compartido.** El paralelismo vive en el manager. Ningún módulo de protocolo cambia ni una línea en este PR.

## `CheckRuntime` también, y sin candados

El issue señalaba que `CheckRuntime.run` tenía exactamente la misma forma secuencial. Lo tiene, y se arregla igual — con un detalle que merece explicarse porque es lo que hace segura la paralelización.

**El runtime recibe el recorrido inyectado**, igual que ya recibe `fetch`, `tls_fetch` y `network_open`. Un `mapper` que por defecto es el `map` de siempre; el manager le pasa su pool. Así `checks.py` sigue sin conocer la configuración y sin montar hilos por su cuenta, que es la línea que separa esa capa de la del manager.

Y **no hace falta ningún candado sobre sus cachés**. `_probe_response` y `_probe_handshake` existen para que tres checks que miran el mismo `GET /` hagan una sola petición, y se indexan por `(host, puerto, método, ruta)`. La unidad de trabajo del pool es **un servicio**, así que cada hilo toca sólo las claves de su propio puerto: dos checks del mismo servicio siguen compartiendo una petición —que es para lo que la caché existe— y dos servicios distintos no compiten por ninguna entrada. Hay un test que lo fija.

## El orden no depende de la carrera

`pool.map` devuelve en el orden de entrada, no en el de terminación, y eso es deliberado: **un escáner cuyos hallazgos cambian de orden entre ejecuciones hace ruido en cualquier comparación posterior**, empezando por la correlación de ciclo de vida. Hay un test que hace contestar antes a los puertos altos y comprueba que el resultado no se da la vuelta.

## Validación

`pytest tests/unit -k "lybra or config"` y los tests de integración de Lybra y Themis: todo pasa. `pylint` sobre `checks.py` y `engine.py` **mejora** respecto a su línea base (68 avisos → 67; se corrige de paso un atributo que se definía fuera de `__init__`).

`tests/unit/test_lybra_host_pool.py`, 8 tests. Lo que protegen no es la velocidad —difícil de afirmar honestamente en un test— sino las cuatro garantías:

- **Que las sondas van de verdad a la vez.** Una barrera que sólo se abre cuando han llegado todas: si el recorrido fuera secuencial, la primera se quedaría esperando y el test agotaría su plazo.
- **Que el tope se respeta.** Doce servicios con el pool en cuatro: el pico de sondas simultáneas nunca pasa de cuatro.
- **Que un tope de uno vuelve al comportamiento de antes** sin montar hilos — la salida de emergencia si el paralelismo diera problemas contra algún objetivo.
- **Que el orden lo fija la entrada**, con los puertos altos contestando primero.
- **Que un dissector que revienta sigue costando sólo su servicio**: cinco servicios, uno que lanza, cinco servicios en la salida y cuatro hallazgos.
- Y tres sobre el runtime de checks: que usa el mapper inyectado, que sin él se comporta como siempre, y que la caché se indexa por servicio.

## Notas

- Ninguna sonda, ningún parser y ningún dissector cambia en este PR. El diff es el manager, el recorrido del runtime y una clave de configuración.
- El `hostPoolSize` queda atado en `test_config_shape.py` como cualquier otra clave.
