### PR TITLE
docs(themis): JARM se archiva, con la razón por escrito

### DIFF
--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -28,8 +28,8 @@ best value-for-effort in the roadmap:
 
 ``tls``
     A single-handshake hygiene check — negotiated protocol version, self-signed
-    and expiry status of the certificate. Not JARM (full bit-exact
-    *identification*, a separate and larger effort left for later).
+    and expiry status of the certificate. **No JARM: archivado**, con la razón
+    escrita en el docstring del módulo y en la Fase F del roadmap.
 
 ``postgres``
     La primera base de datos que **negocia** en vez de ofrecer un banner: un
@@ -108,12 +108,16 @@ result still goes in at the same low-confidence, unconfirmed tier a Nmap CPE
 match would (``qod=70``) — this closes a blind spot, it does not raise
 confidence beyond what the matcher already assigns any version-based guess.
 
-Two techniques are deliberately left for later: full JARM fingerprinting (too
-large and risky to ship without a live TLS lab to validate it against) and OS
-fingerprinting (which the roadmap itself rates low value). Both stay
-oracle-only — handled by Nmap — until picked up. VNC's full protocol beyond its
-version banner, and RPC, stay oracle-only too, per the roadmap's own
-priority-3 rating for that group.
+**JARM está archivado, no pendiente** (L24): su valor es comparativo, y un
+hash que no coincida bit a bit con el de la implementación de referencia no es
+una identificación peor sino ninguna — comprobar esa coincidencia exige un
+laboratorio con varias pilas TLS que no existe aquí. La decisión, con qué haría
+falta para reabrirla, está en ``tls.py`` y en la Fase F del roadmap.
+
+El fingerprinting de sistema operativo (que el roadmap valora bajo) sigue
+aplazado, y con VNC más allá de su banner de versión y RPC sigue siendo
+territorio del oráculo —Nmap— por la valoración de prioridad-3 del propio
+roadmap.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/tls.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/tls.py
@@ -1,10 +1,28 @@
 """The TLS dissector: a single-handshake hygiene check, not identification.
 
 Reads the negotiated protocol version and the self-signed/expiry status of the
-certificate. Full JARM fingerprinting (a bit-exact ten-probe handshake used for
-*identification*, not hygiene) is a separate, larger effort deliberately left
-for later — too large and risky to ship without a live TLS lab to validate it
-against.
+certificate.
+
+**JARM: archivado, no pendiente** (L24, 2026-09-02). Este módulo hace **un**
+handshake, y de ahí salen la versión de protocolo, el autofirmado y la
+caducidad. JARM haría diez saludos deliberadamente distintos y hashearía el
+conjunto para identificar la *pila* TLS, no el producto.
+
+No se va a construir, y la razón de fondo cabe en una frase: **el valor de JARM
+es comparativo**. Un hash que no coincida bit a bit con el de la implementación
+de referencia no es una identificación peor, es ninguna — un número que no se
+puede buscar en ningún catálogo. Y comprobar esa coincidencia exige un
+laboratorio con varias pilas TLS distintas (OpenSSL, BoringSSL, Schannel,
+JSSE), que no existe aquí.
+
+A eso se suma que no es requisito de ninguna definición de hecho —la Fase F se
+cierra con la concordancia frente a Nmap, no con JARM—, que su prioridad medida
+es la más baja del backlog, y que diez saludos por servicio TLS es la sonda más
+cara del catálogo a cambio de un dato que nadie consultaría.
+
+La decisión está escrita, con qué haría falta para reabrirla, en la sección
+Fase F de ``plans/feature/themis/lybra-engine-roadmap.md``. No es un "todavía
+no": es un "no, y por esto".
 """
 
 from __future__ import annotations

--- a/plans/feature/themis/lybra-engine-roadmap.md
+++ b/plans/feature/themis/lybra-engine-roadmap.md
@@ -274,7 +274,7 @@ La pista de **correlación** está completa; la de **bajo nivel** está a medias
 | **6** — Pipeline orquestado | Convergencia | ✓ implementada |
 | **U** — Nuclei: herramienta, corroborador y oráculo | Bajo nivel | ✓ implementada — U1, U2 y U3 hechas; **U4 medido el 2026-07-31: 23,37 % de plantillas HTTP ingeribles frente al umbral de 25 % ⇒ no se ingiere**. Detalle en la sección Fase U más abajo |
 | **R** — Runtime de checks propio | Bajo nivel | ✓ implementada — 16 checks; los cuatro tipos activos (`http`/`tls`/`network`/`script`) existen, el feed vive en YAML, la ingesta está construida y apagada por decisión, y la **precisión está medida: 1,000 (TP=30/FP=0) sobre 9 objetivos etiquetados con señuelos**. Detalle en la sección Fase R más abajo |
-| **F** — Fingerprinting propio | Bajo nivel | ◐ parcial — HTTP, SSH, TLS, y (Fase N) FTP, SMTP/IMAP/POP3, SMB, MySQL/MariaDB, Redis, VNC, **SNMP (Ronda 1, ✓)**; falta JARM, PostgreSQL/MSSQL/MongoDB, RDP, LDAP, Telnet, RPC. Detalle actualizado en la sección Fase N más abajo |
+| **F** — Fingerprinting propio | Bajo nivel | ◐ parcial — HTTP, SSH, TLS, y (Fase N) FTP, SMTP/IMAP/POP3, SMB, MySQL/MariaDB, Redis, VNC, **SNMP (Ronda 1, ✓)**; la Fase 2 añade PostgreSQL, MSSQL, MongoDB, LDAP, RDP, las APIs de administración HTTP y la superficie UDP. **JARM archivado** (ver Fase F); quedan Telnet y RPC. Detalle actualizado en la sección Fase N más abajo |
 | **T** — Transporte propio | Bajo nivel | ◐ parcial — `AsyncConnectScanner` sobre asyncio; **sonda UDP acotada (SNMP) implementada en la Ronda 1** (`scan_udp_ports_sync`, `UDP_PROBES`); faltan SYN sin estado y control de tasa AIMD |
 | **4**, DAST y Etapa 2 (P, E, C, O, A, B, D, G, S, X) | Ambas | ○ planificadas |
 
@@ -299,7 +299,7 @@ El resultado es esta reordenación, que es el cambio de fondo de esta revisión:
 | **4.º** | ~~**R (cierre)**~~ — ✓ cerrada el 2026-07-31 | G1, G4 | `script`, YAML e ingesta construidos; precisión 1,000 medida. La ingesta queda apagada por el veredicto del censo de U4 |
 | **5.º** | **O — Backports por feed de distribución** | **G3** | Ataca la causa nº 1 de falsos positivos sin tocar el host ni pedir credenciales |
 | **6.º** | **D — Credenciales por defecto** | **G4** | Cobertura clásica de OpenVAS, con guardas propias (lockout, tasa, evidencia sin plaintext) |
-| **7.º** | **F y T (cierre) — JARM, SYN sin estado, UDP, AIMD** | — | Independiza de Nmap, no de OpenVAS. Trabajo de identidad y disfrute, no de necesidad |
+| **7.º** | **F y T (cierre) — ~~JARM~~ (archivado), SYN sin estado, UDP, AIMD** | — | Independiza de Nmap, no de OpenVAS. Trabajo de identidad y disfrute, no de necesidad. UDP entregado en la Fase 2 |
 | resto | Etapa 2 (P, E, C, A, B, G, S, X) | — | Capacidades nuevas, ninguna condicionada por la salida de OpenVAS |
 
 Las fases **4** (escaneo autenticado por SSH) y **DAST** bajan de prioridad de forma explícita: la
@@ -346,7 +346,7 @@ sigue gastando un corroborador de cuatro horas en cada `deep=True`.
 | **2** | **E1 + E2** — retirar OpenVAS del producto y del código | Ya sin nada que dependa de él. Diff grande pero mecánico. **E3 se deja aparte**: es el único paso irreversible y no bloquea nada | ✓ hecha, **ampliada a E1+E2+E3+E4** (BD de dev sin filas OpenVAS, no hacía falta backfill) — `9b55cf00`, `d517c821`, `d0fbaf3f`, `1c2d7a97`, `0a351c1f` |
 | **3** | **Baseline de FP por versión → Fase O** | Primero la dimensión `outdated_software` en el banco de precisión sobre la KB real; solo entonces la ingesta OVAL/CSAF. Ataca la causa nº 1 de falsos positivos (G3) | ○ no empezada |
 | **4** | **N (resto) + D** — PostgreSQL/MSSQL/MongoDB, RDP, LDAP; encima, credenciales por defecto | D va detrás de N porque reutiliza sus dissectors, y al final del todo porque es la única fase que **escribe** en el objetivo (G4) | ○ no empezada |
-| **5** | **F + T (cierre)** — JARM, SYN sin estado, AIMD | Solo si aparece evidencia del techo de Python. Si no aparece, archivarlo explícitamente en vez de arrastrarlo como deuda perpetua | ○ no empezada |
+| **5** | **F + T (cierre)** — ~~JARM~~, SYN sin estado, AIMD | JARM **archivado** el 2026-09-02 (ver Fase F): su valor es comparativo y validarlo exige un laboratorio TLS con varias pilas que no existe aquí. Lo demás, solo si aparece evidencia del techo de Python | ◐ JARM cerrado por decisión; el resto sin empezar |
 
 **I-b queda fuera de las rondas a propósito.** Su siguiente paso —el ranking de nombres sin resolver
 más frecuentes para dirigir el feed curado— no es trabajo de ingeniería sino de datos: necesita el
@@ -1761,11 +1761,53 @@ la base de datos ni en la evidencia.
 `nmap -sV`, y con una confianza medible. Es el ojo del motor. La Fase N es, en rigor, su extensión a
 protocolos no-web; esta fase cubre lo que queda del lado web y de calibración.
 
-Lo pendiente aquí es **JARM** —un fingerprint del lado del servidor que envía diez ClientHello
+Lo pendiente aquí era **JARM** —un fingerprint del lado del servidor que envía diez ClientHello
 deliberadamente distintos y hashea el conjunto de respuestas— y, con mucho menos peso porque su
 retorno es bajo, un fingerprint de sistema operativo basado en detalles del stack TCP/IP (TTL inicial,
 tamaño de ventana, orden de las opciones TCP). El principio que gobierna esta capa es la calibración
 por oráculo: Nmap `-sV` es la verdad de referencia en el laboratorio.
+
+#### JARM: archivado (2026-09-02, L24)
+
+**JARM no se va a construir, y esto es la decisión escrita que el §6.3 pedía** en vez de arrastrarlo
+como deuda perpetua. La recomendación de ese apartado era explícita: *"Sólo si aparece evidencia del
+techo de Python. Si no aparece, archivarlo explícitamente en vez de arrastrarlo como deuda
+perpetua"*. No ha aparecido.
+
+Las cuatro razones, de la más decisiva a la menos:
+
+1. **El valor de JARM es comparativo, y sin validar contra la implementación de referencia no vale
+   nada.** JARM no identifica un producto: identifica una **pila TLS**, y sólo sirve porque el hash
+   que produce es el mismo que produce el resto del mundo — así se puede decir "este hash es el de un
+   Cobalt Strike" mirando un catálogo público. Un JARM que no case bit a bit con la implementación de
+   referencia no es una identificación peor, es **ninguna identificación**: un número que no se puede
+   comparar con nada.
+
+   Y validar esa coincidencia exige un laboratorio TLS con varias pilas distintas (OpenSSL,
+   BoringSSL, Schannel, JSSE), porque el hash depende de cómo cada una responde a diez saludos
+   deliberadamente raros. Ese laboratorio no existe aquí y montarlo es un proyecto por sí mismo.
+
+2. **No es requisito de ninguna definición de hecho.** La Fase F se da por cerrada con concordancia
+   ≥ 0,90 por familia frente a Nmap, en laboratorio y en objetivos reales — y eso lo cierra la
+   medición de paridad (#277), no JARM. Está en la fase por herencia de un plan, no porque nada
+   dependa de ello.
+
+3. **Su prioridad medida es la más baja de todo el backlog.** Impacto 2, facilidad 2. El §11 ya lo
+   ponía entre lo primero que se sacrifica si hay que recortar.
+
+4. **Diez ClientHello por servicio TLS no son gratis.** Es la sonda más cara del catálogo, contra el
+   objetivo del cliente, a cambio de un hash que —sin catálogo con el que compararlo— no se usaría
+   para nada.
+
+**Qué haría falta para reabrirlo**, dicho para que la decisión sea revisable y no un cierre en falso:
+un laboratorio con al menos cuatro pilas TLS distintas contra el que comprobar la coincidencia con la
+implementación de referencia, y un consumidor concreto del hash — un catálogo de JARMs conocidos, o
+la necesidad declarada de reconocer infraestructura que no dice nada de sí misma. Con esas dos cosas,
+el ítem vuelve; sin ellas, construirlo sería escribir código que nadie puede comprobar y nadie va a
+consultar.
+
+**Lo que sí queda**, y no es poco: el dissector de TLS sigue leyendo versión de protocolo negociada,
+certificado autofirmado y caducidad, que es lo que alimenta los checks de higiene de certificado.
 
 **Damos la fase por hecha cuando** para los servicios comunes la concordancia con Nmap alcanza 0,90
 por familia, medido en el banco de laboratorio **y** en objetivos reales autorizados (paridad
@@ -2287,7 +2329,7 @@ banco, reusando el traductor) → U4 (el histograma y su recomendación).
 | R | Bajo nivel | L2 | Runtime de checks; faltan `script` y el YAML (`network` ya hecho) — **su cierre requiere U** | G1, G4 — **Nikto** |
 | O | Correlación | L3 | Backports por feeds OVAL/CSAF de distribución | **G3 — el Notus propio** |
 | D | Bajo nivel | L2 | Credenciales por defecto, lockout-safe, sin plaintext | **G4** |
-| F | Bajo nivel | L1 | Fingerprint propio; falta JARM | `nmap -sV`, que pasa a oráculo |
+| F | Bajo nivel | L1 | Fingerprint propio; JARM archivado | `nmap -sV`, que pasa a oráculo |
 | T | Bajo nivel | L0 | Transporte propio; faltan SYN sin estado, UDP, AIMD | El descubrimiento de Nmap |
 | 4 | Correlación | L2 | Escaneo autenticado por SSH — **degradado a nicho** | Cubierto mejor por la Fase I |
 | DAST | Bajo nivel | L2 | Análisis web activo y acotado — opcional | ZAP/Nikto para webapp |
@@ -2421,7 +2463,7 @@ red. La capa L1 del motor.
 **Dissector** — El componente que analiza un protocolo concreto (TLS, HTTP, SSH, SMB, FTP…) para
 producir ese fingerprint. La Fase N es, esencialmente, escribir siete dissectors más.
 
-**JARM** — Técnica de fingerprinting del lado del servidor para TLS: envía diez saludos distintos y
+**JARM** — *(Archivado en este proyecto — ver Fase F.)* Técnica de fingerprinting del lado del servidor para TLS: envía diez saludos distintos y
 hashea el conjunto de respuestas. (No confundir con JA3/JA4, que fingerprintean al cliente.)
 
 **HASSH** — El equivalente de JARM para SSH: fingerprintea el servidor por su lista de algoritmos de


### PR DESCRIPTION
## Resumen

Cierra #295 **archivándolo**, que es una de las dos formas de cierre que el propio issue contempla y la que recomienda.

> *«O bien el JARM de un servidor conocido coincide con el de la implementación de referencia, o bien el roadmap registra por escrito que se archiva y por qué.»*

Y antes de eso, el §6.3 del roadmap ya había dejado escrito el criterio: *«Sólo si aparece evidencia del techo de Python. Si no aparece, archivarlo explícitamente en vez de arrastrarlo como deuda perpetua»*. No ha aparecido.

## Qué es JARM, para quien no lo tenga a mano

Un fingerprint del lado del servidor para TLS. En vez de un handshake normal, manda **diez `ClientHello` deliberadamente distintos** —con combinaciones raras de versiones, cifrados y extensiones— y hashea el conjunto de las diez respuestas.

Lo que identifica no es un producto sino una **pila TLS**: OpenSSL, BoringSSL, Schannel, la de Java. Y eso lo hace útil sobre todo para reconocer infraestructura que no dice nada de sí misma — un panel detrás de un proxy, un servidor de mando y control conocido, un *appliance* mudo.

## La razón de fondo, en una frase

**El valor de JARM es comparativo.**

Un JARM sólo sirve porque el hash que produce nuestra implementación es **el mismo** que produce el resto del mundo. Así se puede coger un hash, buscarlo en un catálogo público y decir «esto es un Cobalt Strike».

De ahí se sigue lo que decide el asunto: **un JARM que no case bit a bit con la implementación de referencia no es una identificación peor — es ninguna identificación.** Es un número que no se puede buscar en ningún sitio. No hay versión degradada aceptable.

Y comprobar esa coincidencia exige un laboratorio con varias pilas TLS distintas contra las que medir, porque el hash depende precisamente de cómo cada una responde a esos diez saludos raros. Ese laboratorio no existe aquí, y montarlo es un proyecto por sí mismo — no un paso previo pequeño.

## Las otras tres razones

**No es requisito de ninguna definición de hecho.** La Fase F se cierra con concordancia ≥ 0,90 por familia frente a Nmap, en laboratorio y en objetivos reales; eso lo cierra la medición de paridad (#277), no JARM. Estaba en la fase por herencia de un plan, no porque nada dependiera de ello.

**Su prioridad medida es la más baja de todo el backlog**: impacto 2, facilidad 2. El §11 ya lo ponía entre lo primero que se sacrifica si hay que recortar.

**Diez `ClientHello` por servicio TLS no son gratis.** Sería la sonda más cara del catálogo, contra el objetivo del cliente, a cambio de un hash que sin catálogo con el que compararlo no se usaría para nada.

## Qué haría falta para reabrirlo

Esto va escrito también, y a propósito: un archivado sin condiciones de reapertura es un cierre en falso, y dentro de un año nadie sabría si la decisión sigue valiendo.

Hacen falta **dos cosas, no una**:

1. Un laboratorio con al menos cuatro pilas TLS distintas contra el que comprobar la coincidencia con la implementación de referencia.
2. Un **consumidor concreto** del hash: un catálogo de JARMs conocidos, o la necesidad declarada de reconocer infraestructura que no se identifica sola.

Con las dos, el ítem vuelve. Sin ellas, construirlo sería escribir código que nadie puede comprobar y que nadie va a consultar.

## Qué cambia en el repositorio

**`plans/feature/themis/lybra-engine-roadmap.md`** gana una sección `#### JARM: archivado (2026-09-02, L24)` dentro de la Fase F, con las cuatro razones y las condiciones de reapertura. Y se corrigen las cuatro tablas que lo listaban como pendiente —el resumen de fases, el orden de ejecución, la planificación por tramos y la tabla de cobertura— además del glosario.

**`fingerprinting/tls.py`** deja de decir *«a separate and larger effort left for later»* y pasa a decir que está archivado, con la razón. La diferencia entre las dos frases es la que este PR resuelve: la primera es una promesa pendiente, la segunda es una decisión.

**`fingerprinting/__init__.py`** igual, en su párrafo de técnicas aplazadas. El fingerprinting de sistema operativo, VNC completo y RPC **siguen** aplazados: eso no cambia.

## Lo que sí queda, y no es poco

El dissector de TLS sigue haciendo su handshake y leyendo versión de protocolo negociada, certificado autofirmado y caducidad — que es lo que alimenta los checks de higiene de certificado, y lo que de verdad produce hallazgos hoy.

## Validación

`pytest tests/unit -k lybra`: todo pasa. `pylint` sobre `tls.py` sin avisos nuevos respecto a su línea base (3 antes, 3 después). El cambio no toca ni una línea ejecutable.

## Notas

- **La rama se llama `chore/...` y no `docs/...`**: el remoto tiene una rama llamada exactamente `docs`, y Git rechaza cualquier referencia `docs/algo` mientras exista (`directory file conflict`). El commit sí lleva el tipo correcto, `docs(themis):`.
- Con esto quedan cerradas las quince necesidades de la Fase 2 más los tres hallazgos que la medición real de #277 destapó.
