### PR TITLE
docs(readme): sincroniza el README con la Fase 2 del motor Lybra

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The REST API (Flask) orchestrates asynchronous scans and analysis over **RQ + Re
 
 ## Features
 
-- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine with banner fingerprinting, active checks, and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler and an authorized-targets registry for scan governance.
+- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine: its own TCP and UDP discovery, protocol dissectors for HTTP, SSH, FTP, SMTP/IMAP/POP3, SMB, TLS, MySQL, PostgreSQL, SQL Server, MongoDB, Redis, LDAP, RDP, VNC, SNMP, DNS, NTP, NetBIOS, mDNS, IKE and unauthenticated admin APIs (Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana), declarative and script checks, and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler and an authorized-targets registry for scan governance.
 - **AI-powered PDF reports** — Scan results enriched by a pluggable LLM backend with "Controls, Not Counts" calibrated risk assessment, plus per-host traceroute.
 - **Anti-phishing analysis** — 46 atomic rules across 10 rule families evaluate email headers and content (SPF, DKIM, DMARC, ARC, QR-code/quishing detection, domain impersonation, IOC extraction), producing a calibrated `Legitimate` / `Suspicious` / `Phishing` verdict with optional AI summaries.
 - **Automated mailbox monitoring** — Connect Gmail or Microsoft 365 via OAuth; Iris periodically pulls new mail and analyzes it automatically, and emails the user when a connected mailbox receives phishing.
@@ -96,7 +96,7 @@ Ellysia/
 
 | Module | Description | Status |
 |---|---|---|
-| **Themis** | Nmap, Nikto, Nuclei and Lybra (self-built engine) scans with PDF reports, traceroute, scheduled execution, AI enrichment, finding triage, folders, and an authorized-targets registry. | Operational |
+| **Themis** | Nmap, Nikto, Nuclei and Lybra (self-built engine: TCP/UDP discovery, 20+ protocol dissectors, declarative and script checks) scans with PDF reports, traceroute, scheduled execution, AI enrichment, finding triage, folders, and an authorized-targets registry. | Operational |
 | **Iris** | Phishing detection via a 46-rule engine across 10 families, IOC extraction, AI summaries, PDF reports, and automated Gmail/Microsoft 365 mailbox monitoring with phishing email notifications. | Operational |
 | **Acheron** | Client-encrypted credential vault with granular sync, optimistic-concurrency updates and a password generator, consumed by the web client and [SeQ-AcheronMobile](https://github.com/gamustea/SeQ-AcheronMobile). | Operational |
 | **Aegis** | AI-generated security awareness pills with current alerts from INCIBE-CERT and the Lybra knowledge base, quizzes, multi-format export (Markdown/HTML/JSON), and campaign delivery with per-recipient tracking. | Operational |


### PR DESCRIPTION
## Resumen

`CLAUDE.md` fija dos reglas sobre el `README.md`: revisarlo al terminar cualquier tarea que cambie algo visible para el usuario, y meter **todos** los cambios del README en un único commit propio, nunca mezclados con los de feature. Esto es ese commit para la Fase 2 del motor Lybra.

## Qué se había quedado corto

El README describía Lybra como *«a self-built detection engine with banner fingerprinting, active checks, and CPE→CVE matching»*. Era cierto cuando se escribió y sigue sin ser falso, pero ya no describe lo que el motor hace.

Después de los dieciocho PR de la Fase 2, Lybra tiene:

- **Descubrimiento propio de TCP y UDP**, no sólo TCP.
- **Más de veinte dissectors de protocolo**, incluidos los cinco que la Fase N había dejado explícitamente fuera (PostgreSQL, SQL Server, MongoDB, LDAP, RDP) y toda la superficie UDP (DNS, NTP, NetBIOS, mDNS, IKE, SQL Server Browser).
- **Las APIs de administración sin autenticar** — Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana — que es la familia con mejor relación valor/coste del backlog.
- **Checks de tipo `script`** además de los declarativos, para lo que un matcher de texto no puede expresar: protocolos binarios y negociaciones de varios pasos.

Y «banner fingerprinting» describe mal la mitad de eso: un `PRELOGIN` de TDS, una negociación de X.224 o un `SESSION_SETUP` de SMB no son banners, son diálogos.

## Qué cambia

Dos líneas, las dos que resumen el módulo para alguien que llega de fuera:

- La entrada de **Features** sobre escaneo de vulnerabilidades, que ahora enumera los protocolos.
- La fila de **Themis** en la tabla de módulos, que gana la descripción corta del motor.

## Notas

- **No se añaden claves de configuración al README** porque no las enumera: documenta el mecanismo (`@config_block`, las cinco entradas raíz de `SecOpsConfig.json`) y no la lista de valores. Las cuatro claves nuevas de la Fase 2 —`bannerTimeout`, `maxBlindProbes`, `udpBudgetSeconds`, `hostPoolSize`— viven bajo `features.themis.scanners.lybra` y están atadas por `test_config_shape.py`, que es donde el repositorio decide que se documenten.
- No hay endpoints nuevos, ni categorías o `external_id` de TaskQueue nuevos, ni migraciones, ni cambios de puertos o de perfiles de Docker. `appVersion` tampoco se toca: subirla es una decisión de publicación, no de este trabajo.
- **La rama se llama `chore/...` y no `docs/...`**: el remoto tiene una rama llamada exactamente `docs`, y Git rechaza cualquier referencia `docs/algo` mientras exista. El commit sí lleva el tipo correcto, `docs(readme):`.