### PR TITLE
El plazo de un job deja de ser capturable, el barrido se pone su propio reloj, y el timeout del panel por fin limita algo

### DIFF
--- a/API/src/modules/features/themis/lybra/transport.py
+++ b/API/src/modules/features/themis/lybra/transport.py
@@ -40,6 +40,15 @@ lista vacía indistinguible de un host genuinamente limpio. Por eso el barrido
 clasifica cada intento (:class:`PortOutcome`), lo reporta entero
 (:class:`PortSweep`) y ``scan_ports_sync`` devuelve ``None`` cuando nada
 contestó de ninguna forma.
+
+**El barrido tiene presupuesto de reloj propio** (``budget_seconds``). El
+plazo que la cola de tareas le pone a un job no sirve para esto: se inyecta con
+``PyThreadState_SetAsyncExc`` y sólo se materializa cuando el hilo vuelve a
+ejecutar bytecode, así que un hilo parado en la llamada al sistema que espera a
+los sockets lo rebasa sin enterarse — en producción, un plazo de 60 s apareció
+a los 159. Un presupuesto que evalúa el propio código, entre sonda y sonda, sí
+puede ser puntual. El plazo de la cola se queda como lo que debe ser: el último
+recurso si esto falla.
 """
 
 from __future__ import annotations
@@ -147,6 +156,11 @@ class PortSweep:
         was_cancelled: Si el barrido se abandonó por cancelación, en cuyo caso
             los puertos no probados no aparecen en ninguna lista y el barrido
             nunca se considera bloqueado.
+        was_truncated: Si el barrido se quedó sin presupuesto de reloj antes de
+            probarlo todo. Como ``was_cancelled``, deja puertos sin probar que
+            no aparecen en ninguna lista — y por el mismo motivo impide
+            concluir que el objetivo esté bloqueado *o* limpio: de lo que no se
+            miró no se sabe nada.
     """
 
     open_ports: Tuple[int, ...]
@@ -154,6 +168,7 @@ class PortSweep:
     timed_out_ports: Tuple[int, ...]
     unreachable_ports: Tuple[int, ...]
     was_cancelled: bool = False
+    was_truncated: bool = False
 
     @property
     def is_blocked(self) -> bool:
@@ -167,9 +182,11 @@ class PortSweep:
         delante y tiraba.
 
         Un barrido cancelado nunca cuenta como bloqueado: se dejó a medias a
-        propósito.
+        propósito. Tampoco uno truncado por presupuesto, por la misma razón —
+        aunque ése no es un resultado utilizable, y quien lo recibe debe
+        tratarlo como un fallo (ver :func:`scan_ports_sync`).
         """
-        if self.was_cancelled:
+        if self.was_cancelled or self.was_truncated:
             return False
         if self.open_ports or self.refused_ports:
             return False
@@ -206,7 +223,8 @@ class AsyncConnectScanner:
         self,
         host: str,
         ports: Iterable[int],
-        cancel_check: Optional[Callable[[], bool]] = None
+        cancel_check: Optional[Callable[[], bool]] = None,
+        deadline: Optional[float] = None,
     ) -> PortSweep:
         """Barrer los puertos de un host y clasificar cómo terminó cada intento.
 
@@ -215,6 +233,16 @@ class AsyncConnectScanner:
             ports: Los puertos a probar.
             cancel_check: Callable opcional, consultado antes de cada sonda; si
                 devuelve ``True`` se omiten las restantes.
+            deadline: Instante de :func:`time.monotonic` a partir del cual no se
+                inician sondas nuevas. Se comprueba en el mismo sitio que
+                ``cancel_check`` porque es la misma decisión: no empezar algo
+                que ya no vamos a poder terminar.
+
+                No corta una sonda ya en vuelo, así que el barrido puede
+                rebasar el plazo hasta el timeout de un puerto (``timeout``,
+                2 s por defecto). Ese rebase está acotado, que es toda la
+                diferencia con no tener presupuesto: sin él, un barrido ancho
+                contra un objetivo que filtra tráfico dura lo que dure.
 
         Returns:
             El :class:`PortSweep` con cada puerto en la lista de su desenlace.
@@ -222,13 +250,25 @@ class AsyncConnectScanner:
         semaphore = asyncio.Semaphore(self._concurrency)
         outcomes: Dict[int, PortOutcome] = {}
         was_cancelled = False
+        was_truncated = False
 
         async def probe(port: int) -> None:
-            nonlocal was_cancelled
-            if cancel_check and cancel_check():
-                was_cancelled = True
-                return
+            nonlocal was_cancelled, was_truncated
+            # Las dos comprobaciones van **dentro** del semáforo, no antes.
+            # ``asyncio.gather`` arranca las corrutinas de todos los puertos a
+            # la vez y el semáforo es lo único que las escalona: hacer la
+            # comprobación antes de adquirirlo la ejecuta para los mil puertos
+            # en el primer instante del barrido, cuando todavía no hay nada que
+            # decidir, y a partir de ahí ya no se vuelve a mirar. Dentro, cada
+            # sonda la evalúa justo antes de salir a la red, que es cuando la
+            # respuesta puede haber cambiado.
             async with semaphore:
+                if cancel_check and cancel_check():
+                    was_cancelled = True
+                    return
+                if deadline is not None and time.monotonic() >= deadline:
+                    was_truncated = True
+                    return
                 outcomes[port] = await self._probe_outcome(host, port)
 
         await asyncio.gather(*(probe(port) for port in ports))
@@ -242,6 +282,7 @@ class AsyncConnectScanner:
             timed_out_ports=ports_with(PortOutcome.TIMED_OUT),
             unreachable_ports=ports_with(PortOutcome.UNREACHABLE),
             was_cancelled=was_cancelled,
+            was_truncated=was_truncated,
         )
 
     async def scan(
@@ -308,6 +349,7 @@ def sweep_ports_sync(
     timeout: float = 2.0,
     opener: Optional[Callable] = None,
     cancel_check: Optional[Callable[[], bool]] = None,
+    budget_seconds: Optional[float] = None,
 ) -> PortSweep:
     """Ejecutar un barrido completo síncronamente, en un bucle de eventos propio.
 
@@ -321,13 +363,16 @@ def sweep_ports_sync(
         timeout: Plazo por puerto, en segundos.
         opener: Abridor de conexión inyectable (ver :class:`AsyncConnectScanner`).
         cancel_check: Callable de cancelación opcional.
+        budget_seconds: Presupuesto de reloj para el barrido entero. ``None``
+            (por defecto) lo deja sin límite, que es como se comportaba antes.
 
     Returns:
         El :class:`PortSweep` del barrido.
     """
     port_list = list(ports) if ports is not None else list(DEFAULT_PORTS)
     scanner = AsyncConnectScanner(concurrency=concurrency, timeout=timeout, opener=opener)
-    return asyncio.run(scanner.sweep(host, port_list, cancel_check=cancel_check))
+    deadline = time.monotonic() + budget_seconds if budget_seconds is not None else None
+    return asyncio.run(scanner.sweep(host, port_list, cancel_check=cancel_check, deadline=deadline))
 
 
 def scan_ports_sync(
@@ -340,6 +385,7 @@ def scan_ports_sync(
     retries: int = 1,
     retry_delay: float = 2.0,
     sleeper: Callable[[float], None] = time.sleep,
+    budget_seconds: Optional[float] = None,
 ) -> Optional[List[int]]:
     """Run a connect scan synchronously, on a fresh event loop of its own.
 
@@ -358,6 +404,15 @@ def scan_ports_sync(
     segundos, y un reintento espaciado cuesta mucho menos que un escaneo
     perdido.
 
+    **También devuelve ``None`` cuando se agota el presupuesto de reloj.** Un
+    barrido truncado deja puertos sin mirar, y de lo que no se miró no se sabe
+    nada: devolver los que sí dio tiempo a encontrar sería exactamente el fallo
+    que arregló L48-c por otra vía, porque el ciclo de vida marcaría como
+    corregido todo lo que estaba abierto y esta vez no se llegó a comprobar. Un
+    escaneo que no cabe en su presupuesto es un escaneo fallido, y decirlo es
+    más útil que un informe a medias que parece completo. Los puertos que sí se
+    encontraron quedan en el log.
+
     Args:
         host: The target host.
         ports: The ports to probe; defaults to :data:`DEFAULT_PORTS`.
@@ -368,22 +423,44 @@ def scan_ports_sync(
         retries: Reintentos adicionales tras un barrido que parece bloqueado.
         retry_delay: Espera entre reintentos, en segundos.
         sleeper: Espera inyectable, para que un test no tenga que dormirla.
+        budget_seconds: Presupuesto de reloj para el descubrimiento entero,
+            reintentos y esperas incluidos. ``None`` lo deja sin límite.
 
     Returns:
-        Los puertos abiertos, ascendentes, o ``None`` si el barrido parece
-        bloqueado incluso tras los reintentos.
+        Los puertos abiertos, ascendentes; o ``None`` si el barrido parece
+        bloqueado incluso tras los reintentos, o si se agotó el presupuesto.
     """
-    sweep = sweep_ports_sync(host, ports, concurrency, timeout, opener, cancel_check)
+    deadline = time.monotonic() + budget_seconds if budget_seconds is not None else None
+
+    def remaining_budget() -> Optional[float]:
+        return None if deadline is None else deadline - time.monotonic()
+
+    sweep = sweep_ports_sync(
+        host, ports, concurrency, timeout, opener, cancel_check, remaining_budget())
     attempts_left = max(0, retries)
     while sweep.is_blocked and attempts_left > 0:
+        # El reintento sale del mismo presupuesto que el barrido: si no queda
+        # reloj para volver a intentarlo, no se intenta.
+        if deadline is not None and remaining_budget() <= retry_delay:
+            break
         logger.warning(
             "Barrido de %s sin una sola respuesta (%s puertos expirados): reintentando",
             host, len(sweep.timed_out_ports),
         )
         if retry_delay > 0:
             sleeper(retry_delay)
-        sweep = sweep_ports_sync(host, ports, concurrency, timeout, opener, cancel_check)
+        sweep = sweep_ports_sync(
+            host, ports, concurrency, timeout, opener, cancel_check, remaining_budget())
         attempts_left -= 1
+
+    if sweep.was_truncated:
+        logger.error(
+            "Descubrimiento de %s sin terminar: se agotó el presupuesto de %.1f s "
+            "con %s puertos abiertos encontrados (%s). Lo que quedó sin probar es "
+            "desconocido, no limpio, así que el escaneo falla en vez de reportarlo",
+            host, budget_seconds, len(sweep.open_ports), list(sweep.open_ports),
+        )
+        return None
 
     if sweep.is_blocked:
         logger.error(

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -1,6 +1,7 @@
 """LybraEngineManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
 
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from typing import List, Optional
@@ -160,7 +161,7 @@ class LybraEngineManager(ScanManager):
 
         self._task_queue.submit(
             func=LybraEngineManager.execute_lybra_scan, # type: ignore
-            args=(scan_id, discover_ports, services),
+            args=(scan_id, discover_ports, services, timeout),
             name=f"LybraScan-{scan_id}",
             category=self.TASK_CATEGORY, # type: ignore
             external_id=self.external_id_for(scan_id),
@@ -174,33 +175,64 @@ class LybraEngineManager(ScanManager):
     def execute_lybra_scan(
         scan_id: int,
         discover_ports: Optional[list] = None,
-        services: Optional[List[Service]] = None
+        services: Optional[List[Service]] = None,
+        timeout: Optional[int] = None,
     ) -> None:
-        """Entry point submitted to the TaskQueue. Runs the engine in the worker."""
+        """Entry point submitted to the TaskQueue. Runs the engine in the worker.
+
+        ``timeout`` es opcional para que un job encolado antes de este cambio
+        —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
+        despliegue en vez de fallar al deserializarse.
+        """
         with job_context():
             manager = LybraEngineManager()
             manager._run_lybra( # type: ignore
                 scan_id,
                 discover_ports,
                 services,
+                timeout,
             )
+
+    @staticmethod
+    def _remaining_budget(deadline: Optional[float]) -> Optional[float]:
+        """Segundos que quedan hasta ``deadline``, o ``None`` si no hay plazo."""
+        return None if deadline is None else max(0.0, deadline - time.monotonic())
 
     def _run_lybra(
         self,
         scan_id: int,
         discover_ports: Optional[list] = None,
         services_payload: Optional[List[Service]] = None,
+        timeout: Optional[int] = None,
     ) -> None:
         """Resolve services (own discovery or a payload), detect, persist.
 
         This is the testable body of the scan (the ``execute_* seam → _run_*``
         pattern). Runs synchronously; safe to call directly in tests without a
         worker.
+
+        ``timeout`` es el que el usuario escribió en el panel de lanzamiento.
+        Hasta ahora sólo alimentaba el plazo de la cola —un plazo que, por cómo
+        se inyecta, un hilo bloqueado en una llamada al sistema rebasa sin
+        enterarse— y por tanto no limitaba el escaneo de verdad. Ahora abre
+        además un plazo de reloj propio del que come el descubrimiento de
+        puertos.
+
+        ponytail: sólo el descubrimiento TCP consume el presupuesto. Es la fase
+        que puede correr sin cota (barrido ancho contra un objetivo que filtra
+        tráfico) y la que aparecía en el incidente; el fingerprinting y los
+        checks tienen plazo por operación. Si algún día hace falta acotarlos
+        también, el plazo ya está aquí: basta pasarles ``_remaining_budget``.
         """
+        deadline = time.monotonic() + timeout if timeout else None
         source = ServiceSource.build_for_args(services_payload, discover_ports)
         probes = DiscoveryProbes(
             is_host_reachable=self.is_host_reachable,
-            discover_ports=self._discover_ports,
+            # El presupuesto se calcula al llamar, no aquí: para cuando el
+            # descubrimiento arranca ya se han gastado la comprobación de
+            # alcanzabilidad y las consultas de apertura del escaneo.
+            discover_ports=lambda target, ports: self._discover_ports(
+                target, ports, budget_seconds=self._remaining_budget(deadline)),
             discover_udp_ports=self._discover_udp_ports,
         )
         try:
@@ -291,7 +323,12 @@ class LybraEngineManager(ScanManager):
             logger.error(f"Error en escaneo Lybra {scan_id}: {e}", exc_info=True)
             self.update_scan_status(scan_id, ScanStatus.FAILED)
 
-    def _discover_ports(self, target: str, discover_ports) -> Optional[list]:
+    def _discover_ports(
+        self,
+        target: str,
+        discover_ports,
+        budget_seconds: Optional[float] = None,
+    ) -> Optional[list]:
         """Discover open ports with Lybra's own connect scan (Fase T).
 
         Returns ``None`` (not ``[]``) when discovery itself failed unexpectedly,
@@ -308,9 +345,13 @@ class LybraEngineManager(ScanManager):
         Desde L48-c el transporte distingue "todo cerrado" de "no me han
         dejado mirar" y devuelve ``None`` en el segundo caso, que es lo que
         este método siempre esperó recibir.
+
+        Lo mismo vale para ``budget_seconds``: un barrido que se queda sin
+        reloj también llega como ``None``, porque de los puertos que no dio
+        tiempo a mirar no se sabe nada, y no saber no es estar limpio.
         """
         try:
-            discovered = scan_ports_sync(target, discover_ports)
+            discovered = scan_ports_sync(target, discover_ports, budget_seconds=budget_seconds)
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
             return None

--- a/API/src/modules/system/taskqueue/worker.py
+++ b/API/src/modules/system/taskqueue/worker.py
@@ -39,7 +39,51 @@ from rq import Queue, SimpleWorker
 from rq.registry import BaseRegistry
 from rq.timeouts import TimerDeathPenalty
 
-BaseRegistry.death_penalty_class = TimerDeathPenalty
+
+class JobDeadlineExceeded(BaseException):
+    """El plazo de un job se agotó y RQ está terminándolo.
+
+    Hereda de ``BaseException``, **no** de ``Exception``, y esa es toda su
+    razón de ser.
+
+    RQ interrumpe un job que se pasa de tiempo lanzándole una excepción desde
+    fuera. La suya, ``rq.timeouts.JobTimeoutException``, hereda de
+    ``Exception``, así que es indistinguible de un error corriente para
+    cualquier ``except Exception``. Y el código de negocio está lleno de ellos
+    por buenas razones: un escaneo no debe hundirse porque un objetivo cierre
+    la conexión. El resultado era que la sentencia de muerte se registraba
+    como «fallo de red», el job seguía corriendo —el temporizador dispara una
+    sola vez, así que a partir de ahí ya no tiene ningún límite— y al terminar
+    RQ escribía ``Successfully completed`` sobre un trabajo que había
+    sobrepasado su plazo.
+
+    Cambiar la clase de excepción lo arregla en los diez módulos a la vez y
+    sin tocar ninguno, que es la razón de hacerlo aquí y no persiguiendo
+    ``except`` uno a uno. Es seguro porque el manejador de RQ en
+    ``Worker.perform_job`` es un ``except:`` pelado, sin tipo: sigue
+    capturándola y marcando el job como fallido exactamente igual que antes.
+    """
+
+
+class _UnswallowableTimerDeathPenalty(TimerDeathPenalty):
+    """``TimerDeathPenalty`` que lanza :class:`JobDeadlineExceeded`.
+
+    RQ codifica ``JobTimeoutException`` en la llamada de ``perform_job`` que
+    construye la penalización, así que la sustitución tiene que hacerse aquí,
+    ignorando la excepción que nos pasan.
+
+    Aviso sobre la clase base: ``TimerDeathPenalty.__init__`` parchea el
+    ``__init__`` de la excepción que reciba para incrustarle el mensaje del
+    plazo (``PyThreadState_SetAsyncExc`` solo admite una *clase*, no una
+    instancia). Es un efecto global sobre la clase, y es otro motivo para
+    darle una nuestra en vez de dejar que lo haga sobre la de RQ.
+    """
+
+    def __init__(self, timeout, exception=None, **kwargs):  # pylint: disable=unused-argument
+        super().__init__(timeout, JobDeadlineExceeded, **kwargs)
+
+
+BaseRegistry.death_penalty_class = _UnswallowableTimerDeathPenalty
 
 import src.modules.system.config_reading as CR
 from src.modules.system.logging import configure_logging
@@ -71,9 +115,13 @@ class _ThreadSafeWorker(SimpleWorker):
     propio ``threading.Thread``, así que forzamos ``TimerDeathPenalty``
     (basado en ``threading.Timer``), que es thread-safe en cualquier
     plataforma.
+
+    Se usa la subclase :class:`_UnswallowableTimerDeathPenalty` para que la
+    excepción de plazo no la pueda capturar un ``except Exception`` del código
+    de negocio; el porqué está en :class:`JobDeadlineExceeded`.
     """
 
-    death_penalty_class = TimerDeathPenalty
+    death_penalty_class = _UnswallowableTimerDeathPenalty
 
     def _install_signal_handlers(self):
         pass

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -51,7 +51,7 @@ def _stub_self_discovery(monkeypatch, tcp_ports: list, udp_ports: list | None = 
     """
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: list(tcp_ports))
+                        lambda self, target, ports, **_kwargs: list(tcp_ports))
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports",
                         lambda self, target: list(udp_ports or []))
 
@@ -143,7 +143,7 @@ def test_lybra_self_discovery_produces_open_port_findings(app, admin_user, monke
     # self-discovery pipeline runs for real.
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [80, 22])
+                        lambda self, target, ports, **_kwargs: [80, 22])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
 
     with app.app_context():
@@ -170,7 +170,7 @@ def test_lybra_self_discovery_disambiguates_the_same_port_over_tcp_and_udp(app, 
     `Finding.protocol` y el arreglo de `compute_dedup_key`."""
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [161])
+                        lambda self, target, ports, **_kwargs: [161])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports",
                         lambda self, target: [161])
 
@@ -216,7 +216,7 @@ def test_lybra_self_discovery_probe_failure_fails_without_false_fixed(app, admin
     must also fail the scan rather than silently proceed with zero findings."""
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: None)
+                        lambda self, target, ports, **_kwargs: None)
 
     with app.app_context():
         mgr = LybraEngineManager()
@@ -246,7 +246,7 @@ def test_lybra_blocked_discovery_never_marks_findings_fixed(app, admin_user, mon
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [80, 443])
+                        lambda self, target, ports, **_kwargs: [80, 443])
 
     with app.app_context():
         mgr = LybraEngineManager()
@@ -256,7 +256,7 @@ def test_lybra_blocked_discovery_never_marks_findings_fixed(app, admin_user, mon
     # Segundo escaneo: el objetivo bloquea el barrido — el transporte lo
     # reconoce y devuelve None en vez de una lista vacía.
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: None)
+                        lambda self, target, ports, **_kwargs: None)
     with app.app_context():
         mgr = LybraEngineManager()
         second = mgr._create_scan_record(target="10.0.0.31", user_id=admin_user.id)
@@ -277,7 +277,7 @@ def test_lybra_self_discovery_genuine_zero_ports_still_marks_fixed(app, admin_us
     a previously-open finding on this target should still be marked fixed."""
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [80])
+                        lambda self, target, ports, **_kwargs: [80])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
 
     with app.app_context():
@@ -288,7 +288,7 @@ def test_lybra_self_discovery_genuine_zero_ports_still_marks_fixed(app, admin_us
 
     # Second scan: discovery ran cleanly and genuinely found nothing open.
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [])
+                        lambda self, target, ports, **_kwargs: [])
     with app.app_context():
         mgr = LybraEngineManager()
         e2 = mgr._create_scan_record(target="10.0.0.7", user_id=admin_user.id)
@@ -912,7 +912,7 @@ def test_lybra_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user, mon
     monkeypatch.setattr(CR, "lybra_config", lambda: CR.LybraConfig(fingerprinting_enabled=True))
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     monkeypatch.setattr(LybraEngineManager, "_discover_ports",
-                        lambda self, target, ports: [80])
+                        lambda self, target, ports, **_kwargs: [80])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
 
     def fake_fetch(self, host, port, method, path):
@@ -949,7 +949,7 @@ def test_lybra_ftp_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user,
     _seed_kb_vsftpd_cve(app)
     monkeypatch.setattr(CR, "lybra_config", lambda: CR.LybraConfig(fingerprinting_enabled=True))
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
-    monkeypatch.setattr(LybraEngineManager, "_discover_ports", lambda self, target, ports: [21])
+    monkeypatch.setattr(LybraEngineManager, "_discover_ports", lambda self, target, ports, **_kwargs: [21])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
     monkeypatch.setattr(FtpProbe, "fetch", lambda self, host, port: "220 (vsFTPd 2.3.4)")
     _authorize_target(app, admin_user.id)
@@ -981,7 +981,7 @@ def test_lybra_mysql_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_use
     _seed_kb_mysql_cve(app)
     monkeypatch.setattr(CR, "lybra_config", lambda: CR.LybraConfig(fingerprinting_enabled=True))
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
-    monkeypatch.setattr(LybraEngineManager, "_discover_ports", lambda self, target, ports: [3306])
+    monkeypatch.setattr(LybraEngineManager, "_discover_ports", lambda self, target, ports, **_kwargs: [3306])
     monkeypatch.setattr(LybraEngineManager, "_discover_udp_ports", lambda self, target: [])
     monkeypatch.setattr(
         MysqlProbe, "fetch",

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -1,0 +1,100 @@
+"""El ``timeout`` del panel de lanzamiento llega hasta el barrido de puertos.
+
+Antes se quedaba a mitad de camino. `run_scan` lo usaba en un único sitio —el
+plazo que se le pone al job en la cola— y nunca lo pasaba al descubrimiento,
+que no tenía presupuesto de reloj de ninguna clase. Como además ese plazo no se
+puede hacer cumplir con puntualidad (se inyecta con
+``PyThreadState_SetAsyncExc`` y un hilo parado en una llamada al sistema lo
+rebasa sin enterarse), el número que el usuario escribía no participaba de
+hecho en ninguna decisión: era un campo decorativo.
+
+Estos tests fijan el recorrido completo del valor.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.modules.features.themis.managers.lybra import engine as engine_module
+from src.modules.features.themis.managers.lybra.engine import LybraEngineManager
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_budget_reaches_the_sweep(monkeypatch):
+    captured = {}
+
+    def fake_scan_ports_sync(target, ports, budget_seconds=None):
+        captured["target"] = target
+        captured["ports"] = ports
+        captured["budget"] = budget_seconds
+        return [80]
+
+    monkeypatch.setattr(engine_module, "scan_ports_sync", fake_scan_ports_sync)
+
+    result = LybraEngineManager()._discover_ports(  # pylint: disable=protected-access
+        "10.0.0.5", [80, 443], budget_seconds=42.0)
+
+    assert result == [80]
+    assert captured["budget"] == 42.0
+
+
+def test_a_scan_without_budget_keeps_the_old_behaviour(monkeypatch):
+    """Los caminos que no pasan ``timeout`` —un escaneo programado, o un job
+    encolado antes de este cambio— siguen barriendo sin límite de reloj."""
+    captured = {}
+
+    def fake_scan_ports_sync(target, ports, budget_seconds=None):
+        captured["budget"] = budget_seconds
+        return []
+
+    monkeypatch.setattr(engine_module, "scan_ports_sync", fake_scan_ports_sync)
+    LybraEngineManager()._discover_ports("10.0.0.5", None)  # pylint: disable=protected-access
+
+    assert captured["budget"] is None
+
+
+def test_remaining_budget_shrinks_and_never_goes_negative():
+    remaining = LybraEngineManager._remaining_budget  # pylint: disable=protected-access
+
+    assert remaining(None) is None
+
+    deadline = time.monotonic() + 10
+    first = remaining(deadline)
+    second = remaining(deadline)
+    assert 0 < second <= first <= 10
+
+    # Un plazo ya vencido da cero, no un número negativo: el barrido lo
+    # traduce en "no empieces nada", que es lo que se quiere, y no en un
+    # presupuesto enorme por desbordamiento de signo.
+    assert remaining(time.monotonic() - 5) == 0.0
+
+
+def test_the_worker_entry_point_carries_the_timeout(monkeypatch):
+    """La tupla de argumentos que viaja a la cola.
+
+    ``timeout`` es el cuarto y es opcional a propósito: un job encolado antes
+    de este cambio viaja con tres argumentos y tiene que seguir ejecutándose
+    tras el despliegue en vez de fallar al deserializarse.
+    """
+    seen = []
+
+    class _NullContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(engine_module, "job_context", lambda: _NullContext())
+    monkeypatch.setattr(
+        LybraEngineManager, "_run_lybra",
+        lambda self, *args: seen.append(args),
+    )
+
+    LybraEngineManager.execute_lybra_scan(7, [80], None, 90)
+    LybraEngineManager.execute_lybra_scan(8, [80])
+
+    assert seen == [(7, [80], None, 90), (8, [80], None, None)]

--- a/API/tests/unit/test_lybra_transport.py
+++ b/API/tests/unit/test_lybra_transport.py
@@ -273,3 +273,71 @@ def test_udp_scan_defaults_to_udp_probes_table():
     # concurrente, así que el orden en que llegan los intentos es cosa del
     # planificador y no del escáner.
     assert sorted(calls) == sorted(list(UDP_PROBES) * 2)
+
+
+# ─────────────────────────────────────────────────── presupuesto de reloj
+#
+# El plazo que la cola de tareas le pone a un job no puede acotar el barrido:
+# se inyecta con ``PyThreadState_SetAsyncExc``, que sólo se materializa cuando
+# el hilo vuelve a ejecutar bytecode, y un hilo parado en la llamada al sistema
+# que espera a los sockets lo rebasa sin enterarse (en producción, un plazo de
+# 60 s apareció a los 159). Estas pruebas fijan el presupuesto que sí evalúa el
+# propio barrido.
+
+
+def _slow_opener(seconds):
+    """Abridor que tarda ``seconds`` y luego acepta la conexión."""
+    async def opener(host, port):
+        await asyncio.sleep(seconds)
+        return None, _FakeWriter()
+    return opener
+
+
+def test_the_sweep_stops_starting_probes_once_the_budget_is_spent():
+    # Concurrencia 1 para que las sondas vayan en fila y el reloj avance de
+    # forma predecible: con 0,05 s cada una, en 0,15 s no caben veinte.
+    ports = list(range(1000, 1020))
+    sweep = sweep_ports_sync("10.0.0.5", ports, concurrency=1,
+                             opener=_slow_opener(0.05), budget_seconds=0.15)
+
+    assert sweep.was_truncated
+    probed = (len(sweep.open_ports) + len(sweep.refused_ports)
+              + len(sweep.timed_out_ports) + len(sweep.unreachable_ports))
+    assert 0 < probed < len(ports), f"se probaron {probed} de {len(ports)}"
+
+
+def test_a_truncated_sweep_is_neither_blocked_nor_clean():
+    """Un barrido truncado no es evidencia de nada sobre lo que no se miró.
+
+    Y en particular no puede llegar al motor como lista de puertos: el ciclo de
+    vida marcaría como corregido todo lo que estaba abierto y esta vez no dio
+    tiempo a comprobar, que es el fallo de L48-c por otra puerta.
+    """
+    ports = list(range(1000, 1020))
+    sweep = sweep_ports_sync("10.0.0.5", ports, concurrency=1,
+                             opener=_slow_opener(0.05), budget_seconds=0.15)
+    assert not sweep.is_blocked
+
+    result = scan_ports_sync("10.0.0.5", ports, concurrency=1,
+                             opener=_slow_opener(0.05), budget_seconds=0.15)
+    assert result is None
+
+
+def test_a_sweep_that_fits_its_budget_is_unaffected():
+    opener = _opener_for({22, 80, 443})
+    result = scan_ports_sync("10.0.0.5", [443, 22, 81, 80, 8080],
+                             opener=opener, budget_seconds=30)
+    assert result == [22, 80, 443]
+
+
+def test_the_retry_does_not_outlive_the_budget():
+    """Reintentar un barrido bloqueado cuesta ``retry_delay`` más otro barrido
+    entero. Si no queda presupuesto para eso, no se intenta."""
+    ports = list(range(1000, 1000 + 16))
+    waits = []
+    result = scan_ports_sync("10.0.0.5", ports, timeout=0.01,
+                             opener=_timing_out_opener(),
+                             retry_delay=0.5, sleeper=waits.append,
+                             budget_seconds=0.05)
+    assert result is None
+    assert waits == [], "se durmió un reintento que no cabía en el presupuesto"

--- a/API/tests/unit/test_taskqueue_deadline.py
+++ b/API/tests/unit/test_taskqueue_deadline.py
@@ -1,0 +1,78 @@
+"""El plazo de un job no se puede tragar con un ``except Exception``.
+
+RQ interrumpe un job que se pasa de tiempo lanzándole una excepción desde
+fuera. La suya hereda de ``Exception``, así que cualquiera de los muchos
+``except Exception`` del código de negocio —que existen por buenas razones: un
+escaneo no debe hundirse porque un objetivo cierre la conexión— la capturaba y
+la registraba como si fuera un error corriente. El job seguía corriendo sin
+límite (el temporizador dispara una sola vez) y al terminar RQ escribía
+``Successfully completed`` sobre un trabajo que había sobrepasado su plazo.
+
+Es lo que se vio en producción el 2026-09-02: un plazo de 60 segundos, un
+``Lybra port discovery failed`` en el log, y el mismo job declarado exitoso
+tras 2 min 39 s.
+
+Estos tests fijan el arreglo: la excepción de plazo deriva de
+``BaseException``, y la penalización del worker la usa en lugar de la de RQ.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from rq.timeouts import JobTimeoutException
+
+from src.modules.system.taskqueue.worker import (
+    JobDeadlineExceeded,
+    _UnswallowableTimerDeathPenalty,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_deadline_exception_is_not_an_ordinary_exception():
+    """La invariante entera del arreglo, en una línea.
+
+    Si algún día alguien la hace heredar de ``Exception`` "para que sea como
+    las demás", el fallo de producción vuelve entero y en silencio.
+    """
+    assert issubclass(JobDeadlineExceeded, BaseException)
+    assert not issubclass(JobDeadlineExceeded, Exception)
+
+
+def test_the_penalty_substitutes_rqs_own_exception():
+    """RQ codifica ``JobTimeoutException`` en la llamada que construye la
+    penalización, así que la sustitución tiene que ignorar lo que nos pasan."""
+    penalty = _UnswallowableTimerDeathPenalty(30, JobTimeoutException, job_id="x")
+    assert penalty._exception is JobDeadlineExceeded  # pylint: disable=protected-access
+
+
+def test_a_broad_except_does_not_swallow_the_deadline():
+    """El caso real: trabajo con ``except Exception`` dentro del plazo.
+
+    El bucle es Python puro a propósito. ``TimerDeathPenalty`` inyecta la
+    excepción con ``PyThreadState_SetAsyncExc``, que sólo se materializa
+    cuando el hilo vuelve a ejecutar bytecode; en producción el hilo estaba
+    parado dentro de una llamada al sistema y por eso un plazo de 60 s
+    apareció a los 159. Aquí interesa comprobar quién la captura, no cuándo
+    llega, así que se le da bytecode que ejecutar.
+    """
+    swallowed = []
+    deadline_escaped = False
+
+    try:
+        with _UnswallowableTimerDeathPenalty(0.1, JobTimeoutException, job_id="x"):
+            limit = time.monotonic() + 5
+            while time.monotonic() < limit:
+                try:
+                    for _ in range(1000):
+                        pass
+                except Exception as e:  # pylint: disable=broad-except
+                    # El manejador que se comía la sentencia de muerte.
+                    swallowed.append(e)
+    except JobDeadlineExceeded:
+        deadline_escaped = True
+
+    assert deadline_escaped, "el plazo no llegó a escapar del trabajo"
+    assert not swallowed, f"un except Exception capturó el plazo: {swallowed}"


### PR DESCRIPTION
## Resumen

Un escaneo de Lybra sobrepasó su plazo, la cola lo mató, el motor se comió la sentencia de muerte creyendo que era un fallo de red, el trabajo siguió corriendo sin límite durante casi dos minutos más, y al terminar el worker escribió `Successfully completed` — mientras la fila del escaneo quedaba marcada como `failed` en la base de datos.

Este PR arregla los tres defectos que se apilaban ahí. El primero no es de Lybra: afecta por igual a cualquier trabajo de fondo de cualquiera de los diez módulos.

### Related Issue

Closes #395

---

## El log que lo destapó

```
[ERROR] ...lybra.engine: Lybra port discovery failed for 195.20.230.152
Traceback (most recent call last):
  File ".../lybra/engine.py", line 313, in _discover_ports
    discovered = scan_ports_sync(target, discover_ports)
  ...
  File "/usr/local/lib/python3.11/selectors.py", line 468, in select
    fd_event_list = self._selector.poll(timeout, max_ev)
rq.timeouts.JobTimeoutException: Task exceeded maximum timeout value (60 seconds)
[INFO] rq.worker: Successfully completed ...execute_lybra_scan(283, [...]) job in 0:02:39
```

Tres cosas de las que fijarse: el plazo era de 60 segundos y la excepción aparece a los 159; el motor la registró como «descubrimiento fallido»; y la cola declaró éxito.

---

## Implementación

### Fase 1 — La sentencia de muerte deja de ser capturable

**Qué es una «death penalty».** RQ, la librería de colas del proyecto, interrumpe un trabajo que se pasa de tiempo lanzándole una excepción desde fuera. En Linux lo habitual es una alarma del sistema operativo (`SIGALRM`), pero esa vía sólo funciona en el hilo principal del proceso, y nuestro worker ejecuta cada trabajo en su propio hilo. Por eso `worker.py` fuerza deliberadamente `TimerDeathPenalty`, la variante basada en `threading.Timer`. Esa decisión es correcta y no cambia.

El problema es la **clase** de excepción que viaja: `rq.timeouts.JobTimeoutException` hereda de `Exception`, así que es indistinguible de un error corriente para cualquier `except Exception`. Y el código de negocio está lleno de ellos por buenas razones — un escaneo no debe hundirse porque un objetivo cierre la conexión. `_discover_ports` es el que aparece en el log:

```python
try:
    discovered = scan_ports_sync(target, discover_ports)
except Exception:
    logger.exception("Lybra port discovery failed for %s", target)
    return None
```

Y aquí está lo que convierte un log feo en un fallo de verdad: **el temporizador dispara una sola vez**. Tragada la excepción, no hay segundo aviso, y el trabajo pasa a correr sin ningún límite hasta que acabe por su cuenta. Cuando la función retorna con normalidad, RQ no tiene forma de saber que pasó nada.

El arreglo cambia la clase en vez de perseguir los `except` uno a uno: `JobDeadlineExceeded` deriva de **`BaseException`**, no de `Exception`. Ningún `except Exception` puede capturarla, en los diez módulos a la vez y sin tocar ninguno.

Verificado que es seguro: el manejador de RQ en `Worker.perform_job` es un `except:` pelado, sin tipo, así que sigue capturándola y marcando el trabajo como fallido igual que antes. De paso, eso reconcilia las dos versiones que la cola y la base de datos daban del mismo escaneo.

### Fase 2 — El barrido se pone su propio reloj

Aunque la excepción ya no se pueda tragar, el plazo de la cola sigue sin poder ser puntual, y por un motivo de mecanismo, no de configuración: `TimerDeathPenalty` inyecta la excepción con `PyThreadState_SetAsyncExc`, que la deja «pendiente» y sólo la materializa cuando el hilo vuelve a ejecutar bytecode de Python. Un hilo parado dentro de la llamada al sistema que espera a los sockets la rebasa sin enterarse. Por eso un plazo de 60 segundos apareció a los 159, y el traceback señala exactamente esa llamada.

Así que `scan_ports_sync` acepta ahora `budget_seconds` y lo comprueba **entre sonda y sonda**, que es un sitio donde el código sí está ejecutando bytecode y el corte puede ser puntual. No interrumpe una sonda ya en vuelo, de modo que el rebase queda acotado por el timeout de un puerto (2 s) en lugar de ser ilimitado.

Un barrido truncado se marca (`PortSweep.was_truncated`) y `scan_ports_sync` devuelve `None`, igual que uno bloqueado. **Devolver los puertos que sí dio tiempo a encontrar sería el fallo de #370 por otra puerta**: el ciclo de vida compara con el escaneo anterior y marca como `fixed` lo que ya no aparece, así que un barrido a medias le diría al usuario que sus vulnerabilidades fueron remediadas. De lo que no se miró no se sabe nada. Los puertos encontrados quedan en el log.

Un detalle que hubo que corregir para que el presupuesto sirviera de algo: las comprobaciones pasan a hacerse **dentro** del semáforo. `asyncio.gather` arranca las corrutinas de todos los puertos a la vez y el semáforo es lo único que las escalona, así que comprobar antes de adquirirlo las evaluaba todas en el primer instante del barrido, cuando todavía no hay nada que decidir, y no se volvían a mirar. Eso hacía inservible el presupuesto y era también el motivo de que `cancel_check` no pudiera cortar un barrido ya empezado — así que la cancelación mejora de rebote, aunque #309 sigue abierto por lo demás.

### Fase 3 — El campo del panel se conecta

El `timeout` que el usuario escribe hacía este recorrido: `LybraLaunchPanel.vue` → endpoint → `run_scan` → `submit(timeout=timeout + margen)`. Y ahí se acababa. Nunca llegaba al barrido. Sumado a que el plazo de la cola no se puede hacer cumplir, el número que el usuario elegía no participaba de hecho en ninguna decisión.

Ahora abre un plazo de reloj al empezar el escaneo, y el descubrimiento TCP recibe **lo que quede de él** en el momento de arrancar — no el total, porque para entonces ya se han gastado la comprobación de alcanzabilidad y las consultas de apertura.

Sólo el descubrimiento TCP consume el presupuesto, y queda anotado en el código como tal: es la fase que puede correr sin cota y la que aparecía en el incidente, mientras que el fingerprinting y los checks tienen plazo por operación. El plazo ya vive en `_run_lybra`, así que acotarlos también sería pasarles `_remaining_budget`.

`execute_lybra_scan` gana un cuarto argumento **opcional**: un job encolado antes del despliegue viaja con una tupla de tres y tiene que seguir ejecutándose en vez de fallar al deserializarse.

---

## Validación

- `tests/unit/test_taskqueue_deadline.py` (nuevo, 3 tests) — que `JobDeadlineExceeded` no es una `Exception`, que la penalización sustituye la clase de RQ, y el caso real: un `except Exception` dentro del trabajo ya no la captura.
- `tests/unit/test_lybra_transport.py` (+4 tests) — el barrido deja de iniciar sondas al agotarse el presupuesto; un barrido truncado no es ni bloqueado ni limpio y llega al motor como `None`; un barrido que cabe en su presupuesto no cambia; y el reintento no se duerme si no cabe.
- `tests/unit/test_lybra_scan_budget.py` (nuevo, 4 tests) — el recorrido del valor: el presupuesto llega al barrido, la ausencia de presupuesto conserva el comportamiento anterior, el cálculo del restante no se va a negativo, y la tupla de argumentos del worker admite las dos formas.
- `pytest tests/unit -k "lybra or taskqueue or themis"` — 874 tests en verde.
- Comprobado aparte que el fallo **se reproduce** con la clase de RQ: la excepción no escapa del trabajo y aparece dentro del `except Exception`. Sin eso, el test nuevo pasaría igual estando roto el arreglo.

La suite completa y `pylint src` se ejecutan al cerrar los tres PR de esta tanda, por petición del autor; el CI de este PR corre igualmente.

---

## Notas

- **Cambio de comportamiento visible**: un escaneo cuyo descubrimiento no quepa en su `timeout` pasa a fallar, donde antes se alargaba en silencio. Es intencionado, y es lo que el campo prometía desde el principio.
- No hay migraciones, ni claves de configuración nuevas, ni cambios en la superficie REST.
- **Fuera de alcance**, con issue propio: #307 (L39) quiere sacar a `SecOpsConfig.json` los parámetros que están a fuego —concurrencia, timeout por puerto, lista de puertos—; aquí no se añade ninguna clave, sólo se conecta un parámetro que ya existía. Y #309 (L41), progreso y cancelación, sigue abierto pese a la mejora de rebote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
