### PR TITLE
«Ver más» y el refresco de Lybra dejan de pelearse por la misma variable

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,8 @@
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs",
-    "test:iris": "node test/iris.intake.test.mjs"
+    "test:iris": "node test/iris.intake.test.mjs",
+    "test:themis": "node test/themis.scanWindow.test.mjs"
   },
   "dependencies": {
     "hash-wasm": "^4.12.0",

--- a/web/app/src/components/themis/lybra/LybraResults.vue
+++ b/web/app/src/components/themis/lybra/LybraResults.vue
@@ -184,7 +184,7 @@
           </Transition>
         </article>
 
-        <button v-if="scans.length < totalCount" class="load-more" :disabled="loading" @click="$emit('load-more')">
+        <button v-if="canLoadMore" class="load-more" :disabled="loading" @click="$emit('load-more')">
           {{ loading ? 'Cargando…' : `Ver más (${scans.length} de ${totalCount})` }}
         </button>
       </div>
@@ -193,8 +193,9 @@
 </template>
 
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import StatusBadge from '@/components/themis/StatusBadge.vue'
+import { MAX_PER_PAGE } from '@/stores/scanWindow'
 
 const props = defineProps({
   scans: { type: Array, default: () => [] },
@@ -206,6 +207,15 @@ const emit = defineEmits(['refresh', 'delete', 'load-docs', 'generate-pdf', 'dow
 
 /** Veredictos fantasma mientras carga: los que caben sin alargar la caja. */
 const SKELETON_ROWS = 4
+
+/**
+ * "Ver más" desaparece al llegar al tope de la ventana, no sólo al haberlos
+ * cargado todos. El store pide la lista revelada en una sola petición, y
+ * `per_page` está topado en el backend (`ResultsQuerySchema`), así que más allá
+ * de ahí el botón seguiría ahí sin hacer nada — que es peor que no estar.
+ */
+const canLoadMore = computed(
+  () => props.scans.length < props.totalCount && props.scans.length < MAX_PER_PAGE)
 
 const LADDER = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
 const PRIO_RANK = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, INFO: 4 }

--- a/web/app/src/stores/scanWindow.js
+++ b/web/app/src/stores/scanWindow.js
@@ -1,0 +1,69 @@
+/**
+ * Qué ventana de escaneos hay que pedirle al backend.
+ *
+ * Vive fuera de `themisStore` porque es la parte del arreglo que se puede
+ * probar sola: el store arrastra Pinia, Vue y media docena de composables, y lo
+ * que aquí falló es una cuenta de dos líneas.
+ *
+ * **El fallo que arregla.** La lista de escaneos de Lybra crece con un botón
+ * "ver más" que añade la siguiente página al final; el refresco (manual, y el
+ * sondeo automático que se rearma solo mientras haya un escaneo corriendo)
+ * reemplaza la lista con una sola página. Las dos cosas leían el mismo campo
+ * `page`, y le daban significados incompatibles: para "ver más" era *la última
+ * página traída*, para el refresco *la única página a mostrar*. Con una sola
+ * página coinciden y no se nota nada; en cuanto se pulsa "ver más" divergen.
+ * El usuario tenía 30 escaneos en pantalla, saltaba el sondeo, y se quedaba con
+ * 10 — los más antiguos de los tres bloques, porque se pedía la página 3.
+ *
+ * **La solución.** El estado guarda cuántas páginas se han revelado, y la
+ * petición pide siempre desde la primera con una ventana del tamaño acumulado.
+ * Tres ventajas sobre reconstruir la lista pidiendo N páginas seguidas:
+ *
+ *   - un refresco es *una* petición, no una por página revelada;
+ *   - al pedir siempre desde el principio, un escaneo nuevo entra por arriba
+ *     sin descolocar la ventana, así que desaparece de paso el duplicado que
+ *     produce la paginación por desplazamiento cuando la colección crece por
+ *     el mismo extremo que se está paginando;
+ *   - con una sola página revelada la petición es idéntica a la de antes, así
+ *     que los tipos que usan paginación clásica (`nmap`, `nikto`, `nuclei`,
+ *     vía `goToPage`) no cambian de comportamiento.
+ */
+
+/**
+ * Tope de `per_page` del endpoint. Lo impone el backend
+ * (`ResultsQuerySchema`: `validate.Range(min=1, max=100)`), así que pedir más
+ * no sería una ventana más grande sino un 422.
+ */
+export const MAX_PER_PAGE = 100
+
+/**
+ * Traduce el estado de una lista a los parámetros de la petición.
+ *
+ * @param {{page?: number, perPage?: number, loadedPages?: number}} state
+ *        El estado por tipo de escaneo (`scans.lybra`, `scans.nmap`, …).
+ * @returns {{page: number, perPage: number}} Lo que va en la query.
+ */
+export function scanWindow(state) {
+  // Un valor ausente y uno absurdo (0, negativo, NaN) se tratan igual: se cae
+  // al defecto en vez de propagar una query que el backend rechazaría.
+  const page = state?.page > 0 ? state.page : 1
+  const perPage = state?.perPage > 0 ? state.perPage : 10
+  const loadedPages = state?.loadedPages > 0 ? state.loadedPages : 1
+  return { page, perPage: Math.min(perPage * loadedPages, MAX_PER_PAGE) }
+}
+
+/**
+ * Si queda algo por revelar con "ver más".
+ *
+ * Además del clásico "ya están todos", corta al llegar al tope de `per_page`:
+ * revelar otra página pediría una ventana que el backend rechaza, y el botón
+ * dejaría de funcionar en vez de dejar de estar.
+ *
+ * @param {{results?: Array, totalCount?: number, perPage?: number, loadedPages?: number}} state
+ * @returns {boolean}
+ */
+export function canRevealMore(state) {
+  const loaded = state?.results?.length ?? 0
+  if (loaded >= (state?.totalCount ?? 0)) return false
+  return scanWindow(state).perPage < MAX_PER_PAGE
+}

--- a/web/app/src/stores/themisStore.js
+++ b/web/app/src/stores/themisStore.js
@@ -7,6 +7,7 @@ import { useUtils } from '@/composables/useUtils'
 import { useToastStore } from '@/stores/toastStore'
 import { useThemisFoldersStore } from '@/stores/themisFoldersStore'
 import { useThemisHistoryStore } from '@/stores/themisHistoryStore'
+import { scanWindow, canRevealMore } from '@/stores/scanWindow'
 
 /**
  * Store de Themis — gestiona escaneos, estadísticas, modales y documentos.
@@ -46,15 +47,15 @@ export const useThemisStore = defineStore('themis', () => {
 
   /* ════════════════════════════════ SCANS POR TIPO ═════════════════════ */
   const scans = reactive({
-    nmap:    { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null },
-    nikto:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null },
-    lybra:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null },
-    nuclei:  { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null },
+    nmap:    { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
+    nikto:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
+    lybra:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
+    nuclei:  { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
     // Fase I: los escaneos del activo Hygeia seleccionado. Mismo tipo de
     // escaneo que `lybra` y misma forma de estado —por eso `LybraResults` se
     // reutiliza tal cual—, pero su propia lista: el backend los sirve por
     // separado (`assetId`) y jamás los mezcla con los del panel.
-    agentLybra: { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null },
+    agentLybra: { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
   })
 
   // Escaneos Nmap terminados, para el modo "analizar un Nmap existente" de Lybra.
@@ -194,7 +195,13 @@ export const useThemisStore = defineStore('themis', () => {
     }
     d.loading = true
     try {
-      const params = _scanQuery(type, d.page, d.perPage)
+      // La ventana, no la página suelta: si el usuario ha revelado tres
+      // páginas con "ver más", refrescar tiene que devolverle las tres. Antes
+      // se pedía `d.page` —que "ver más" había dejado en 3— y se reemplazaba
+      // la lista con ella, así que un sondeo automático le dejaba en pantalla
+      // diez escaneos donde tenía treinta, y encima los más antiguos.
+      const window = scanWindow(d)
+      const params = _scanQuery(type, window.page, window.perPage)
       const res = await apiFetch(`/themis/results?${params}`)
       if (!res?.ok) {
         d.results = []
@@ -219,6 +226,7 @@ export const useThemisStore = defineStore('themis', () => {
     activeTab.value = type
     const d = _scandata(type)
     d.page = 1
+    d.loadedPages = 1
     loadScans(type)
   }
 
@@ -232,6 +240,10 @@ export const useThemisStore = defineStore('themis', () => {
   function goToPage(type, page) {
     const d = _scandata(type)
     d.page = page
+    // Navegar a una página concreta y revelar páginas con "ver más" son dos
+    // formas de recorrer la lista que no se mezclan: entrar por aquí vuelve a
+    // la ventana de una página.
+    d.loadedPages = 1
     loadScans(type)
   }
 
@@ -257,26 +269,24 @@ export const useThemisStore = defineStore('themis', () => {
   }
 
   /**
-   * "Ver más": añade la siguiente página de escaneos Lybra a la lista ya
-   * cargada (en vez de reemplazarla, como hace loadScans/goToPage) — el
-   * listado de veredictos crece hacia abajo sin perder el scroll ni el
-   * estado expandido de las tarjetas ya visibles.
+   * "Ver más": revela una página más de escaneos Lybra — el listado de
+   * veredictos crece hacia abajo sin perder el estado expandido de las
+   * tarjetas ya visibles (que vive en `LybraResults`, indexado por id de
+   * escaneo, y por tanto sobrevive a que la lista se vuelva a pintar).
+   *
+   * Antes esto pedía la página siguiente y la concatenaba, avanzando `d.page`.
+   * Ese avance era el fallo: `loadScans` lee el mismo campo entendiendo que es
+   * la única página a mostrar, así que el siguiente refresco reemplazaba los
+   * treinta escaneos en pantalla por los diez de la tercera página. Ahora sólo
+   * se agranda la ventana y se recarga con la ruta normal — una petición, sin
+   * dos caminos que puedan divergir, y sin el duplicado que aparecía cuando
+   * entraba un escaneo nuevo entre una página y la siguiente.
    */
   async function loadMoreLybraScans(type = 'lybra') {
     const d = _scandata(type)
-    if (d.loading || d.results.length >= d.totalCount) return
-    d.loading = true
-    try {
-      const nextPage = d.page + 1
-      const res = await apiFetch(`/themis/results?${_scanQuery(type, nextPage, d.perPage)}`)
-      if (!res?.ok) return
-      const data = await res.json()
-      d.results = [...d.results, ...(data.results ?? [])]
-      d.totalCount = data.totalCount ?? d.totalCount
-      d.page = nextPage
-    } finally {
-      d.loading = false
-    }
+    if (d.loading || !canRevealMore(d)) return
+    d.loadedPages += 1
+    await loadScans(type)
   }
 
   /* ── AGENTES (Fase I: escaneos nacidos del inventario de Hygeia) ── */
@@ -290,6 +300,7 @@ export const useThemisStore = defineStore('themis', () => {
     selectedAssetId.value = assetId
     const d = scans.agentLybra
     d.page = 1
+    d.loadedPages = 1
     d.results = []
     d.totalCount = 0
     if (assetId) loadScans('agentLybra')
@@ -414,7 +425,10 @@ export const useThemisStore = defineStore('themis', () => {
       if (d.results.length === 0 && d.totalCount > 0 && d.page > 1) {
         d.page--
         await loadScans(activeTab.value)
-      } else if (d.results.length < d.perPage && d.totalCount > d.page * d.perPage) {
+      } else if (d.results.length < scanWindow(d).perPage
+                 && d.totalCount > d.page * scanWindow(d).perPage) {
+        // Contra el tamaño de la ventana revelada, no contra el de una página:
+        // borrar un escaneo de una lista de treinta debe rellenar el hueco.
         await loadScans(activeTab.value)
       }
     }
@@ -787,7 +801,7 @@ export const useThemisStore = defineStore('themis', () => {
     statsError.value = null
 
     for (const type of ['nmap', 'nikto', 'lybra', 'nuclei', 'agentLybra']) {
-      Object.assign(scans[type], { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, error: null })
+      Object.assign(scans[type], { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null })
     }
 
     Object.assign(authorizedTargets, { items: [], loading: false, error: null })

--- a/web/app/test/themis.scanWindow.test.mjs
+++ b/web/app/test/themis.scanWindow.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * Tests de `scanWindow` — la ventana de escaneos que se le pide al backend.
+ *
+ * Node puro, sin framework, misma convención que el resto de `test/`.
+ *
+ * El fallo que cubren: la lista de Lybra crece con "ver más", que añadía la
+ * siguiente página al final y avanzaba `page`; el refresco (manual, y el
+ * sondeo automático que se rearma solo mientras haya un escaneo corriendo)
+ * leía ese mismo `page` entendiendo que era la única página a mostrar, y
+ * reemplazaba la lista con ella. Resultado: el usuario tenía treinta escaneos
+ * en pantalla, saltaba el sondeo, y se quedaba con diez — y encima los más
+ * antiguos, que son los de la tercera página.
+ */
+
+import assert from 'node:assert/strict'
+
+const { scanWindow, canRevealMore, MAX_PER_PAGE } =
+  await import('../src/stores/scanWindow.js')
+
+let failures = 0
+function test(name, fn) {
+  try { fn(); console.log(`  ok   ${name}`) }
+  catch (err) { failures++; console.error(`  FAIL ${name}\n       ${err.message}`) }
+}
+
+console.log('scanWindow')
+
+test('sin revelar nada, la petición es la de siempre', () => {
+  assert.deepEqual(
+    scanWindow({ page: 1, perPage: 10, loadedPages: 1 }),
+    { page: 1, perPage: 10 },
+  )
+})
+
+test('la paginación clásica no cambia de comportamiento', () => {
+  // nmap/nikto/nuclei van por goToPage y nunca revelan páginas: tienen que
+  // seguir pidiendo exactamente la página que se les pide.
+  assert.deepEqual(
+    scanWindow({ page: 4, perPage: 10, loadedPages: 1 }),
+    { page: 4, perPage: 10 },
+  )
+})
+
+test('revelar páginas agranda la ventana, no avanza la página', () => {
+  // Justo el fallo: tras dos "ver más" hay que pedir los 30 desde el
+  // principio, no la página 3.
+  assert.deepEqual(
+    scanWindow({ page: 1, perPage: 10, loadedPages: 3 }),
+    { page: 1, perPage: 30 },
+  )
+})
+
+test('la ventana no rebasa el tope de per_page del backend', () => {
+  // `ResultsQuerySchema` valida per_page con Range(min=1, max=100): pedir más
+  // no sería una ventana mayor sino un 422.
+  assert.equal(scanWindow({ page: 1, perPage: 10, loadedPages: 40 }).perPage, MAX_PER_PAGE)
+})
+
+test('un estado incompleto no produce una petición inválida', () => {
+  assert.deepEqual(scanWindow({}), { page: 1, perPage: 10 })
+  assert.deepEqual(scanWindow(undefined), { page: 1, perPage: 10 })
+  assert.deepEqual(scanWindow({ page: 0, perPage: 0, loadedPages: 0 }), { page: 1, perPage: 10 })
+})
+
+console.log('canRevealMore')
+
+test('hay más que revelar mientras falten escaneos', () => {
+  assert.equal(
+    canRevealMore({ results: new Array(10), totalCount: 42, perPage: 10, loadedPages: 1 }),
+    true,
+  )
+})
+
+test('no hay más que revelar cuando ya están todos', () => {
+  assert.equal(
+    canRevealMore({ results: new Array(42), totalCount: 42, perPage: 10, loadedPages: 5 }),
+    false,
+  )
+})
+
+test('no se revela más allá del tope, aunque queden escaneos', () => {
+  // Sin este corte, "ver más" agrandaría la ventana a 110, el backend la
+  // rechazaría, y el botón se quedaría sin hacer nada.
+  assert.equal(
+    canRevealMore({ results: new Array(100), totalCount: 500, perPage: 10, loadedPages: 10 }),
+    false,
+  )
+})
+
+if (failures) {
+  console.error(`\n${failures} test(s) fallaron`)
+  process.exit(1)
+}
+console.log('\ntodo en verde')


### PR DESCRIPTION
## Resumen

En el panel de Lybra, la lista de escaneos crece con un botón «ver más» que añade la siguiente página al final. Pero el refresco —el manual, y el sondeo automático— **reemplaza** la lista con una sola página. Como los dos leían la misma variable dándole significados incompatibles, después de pulsar «ver más» el siguiente refresco encogía la lista y mostraba los escaneos equivocados.

### Related Issue

Closes #396

---

## El fallo

Todo ocurre en `web/app/src/stores/themisStore.js`. Dos funciones comparten el campo `d.page` del estado de cada tipo de escaneo:

- **`loadMoreLybraScans`** lo trataba como *la última página que se ha traído*: pedía `d.page + 1`, **concatenaba** el resultado y guardaba el nuevo número.
- **`loadScans`** lo trata como *la única página que hay que mostrar*: pide `d.page` y **reemplaza** la lista entera.

Mientras sólo exista una página las dos lecturas coinciden y no se nota nada. En cuanto se pulsa «ver más» divergen, y gana la última que se ejecute:

1. El usuario abre el panel: 10 escaneos, `page = 1`.
2. Pulsa «ver más» dos veces: 30 escaneos en pantalla, `page = 3`.
3. Salta el sondeo automático y la lista pasa a tener **10 elementos: los del tercer bloque**, es decir los más antiguos.

Desde fuera parece que han desaparecido veinte escaneos. No han desaparecido: se ha sustituido la lista entera por la tercera página.

Y el sondeo no es un caso raro. `_scheduleScanPoll` se rearma en el `finally` de `loadScans` siempre que haya algún escaneo `pending` o `running` — exactamente el momento en el que el usuario está mirando la pantalla.

---

## Implementación

El estado deja de usar un número para dos preguntas distintas. Guarda **cuántas páginas se han revelado** (`loadedPages`), y la petición pide siempre desde la primera con una ventana del tamaño acumulado: `page = 1`, `per_page = perPage × loadedPages`.

Frente a la alternativa —reconstruir la lista pidiendo N páginas seguidas— esto tiene tres ventajas:

- **Un refresco es una petición**, no una por página revelada.
- **Desaparece el duplicado por desplazamiento.** Con paginación por `page`/`per_page` sobre una lista ordenada por fecha, lanzar un escaneo nuevo mientras hay dos páginas cargadas corre todo un puesto, y el siguiente «ver más» trae repetido el elemento de la frontera. Al pedir siempre desde el principio, el escaneo nuevo entra por arriba y la ventana no se descoloca. No hizo falta código para esto: sale de la forma de la petición.
- **Cero riesgo para el resto.** Con una sola página revelada la query es idéntica a la de antes, byte a byte, así que `nmap`, `nikto` y `nuclei` —que usan paginación clásica vía `goToPage`— no cambian de comportamiento.

`loadMoreLybraScans` pierde su ruta de carga propia: agranda la ventana y llama a `loadScans`. Dos caminos que ya no pueden divergir porque sólo queda uno.

### Por qué la cuenta vive en un fichero aparte

`scanWindow.js` existe para poder probar el arreglo. El store arrastra Pinia, Vue y media docena de composables con imports por alias `@/`, que un test de Node pelado —la convención de `web/app/test/`— no resuelve; y lo que aquí falló son dos líneas de aritmética. Sacarlas permite cubrirlas de verdad en lugar de dar por bueno el arreglo.

Ahí vive también `MAX_PER_PAGE`, el tope que impone el backend: `ResultsQuerySchema` valida `per_page` con `Range(min=1, max=100)`, así que revelar más allá de ahí no daría una ventana mayor sino un 422. Con ese dato en un solo sitio, `canRevealMore` corta en el store y `LybraResults` esconde el botón al llegar al límite, en vez de dejarlo a la vista sin hacer nada.

### Detalle adicional

La limpieza tras borrar un escaneo comparaba contra el tamaño de *una página* para decidir si rellenar el hueco. Ahora compara contra el de la ventana revelada: borrar uno de una lista de treinta debe recargar treinta, no dejarlo pasar porque veintinueve ya son más de diez.

---

## Validación

- `npm run test:themis` (nuevo, 8 tests) — que la paginación clásica no cambia; que revelar páginas agranda la ventana en vez de avanzar la página; que la ventana no rebasa el tope del backend; que un estado incompleto no produce una query inválida; y los tres casos de `canRevealMore`, incluido el corte en el tope.
- `npm run build` — en verde.
- Entrada `test:themis` añadida a `package.json`, en la misma convención que las otras siete.

---

## Notas

- No hay cambios de API: `GET /themis/results` ya aceptaba todo lo que hace falta.
- **Fuera de alcance**, con issue propio: #230 (B17) es la revisión de fondo de la paginación del producto, incluido pasar a paginación por cursor; esto no la adelanta. Y el tamaño de la respuesta del listado —que cada escaneo viaje con todos sus hallazgos dentro— es el issue #397, no éste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
