### PR TITLE
feat(themis): los parámetros de red del motor se configuran sin tocar código

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -189,7 +189,6 @@
         },
         "lybra": {
           "activeChecks": true,
-          "bannerTimeout": 2.0,
           "colorPalette": {
             "black": "#1a2410",
             "dark": "#4a6132",
@@ -198,19 +197,31 @@
             "secondary": "#a8c98f",
             "white": "#f3f8ee"
           },
+          "engine": {
+            "tcpConcurrency": 200,
+            "tcpTimeout": 2.0,
+            "udpTimeout": 2.0,
+            "udpRetries": 1,
+            "udpBudgetSeconds": 20.0,
+            "rateLimitInterval": 0.2,
+            "hostPoolSize": 8,
+            "httpTimeout": 8,
+            "httpMaxBodyBytes": 131072,
+            "httpUserAgent": "Lybra/1.0",
+            "networkTimeout": 5.0,
+            "bannerTimeout": 2.0,
+            "maxBlindProbes": 2
+          },
           "fingerprintingEnabled": true,
-          "hostPoolSize": 8,
           "ingest": {
             "enabled": false,
             "minSeverity": "MEDIUM",
             "maxChecks": 300
           },
-          "maxBlindProbes": 2,
           "prompts": {
             "system": "Eres un analista senior de seguridad ofensiva redactando la sección ejecutiva de un informe de pentest. Analizas la salida ya estructurada del motor de detección Lybra: cada hallazgo trae su CVE, CVSS, EPSS (probabilidad de explotación en 30 días), si está en la lista CISA KEV (explotación activa confirmada), y si fue 'confirmado' activamente o es una 'hipótesis' por versión de banner.\n\nDATOS QUE RECIBES:\n- 'servicios_afectados': el inventario agrupado por producto y puerto. Cada grupo trae 'total_hallazgos', 'total_cves', 'cves_en_kev', 'max_cvss', 'max_epss', 'confirmados', el desglose 'por_prioridad' y 'corregido_en': la versión a la que hay que actualizar para cerrar TODO el grupo de una vez. Es tu unidad de trabajo: se remedia un servicio, no un CVE suelto.\n- 'hallazgos_destacados': el detalle de los hallazgos de mayor prioridad (los confirmados y los de KEV van siempre incluidos), cada uno con su 'descripcion' oficial del CVE y su propio 'corregido_en'. Es la evidencia concreta que debes citar.\nEl total de hallazgos del escaneo es mayor que el número de 'hallazgos_destacados' que ves en detalle: el recuento real está en la cabecera y en 'servicios_afectados'. Nunca escribas que el escaneo encontró únicamente los que aparecen detallados.\n\nREGLAS ABSOLUTAS:\n1. Generas EXCLUSIVAMENTE JSON válido, sin markdown, sin texto antes ni después.\n2. NUNCA inventas un CVE, CVSS o EPSS que no esté en los datos proporcionados. Si un hallazgo no trae CVSS, no le asignes uno.\n3. Un hallazgo 'confirmado=true' es un hecho verificado; uno 'confirmado=false' es una hipótesis por versión que puede ser un falso positivo (backport). Nunca los trates con el mismo nivel de certeza en el texto.\n4. 'en_kev=true' es la señal más fuerte de urgencia (se explota activamente en el mundo real) y debe mencionarse explícitamente si aparece en algún hallazgo.\n5. El 'risk_level' es un techo, no un promedio: si existe al menos un hallazgo confirmado o en KEV con CVSS alto, el nivel debe reflejarlo aunque el resto de hallazgos sean informativos.\n6. Las 'recommendations' deben ser accionables y concretas. Cuando el grupo traiga 'corregido_en', la remediación DEBE nombrar esa versión destino exacta. 'Actualizar a la última versión estable' NO es una remediación válida: si tienes el dato, lo escribes.\n7. Si prácticamente todos los hallazgos son de categoría 'open_port' sin CVEs, dilo explícitamente: es un mapa de superficie, no una lista de vulnerabilidades.\n8. Escribe con densidad: cada frase debe apoyarse en un dato de los que recibes (una versión, un CVE, un CVSS, un porcentaje de EPSS, un recuento). No rellenes con generalidades sobre la importancia de la seguridad. Si te faltan datos para alcanzar la extensión pedida, escribe menos: preferimos corto y exacto antes que largo y vacío.\n\nCONFIRMADO Y KEV SON DOS EJES DISTINTOS. No los mezcles nunca:\n- 'confirmado' responde a \"¿lo hemos verificado en ESTE host?\". true = comprobado activamente. false = deducido de la versión del banner, y puede ser un falso positivo por backport.\n- 'en_kev' responde a \"¿se explota en el mundo real, en cualquier host?\". No dice nada sobre este objetivo en concreto.\nUn hallazgo con en_kev=true y confirmado=false es una hipótesis por versión sobre una vulnerabilidad que sí se explota activamente ahí fuera: urgente de verificar, pero NO verificada aquí. Escríbelo así. Está terminantemente prohibido usar las palabras 'confirmado', 'confirmada' o 'verificado' para un hallazgo cuyo campo 'confirmado' sea false, por alto que sea su CVSS o su EPSS.\nAntes de dar por buena tu respuesta, repasa cada hallazgo que hayas llamado confirmado y comprueba que su campo 'confirmado' es realmente true.\n\nCOBERTURA OBLIGATORIA DE LAS RECOMENDACIONES:\nRecorre TODAS las entradas de 'servicios_afectados' antes de cerrar la lista, no solo las que traen CVEs. Necesita recomendación propia toda entrada que cumpla al menos una de estas condiciones:\n- tiene algún hallazgo con 'confirmados' mayor que cero (son los únicos hechos verificados del escaneo: nunca pueden quedarse fuera),\n- su desglose 'por_prioridad' incluye MEDIUM, HIGH o CRITICAL,\n- o trae algún CVE en KEV.\nLas entradas sin CVEs cuentan igual: unas cabeceras de seguridad ausentes o un puerto de administración expuesto son unidades remediables con su propia acción concreta. Agrupar dos productos distintos en una sola recomendación no vale; agrupar los hallazgos de un mismo producto, sí — para eso está el rollup.\n\nFORMATO DE RESPUESTA (JSON estricto):\n{\n  \"risk_level\": \"CRÍTICO|ALTO|MEDIO|BAJO|INFORMATIVO\",\n  \"executive_summary\": \"6-8 frases en español para un lector no técnico: qué hay expuesto, qué productos concretos están desactualizados y a qué versión hay que subirlos, cuántos hallazgos cierra cada actualización, y qué se está explotando activamente hoy. Lenguaje llano, pero con las cifras concretas.\",\n  \"technical_analysis\": \"Entre 1500 y 2500 caracteres, organizado POR SERVICIO AFECTADO: para cada entrada relevante de 'servicios_afectados' escribe un bloque que explique qué expone ese servicio, cuáles son sus CVEs más graves citando CVE + CVSS + EPSS reales, qué separa lo confirmado de lo hipotético por banner, y cuál es la versión que cierra el grupo entero. Termina relacionando los servicios entre sí si comparten superficie o cadena de ataque.\",\n  \"recommendations\": [\n    {\"title\": \"...\", \"description\": \"qué se corrige y por qué importa, con las cifras del grupo\", \"priority\": \"ALTA|MEDIA|BAJA\", \"remediation\": \"acción concreta con versión destino o directiva exacta\", \"cve_refs\": [\"CVE-YYYY-NNNNN\"]}\n  ],\n  \"conclusions\": \"2-4 frases: en qué orden hay que actuar y qué queda pendiente de verificar manualmente.\"\n}\n\nGenera una recomendación por unidad remediable (producto + puerto). Cuando haya varias unidades afectadas, aporta entre 4 y 7 recomendaciones ordenadas por urgencia real: primero KEV y confirmados, después el resto. Si solo hay una unidad remediable, no inventes más para llegar al número.\n",
             "userTemplate": "Escaneo Lybra sobre {{target}} (exposición: {{exposure}}), iniciado el {{started}}.\n\nTotal de hallazgos: {{total_findings}} | Confirmados activamente: {{confirmed_count}} | En CISA KEV: {{kev_count}}\n\nSERVICIOS AFECTADOS (inventario agrupado — tu unidad de remediación; 'corregido_en' es la versión destino que cierra el grupo entero):\n{{services_json}}\n\nHALLAZGOS DESTACADOS (detalle de los de mayor prioridad; los confirmados y los de KEV van siempre incluidos):\n{{findings_json}}\n\nGenera el análisis en el formato JSON indicado en las instrucciones del sistema, respetando la extensión pedida para cada campo.\n"
-          },
-          "udpBudgetSeconds": 20.0
+          }
         }
       }
     },

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1494,6 +1494,7 @@ class HttpProbe:
         detect_scheme: An injectable ``(host, port) -> bool`` telling whether
             the service speaks TLS. Defaults to :func:`negotiates_tls`; a test
             passes a stub instead of opening a socket.
+        user_agent: The ``User-Agent`` header the probe presents (L39).
     """
 
     def __init__(
@@ -1501,9 +1502,11 @@ class HttpProbe:
         timeout: int = 8,
         max_bytes: int = 131072,
         detect_scheme: Optional[Callable[[str, Optional[int]], bool]] = None,
+        user_agent: str = "Lybra/1.0",
     ) -> None:
         self._timeout = timeout
         self._max_bytes = max_bytes
+        self._user_agent = user_agent
         self._detect_scheme = detect_scheme or (lambda host, port: negotiates_tls(host, port, timeout))
         # El esquema se observa una vez por servicio y se recuerda: la pregunta
         # es sobre el servicio, no sobre la petición, y no cambia entre una y
@@ -1580,7 +1583,7 @@ class HttpProbe:
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
         try:
-            request = urllib.request.Request(url, method=method, headers={"User-Agent": "Lybra/1.0"})
+            request = urllib.request.Request(url, method=method, headers={"User-Agent": self._user_agent})
             with self._opener.open(request, timeout=self._timeout) as response:
                 return response.status, response.read(self._max_bytes), dict(response.headers)
         except urllib.error.HTTPError as err:

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -364,9 +364,15 @@ class LybraEngineManager(ScanManager):
           escaneo sigue adelante con lo que hay y se marca como parcial, en
           lugar de tirar información verificada.
         """
+        engine = CR.lybra_engine_config()
         try:
             sweep = sweep_with_retries(
-                target, discover_ports, budget_seconds=budget_seconds)
+                target, discover_ports,
+                concurrency=engine.tcp_concurrency,
+                timeout=engine.tcp_timeout,
+                retries=engine.udp_retries,
+                budget_seconds=budget_seconds,
+            )
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
             return None
@@ -398,8 +404,13 @@ class LybraEngineManager(ScanManager):
         list): a user-supplied ``discover_ports`` is a TCP list.
         """
         try:
+            engine = CR.lybra_engine_config()
             return scan_udp_ports_sync(
-                target, budget_seconds=CR.lybra_config().udp_budget_seconds)
+                target,
+                timeout=engine.udp_timeout,
+                retries=engine.udp_retries,
+                budget_seconds=engine.udp_budget_seconds,
+            )
         except Exception:
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
@@ -412,13 +423,18 @@ class LybraEngineManager(ScanManager):
         findings rather than failing the whole scan. Safe mode only.
         """
         try:
+            engine = CR.lybra_engine_config()
             runtime = CheckRuntime(
                 load_checks() + self._ingested_checks(services),
-                HttpProbe().fetch,
+                HttpProbe(
+                    timeout=engine.http_timeout,
+                    max_bytes=engine.http_max_body_bytes,
+                    user_agent=engine.http_user_agent,
+                ).fetch,
                 mode="safe",
-                rate_limiter=HostRateLimiter(),
+                rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval),
                 tls_fetch=TlsProbe().fetch,
-                network_open=NetworkProbe().open,
+                network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
@@ -499,8 +515,8 @@ class LybraEngineManager(ScanManager):
             fingerprint findings.
         """
         dissectors = default_dissectors()
-        rate_limiter = HostRateLimiter()
-        cascade_config = CR.lybra_config()
+        cascade_config = CR.lybra_engine_config()
+        rate_limiter = HostRateLimiter(min_interval=cascade_config.rate_limit_interval)
 
         def identify(service):
             """Sonda un servicio y devuelve ``(servicio, resultado)``.
@@ -589,7 +605,7 @@ class LybraEngineManager(ScanManager):
         items = list(items)
         if not items:
             return []
-        workers = max(1, min(CR.lybra_config().host_pool_size, len(items)))
+        workers = max(1, min(CR.lybra_engine_config().host_pool_size, len(items)))
         if workers == 1:
             return [work(item) for item in items]
         with ThreadPoolExecutor(max_workers=workers) as pool:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -804,47 +804,99 @@ class LybraConfig:
     Lybra solo toca un objetivo que el llamante haya autorizado explícitamente,
     valga lo que valga este flag. Existen como interruptor de emergencia para
     desactivar la funcionalidad en todo el despliegue.
+
+    Los **parámetros de red** —timeouts, concurrencia, ritmo, presupuestos—
+    viven aparte, en :class:`LybraEngineConfig` (L39): un interruptor de
+    despliegue y un dial de afinado son cosas distintas, y mezclarlos haría el
+    bloque ilegible en cuanto pasara de dos campos.
     """
 
     active_checks: bool = True
     fingerprinting_enabled: bool = True
 
-    banner_timeout: float = 2.0
-    """Plazo, en segundos, de la lectura del saludo que la cascada de
-    identificación hace contra un servicio que ningún dissector reclama
-    (``fingerprinting/cascade.py``). Es corto a propósito: un servicio que no
-    saluda lo agota entero, y ese coste se paga una vez por cada puerto
-    desconocido del objetivo."""
 
-    max_blind_probes: int = 2
-    """Cuántas sondas activas se permiten contra un servicio que no ha dicho
-    nada. El presupuesto que separa "prueba lo que ya sabes leer" de un escaneo
-    de servicios completo: hoy hay dos protocolos que se pueden intentar a
-    ciegas (Redis y HTTP), y este tope impide que añadir un tercero encarezca
-    en silencio cada escaneo. A cero, la cascada se queda sólo en la lectura
-    del saludo."""
+@config_block("features.themis.scanners.lybra.engine")
+@dataclass(frozen=True)
+class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
+    """Los diales de red del motor: cuánto tarda, cuánta carga mete y qué mira.
+
+    Hasta L39 cada uno de estos valores era un literal en la firma de un
+    constructor —``concurrency=200``, ``timeout=2.0``, ``min_interval=0.2``— y
+    el manager instanciaba las sondas sin argumentos, así que no había forma de
+    tocarlos sin editar código. OpenVAS lleva veinte años teniendo *scan
+    configs* por una razón: un escaneo contra un enlace lento, contra un
+    appliance frágil o contra un rango grande necesita otros números, y quien
+    opera el escáner es quien sabe cuáles.
+
+    **Los valores por defecto son exactamente los que estaban a fuego**, así
+    que el cambio es invisible hasta que alguien mueve un dial. Cada campo tiene
+    un consumidor real en ``managers/lybra/engine.py`` — no hay ningún dial que
+    no llegue a una sonda, porque un parámetro que nadie lee es peor que uno a
+    fuego: parece configurable y no lo es.
+    """
+
+    # --- Descubrimiento TCP (transport.AsyncConnectScanner / scan_ports_sync)
+    tcp_concurrency: int = 200
+    """Conexiones TCP en vuelo a la vez durante el barrido de puertos."""
+
+    tcp_timeout: float = 2.0
+    """Plazo por puerto TCP, en segundos."""
+
+    # --- Descubrimiento UDP (transport.scan_udp_ports_sync)
+    udp_timeout: float = 2.0
+    """Plazo por sonda UDP, en segundos."""
+
+    udp_retries: int = 1
+    """Reintentos tras un primer silencio UDP. No es 0 a propósito: un
+    datagrama perdido (no un puerto cerrado) haría oscilar el puerto entre
+    abierto y cerrado entre escaneos, y el ciclo de vida lo leería como
+    ``fixed``/``regressed`` falsos."""
 
     udp_budget_seconds: float = 20.0
-    """Plazo total del barrido de puertos UDP (``transport.scan_udp_ports_sync``).
+    """Plazo total del barrido UDP. En UDP el silencio no significa
+    "cerrado" sino "no lo sabemos", así que cada sonda paga su plazo entero
+    contra un host que no tenga ese servicio; con siete filas eso se acumula.
+    Agotarlo **no** marca nada como cerrado: los puertos que no han contestado
+    se dan por no observados, que es lo que ya eran."""
 
-    En UDP el silencio no significa "cerrado" sino "no lo sabemos", así que
-    cada sonda paga su plazo entero contra un host que no tenga ese servicio.
-    Con siete filas en la tabla eso se acumula, y este presupuesto es el techo.
-    Agotarlo **no** marca nada como cerrado: los puertos que aún no han
-    contestado simplemente se dan por no observados, que es lo que ya eran."""
+    # --- Ritmo por host (checks.HostRateLimiter) y paralelismo (L23)
+    rate_limit_interval: float = 0.2
+    """Intervalo mínimo, en segundos, entre dos peticiones al mismo
+    host. Es la cortesía con el objetivo, y manda por encima del pool."""
 
     host_pool_size: int = 8
+    """Cuántos servicios del **mismo host** se sondan a la vez. El
+    fingerprinting y los checks activos son espera de red casi entera, y en fila
+    india un servicio mudo retrasa a los que vienen detrás. Va acotado por host
+    y no es grande a propósito: el límite es la cortesía con el objetivo, no la
+    máquina que escanea."""
 
-"""Cuántos servicios del **mismo host** se sondan a la vez.
+    # --- Sondas HTTP (checks.HttpProbe)
+    http_timeout: int = 8
+    """Plazo por petición HTTP, en segundos."""
 
-    El fingerprinting y los checks activos son entrada/salida pura: casi todo
-    su tiempo es esperar a que un servicio conteste o a que se agote su plazo.
-    En fila india, un servicio mudo retrasa a todos los que vienen detrás.
+    http_max_body_bytes: int = 131072
+    """Cuerpo máximo de respuesta que una sonda HTTP lee (128 KiB)."""
 
-    El pool va acotado **por host** y no es un número grande a propósito: el
-    límite no es la máquina que escanea, es la cortesía con el objetivo. El
-    limitador de ritmo sigue mandando por encima de esto — el pool decide
-    cuántas sondas pueden estar esperando a la vez, no a qué ritmo salen."""
+    http_user_agent: str = "Lybra/1.0"
+    """El ``User-Agent`` con el que el motor se presenta. Configurable
+    porque a veces hay que declararse ante un WAF, y a veces conviene no
+    hacerlo."""
+
+    # --- Sondas de red cruda (checks.NetworkProbe)
+    network_timeout: float = 5.0
+    """Plazo de conexión de una sesión de red cruda, en segundos."""
+
+    # --- Cascada de identificación (fingerprinting/cascade.py)
+    banner_timeout: float = 2.0
+    """Plazo de la lectura del saludo que la cascada hace contra un
+    servicio que ningún dissector reclama. Corto a propósito: un servicio que no
+    saluda lo agota entero, una vez por puerto desconocido."""
+
+    max_blind_probes: int = 2
+    """Sondas activas máximas contra un servicio que no dijo nada. El
+    presupuesto que separa "prueba lo que ya sabes leer" de un escaneo de
+    servicios completo. A cero, la cascada se queda sólo en el saludo."""
 
 
 @config_block("features.themis.scanners.lybra.ingest")
@@ -1014,6 +1066,10 @@ def knowledge_base_config() -> KnowledgeBaseConfig:
 
 def lybra_config() -> LybraConfig:
     return load_block(LybraConfig)
+
+
+def lybra_engine_config() -> LybraEngineConfig:
+    return load_block(LybraEngineConfig)
 
 
 def lybra_ingest_config() -> LybraIngestConfig:

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -197,6 +197,7 @@ CONFIG_BLOCKS = [
     (CR.TracerouteConfig, CR.traceroute_config),
     (CR.KnowledgeBaseConfig, CR.knowledge_base_config),
     (CR.LybraConfig, CR.lybra_config),
+    (CR.LybraEngineConfig, CR.lybra_engine_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),

--- a/API/tests/unit/test_lybra_engine_config.py
+++ b/API/tests/unit/test_lybra_engine_config.py
@@ -1,0 +1,77 @@
+"""El bloque de configuración del motor (L39).
+
+Hasta L39 cada timeout, cada nivel de concurrencia y cada intervalo de ritmo
+era un literal en la firma de un constructor, y el manager instanciaba las
+sondas sin argumentos. Este fichero comprueba las dos mitades del arreglo: que
+el bloque existe y está atado, y —lo que de verdad importa— que el manager
+**usa** los valores configurados en vez de los defectos del constructor.
+"""
+
+import pytest
+
+from src.modules.system import config_reading as CR
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_engine_block_keeps_the_old_values_as_defaults():
+    """El cambio es invisible hasta que alguien mueve un dial: los defaults son
+    exactamente los que estaban a fuego."""
+    engine = CR.lybra_engine_config()
+    assert engine.tcp_concurrency == 200
+    assert engine.tcp_timeout == 2.0
+    assert engine.rate_limit_interval == 0.2
+    assert engine.http_timeout == 8
+    assert engine.http_max_body_bytes == 131072
+    assert engine.http_user_agent == "Lybra/1.0"
+    assert engine.network_timeout == 5.0
+
+
+def test_the_operator_switches_stay_out_of_the_engine_block():
+    """Un interruptor de despliegue y un dial de afinado son cosas distintas:
+    `LybraConfig` se queda con los dos booleanos y nada más."""
+    assert set(CR.LybraConfig.__dataclass_fields__) == {
+        "active_checks", "fingerprinting_enabled"}
+
+
+def test_the_http_probe_presents_the_configured_user_agent():
+    from src.modules.features.themis.lybra.checks import HttpProbe
+
+    seen = {}
+
+    class _Opener:
+        def open(self, request, timeout=None):
+            seen["ua"] = request.get_header("User-agent")
+            raise OSError("no real network")
+
+    probe = HttpProbe(user_agent="Escaner-Auditoria/2.0")
+    probe._opener = _Opener()                      # pylint: disable=protected-access
+    probe._scheme_for = lambda host, port: "http"  # pylint: disable=protected-access
+    probe._request("10.0.0.5", 80, "GET", "/")     # pylint: disable=protected-access
+    assert seen["ua"] == "Escaner-Auditoria/2.0"
+
+
+def test_the_discovery_scan_receives_the_configured_dials(monkeypatch):
+    """El dial llega a la sonda: sin esto, el bloque sería config muerta."""
+    from src.modules.features.themis.managers.lybra import engine as engine_module
+    from src.modules.features.themis.lybra.transport import PortSweep
+
+    captured = {}
+
+    def fake_sweep(target, ports, **kwargs):
+        captured.update(kwargs)
+        return PortSweep(open_ports=(80,), refused_ports=(), timed_out_ports=(),
+                         unreachable_ports=())
+
+    monkeypatch.setattr(engine_module, "sweep_with_retries", fake_sweep)
+    monkeypatch.setattr(
+        engine_module.CR, "lybra_engine_config",
+        lambda: type("_Cfg", (), {
+            "tcp_concurrency": 50, "tcp_timeout": 0.5, "udp_retries": 3,
+        })())
+
+    engine_module.LybraEngineManager()._discover_ports(  # pylint: disable=protected-access
+        "10.0.0.5", [80])
+
+    assert captured["concurrency"] == 50
+    assert captured["timeout"] == 0.5

--- a/API/tests/unit/test_lybra_host_pool.py
+++ b/API/tests/unit/test_lybra_host_pool.py
@@ -58,9 +58,10 @@ def _run_fingerprint(monkeypatch, dissector, services, pool_size=8):
 
     monkeypatch.setattr(engine_module, "default_dissectors", lambda: [dissector])
     monkeypatch.setattr(
-        engine_module.CR, "lybra_config",
+        engine_module.CR, "lybra_engine_config",
         lambda: type("_Config", (), {
             "host_pool_size": pool_size, "banner_timeout": 0.1, "max_blind_probes": 0,
+            "rate_limit_interval": 0.0,
         })(),
     )
     return LybraEngineManager()._fingerprint_services("10.0.0.5", services)

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -32,7 +32,7 @@ def _clean_sweep(open_ports=(80,), truncated=False) -> PortSweep:
 def test_the_budget_reaches_the_sweep(monkeypatch):
     captured = {}
 
-    def fake_sweep(target, ports, budget_seconds=None):
+    def fake_sweep(target, ports, budget_seconds=None, **kwargs):
         captured["target"] = target
         captured["ports"] = ports
         captured["budget"] = budget_seconds
@@ -52,7 +52,7 @@ def test_a_scan_without_budget_keeps_the_old_behaviour(monkeypatch):
     encolado antes de este cambio— siguen barriendo sin límite de reloj."""
     captured = {}
 
-    def fake_sweep(target, ports, budget_seconds=None):
+    def fake_sweep(target, ports, budget_seconds=None, **kwargs):
         captured["budget"] = budget_seconds
         return _clean_sweep(open_ports=())
 


### PR DESCRIPTION
## Resumen

Cierra #307.

El bloque de configuración de Lybra tenía exactamente **dos interruptores** (`activeChecks`, `fingerprintingEnabled`) más el subbloque de ingesta. Todo lo demás —cada parámetro que decide cuánto tarda un escaneo, cuánta carga mete en el objetivo y qué superficie mira— era un valor literal en la firma de un constructor:

| Parámetro | Valor | Dónde |
|---|---|---|
| Concurrencia del connect scan | 200 | `transport.py` |
| Timeout por puerto TCP | 2,0 s | `transport.py` |
| Timeout / reintentos UDP | 2,0 s / 1 | `transport.py` |
| Intervalo del limitador | 0,2 s | `checks.py` |
| Timeout HTTP | 8 s | `HttpProbe` |
| Cuerpo máximo | 128 KiB | `HttpProbe` |
| User-Agent | `Lybra/1.0` | `HttpProbe._request` |
| Timeout de sesión de red | 5,0 s | `NetworkProbe` |

Y ninguno de esos constructores recibía nada desde el manager: `_run_active_checks` los instanciaba sin argumentos. Un motor que no se puede afinar no se puede operar; sólo se puede lanzar y esperar. OpenVAS lleva veinte años teniendo *scan configs* por una razón.

## Qué cambia

Un bloque `LybraEngineConfig` en `features.themis.scanners.lybra.engine`, con `@config_block` al pie del patrón de la casa: defaults **sólo** en el campo, `snake_case` → `camelCase` automático, registrado en `CONFIG_BLOCKS` de `test_config_shape.py`, recarga en caliente por `PUT /system`.

Consolida todos los diales de red, **incluidas las cuatro claves que la Fase 2 había dejado sueltas** directamente en `lybra` (`bannerTimeout`, `maxBlindProbes`, `udpBudgetSeconds`, `hostPoolSize`). Con eso, `LybraConfig` se queda con los dos interruptores y nada más: un dial de afinado y un interruptor de despliegue son cosas distintas, y mezclarlos hacía el bloque ilegible en cuanto pasara de dos campos.

## Dos garantías que el issue pide, y sus tests

**Los valores por defecto son exactamente los que estaban a fuego**, así que el cambio es invisible hasta que alguien mueve un dial. `test_the_engine_block_keeps_the_old_values_as_defaults` lo fija.

**Cada campo tiene un consumidor real** en `managers/lybra/engine.py`. No hay ningún dial que no llegue a una sonda, y esto no es un detalle: un parámetro que nadie lee es peor que uno a fuego, porque parece configurable y no lo es (`CLAUDE.md` lo advierte). El manager pasa a construir `HttpProbe`, `HostRateLimiter`, `NetworkProbe`, el connect scan y la cascada con los valores del bloque. `test_the_discovery_scan_receives_the_configured_dials` y `test_the_http_probe_presents_the_configured_user_agent` comprueban que el dial llega hasta el borde de red.

## Validación

`pytest tests/unit -k "lybra or config"` y `tests/integration/test_lybra.py`: todo pasa. `pylint` **un aviso menos** que la línea base (se corrigió de paso un docstring de campo mal colocado que la Fase 2 había dejado como string suelto).

Tres tests existentes se ajustan, ninguno de intención: los fakes de `sweep_with_retries` en `test_lybra_scan_budget.py` aceptan ahora `**kwargs` (el manager les pasa `concurrency`/`timeout`), y el mock de `test_lybra_host_pool.py` apunta a `lybra_engine_config` en vez de a `lybra_config`.

## Notas

- **`ports` / `maxScanSeconds` quedan fuera a propósito.** El issue los lista como opcionales (`ports` como lista o `profile`; el presupuesto total de escaneo). No los incluyo porque hoy no tendrían un consumidor —`DEFAULT_PORTS` sigue a fuego y no hay un mecanismo de parada por reloj de escaneo completo— y eso sería la config muerta que el criterio de cierre prohíbe. El presupuesto total encaja mejor junto a #309 (cancelación), que es donde el reloj del escaneo entero cobra sentido.
- Este bloque es la precondición práctica que #308, #294 y #313 citaban.
