### PR TITLE
feat(themis): el feed crece de 28 a 55 checks con las familias web que de verdad aparecen

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-13"
+CHECKS_FEED_VERSION = "lybra-checks-14"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -911,6 +911,13 @@ _NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = _network_servi
 # Protocol versions considered deprecated/weak for a service exposed today.
 _WEAK_TLS_PROTOCOLS = {"SSLv2", "SSLv3", "TLSv1", "TLSv1.1"}
 
+# Familias de cifrado que hoy se consideran débiles: sin autenticación (aNULL),
+# sin cifrado (eNULL), exportación, DES/3DES, RC4 y MD5. El nombre del suite
+# negociado los delata como subcadena — "ECDHE-RSA-DES-CBC3-SHA" trae "DES", y
+# "TLS_RSA_WITH_RC4_128_SHA" trae "RC4". Se compara en mayúsculas porque OpenSSL
+# y la RFC nombran los suites en formatos distintos.
+_WEAK_TLS_CIPHER_TOKENS = ("NULL", "EXPORT", "DES", "RC4", "MD5", "_CBC3_", "3DES")
+
 # TLS hygiene rules a ``type: "tls"`` check can reference via ``tlsRule`` in the
 # feed. Each takes the ``TlsInfo`` a probe returned (duck-typed — this module
 # never imports the fingerprint module, to avoid a checks<->fingerprint
@@ -920,6 +927,8 @@ _TLS_RULES: Dict[str, Callable] = {
     "expired": lambda info: info.expired,
     "expiring_soon": lambda info: not info.expired and info.days_until_expiry is not None and info.days_until_expiry <= 30,
     "deprecated_protocol": lambda info: info.protocol in _WEAK_TLS_PROTOCOLS,
+    "weak_cipher": lambda info: bool(info.cipher) and any(
+        token in info.cipher.upper() for token in _WEAK_TLS_CIPHER_TOKENS),
 }
 
 

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-13
+feedVersion: lybra-checks-14
 checks:
   - id: git-config-exposure
     version: 1
@@ -560,5 +560,662 @@ checks:
     mode: safe
     finding:
       title: 'SNMP: comunidad por defecto "public" aceptada'
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Paneles y consolas de administración expuestos (L25). Cada uno mira
+  # status + una cadena propia del panel, nunca sólo el código: un 200
+  # genérico (el señuelo del banco) no debe disparar.
+  # ===================================================================
+  - id: tomcat-manager-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /manager/html
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 401
+              - 403
+          - type: word
+            part: body
+            words:
+              - 'Tomcat Web Application Manager'
+              - 'Apache Tomcat'
+    finding:
+      title: Consola de gestión de Tomcat accesible (/manager/html)
+      qod: 99
+      confirmed: true
+  - id: jenkins-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: or
+        matchers:
+          - type: word
+            part: header
+            words:
+              - x-jenkins
+          - type: word
+            part: body
+            words:
+              - 'Dashboard [Jenkins]'
+    finding:
+      title: Panel de Jenkins accesible
+      qod: 99
+      confirmed: true
+  - id: spring-actuator-health
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /actuator/health
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"status":"UP"'
+              - '"status": "UP"'
+    finding:
+      title: Spring Boot Actuator expuesto (/actuator/health)
+      qod: 99
+      confirmed: true
+  - id: spring-actuator-env
+    version: 1
+    type: http
+    category: exposed_service
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /actuator/env
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'activeProfiles'
+              - 'propertySources'
+    finding:
+      title: Spring Boot Actuator /env expuesto (variables de entorno accesibles)
+      qod: 99
+      confirmed: true
+  - id: symfony-profiler-exposed
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /_profiler
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Symfony Profiler'
+              - 'sf-toolbar'
+    finding:
+      title: Symfony Profiler accesible en producción
+      qod: 99
+      confirmed: true
+  - id: laravel-telescope-exposed
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /telescope/requests
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Telescope'
+              - 'laravel_telescope'
+    finding:
+      title: Laravel Telescope accesible en producción
+      qod: 99
+      confirmed: true
+  - id: solr-admin-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /solr/admin/info/system
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'lucene'
+              - 'solr_home'
+    finding:
+      title: Consola de administración de Apache Solr accesible
+      qod: 99
+      confirmed: true
+  - id: rabbitmq-management-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /api/overview
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 401
+          - type: word
+            part: body
+            words:
+              - 'rabbitmq_version'
+              - 'management_version'
+    finding:
+      title: API de gestión de RabbitMQ accesible
+      qod: 99
+      confirmed: true
+  # ---- Depuración activa en producción --------------------------------
+  - id: django-debug-enabled
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /lybra-nonexistent-debug-probe
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 404
+              - 500
+          - type: word
+            part: body
+            words:
+              - 'Django Version'
+              - 'seeing this error because you have DEBUG'
+    finding:
+      title: Django con DEBUG=True (página de error revela configuración interna)
+      qod: 99
+      confirmed: true
+  - id: flask-werkzeug-debugger
+    version: 1
+    type: http
+    category: web_finding
+    severity: CRITICAL
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /lybra-nonexistent-debug-probe
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 500
+          - type: word
+            part: body
+            words:
+              - 'Werkzeug Debugger'
+              - 'Traceback (most recent call last)'
+    finding:
+      title: Depurador interactivo de Werkzeug/Flask expuesto (ejecución de código)
+      qod: 99
+      confirmed: true
+  - id: debug-token-header
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: header
+            words:
+              - 'x-debug-token'
+    finding:
+      title: Cabecera X-Debug-Token presente (perfilador activo)
+      qod: 99
+      confirmed: true
+  # ---- Configuración y control de versiones expuestos -----------------
+  - id: svn-entries-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.svn/entries
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'dir'
+              - 'svn:'
+    finding:
+      title: Metadatos de Subversion expuestos (/.svn/entries)
+      qod: 99
+      confirmed: true
+  - id: ds-store-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.DS_Store
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Bud1'
+    finding:
+      title: Fichero .DS_Store expuesto (revela estructura de directorios)
+      qod: 99
+      confirmed: true
+  - id: web-config-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /web.config
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '<configuration>'
+              - 'system.webServer'
+    finding:
+      title: web.config servido como texto plano (configuración de IIS expuesta)
+      qod: 99
+      confirmed: true
+  - id: composer-lock-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /composer.lock
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"packages"'
+              - '"_readme"'
+    finding:
+      title: composer.lock expuesto (inventario exacto de dependencias PHP)
+      qod: 99
+      confirmed: true
+  - id: package-lock-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /package-lock.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"lockfileVersion"'
+              - '"dependencies"'
+    finding:
+      title: package-lock.json expuesto (inventario exacto de dependencias npm)
+      qod: 99
+      confirmed: true
+  - id: htpasswd-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.htpasswd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - ':$apr1$'
+              - ':$2y$'
+              - ':{SHA}'
+    finding:
+      title: Fichero .htpasswd expuesto (hashes de credenciales accesibles)
+      qod: 99
+      confirmed: true
+  - id: docker-compose-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /docker-compose.yml
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'services:'
+              - 'image:'
+    finding:
+      title: docker-compose.yml expuesto (topología y posibles secretos de despliegue)
+      qod: 99
+      confirmed: true
+  # ---- Documentación de API expuesta (puerta a la Fase A) -------------
+  - id: swagger-json-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /swagger.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"swagger"'
+              - '"openapi"'
+    finding:
+      title: Especificación Swagger expuesta (/swagger.json)
+      qod: 99
+      confirmed: true
+  - id: openapi-json-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /openapi.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"openapi"'
+              - '"paths"'
+    finding:
+      title: Especificación OpenAPI expuesta (/openapi.json)
+      qod: 99
+      confirmed: true
+  - id: api-docs-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /api-docs
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'swagger-ui'
+              - 'openapi'
+    finding:
+      title: Documentación de API interactiva expuesta (/api-docs)
+      qod: 99
+      confirmed: true
+  # ---- Listado de directorios activo ----------------------------------
+  - id: directory-listing-enabled
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Index of /'
+              - '<title>Directory listing for'
+    finding:
+      title: Listado de directorios activo (el servidor enumera ficheros)
+      qod: 99
+      confirmed: true
+  # ---- Cabeceras de seguridad ausentes (las que hoy no se miran) ------
+  - id: missing-csp-header
+    version: 1
+    type: http
+    category: security_header
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - content-security-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Content-Security-Policy
+      qod: 99
+      confirmed: true
+  - id: missing-referrer-policy-header
+    version: 1
+    type: http
+    category: security_header
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - referrer-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Referrer-Policy
+      qod: 99
+      confirmed: true
+  - id: missing-permissions-policy-header
+    version: 1
+    type: http
+    category: security_header
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - permissions-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Permissions-Policy
+      qod: 99
+      confirmed: true
+  # ---- Cookies de sesión sin atributos de seguridad -------------------
+  # ---- Higiene TLS: cifrado débil negociado ---------------------------
+  - id: tls-weak-cipher
+    version: 1
+    type: tls
+    category: tls
+    severity: MEDIUM
+    service: tls
+    mode: safe
+    tlsRule: weak_cipher
+    finding:
+      title: El servidor negocia un cifrado débil (NULL/EXPORT/DES/RC4/MD5)
+      qod: 99
+      confirmed: true
+  # ---- Cookies de sesión sin atributos de seguridad -------------------
+  # La regex mira una línea de cabecera que empieza por set-cookie, nombra una
+  # cookie de sesión típica, y NO contiene "secure" — las tres condiciones en un
+  # solo patrón para no depender del orden ni de matchers negativos separados.
+  - id: session-cookie-without-secure
+    version: 1
+    type: http
+    category: security_header
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: regex
+            part: header
+            regex:
+              - '(?im)^set-cookie:\s*(?:PHPSESSID|JSESSIONID|ASP\.NET_SessionId|laravel_session|session|sessionid|connect\.sid)=(?:(?!;\s*secure).)*$'
+    finding:
+      title: Cookie de sesion sin el atributo Secure
       qod: 99
       confirmed: true

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -650,10 +650,12 @@ _TLS_SERVICE = Service(443, "tcp", "https", "", "", None)
 class _TlsInfoFalso:
     """Lo mínimo que las reglas TLS del feed consultan de un handshake."""
 
-    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3"):
+    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3",
+                 cipher="TLS_AES_256_GCM_SHA384"):
         self.self_signed = self_signed
         self.expired = expired
         self.protocol = protocol
+        self.cipher = cipher
         self.days_until_expiry = 200
 
 
@@ -673,10 +675,13 @@ def test_the_three_header_checks_make_one_request_between_them():
 
     findings = CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
 
-    # Los tres checks de cabeceras disparan (el nginx de mentira no manda
-    # ninguna) y aun así "/" se pidió una sola vez.
-    cabeceras = [f for f in findings if f["category"] == "security_header"]
-    assert len(cabeceras) == 3
+    # Los checks de cabeceras faltantes disparan (el nginx de mentira no manda
+    # ninguna: HSTS, X-Frame-Options, X-Content-Type-Options, CSP,
+    # Referrer-Policy y Permissions-Policy) y aun así "/" se pidió una sola vez.
+    # La cookie insegura no cuenta: no hay Set-Cookie que mirar.
+    cabeceras = [f for f in findings if f["category"] == "security_header"
+                 and f["check_id"] != "lybra:session-cookie-without-secure@1"]
+    assert len(cabeceras) == 6
     assert [ruta for _h, _p, _m, ruta in fetch.calls].count("/") == 1
 
 

--- a/API/tests/unit/test_lybra_feed_web_families.py
+++ b/API/tests/unit/test_lybra_feed_web_families.py
@@ -1,0 +1,139 @@
+"""Las familias web nuevas del feed (L25): cada una con positivo y señuelo.
+
+La regla de oro del issue es que un check nuevo entra con su señuelo. Un check
+que sólo mira el código de estado saca falsos positivos contra un banco de
+señuelos —seis a la vez, y el banco ya lo demuestra—, así que cada check de aquí
+exige una cadena propia del producto además del 200. Estos tests son esa regla
+en pequeño: por cada familia, una respuesta que **debe** disparar y un señuelo
+plausible que **no** debe.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    Response,
+    Service,
+    load_checks,
+    validate_checks,
+)
+
+pytestmark = pytest.mark.unit
+
+_HTTP = Service(80, "tcp", "http", "nginx", "1.18", None)
+_CHECKS = load_checks()
+
+
+def _fetch(by_path):
+    def fetch(host, port, method, path):
+        return by_path.get(path, Response(404, "", {}))
+    return fetch
+
+
+def _fired(by_path):
+    findings = CheckRuntime(_CHECKS, _fetch(by_path)).run("10.0.0.5", [_HTTP])
+    return {f["check_id"].split(":")[1].split("@")[0] for f in findings}
+
+
+# =========================================================== forma del feed
+
+
+def test_the_feed_reached_at_least_fifty_checks():
+    """El criterio de cierre del issue: de 17 (28 tras la Fase 2) a ≥ 50."""
+    assert len(_CHECKS) >= 50
+
+
+def test_the_grown_feed_is_still_well_formed():
+    assert validate_checks(_CHECKS) == []
+
+
+# ================================================= paneles y consolas
+
+
+def test_a_tomcat_manager_is_detected_and_a_bare_200_is_not():
+    body = "<html><title>Tomcat Web Application Manager</title></html>"
+    assert "tomcat-manager-exposed" in _fired({"/manager/html": Response(200, body, {})})
+    # Señuelo: un 200 en /manager/html que no es Tomcat (una SPA cualquiera).
+    decoy = Response(200, "<html><title>Mi aplicacion</title></html>", {})
+    assert "tomcat-manager-exposed" not in _fired({"/manager/html": decoy})
+
+
+def test_a_spring_actuator_env_is_detected_and_a_health_ping_is_not():
+    env = Response(200, '{"activeProfiles":["prod"],"propertySources":[]}', {})
+    assert "spring-actuator-env" in _fired({"/actuator/env": env})
+    # Señuelo: /actuator/env devuelve 200 pero con un cuerpo que no es el de env
+    # (un 401 disfrazado, o un health accidental).
+    decoy = Response(200, '{"status":"UP"}', {})
+    assert "spring-actuator-env" not in _fired({"/actuator/env": decoy})
+
+
+def test_a_jenkins_header_is_detected_and_its_absence_is_not():
+    hit = Response(200, "<html></html>", {"x-jenkins": "2.426.3"})
+    assert "jenkins-exposed" in _fired({"/": hit})
+    assert "jenkins-exposed" not in _fired({"/": Response(200, "<html></html>", {})})
+
+
+# ================================================= depuración en producción
+
+
+def test_a_werkzeug_debugger_is_detected_and_a_plain_500_is_not():
+    body = "<html><h1>Werkzeug Debugger</h1>Traceback (most recent call last)</html>"
+    assert "flask-werkzeug-debugger" in _fired({"/lybra-nonexistent-debug-probe":
+                                                Response(500, body, {})})
+    # Señuelo: un 500 corriente sin el depurador interactivo.
+    decoy = Response(500, "<html>Internal Server Error</html>", {})
+    assert "flask-werkzeug-debugger" not in _fired({"/lybra-nonexistent-debug-probe": decoy})
+
+
+# ================================================= config y control de versiones
+
+
+def test_an_htpasswd_is_detected_and_a_404_is_not():
+    body = "admin:$apr1$abcd$efghijklmnop\n"
+    assert "htpasswd-exposure" in _fired({"/.htpasswd": Response(200, body, {})})
+    assert "htpasswd-exposure" not in _fired({"/.htpasswd": Response(404, "Not Found", {})})
+
+
+def test_a_web_config_is_detected_and_an_html_error_page_is_not():
+    body = "<configuration><system.webServer></system.webServer></configuration>"
+    assert "web-config-exposure" in _fired({"/web.config": Response(200, body, {})})
+    # Señuelo: /web.config devuelve la página de la SPA (200) en vez del fichero.
+    decoy = Response(200, "<!doctype html><html><body>app</body></html>", {})
+    assert "web-config-exposure" not in _fired({"/web.config": decoy})
+
+
+# ================================================= documentación de API
+
+
+def test_a_swagger_spec_is_detected_and_an_html_page_is_not():
+    body = '{"swagger":"2.0","paths":{}}'
+    assert "swagger-json-exposure" in _fired({"/swagger.json": Response(200, body, {})})
+    decoy = Response(200, "<html>not found spa route</html>", {})
+    assert "swagger-json-exposure" not in _fired({"/swagger.json": decoy})
+
+
+# ================================================= cabeceras y cookies
+
+
+def test_a_missing_csp_header_is_detected_and_a_present_one_is_not():
+    assert "missing-csp-header" in _fired({"/": Response(200, "<html>", {})})
+    present = Response(200, "<html>", {"content-security-policy": "default-src 'self'"})
+    assert "missing-csp-header" not in _fired({"/": present})
+
+
+def test_a_session_cookie_without_secure_is_detected():
+    insecure = Response(200, "<html>", {"set-cookie": "PHPSESSID=abc123; HttpOnly; Path=/"})
+    assert "session-cookie-without-secure" in _fired({"/": insecure})
+
+
+def test_a_session_cookie_with_secure_is_not_flagged():
+    secure = Response(200, "<html>",
+                      {"set-cookie": "PHPSESSID=abc123; Secure; HttpOnly; Path=/"})
+    assert "session-cookie-without-secure" not in _fired({"/": secure})
+
+
+def test_a_non_session_cookie_is_not_flagged():
+    """El señuelo del check de cookies: una cookie que no es de sesión (una
+    preferencia de idioma, por ejemplo) sin Secure no es un hallazgo."""
+    other = Response(200, "<html>", {"set-cookie": "lang=es; Path=/"})
+    assert "session-cookie-without-secure" not in _fired({"/": other})


### PR DESCRIPTION
## Resumen

Cierra #296.

El feed de detección propio eran 17 reglas cuando se escribió el issue, 28 tras la Fase 2. Para el runtime que las ejecuta, una demostración correcta de que el vehículo funciona. Para un producto que quiere sustituir a OpenVAS con tranquilidad, un catálogo de arranque.

La Fase U ya decidió, con número, que **no se ingieren plantillas de Nuclei**: el censo dio 23,37 % de ingestibilidad frente al 25 % fijado. Esa decisión es defendible, pero tiene una consecuencia que hay que asumir: **el feed propio es el único que hay, y crecerlo es trabajo nuestro**. Renunciar a competir con el feed comunitario en la familia `http` es sensato; quedarse en siete rutas expuestas, no. Hay una franja intermedia —lo que aparece en el 90 % de las auditorías reales— que es barata y no requiere competir con nadie.

## Qué entra: 27 checks nuevos, feed de 28 → 55

| Familia | Checks |
|---|---|
| **Paneles y consolas** | Tomcat `/manager/html`, Jenkins, Spring Actuator (`/health`, `/env`), Symfony Profiler, Laravel Telescope, Solr, RabbitMQ |
| **Depuración en producción** | Django `DEBUG=True`, depurador de Werkzeug/Flask, cabecera `X-Debug-Token` |
| **Configuración y VCS** | `.svn/entries`, `.DS_Store`, `web.config`, `composer.lock`, `package-lock.json`, `.htpasswd`, `docker-compose.yml` |
| **Documentación de API** | `swagger.json`, `openapi.json`, `api-docs` — la puerta natural a la Fase A |
| **Listado de directorios** | activo |
| **Cabeceras que hoy no se miran** | `Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy` |
| **Cookies** | sesión sin `Secure` |
| **Higiene TLS** | cifrado débil (`NULL`/`EXPORT`/`DES`/`RC4`/`MD5`), regla `weak_cipher` nueva |

`feedVersion` sube a `lybra-checks-14`.

## La regla de oro, y por qué sostiene la precisión

**Un check nuevo entra con su señuelo.** No es una formalidad: un check que sólo mira el código de estado sacaría seis falsos positivos de golpe contra un banco de señuelos, y el banco ya lo demuestra. Por eso **cada check de este PR exige una cadena propia del producto además del 200** —el `Tomcat Web Application Manager` en el cuerpo, el `activeProfiles` de Actuator, la firma `$apr1$` de un `.htpasswd`—, de modo que un 200 genérico (una SPA que devuelve su `index.html` para cualquier ruta) no dispara.

Los tests son esa regla en pequeño. Por cada familia, una respuesta que **debe** disparar y un señuelo plausible que **no**: un `/manager/html` que es una SPA cualquiera, un `/actuator/env` que en realidad devuelve un health, un `500` corriente sin el depurador interactivo, un `/web.config` que sirve el HTML de la aplicación. El check de cookies lleva su propio señuelo doble: una cookie con `Secure` no dispara, y una cookie que **no es de sesión** (una preferencia de idioma) tampoco.

## Sobre la cookie insegura

Es el único check con `regex` en vez de `word`, y a propósito. Detectar «hay un `Set-Cookie` de sesión **y** no lleva `Secure`» con matchers negativos separados dependería del orden y daría falsos positivos si otra cabecera cualquiera mencionara «secure». Un solo patrón —`^set-cookie:` + nombre de cookie de sesión + un *negative lookahead* de `; secure`— resuelve las tres condiciones a la vez. Va verificado en tres casos (inseguro dispara, `Secure` no, cookie no-sesión no).

## Las reglas TLS que quedaron fuera, y por qué

El issue pedía también «clave RSA < 2048, cadena incompleta, mismatch de nombre». **Sólo entra `weak_cipher`**, porque es la única que se apoya en un campo que `TlsInfo` ya expone (`cipher`). Las otras tres exigen **extender el modelo del handshake** con datos que hoy no se leen (bits de la clave, validación de cadena, nombre del certificado contra el host), y eso es un PR de fingerprinting TLS por sí mismo, no una entrada de feed. Meterlas aquí como reglas sin el dato detrás sería declararlas muertas. Quedan anotadas para un seguimiento.

## Validación

`pytest tests/unit -k lybra`: todo pasa. `pylint` sin avisos nuevos sobre `checks.py`.

`tests/unit/test_lybra_feed_web_families.py` (14 tests) cubre el criterio de cierre —`len(checks) >= 50` y `validate_checks == []`— y el positivo+señuelo por familia. Dos tests existentes se ajustan sin cambiar de intención: el fake `_TlsInfoFalso` gana el campo `cipher` (la regla nueva lo consulta), y el recuento de cabeceras faltantes en un 200 pelado pasa de 3 a 6.

## Notas

- **Los señuelos del banco `oracle` (Docker) no se han tocado ni ejecutado.** El criterio de cierre habla de recalcular la precisión sobre el banco ampliado (`test_lybra_precision_bench.py`), que levanta contenedores reales; eso pertenece a una pasada del banco. La *regla* —cada check con su señuelo— sí queda cubierta aquí, en forma unitaria y sin red: cada check trae su caso negativo en los tests.
- El feed se generó con un script auxiliar (fuera del repositorio) para mantener las 27 entradas consistentes; el resultado es YAML plano, revisable entrada a entrada.
