### PR TITLE
feat(themis): los checks de configuración de red que faltaban cierran la brecha G1

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-14"
+CHECKS_FEED_VERSION = "lybra-checks-15"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -160,6 +160,8 @@ _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
 _VNC_PORTS = {5900}
+_TELNET_SERVICE_NAMES = {"telnet"}
+_TELNET_PORTS = {23}
 # SNMP — el primer protocolo de esta tabla que habla UDP (Fase N/Ronda 1,
 # roadmap §6.3). 161 también aparece en WELL_KNOWN_PORTS como TCP, así que
 # is_snmp_service (más abajo) es el único predicado de este módulo que mira
@@ -762,6 +764,16 @@ def is_redis_service(service: Service) -> bool:
     """Return whether a service should be probed by the Redis dissector or
     ``type: "network"`` checks (Fase N)."""
     return (service.name or "").lower() in _REDIS_SERVICE_NAMES or service.port in _REDIS_PORTS
+
+
+def is_telnet_service(service: Service) -> bool:
+    """Return whether a service is a Telnet endpoint.
+
+    Que exista un Telnet respondiendo **es** el hallazgo —credenciales en claro
+    por diseño—, así que este predicado no necesita distinguir producto ni
+    versión: sólo a qué servicios acercarse.
+    """
+    return (service.name or "").lower() in _TELNET_SERVICE_NAMES or service.port in _TELNET_PORTS
 
 
 def is_vnc_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-14
+feedVersion: lybra-checks-15
 checks:
   - id: git-config-exposure
     version: 1
@@ -1217,5 +1217,122 @@ checks:
               - '(?im)^set-cookie:\s*(?:PHPSESSID|JSESSIONID|ASP\.NET_SessionId|laravel_session|session|sessionid|connect\.sid)=(?:(?!;\s*secure).)*$'
     finding:
       title: Cookie de sesion sin el atributo Secure
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Checks de configuración de red que la Fase N prometió (L26). Cierran
+  # la parte de la brecha G1 que no se resuelve escribiendo ojos: una
+  # configuración insegura no tiene CVE y no aparece por la vía de la
+  # versión. Alguien tiene que ir y preguntarla.
+  # ===================================================================
+  - id: telnet-enabled
+    version: 1
+    type: script
+    script: telnet-enabled
+    category: network_config
+    severity: HIGH
+    service: telnet
+    mode: safe
+    finding:
+      title: 'Telnet: servicio activo (credenciales en claro por diseño)'
+      qod: 99
+      confirmed: true
+  - id: vnc-no-authentication
+    version: 1
+    type: script
+    script: vnc-no-authentication
+    category: default_credentials
+    severity: CRITICAL
+    service: vnc
+    mode: safe
+    finding:
+      title: 'VNC: acceso sin autenticación (tipo de seguridad None ofrecido)'
+      qod: 99
+      confirmed: true
+  # SMTP relay abierto: el servidor acepta un RCPT a un dominio externo desde un
+  # remitente externo. No se llega a DATA — no se envía correo, sólo se observa
+  # que aceptaría enrutarlo. Un servidor bien configurado responde 550/554.
+  - id: smtp-open-relay
+    version: 1
+    type: network
+    category: network_config
+    severity: HIGH
+    service: smtp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "EHLO lybra.local\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+      - send: "MAIL FROM:<probe@lybra-external.example>\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+      - send: "RCPT TO:<relay-test@lybra-nonexistent-external.example>\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+    finding:
+      title: 'SMTP: relay abierto (acepta enrutar correo de terceros)'
+      qod: 99
+      confirmed: true
+  # SMTP sin STARTTLS: el EHLO no anuncia STARTTLS entre sus capacidades, así
+  # que las credenciales de autenticación viajarían en claro.
+  - id: smtp-no-starttls
+    version: 1
+    type: network
+    category: network_config
+    severity: MEDIUM
+    service: smtp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "EHLO lybra.local\r\n"
+        read: block
+        matchers-condition: and
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+          - type: word
+            part: body
+            words:
+              - STARTTLS
+            negative: true
+    finding:
+      title: 'SMTP: sin STARTTLS anunciado (autenticación en claro posible)'
+      qod: 99
+      confirmed: true
+  # FTP sin cifrado: el servidor rechaza AUTH TLS, así que credenciales y datos
+  # viajan en claro. Un servidor que soporta FTPS responde 234.
+  - id: ftp-no-tls
+    version: 1
+    type: network
+    category: network_config
+    severity: MEDIUM
+    service: ftp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "AUTH TLS\r\n"
+        read: block
+        matchers:
+          - type: regex
+            part: body
+            regex:
+              - '^(?:500|502|504|530|534|431)'
+    finding:
+      title: 'FTP: sin cifrado disponible (AUTH TLS no soportado)'
       qod: 99
       confirmed: true

--- a/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
@@ -1,0 +1,73 @@
+"""La sonda de Telnet — porque que exista ya es el hallazgo.
+
+El roadmap descartó el *dissector* de Telnet con buen criterio: su negociación
+de opciones (IAC) no deja un texto identificable de forma fiable sin inventar
+patrones, así que no hay un producto/versión que leer. Pero el *check* es otra
+cosa. Telnet manda credenciales en claro por diseño; que un servicio esté ahí,
+hablando el protocolo, ya es un hallazgo de configuración de red —el que la
+Fase N prometía— sin necesidad de identificar nada.
+
+Lo que este módulo comprueba es exactamente eso y nada más: que al otro lado
+hay algo que **habla Telnet**. Un servidor Telnet abre la conversación
+negociando opciones, y esa negociación empieza siempre por el byte ``IAC``
+(``0xFF``, RFC 854). Ese byte es la firma: un puerto 23 que lo envía es Telnet;
+uno que acepta la conexión y calla, o que manda otra cosa, no se cuenta —
+podría ser cualquier servicio mudo en un puerto reutilizado.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# IAC — "Interpret As Command", el byte que abre toda negociación de opciones
+# de Telnet (RFC 854). Su sola presencia al principio de la respuesta es la
+# firma del protocolo.
+TELNET_IAC = 0xFF
+
+
+class TelnetProbe:  # pylint: disable=too-few-public-methods
+    """Comprueba si un puerto habla Telnet leyendo su negociación de apertura.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable, para que
+            un test use un socket falso.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def speaks_telnet(self, host: str, port: int = 23) -> bool:
+        """Devuelve ``True`` sólo si el servicio abre negociando opciones Telnet.
+
+        Args:
+            host: El objetivo.
+            port: El puerto.
+
+        Returns:
+            ``True`` cuando la respuesta empieza por ``IAC``. Un servicio mudo o
+            que manda otra cosa devuelve ``False``: no se infiere Telnet de un
+            puerto abierto, se confirma por lo que responde.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("Telnet: conexión fallida a %s:%s: %s", host, port, err)
+            return False
+        try:
+            sock.settimeout(self._timeout)
+            data = sock.recv(3)
+            return bool(data) and data[0] == TELNET_IAC
+        except OSError as err:
+            logger.debug("Telnet: sin respuesta de %s:%s: %s", host, port, err)
+            return False
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass

--- a/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
@@ -119,6 +119,63 @@ class VncProbe:
             except OSError:
                 pass
 
+    def security_types(self, host: str, port: int = 5900) -> Optional[list]:
+        """Completa el handshake RFB y devuelve los tipos de seguridad ofrecidos.
+
+        Tras enviar su versión, el servidor RFB (3.7/3.8) responde con un byte
+        de recuento y esa lista de tipos de seguridad. El tipo **1 es ``None``**
+        (RFC 6143 §7.1.2): acceso sin autenticación, que es el hallazgo. Un
+        recuento 0 significa que el servidor rechazó, y sigue un motivo de error.
+
+        No se avanza más allá de leer la lista: **no se intenta autenticar** ni
+        se envía ninguna respuesta de seguridad, así que no se establece sesión.
+
+        Args:
+            host: El objetivo.
+            port: El puerto.
+
+        Returns:
+            La lista de tipos como enteros, ``[]`` si el servidor rechazó con
+            recuento 0, o ``None`` si al otro lado no había un RFB legible.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("VNC security probe connect failed for %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            banner = b""
+            while not banner.endswith(b"\n") and len(banner) < 12:
+                chunk = sock.recv(1)
+                if not chunk:
+                    break
+                banner += chunk
+            if not _RFB_RE.match(banner):
+                return None
+            sock.sendall(b"RFB 003.008\n")
+            count_byte = sock.recv(1)
+            if not count_byte:
+                return None
+            count = count_byte[0]
+            if count == 0:
+                return []
+            types = b""
+            while len(types) < count:
+                chunk = sock.recv(count - len(types))
+                if not chunk:
+                    break
+                types += chunk
+            return list(types)
+        except OSError as err:
+            logger.debug("VNC security probe failed for %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
 
 @register_dissector
 class VncDissector(Dissector):

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -47,6 +47,8 @@ from .checks import (
     is_postgres_service,
     is_smb_service,
     is_snmp_service,
+    is_telnet_service,
+    is_vnc_service,
 )
 from .engine import Service
 from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
@@ -55,6 +57,8 @@ from .fingerprinting.mongo import MongoProbe, fingerprint_mongo
 from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
 from .fingerprinting.rdp import RdpProbe, fingerprint_rdp
 from .fingerprinting.snmp import SnmpProbe
+from .fingerprinting.telnet import TelnetProbe
+from .fingerprinting.vnc import VncProbe
 from .fingerprinting.udp_services import (
     DnsProbe,
     NtpProbe,
@@ -417,6 +421,73 @@ class NtpMonlistPlugin(ScriptPlugin):
             self._probe.fetch_monlist(context.target, context.service.port or 123))
 
 
+class TelnetEnabledPlugin(ScriptPlugin):
+    """Detecta un servicio Telnet activo.
+
+    Telnet manda credenciales en claro por diseño: usuario y contraseña viajan
+    sin cifrar por la red, legibles para cualquiera que escuche. No hay una
+    "mala configuración" que arreglar — el hallazgo es que el protocolo esté en
+    uso. Por eso este check no identifica producto ni versión: le basta con
+    confirmar que al otro lado hay algo que **habla Telnet**, cosa que un
+    servidor delata abriendo su negociación de opciones con el byte IAC (ver
+    :class:`~.fingerprinting.telnet.TelnetProbe`).
+
+    Un puerto 23 abierto no basta como evidencia: podría ser cualquier servicio
+    mudo en un puerto reutilizado. Lo que dispara es la firma del protocolo, no
+    la apertura del puerto.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "telnet-enabled"
+
+    def __init__(self, probe: Optional[TelnetProbe] = None) -> None:
+        self._probe = probe or TelnetProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_telnet_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        return self._probe.speaks_telnet(context.target, context.service.port or 23)
+
+
+class VncNoAuthenticationPlugin(ScriptPlugin):
+    """Detecta un servidor VNC que ofrece acceso **sin autenticación**.
+
+    El protocolo RFB negocia, tras el saludo de versión, qué tipos de seguridad
+    admite el servidor. El tipo 1 es ``None`` (RFC 6143 §7.1.2): entrar sin
+    contraseña. Un VNC que lo ofrece deja el escritorio del objetivo a
+    disposición de cualquiera que alcance el puerto.
+
+    La evidencia es un hecho observado —el servidor **anuncia** ese tipo en su
+    lista—, no una inferencia, así que el hallazgo nace ``confirmed``. Y no se
+    cruza la línea: se lee la lista de tipos ofrecidos y ahí acaba, sin
+    responder a la negociación y sin abrir sesión (ver
+    :meth:`~.fingerprinting.vnc.VncProbe.security_types`).
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "vnc-no-authentication"
+    _SECURITY_NONE = 1
+
+    def __init__(self, probe: Optional[VncProbe] = None) -> None:
+        self._probe = probe or VncProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_vnc_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        types = self._probe.security_types(context.target, context.service.port or 5900)
+        if types is None:
+            return False
+        return self._SECURITY_NONE in types
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -435,5 +506,7 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         LdapAnonymousBindPlugin(),
         LdapCleartextWithLdapsPlugin(),
         RdpNlaNotRequiredPlugin(),
+        TelnetEnabledPlugin(),
+        VncNoAuthenticationPlugin(),
     )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -263,8 +263,10 @@ def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     assert ftp[0]["qod"] == 99 and ftp[0]["confirmed"] is True
     assert ftp[0]["category"] == "default_credentials"
     assert ftp[0]["port"] == 21
-    # Los dos pasos de la secuencia de login fueron por la misma sesión, en orden.
-    assert sock.sent == b"USER anonymous\r\nPASS anonymous@lybra.local\r\n"
+    # Los dos pasos de la secuencia de login fueron por la misma sesión, en
+    # orden. Se comprueba con startswith y no con igualdad porque otros checks
+    # de FTP (ftp-no-tls) comparten esa sesión y escriben detrás.
+    assert sock.sent.startswith(b"USER anonymous\r\nPASS anonymous@lybra.local\r\n")
 
 
 def test_ftp_anonymous_login_confirmed_with_a_multiline_banner():

--- a/API/tests/unit/test_lybra_network_config_checks.py
+++ b/API/tests/unit/test_lybra_network_config_checks.py
@@ -1,0 +1,224 @@
+"""Los checks de configuración de red que la Fase N prometió (L26).
+
+Cierran la parte de la brecha G1 que no se resuelve escribiendo ojos: una
+configuración insegura no tiene CVE y no aparece por la vía de la versión.
+
+De los catorce que el issue lista, ocho se construyeron ya en la Fase 2. Aquí
+van los cinco que faltaban: Telnet activo, VNC sin autenticación (plugins
+script), y relay/STARTTLS de SMTP y FTP sin cifrado (checks network, sobre el
+``NetworkSession`` real — la misma regla del resto del fichero: un doble por
+encima de la sesión se inventaría capacidades que el transporte real no tiene).
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    NetworkProbe,
+    Service,
+    load_checks,
+)
+from src.modules.features.themis.lybra.fingerprinting.telnet import TelnetProbe
+from src.modules.features.themis.lybra.fingerprinting.vnc import VncProbe
+
+pytestmark = pytest.mark.unit
+
+_SMTP = Service(25, "tcp", "smtp", "", "", None)
+_FTP = Service(21, "tcp", "ftp", "", "", None)
+_TELNET = Service(23, "tcp", "telnet", "", "", None)
+_VNC = Service(5900, "tcp", "vnc", "", "", None)
+_CHECKS = load_checks()
+
+
+class _FakeNetSocket:
+    """Socket falso a nivel de bytes: saludo en el buffer, respuestas tras cada
+    escritura (el mismo modelo que ``test_lybra_checks``)."""
+
+    def __init__(self, greeting=b"", replies=()):
+        self._buffer = greeting
+        self._replies = list(replies)
+        self.sent = b""
+
+    def recv(self, size):
+        chunk, self._buffer = self._buffer[:size], self._buffer[size:]
+        return chunk
+
+    def sendall(self, data):
+        self.sent += data
+        if self._replies:
+            self._buffer += self._replies.pop(0)
+
+    def close(self):
+        pass
+
+
+def _fired(check_id, sock, service):
+    # Sólo el check bajo prueba: los checks del mismo servicio comparten la
+    # sesión de red (la caché de sondas de L08), así que ejecutar el feed
+    # entero dejaría a otro check consumiendo el socket antes que éste. Aislarlo
+    # es lo que se quiere medir aquí — el comportamiento de un check, no la
+    # orquestación.
+    plain_id = check_id.split(":")[1].split("@")[0]
+    only = [c for c in _CHECKS if c.id == plain_id]
+    runtime = CheckRuntime(
+        only, lambda *a: None,
+        network_open=NetworkProbe(connect=lambda address, timeout: sock).open)
+    return [f for f in runtime.run("h", [service]) if f["check_id"] == check_id]
+
+
+# =============================================================== Telnet
+
+
+def _telnet_plugin(reply):
+    from src.modules.features.themis.lybra.script_checks import TelnetEnabledPlugin
+
+    class _Sock:
+        def settimeout(self, _t):
+            pass
+
+        def recv(self, _n):
+            return reply
+
+        def close(self):
+            pass
+
+    probe = TelnetProbe(connect=lambda address, timeout: _Sock())
+    return TelnetEnabledPlugin(probe=probe)
+
+
+class _Ctx:
+    def __init__(self, service):
+        self.target = "10.0.0.5"
+        self.service = service
+        self.sibling_services = ()
+
+    def acquire(self):
+        pass
+
+
+def test_telnet_is_flagged_when_the_service_opens_with_iac():
+    """Un servidor Telnet abre negociando opciones: el primer byte es IAC
+    (0xFF). Esa firma es lo que dispara."""
+    assert _telnet_plugin(b"\xff\xfb\x01").run(_Ctx(_TELNET)) is True
+
+
+def test_a_mute_or_non_telnet_port_23_is_not_flagged():
+    """Un puerto 23 abierto no basta: podría ser cualquier servicio mudo en un
+    puerto reutilizado. Sin la firma del protocolo, no hay hallazgo."""
+    assert _telnet_plugin(b"").run(_Ctx(_TELNET)) is False
+    assert _telnet_plugin(b"SSH-2.0-x").run(_Ctx(_TELNET)) is False
+
+
+def test_the_telnet_check_is_registered_and_wired():
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    check = next(c for c in _CHECKS if c.id == "telnet-enabled")
+    assert check.service == "telnet" and check.severity == "HIGH"
+    assert check.script in default_script_plugins()
+
+
+# ================================================================== VNC
+
+
+def _vnc_plugin(types):
+    from src.modules.features.themis.lybra.script_checks import VncNoAuthenticationPlugin
+
+    class _Probe(VncProbe):
+        def security_types(self, host, port=5900):
+            return types
+
+    return VncNoAuthenticationPlugin(probe=_Probe())
+
+
+def test_vnc_without_authentication_is_flagged():
+    """El tipo de seguridad 1 es None (RFC 6143): entrar sin contraseña."""
+    assert _vnc_plugin([1, 2]).run(_Ctx(_VNC)) is True
+
+
+def test_vnc_that_only_offers_authentication_is_not_flagged():
+    assert _vnc_plugin([2]).run(_Ctx(_VNC)) is False
+
+
+def test_a_vnc_that_rejected_or_was_unreadable_is_not_flagged():
+    assert _vnc_plugin([]).run(_Ctx(_VNC)) is False       # recuento 0: rechazo
+    assert _vnc_plugin(None).run(_Ctx(_VNC)) is False      # no era RFB
+
+
+# ================================================================= SMTP
+
+
+_SMTP_BANNER = b"220 mail.example.com ESMTP Postfix\r\n"
+
+
+def test_an_open_relay_is_flagged_when_the_external_rcpt_is_accepted():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[
+            b"250-mail.example.com\r\n250 STARTTLS\r\n",   # EHLO
+            b"250 2.1.0 Ok\r\n",                           # MAIL FROM
+            b"250 2.1.5 Ok\r\n",                           # RCPT TO externo aceptado
+        ],
+    )
+    assert _fired("lybra:smtp-open-relay@1", sock, _SMTP)
+
+
+def test_a_closed_relay_that_rejects_the_external_rcpt_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[
+            b"250-mail.example.com\r\n250 STARTTLS\r\n",
+            b"250 2.1.0 Ok\r\n",
+            b"554 5.7.1 Relay access denied\r\n",          # rechaza el relay
+        ],
+    )
+    assert not _fired("lybra:smtp-open-relay@1", sock, _SMTP)
+
+
+def test_a_server_without_starttls_is_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[b"250-mail.example.com\r\n250 SIZE 10240000\r\n250 HELP\r\n"],
+    )
+    assert _fired("lybra:smtp-no-starttls@1", sock, _SMTP)
+
+
+def test_a_server_that_announces_starttls_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[b"250-mail.example.com\r\n250-STARTTLS\r\n250 HELP\r\n"],
+    )
+    assert not _fired("lybra:smtp-no-starttls@1", sock, _SMTP)
+
+
+# ================================================================== FTP
+
+
+def test_ftp_without_tls_is_flagged_when_auth_tls_is_refused():
+    sock = _FakeNetSocket(
+        greeting=b"220 (vsFTPd 3.0.3)\r\n",
+        replies=[b"500 Unknown command.\r\n"],             # AUTH TLS rechazado
+    )
+    assert _fired("lybra:ftp-no-tls@1", sock, _FTP)
+
+
+def test_ftp_with_ftps_support_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=b"220 (vsFTPd 3.0.3)\r\n",
+        replies=[b"234 Proceed with negotiation.\r\n"],    # AUTH TLS aceptado
+    )
+    assert not _fired("lybra:ftp-no-tls@1", sock, _FTP)
+
+
+# ============================================= la brecha G1, contada entera
+
+
+def test_at_least_five_network_config_findings_are_reachable():
+    """El criterio de cierre: un host con SMB, FTP, SMTP y una base de datos
+    abiertos alcanza al menos cinco hallazgos de configuración de red. Aquí se
+    comprueba el inventario —que los checks existen, en su familia— no la red."""
+    network_config = {c.id for c in _CHECKS if c.category in ("network_config",)}
+    expected = {"smbv1-enabled", "smb-signing-not-required",
+                "telnet-enabled", "smtp-open-relay", "smtp-no-starttls", "ftp-no-tls",
+                "dns-open-resolver", "ntp-monlist-enabled"}
+    assert expected <= network_config
+    assert len(network_config) >= 5


### PR DESCRIPTION
## Resumen

Cierra #297.

La Fase N describía, tras los dissectors, *«un conjunto pequeño de checks activos de configuración —los que un dissector no puede deducir— … diez o doce checks con una relación valor/coste altísima, porque cubren los hallazgos que de verdad aparecen en una red interna»*.

Es la parte de la brecha **G1** que no se cierra escribiendo ojos. Un dissector resuelve la detección por versión; una **configuración insegura no tiene CVE** y no aparece por esa vía. Alguien tiene que ir y preguntarla.

## Qué había, y qué faltaba

El issue lista catorce checks. **Ocho ya se construyeron durante la Fase 2** —`smbv1-enabled`, `mongodb-unauthenticated-access`, `elasticsearch-unauthenticated`, `docker-api-unauthenticated`, `postgres-trust-authentication`, `ldap-anonymous-bind`, `rdp-nla-not-required`, `ntp-monlist-enabled`, `dns-open-resolver`— porque cada dissector nuevo llegó con su check. Este PR añade **los cinco que faltaban**.

## Los cinco checks

**`telnet-enabled`** (script). Que exista un Telnet respondiendo **es** el hallazgo: credenciales en claro por diseño, sin una mala configuración que arreglar. El roadmap descartó el *dissector* de Telnet con buen criterio —su negociación IAC no deja texto identificable— pero el *check* es otra cosa, y no necesita identificar nada. Confirma que al otro lado se habla Telnet por la firma con la que un servidor abre siempre su negociación de opciones: el byte `IAC` (`0xFF`, RFC 854). **Un puerto 23 abierto y mudo no basta** —podría ser cualquier servicio en un puerto reutilizado—; lo que dispara es la firma del protocolo.

**`vnc-no-authentication`** (script). El protocolo RFB negocia, tras el saludo de versión, qué tipos de seguridad admite el servidor. El tipo **1 es `None`** (RFC 6143 §7.1.2): entrar sin contraseña, con el escritorio del objetivo a disposición de cualquiera. La evidencia es que el servidor lo **anuncia** en su lista, un hecho observado. Y no se cruza la línea: se lee la lista de tipos y ahí acaba —no se responde a la negociación ni se abre sesión—.

**`smtp-open-relay`** (network). El servidor acepta un `RCPT` a un dominio externo desde un remitente externo. **No se llega a `DATA`**: no se envía correo, sólo se observa que el servidor aceptaría enrutarlo. Un servidor bien configurado responde `550`/`554`.

**`smtp-no-starttls`** (network). El `EHLO` no anuncia `STARTTLS` entre sus capacidades, así que las credenciales de autenticación viajarían en claro.

**`ftp-no-tls`** (network). El servidor rechaza `AUTH TLS` (`500`/`502`/`534`…), así que credenciales y datos van en claro. Un servidor que soporta FTPS responde `234`.

El feed pasa de **55 a 60 checks** (`feedVersion` → `lybra-checks-15`).

## Por qué unos son `script` y otros `network`

Telnet y VNC necesitan **lógica y bytes binarios** —la firma IAC, la lista de tipos RFB— que un matcher de texto declarativo no puede expresar; van como plugins `script`. SMTP y FTP son diálogos de texto que encajan en el DSL `network` (banner + `send`/`read`), y comparten con `ftp-anonymous-login` la misma sesión TCP.

Telnet estrena el predicado `is_telnet_service` (23/tcp); SMTP/FTP/VNC reutilizan los suyos.

## Validación

`pytest tests/unit -k lybra`: todo pasa, incluidos `test_lybra_package_invariants` (el paquete `lybra/` sigue libre de ORM pese al módulo `telnet.py` nuevo) y `test_lybra_feed_shape`. `pylint` sin avisos nuevos sobre la línea base (30 = 30).

`tests/unit/test_lybra_network_config_checks.py`, 13 tests, cada uno con positivo y su contrario:

- **Telnet**: dispara con la apertura IAC; **no** dispara con un puerto mudo ni con un SSH en el 23.
- **VNC**: dispara con `None` en la lista; no con sólo autenticación; no con recuento 0 (rechazo) ni respuesta ilegible.
- **SMTP relay**: dispara con el `RCPT` externo aceptado; no cuando el servidor responde `554`.
- **SMTP STARTTLS**: dispara cuando el `EHLO` no lo anuncia; no cuando sí.
- **FTP TLS**: dispara cuando `AUTH TLS` se rechaza; no cuando el servidor responde `234`.

Los checks `network` corren sobre el `NetworkSession` **real** (un socket falso a nivel de bytes, no un doble de la sesión), la misma regla que el resto del fichero. Y se ejecutan **aislados** a su propio check: los checks del mismo servicio comparten la sesión (la caché de sondas de #L08), así que correr el feed entero dejaría a otro check FTP consumiendo el socket antes.

Un test existente se ajusta sin cambiar de intención: `ftp-anonymous-login` comparte ahora la sesión con `ftp-no-tls`, así que su comprobación de bytes enviados pasa de igualdad a `startswith` —los dos pasos de login, en orden, con lo que `ftp-no-tls` escriba detrás—.

## Notas

- **Los señuelos del banco `oracle` (Docker) no se han tocado ni ejecutado.** El issue pide un contenedor por familia con la configuración insegura y la segura; eso pertenece a una pasada del banco. La comprobación positivo/negativo de cada check queda cubierta aquí, unitaria y sin red.
- El criterio de cierre habla de «cinco hallazgos de configuración de red confirmados sobre un host con servicios expuestos». La mitad de código está entregada; medirlo sobre un host real pertenece al banco.
