### PR TITLE
feat(themis): un escaneo Lybra reporta progreso y se puede cancelar a mitad

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1089,6 +1089,7 @@ class CheckRuntime:
         # (L23), igual que ya inyecta las sondas — este módulo no conoce la
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
+        self._cancel_check: Optional[Callable[[], bool]] = None
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
         # pueda ver los servicios hermanos sin descubrirlos por su cuenta.
@@ -1121,7 +1122,8 @@ class CheckRuntime:
             ),
         )
 
-    def run(self, host: str, services: Iterable[Service]) -> List[dict]:
+    def run(self, host: str, services: Iterable[Service],
+            cancel_check: Optional[Callable[[], bool]] = None) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
         Probes are shared within one call: several checks reading the same
@@ -1158,6 +1160,7 @@ class CheckRuntime:
         # redescubrirla por su cuenta.
         self._services = services
         self._host = host
+        self._cancel_check = cancel_check
 
         per_service = self._mapper(self._run_for_service, services)
         return [finding for group in per_service for finding in group]
@@ -1176,8 +1179,13 @@ class CheckRuntime:
             service: El servicio a evaluar.
 
         Returns:
-            Los hallazgos de ese servicio, en el orden del feed.
+            Los hallazgos de ese servicio, en el orden del feed. Vacíos si la
+            cancelación llegó antes de tocar este servicio: como en el
+            fingerprinting, las unidades ya lanzadas terminan pero las que aún
+            no han arrancado devuelven de inmediato.
         """
+        if getattr(self, "_cancel_check", None) is not None and self._cancel_check():
+            return []
         findings: List[dict] = []
         for family in self._families:
             if not family.applies_to_service(service):

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -4,7 +4,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
-from typing import List, Optional
+from typing import Callable, List, Optional
 import src.modules.system.config_reading as CR
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.system.taskqueue import ITaskQueue, job_context
@@ -189,13 +189,15 @@ class LybraEngineManager(ScanManager):
         —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
         despliegue en vez de fallar al deserializarse.
         """
-        with job_context():
+        with job_context() as job:
             manager = LybraEngineManager()
             manager._run_lybra( # type: ignore
                 scan_id,
                 discover_ports,
                 services,
                 timeout,
+                cancel_check=job.cancelled,
+                progress=job.progress,
             )
 
     @staticmethod
@@ -203,12 +205,14 @@ class LybraEngineManager(ScanManager):
         """Segundos que quedan hasta ``deadline``, o ``None`` si no hay plazo."""
         return None if deadline is None else max(0.0, deadline - time.monotonic())
 
-    def _run_lybra(
+    def _run_lybra(  # pylint: disable=too-many-arguments
         self,
         scan_id: int,
         discover_ports: Optional[list] = None,
         services_payload: Optional[List[Service]] = None,
         timeout: Optional[int] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+        progress: Optional[Callable[[int], None]] = None,
     ) -> None:
         """Resolve services (own discovery or a payload), detect, persist.
 
@@ -230,14 +234,24 @@ class LybraEngineManager(ScanManager):
         también, el plazo ya está aquí: basta pasarles ``_remaining_budget``.
         """
         deadline = time.monotonic() + timeout if timeout else None
+        is_cancelled = cancel_check or (lambda: False)
+
+        def report(pct: int) -> None:
+            if progress is not None:
+                progress(pct)
+
         source = ServiceSource.build_for_args(services_payload, discover_ports)
         probes = DiscoveryProbes(
             is_host_reachable=self.is_host_reachable,
             # El presupuesto se calcula al llamar, no aquí: para cuando el
             # descubrimiento arranca ya se han gastado la comprobación de
-            # alcanzabilidad y las consultas de apertura del escaneo.
+            # alcanzabilidad y las consultas de apertura del escaneo. El
+            # cancel_check baja hasta el barrido de puertos —la fase más larga—
+            # para que un escaneo grande se pueda parar a mitad.
             discover_ports=lambda target, ports: self._discover_ports(
-                target, ports, budget_seconds=self._remaining_budget(deadline)),
+                target, ports,
+                budget_seconds=self._remaining_budget(deadline),
+                cancel_check=cancel_check),
             discover_udp_ports=self._discover_udp_ports,
         )
         try:
@@ -261,7 +275,15 @@ class LybraEngineManager(ScanManager):
                     self.update_scan_status(scan_id, ScanStatus.FAILED)
                     return
                 services, source_host_id, source_target = resolved.services, resolved.host_id, resolved.target
-                is_partial = resolved.is_partial
+                # Un escaneo cancelado a mitad es, a efectos del ciclo de vida,
+                # lo mismo que uno truncado por reloj: vio parte del objetivo,
+                # no todo. Comparte la bandera ``is_partial`` para no cerrar por
+                # omisión lo que no llegó a comprobar (el fallo de L48-c).
+                is_partial = resolved.is_partial or is_cancelled()
+                # Descubrimiento hecho: 40 % del trabajo (pesos honestos del §3
+                # del issue — descubrimiento 40, fingerprint 30, checks 20,
+                # correlación y persistencia 10).
+                report(40)
 
                 fingerprint_findings: list = []
                 if (
@@ -269,11 +291,15 @@ class LybraEngineManager(ScanManager):
                     and source_target
                     and is_target_authorized
                     and CR.lybra_config().fingerprinting_enabled
+                    and not is_cancelled()
                 ):
                     services, fingerprint_findings = self._fingerprint_services(
                         source_target,
-                        services
+                        services,
+                        cancel_check=cancel_check,
                     )
+                    is_partial = is_partial or is_cancelled()
+                report(70)
 
                 previous_map = self._previous_findings_map(
                     scan_repo,
@@ -297,8 +323,12 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(fingerprint_findings)
                 findings_data.extend(surface_findings)
 
-            if source.probes_target_network and source_target and is_target_authorized and CR.lybra_config().active_checks:
-                findings_data.extend(self._run_active_checks(source_target, services))
+            if (source.probes_target_network and source_target and is_target_authorized
+                    and CR.lybra_config().active_checks and not is_cancelled()):
+                findings_data.extend(
+                    self._run_active_checks(source_target, services, cancel_check=cancel_check))
+                is_partial = is_partial or is_cancelled()
+            report(90)
 
             for finding in findings_data:
                 finding["host_id"] = source_host_id
@@ -331,6 +361,7 @@ class LybraEngineManager(ScanManager):
                 scan.status = ScanStatus.FINISHED.value  # type: ignore
                 scan.finished_at = utcnow_naive()  # type: ignore
 
+            report(100)
             if is_partial:
                 logger.warning(
                     "Escaneo Lybra %s completado PARCIALMENTE: %s hallazgos sobre una "
@@ -348,6 +379,7 @@ class LybraEngineManager(ScanManager):
         target: str,
         discover_ports,
         budget_seconds: Optional[float] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Optional[PortSweep]:
         """Discover open ports with Lybra's own connect scan (Fase T).
 
@@ -372,6 +404,7 @@ class LybraEngineManager(ScanManager):
                 timeout=engine.tcp_timeout,
                 retries=engine.udp_retries,
                 budget_seconds=budget_seconds,
+                cancel_check=cancel_check,
             )
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
@@ -415,7 +448,7 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services) -> list:
+    def _run_active_checks(self, target: str, services, cancel_check=None) -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
@@ -442,7 +475,7 @@ class LybraEngineManager(ScanManager):
                 # fila india.
                 mapper=self._in_host_pool,
             )
-            return runtime.run(target, services)
+            return runtime.run(target, services, cancel_check=cancel_check)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
             return []
@@ -487,7 +520,7 @@ class LybraEngineManager(ScanManager):
             logger.exception("Fallo ingiriendo plantillas de Nuclei; se sigue con el feed propio")
             return []
 
-    def _fingerprint_services(self, target: str, services: list) -> tuple:
+    def _fingerprint_services(self, target: str, services: list, cancel_check=None) -> tuple:
         """Run Lybra's own HTTP/SSH/FTP dissectors and identify each service.
 
         Fase F. La identificación que sale de aquí **es** la identificación del
@@ -524,7 +557,14 @@ class LybraEngineManager(ScanManager):
             Se define dentro para que cada llamada comparta los ``dissectors`` y
             el ``rate_limiter`` de **esta** ejecución: el limitador es lo que
             mantiene el ritmo por host cuando varias sondas van a la vez, así que
-            compartirlo es justo el punto."""
+            compartirlo es justo el punto.
+
+            Comprueba la cancelación al entrar: con el pool concurrente, las
+            unidades ya lanzadas terminan, pero las que aún no han arrancado
+            devuelven de inmediato — que es lo que hace que un fingerprint de
+            veinte servicios se corte pronto y no al final."""
+            if cancel_check is not None and cancel_check():
+                return service, None
             dissector = next((dissector for dissector in dissectors if dissector.applies(service)), None)
             result = None
             if dissector is not None:

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1299,3 +1299,89 @@ def test_the_partial_flag_reaches_the_api(client, monkeypatch, app, admin_user, 
     result = client.get("/themis/results?type=lybra&page=1&per_page=10",
                         headers=auth_headers(admin_user)).get_json()["results"][0]
     assert result["isPartial"] is True
+
+
+# ============================================ progreso y cancelación (L41)
+
+
+def test_a_scan_reports_progress_by_phase(monkeypatch, app, admin_user):
+    """El escaneo publica progreso por fase con pesos honestos: descubrimiento
+    40, fingerprint 70, checks 90, persistencia 100 (§3 del issue)."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+
+    reported = []
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, progress=reported.append)
+
+    # Monótono, empieza por debajo de 100 y llega a 100.
+    assert reported == sorted(reported)
+    assert reported[-1] == 100
+    assert 40 in reported
+
+
+def test_a_cancelled_scan_stops_persists_and_is_marked_partial(monkeypatch, app, admin_user):
+    """Cancelado tras el descubrimiento: no corre fingerprint ni checks, pero
+    persiste lo hallado y queda marcado como parcial — nunca tira lo verificado."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80, 443])
+
+    fingerprinted = []
+    original_fp = LybraEngineManager._fingerprint_services
+    monkeypatch.setattr(
+        LybraEngineManager, "_fingerprint_services",
+        lambda self, target, services, **kw: (fingerprinted.append(True)
+                                              or original_fp(self, target, services, **kw)))
+
+    # Cancelado desde el primer chequeo: el descubrimiento ya devolvió, pero
+    # fingerprint y checks no deben arrancar.
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, cancel_check=lambda: True)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            escan = repo.get_by_id(escan.id)
+            findings = repo.get_findings_by_scan(escan.id)
+
+    assert escan.status == ScanStatus.FINISHED.value
+    assert escan.is_partial is True
+    assert fingerprinted == []          # no se llegó a fingerprintear
+    # Lo descubierto se persiste: los puertos son un hecho verificado.
+    assert sorted(f.port for f in findings if f.category == "open_port") == [80, 443]
+
+
+def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, admin_user):
+    """La interacción crítica con el ciclo de vida: un escaneo cancelado a mitad
+    no vio todo el objetivo, así que la ausencia de un hallazgo anterior no es
+    evidencia de que se haya corregido (el fallo de L48-c por otra puerta)."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+
+    # Primer escaneo completo: 80 y 443 abiertos.
+    _stub_self_discovery(monkeypatch, [80, 443])
+    with app.app_context():
+        mgr = LybraEngineManager()
+        first = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id)
+        mgr._run_lybra(first.id)
+
+    # Segundo escaneo cancelado a mitad: sólo llega a ver el 80.
+    _stub_self_discovery(monkeypatch, [80])
+    with app.app_context():
+        mgr = LybraEngineManager()
+        second = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id)
+        mgr._run_lybra(second.id, cancel_check=lambda: True)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            findings = repo.get_findings_by_scan(second.id)
+
+    # El 443, que no se llegó a recorrer, no se cierra como corregido.
+    fixed = [f for f in findings if f.state == "fixed"]
+    assert fixed == []

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -94,13 +94,21 @@ def test_the_worker_entry_point_carries_the_timeout(monkeypatch):
         def __exit__(self, *exc):
             return False
 
+        def cancelled(self):
+            return False
+
+        def progress(self, _pct):
+            pass
+
     monkeypatch.setattr(engine_module, "job_context", lambda: _NullContext())
     monkeypatch.setattr(
         LybraEngineManager, "_run_lybra",
-        lambda self, *args: seen.append(args),
+        lambda self, *args, **kwargs: seen.append(args),
     )
 
     LybraEngineManager.execute_lybra_scan(7, [80], None, 90)
     LybraEngineManager.execute_lybra_scan(8, [80])
 
+    # El timeout sigue viajando como cuarto posicional; cancel_check y progress
+    # van como kwargs (el JobHandle del worker), fuera de esta comprobación.
     assert seen == [(7, [80], None, 90), (8, [80], None, None)]


### PR DESCRIPTION
## Resumen

Cierra #309.

El proyecto tiene resueltos, para el resto de escáneres, la cancelación cooperativa y el reporte de progreso: `TaskQueue` publica una clave Redis `taskqueue:cancel:{job_id}`, los workers la sondean, y `job.meta["progress"]` transporta el avance. **Lybra no lo usaba.** `_run_lybra` corría de principio a fin sin consultar la cancelación ni una vez y sin publicar progreso —siendo el escaneo con más razones para necesitarlo: descubre puertos, fingerprintea cada servicio, corre decenas de checks y consulta la KB—.

Para el usuario, un escaneo que no dice por dónde va y que ignora el botón de cancelar es un escaneo que no está bajo control. Y para un escáner que toca objetivos de terceros, no poder pararlo es un problema de seguridad operativa: si un cliente llama diciendo «para eso», hay que poder pararlo.

Lo llamativo, como apunta el issue, es que **el mecanismo estaba pedido y no se pasaba**: el `JobHandle` que `job_context()` ya expone tiene `.cancelled()` y `.progress()`, y `execute_lybra_scan` abría el contexto y descartaba el handle.

## Qué cambia

**`execute_lybra_scan` captura el handle** y lo cablea:

```python
with job_context() as job:
    manager._run_lybra(..., cancel_check=job.cancelled, progress=job.progress)
```

Fuera de un worker (tests, CLI) el `JobHandle` es un no-op defensivo, así que el cambio es invisible ahí.

**El `cancel_check` baja hasta donde importa:**

- Al **barrido de puertos** —la fase más larga—, que ya aceptaba un `cancel_check` que nadie le daba. Un escaneo grande se puede parar a mitad del descubrimiento.
- **Entre servicios** en `_fingerprint_services` y en `CheckRuntime.run`. Los dos usan el pool concurrente de #294, así que la cancelación se comprueba **al entrar en cada unidad de trabajo**: las ya lanzadas terminan, pero las que aún no han arrancado devuelven de inmediato. Es lo que hace que un fingerprint de veinte servicios se corte pronto y no al final.

**El progreso se publica por fase**, con los pesos honestos que el §3 del issue pide: descubrimiento 40 %, fingerprint 70 %, checks 90 %, correlación y persistencia 100 %.

## El punto que hay que pensar con cuidado

El §4 del issue lo señala: la interacción entre cancelación y ciclo de vida. Un escaneo cancelado a mitad **no vio todo el objetivo**, así que la ausencia de un hallazgo que no llegó a comprobar no es evidencia de que se haya corregido. Cerrarlo como `fixed` sería exactamente el fallo de #L48-c por otra puerta —decirle al usuario que sus vulnerabilidades se arreglaron solas—.

La pieza receptora ya existía: #402 introdujo la bandera `is_partial` y `apply_lifecycle(..., close_missing=not is_partial)` para el descubrimiento truncado por reloj. **Un escaneo cancelado es, a efectos del ciclo de vida, lo mismo que uno truncado**: vio parte, no todo. Así que reutiliza esa misma bandera —`is_partial = resolved.is_partial or is_cancelled()`— y hereda la garantía de no cerrar nada por omisión.

## Validación

`pytest tests/unit tests/integration/test_lybra.py -k lybra`: todo pasa. `pylint` sin avisos nuevos sobre la línea base (69 = 69).

Tres tests de integración nuevos:

- `test_a_scan_reports_progress_by_phase` — el progreso es monótono, empieza por debajo de 100 e incluye el 40 del descubrimiento y el 100 final.
- `test_a_cancelled_scan_stops_persists_and_is_marked_partial` — cancelado tras el descubrimiento: **no** se llega a fingerprintear, pero los puertos hallados **se persisten** (son un hecho verificado) y el escaneo queda `is_partial`.
- `test_a_cancelled_scan_does_not_close_findings_by_omission` — la interacción crítica: dos escaneos sobre el mismo objetivo, el segundo cancelado a mitad viendo sólo un puerto; el otro, que no se recorrió, **no se marca `fixed`**.

Un test existente se ajusta sin cambiar de intención: el `_NullContext` que dobla `job_context()` en `test_lybra_scan_budget` gana los métodos `cancelled`/`progress` del handle, y el mock de `_run_lybra` acepta los kwargs nuevos.

## Notas

- **Sólo el fingerprint TCP y los checks se cancelan entre unidades; el descubrimiento UDP no.** Es best-effort y corto (su propio presupuesto de reloj lo acota), y meterle cancelación fina no cambia el «menos de cinco segundos» que el criterio pide, que lo domina el descubrimiento TCP.
- No se toca el banco `oracle`.
