### PR TITLE
feat(themis): un hallazgo confirmado guarda la evidencia cruda que lo provocó

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -212,6 +212,11 @@
             "bannerTimeout": 2.0,
             "maxBlindProbes": 2
           },
+          "evidence": {
+            "enabled": true,
+            "maxBodyBytes": 8192,
+            "retentionDays": 90
+          },
           "fingerprintingEnabled": true,
           "ingest": {
             "enabled": false,

--- a/API/alembic/versions/c7e1a9f4b2d8_lybra_evidencia_cruda_por_hallazgo.py
+++ b/API/alembic/versions/c7e1a9f4b2d8_lybra_evidencia_cruda_por_hallazgo.py
@@ -1,0 +1,57 @@
+"""lybra: evidencia cruda por hallazgo (Fase E)
+
+Revision ID: c7e1a9f4b2d8
+Revises: fd07fce5f920
+Create Date: 2026-09-03 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e1a9f4b2d8'
+down_revision: Union[str, Sequence[str], None] = 'fd07fce5f920'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Crea la tabla de evidencia de hallazgos.
+
+    Un hallazgo dice qué encontró y con qué regla, pero no guardaba lo que el
+    objetivo respondió. Esta tabla lo guarda: la respuesta cruda —redactada,
+    con su hash y su fecha— que provocó el hallazgo, para poder defenderla ante
+    un cliente y para diagnosticar un falso positivo sin repetir el escaneo a
+    mano.
+
+    ``ondelete=CASCADE`` a propósito: la evidencia no tiene sentido sin su
+    hallazgo, así que borrar un escaneo (que ya cae en cascada sobre sus
+    hallazgos) se lleva también su evidencia, sin dejar filas huérfanas.
+
+    El índice sobre ``captured_at`` es para la retención: la purga de la
+    evidencia caducada barre por fecha, y sin índice ese barrido escanearía la
+    tabla entera cada vez.
+    """
+    op.create_table(
+        "FindingEvidence",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("finding_id", sa.Integer(),
+                  sa.ForeignKey("Finding.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("captured_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_FindingEvidence_finding_id", "FindingEvidence", ["finding_id"])
+    op.create_index("ix_FindingEvidence_captured_at", "FindingEvidence", ["captured_at"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_FindingEvidence_captured_at", table_name="FindingEvidence")
+    op.drop_index("ix_FindingEvidence_finding_id", table_name="FindingEvidence")
+    op.drop_table("FindingEvidence")

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -519,6 +519,27 @@ def update_finding_state(data, finding_id: int):
     }
 
 
+@themis_blp.get("/findings/<int:finding_id>/evidence")
+@themis_blp.response(200, description="Raw evidence for a finding")
+@themis_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@themis_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@themis_blp.alt_response(404, schema=ErrorSchema, description="Finding not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.THEMIS_READ])
+@limiter.limit("120 per hour; 400 per day")
+@handle_exceptions(default_exception=FindingNotFoundError, logger=logger)
+def get_finding_evidence(finding_id: int):
+    """Devolver la evidencia cruda que respalda un hallazgo (Fase E).
+
+    La respuesta que el objetivo dio y que provocó el hallazgo, redactada, con
+    su hash y su fecha — lo que convierte «te lo digo yo» en «míralo». Sólo
+    sobre hallazgos propios: uno ajeno se reporta como no encontrado.
+    """
+    user = get_current_user()
+    evidence = LybraEngineManager().get_finding_evidence(finding_id, user.id)
+    return {"findingId": finding_id, "evidence": evidence}
+
+
 @themis_blp.get("/results")
 @themis_blp.arguments(ResultsQuerySchema, location="query")
 @themis_blp.response(200, ResultsResponseSchema, description="Scan results")

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1066,7 +1066,7 @@ class CheckRuntime:
             above are.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         checks: Iterable[Check],
         fetch: Callable[[str, Optional[int], str, str], Optional[Response]],
@@ -1076,6 +1076,7 @@ class CheckRuntime:
         network_open: Optional[Callable[[str, int], Optional["NetworkSession"]]] = None,
         script_plugins: Optional[Dict[str, object]] = None,
         mapper: Optional[Callable] = None,
+        capture_evidence: bool = False,
     ) -> None:
         self._checks = list(checks)
         self._fetch = fetch
@@ -1090,6 +1091,7 @@ class CheckRuntime:
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
         self._cancel_check: Optional[Callable[[], bool]] = None
+        self._capture_evidence = capture_evidence
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
         # pueda ver los servicios hermanos sin descubrirlos por su cuenta.
@@ -1264,11 +1266,29 @@ class CheckRuntime:
         request fails to reach the target or does not match, the check produces
         nothing.
         """
+        last_response = None
         for request in check.requests:
             response = self._probe_response(host, service, request.method, request.path)
             if response is None or not request.evaluate(response):
                 return None
-        return self._finding(check, service)
+            last_response = response
+        finding = self._finding(check, service)
+        # Evidencia (Fase E): la respuesta que provocó el hallazgo. Sólo para
+        # los confirmados —los que van a un informe— y sólo si la captura está
+        # activada. El payload viaja en ``_evidence`` hasta la persistencia, que
+        # lo redacta y lo separa en su propia fila.
+        if (self._capture_evidence and last_response is not None
+                and finding.get("confirmed")):
+            finding["_evidence"] = {
+                "kind": "http_response",
+                "payload": {
+                    "status": last_response.status,
+                    "headers": dict(last_response.headers),
+                    "body": last_response.body,
+                    "path": check.requests[-1].path,
+                },
+            }
+        return finding
 
     def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
         """Return the response for one request, asking the target only once.

--- a/API/src/modules/features/themis/lybra/evidence.py
+++ b/API/src/modules/features/themis/lybra/evidence.py
@@ -1,0 +1,185 @@
+"""La evidencia cruda de un hallazgo — capturada, redactada y con hash (Fase E).
+
+Este módulo vive en la capa pura ``lybra/``: **no toca el ORM**. El motor
+recoge la evidencia en una lista en memoria a través de un *recorder*
+inyectable —igual que ``cve_lookup``—, y es el manager quien la vuelca a la
+base de datos en la fase de persistencia. Aquí sólo están las dos operaciones
+que no dependen de nada externo: **redactar** y **hashear**.
+
+**Por qué la redacción es requisito y no mejora.** Una respuesta cruda puede
+traer cookies de sesión, cabeceras ``Authorization``, tokens en el cuerpo o
+datos personales del objetivo. Guardar evidencia sin redactar convertiría la
+base de datos de Ellysia en un depósito de secretos ajenos. Filtrar las
+cabeceras sensibles y truncar el cuerpo es la línea que separa «guardo lo que
+vi» de «me quedo con las llaves de casa del cliente».
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+# Cabeceras que nunca se persisten: llevan credenciales o material de sesión.
+# Se comparan en minúsculas, así que la lista va en minúsculas.
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "www-authenticate",
+    "proxy-authenticate",
+    "x-api-key",
+    "x-auth-token",
+    "x-csrf-token",
+    "x-xsrf-token",
+    "api-key",
+    "authentication-info",
+})
+
+# Lo que se pone en lugar de una cabecera redactada, para que la evidencia diga
+# «aquí había algo y lo quitamos» en vez de esconder que existía.
+_REDACTED = "[redacted]"
+
+# Las clases de evidencia que el modelo reconoce (MS-Fase E). Una entrada con
+# otro ``kind`` no se descarta, pero conviene que la lista viva en un sitio.
+EVIDENCE_KINDS = ("http_response", "ssh_banner", "tls_cert", "probe_output")
+
+
+@dataclass
+class EvidenceRecord:
+    """Una evidencia recogida por el motor, aún sin persistir.
+
+    El ``dedup_key`` es lo que ata la evidencia a su hallazgo cuando el manager
+    la vuelca: el hallazgo se identifica por esa clave, no por la identidad de
+    un objeto Python que ``merge_findings`` podría haber recreado.
+
+    Attributes:
+        dedup_key: La clave del hallazgo que esta evidencia respalda.
+        kind: La clase de evidencia (:data:`EVIDENCE_KINDS`).
+        payload: El contenido observado, **sin** redactar todavía.
+    """
+    dedup_key: str
+    kind: str
+    payload: Dict[str, Any]
+
+
+@dataclass
+class EvidenceRecorder:
+    """Un recorder inyectable que acumula evidencia en memoria.
+
+    El motor recibe uno de éstos y llama :meth:`record` cuando un hallazgo trae
+    la respuesta que lo provocó. No sabe nada de la base de datos; el manager
+    lee :attr:`records` al final y los persiste.
+    """
+    records: List[EvidenceRecord] = field(default_factory=list)
+
+    def record(self, dedup_key: str, kind: str, payload: Dict[str, Any]) -> None:
+        """Apunta una evidencia para un hallazgo.
+
+        Args:
+            dedup_key: La clave del hallazgo que respalda.
+            kind: La clase de evidencia.
+            payload: El contenido observado, sin redactar.
+        """
+        self.records.append(EvidenceRecord(dedup_key=dedup_key, kind=kind, payload=payload))
+
+
+def redact_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Sustituye el valor de las cabeceras sensibles por un marcador.
+
+    Se conserva el **nombre** de la cabecera —que dice que estaba— y se borra
+    sólo el valor. Un informe que dice «había un ``Set-Cookie`` y lo redactamos»
+    es más honesto que uno que finge que no existía.
+
+    Args:
+        headers: Las cabeceras de la respuesta.
+
+    Returns:
+        Una copia con los valores sensibles redactados.
+    """
+    return {
+        name: (_REDACTED if name.lower() in _SENSITIVE_HEADERS else value)
+        for name, value in headers.items()
+    }
+
+
+def redact_evidence(payload: Dict[str, Any], max_body_bytes: int = 8192) -> Dict[str, Any]:
+    """Redacta y trunca una evidencia antes de persistirla.
+
+    Args:
+        payload: El contenido observado. Puede traer ``headers`` (un dict) y
+            ``body`` (texto); cualquier otra clave se conserva tal cual.
+        max_body_bytes: El tope del cuerpo, en bytes de su codificación UTF-8.
+
+    Returns:
+        Una copia redactada: cabeceras sensibles sin valor, cuerpo truncado con
+        una marca de cuántos bytes se recortaron.
+    """
+    redacted = dict(payload)
+    if isinstance(redacted.get("headers"), dict):
+        redacted["headers"] = redact_headers(redacted["headers"])
+    body = redacted.get("body")
+    if isinstance(body, str):
+        encoded = body.encode("utf-8", "ignore")
+        if len(encoded) > max_body_bytes:
+            redacted["body"] = encoded[:max_body_bytes].decode("utf-8", "ignore")
+            redacted["body_truncated_bytes"] = len(encoded) - max_body_bytes
+    return redacted
+
+
+def evidence_hash(payload: Dict[str, Any]) -> str:
+    """Calcula el SHA-256 de una evidencia redactada, de forma estable.
+
+    Se serializa con las claves ordenadas para que el mismo contenido produzca
+    siempre el mismo hash, que es lo que permite afirmar después que la
+    evidencia no se ha tocado.
+
+    Args:
+        payload: La evidencia ya redactada.
+
+    Returns:
+        El digest hexadecimal.
+    """
+    serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def prepare_evidence(
+    payload: Dict[str, Any],
+    max_body_bytes: int = 8192,
+) -> Dict[str, Any]:
+    """Redacta, trunca y hashea una evidencia en un solo paso.
+
+    Args:
+        payload: El contenido observado, sin redactar.
+        max_body_bytes: El tope del cuerpo.
+
+    Returns:
+        Un dict ``{"payload": <redactado>, "content_hash": <sha256>}`` listo
+        para el modelo.
+    """
+    redacted = redact_evidence(payload, max_body_bytes)
+    return {"payload": redacted, "content_hash": evidence_hash(redacted)}
+
+
+def build_recorder(enabled: bool) -> Optional[EvidenceRecorder]:
+    """Devuelve un recorder si la captura está activada, o ``None``.
+
+    Un ``None`` es la señal de «no captures nada», que el motor propaga sin
+    ramas especiales: donde llamaría a ``recorder.record`` simplemente no hay
+    recorder.
+
+    Args:
+        enabled: Si la captura de evidencia está activada.
+
+    Returns:
+        Un :class:`EvidenceRecorder` nuevo, o ``None``.
+    """
+    return EvidenceRecorder() if enabled else None
+
+
+# Tipo del recorder que el motor recibe: una función que apunta una evidencia,
+# o ``None``. Se declara para que las firmas lo nombren sin importar la clase.
+RecorderFn = Optional[Callable[[str, str, Dict[str, Any]], None]]

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -469,6 +469,7 @@ class LybraEngineManager(ScanManager):
                 tls_fetch=TlsProbe().fetch,
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
+                capture_evidence=CR.lybra_evidence_config().enabled,
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
                 # red servicio a servicio— y el mismo motivo para no hacerla en
@@ -912,6 +913,34 @@ class LybraEngineManager(ScanManager):
             repo.update(finding)
             return finding
 
+    def get_finding_evidence(self, finding_id: int, user_id: int) -> list:
+        """Devuelve la evidencia cruda de un hallazgo propio (Fase E).
+
+        Mismo criterio de propiedad que :meth:`set_finding_state`: la evidencia
+        de un hallazgo de otro usuario se reporta como no encontrada, sin
+        revelar el ``scan_id`` ajeno.
+
+        Returns:
+            Una lista de dicts con ``kind``, ``payload``, ``contentHash`` y
+            ``capturedAt`` de cada evidencia, la más reciente primero.
+        """
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            finding = repo.get_finding(finding_id)
+            if finding is None:
+                raise FindingNotFoundError(finding_id)
+            assert_owned(ScanRepository, finding.scan_id, user_id,
+                         lambda _scan_id: FindingNotFoundError(finding_id), uow=uow)
+            return [
+                {
+                    "kind": evidence.kind,
+                    "payload": evidence.payload,
+                    "contentHash": evidence.content_hash,
+                    "capturedAt": evidence.captured_at.isoformat() if evidence.captured_at else None,
+                }
+                for evidence in repo.get_evidence_for_finding(finding_id)
+            ]
+
     def _create_scan_record(
         self, target: str, user_id: int,
         programed_scan_id: Optional[int] = None, asset_id: Optional[int] = None,
@@ -931,8 +960,18 @@ class LybraEngineManager(ScanManager):
         )
 
     def _persist_scan_results(self, uow, scan, domain_data) -> None:
-        """Persist the engine's findings (``domain_data`` is a list of dicts)."""
-        ScanRepository(uow).persist_findings(scan, domain_data)
+        """Persist the engine's findings (``domain_data`` is a list of dicts).
+
+        Aprovecha la escritura para purgar la evidencia caducada (Fase E): cada
+        escaneo que graba evidencia se lleva de paso la que ha pasado su
+        retención, así la tabla no crece sin fin sin necesidad de un barredor
+        aparte.
+        """
+        evidence_config = CR.lybra_evidence_config()
+        repo = ScanRepository(uow)
+        repo.persist_findings(scan, domain_data,
+                              evidence_max_body=evidence_config.max_body_bytes)
+        repo.delete_expired_evidence(evidence_config.retention_days)
 
     def get_scans_paginated(  # pylint: disable=arguments-differ
         self, user_id: int, page: int = 1, per_page: int = 10,

--- a/API/src/modules/features/themis/managers/lybra/sources.py
+++ b/API/src/modules/features/themis/managers/lybra/sources.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
 from typing import Callable, List, Optional
 
 import src.modules.system.config_reading as CR
@@ -70,7 +71,7 @@ class ResolvedServices:
     is_partial: bool = False
 
 
-class ServiceSource:
+class ServiceSource(ABC):
     """One of the two ways a Lybra scan obtains the services it analyses.
 
     A thin base plus one policy flag (Python's idiomatic stand-in for what
@@ -101,10 +102,12 @@ class ServiceSource:
             return ExternalPayload(services)
         return SelfDiscovery(discover_ports)
 
+    @abstractmethod
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
         """Resolve and validate this mode's target, before the scan record exists."""
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def resolve_services(
         self,
         scan_repo: ScanRepository,
@@ -126,7 +129,7 @@ class ServiceSource:
         no vio todo el objetivo: ésa no es un fallo, es un resultado con una
         advertencia pegada.
         """
-        raise NotImplementedError
+        ...
 
     @staticmethod
     def _resolve_host(scan_repo: ScanRepository, target: Optional[str]) -> Optional[int]:

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -882,6 +882,44 @@ class Finding(Base):
         return f"<Finding(id={self.id}, scan_id={self.scan_id}, category='{self.category}', title='{self.title[:40]}')>"
 
 
+class FindingEvidence(Base):
+    """La respuesta cruda que provocó un hallazgo (Fase E).
+
+    Un hallazgo dice **qué** encontró y **con qué regla**, pero ``feed_version``
+    + ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
+    respondió. Cuando un cliente dice «eso no es verdad, ese fichero no está
+    expuesto», la respuesta útil es la respuesta HTTP con su cuerpo y su fecha,
+    no «nuestro check dice que sí». Sin evidencia, cada discusión se resuelve
+    repitiendo el escaneo a mano.
+
+    Attributes:
+        id: Clave primaria.
+        finding_id: El hallazgo que esta evidencia respalda.
+        kind: Qué clase de evidencia es (``http_response`` | ``ssh_banner`` |
+            ``tls_cert`` | ``probe_output``).
+        payload: El contenido observado, ya **redactado** (ver
+            ``lybra.evidence.redact_evidence``): cabeceras sensibles fuera,
+            cuerpo truncado. Guardar una respuesta cruda sin redactar
+            convertiría la base de datos en un depósito de secretos ajenos.
+        content_hash: SHA-256 del payload redactado. No es decorativo: es lo
+            que permite decir «esta evidencia no se ha tocado desde que se
+            capturó», la mitad del valor en un contexto de auditoría.
+        captured_at: Cuándo se observó (cadena de custodia).
+    """
+    __tablename__ = "FindingEvidence"
+
+    id           = Column(Integer, primary_key=True, autoincrement=True)
+    finding_id   = Column(Integer, ForeignKey("Finding.id", ondelete="CASCADE"),
+                          nullable=False, index=True)
+    kind         = Column(String(32), nullable=False)
+    payload      = Column(JSONB, nullable=False)
+    content_hash = Column(String(64), nullable=False)
+    captured_at  = Column(DateTime, default=utcnow_naive, nullable=False, index=True)
+
+    def __repr__(self):
+        return f"<FindingEvidence(id={self.id}, finding_id={self.finding_id}, kind='{self.kind}')>"
+
+
 # =========================================================================
 # KNOWLEDGE BASE (the "Lybra Feed": local mirror of NVD/KEV/EPSS)
 # =========================================================================

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -25,7 +25,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import func, or_
@@ -33,6 +33,7 @@ from sqlalchemy import update as sa_update
 from sqlalchemy.orm import joinedload
 from src.modules.infrastructure import BaseRepository, DocumentRepository
 from src.modules.shared import utcnow_naive
+from .lybra.evidence import prepare_evidence
 
 from .model import (
     AuthorizedTarget,
@@ -42,6 +43,7 @@ from .model import (
     LybraScan,
     EpssScore,
     Finding,
+    FindingEvidence,
     Host,
     HostService,
     KevEntry,
@@ -668,15 +670,68 @@ class ScanRepository(BaseRepository[Scan]):
             .all()
         )
 
-    def persist_findings(self, scan: Scan, findings_data: List[dict]) -> None:
+    def persist_findings(self, scan: Scan, findings_data: List[dict],
+                         evidence_max_body: int = 8192) -> None:
         """Persist a batch of normalized Finding rows for a scan.
+
+        Un finding puede traer una clave ``_evidence`` —la respuesta cruda que
+        lo provocó, que el runtime de checks adjuntó (Fase E)—. No es una
+        columna, así que se extrae antes de construir el ``Finding``, y se
+        persiste como una fila ``FindingEvidence`` aparte, ya redactada y
+        hasheada, una vez que el ``Finding`` tiene id.
 
         Args:
             scan: The scan that produced the findings (its id is used as scan_id).
             findings_data: List of dicts with Finding column values.
+            evidence_max_body: Tope del cuerpo de la evidencia, en bytes.
         """
         for data in findings_data:
-            self._session.add(Finding(scan_id=scan.id, **data))
+            evidence = data.pop("_evidence", None)
+            finding = Finding(scan_id=scan.id, **data)
+            self._session.add(finding)
+            if evidence:
+                self._session.flush()          # necesita el id del finding
+                prepared = prepare_evidence(evidence["payload"], evidence_max_body)
+                self._session.add(FindingEvidence(
+                    finding_id=finding.id,
+                    kind=evidence["kind"],
+                    payload=prepared["payload"],
+                    content_hash=prepared["content_hash"],
+                    captured_at=utcnow_naive(),
+                ))
+
+    def get_evidence_for_finding(self, finding_id: int) -> List[FindingEvidence]:
+        """Return the evidence rows backing a finding, newest first."""
+        return (
+            self._session.query(FindingEvidence)
+            .filter(FindingEvidence.finding_id == finding_id)
+            .order_by(FindingEvidence.captured_at.desc())
+            .all()
+        )
+
+    def delete_expired_evidence(self, retention_days: int) -> int:
+        """Borra la evidencia más vieja que ``retention_days``.
+
+        La evidencia crece rápido —hasta varios KiB por hallazgo confirmado, por
+        escaneo, por activo— y necesita caducidad desde el primer día, no cuando
+        la tabla ocupe gigas. Un valor 0 o negativo desactiva la purga (retención
+        indefinida), para el caso de auditoría que exige conservarlo todo.
+
+        Args:
+            retention_days: Días que se conserva la evidencia.
+
+        Returns:
+            El número de filas borradas.
+        """
+        if retention_days <= 0:
+            return 0
+        cutoff = utcnow_naive() - timedelta(days=retention_days)
+        deleted = (
+            self._session.query(FindingEvidence)
+            .filter(FindingEvidence.captured_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        return deleted
 
     def get_findings_by_scan(self, scan_id: int) -> List[Finding]:
         """Return all findings of a scan, newest first."""

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1072,6 +1072,36 @@ def lybra_engine_config() -> LybraEngineConfig:
     return load_block(LybraEngineConfig)
 
 
+@config_block("features.themis.scanners.lybra.evidence")
+@dataclass(frozen=True)
+class LybraEvidenceConfig:
+    """La captura de evidencia cruda por hallazgo (Fase E, L44).
+
+    Un hallazgo dice qué encontró y con qué regla, pero ``feed_version`` +
+    ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
+    respondió. Esta captura sí: la respuesta HTTP que provocó el hallazgo,
+    redactada, con su hash y su fecha, para poder defenderla ante un cliente.
+    """
+
+    enabled: bool = True
+    """Si se guarda la evidencia de los hallazgos confirmados."""
+
+    max_body_bytes: int = 8192
+    """Tope del cuerpo de respuesta que se guarda como evidencia (8
+    KiB). Una respuesta más larga se trunca, dejando constancia de cuántos
+    bytes se recortaron."""
+
+    retention_days: int = 90
+    """Días que se conserva la evidencia antes de purgarla. La
+    evidencia crece rápido —KiB por hallazgo, por escaneo, por activo— y necesita
+    caducidad desde el primer día. A 0 o menos, retención indefinida (el caso de
+    auditoría que exige conservarlo todo)."""
+
+
+def lybra_evidence_config() -> LybraEvidenceConfig:
+    return load_block(LybraEvidenceConfig)
+
+
 def lybra_ingest_config() -> LybraIngestConfig:
     return load_block(LybraIngestConfig)
 

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1385,3 +1385,84 @@ def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, 
     # El 443, que no se llegó a recorrer, no se cierra como corregido.
     fixed = [f for f in findings if f.state == "fixed"]
     assert fixed == []
+
+
+# ================================================= evidencia cruda (L44)
+
+
+def test_a_confirmed_http_finding_stores_its_redacted_evidence(monkeypatch, app, admin_user):
+    """Un hallazgo http confirmado guarda la respuesta que lo provocó, con las
+    cabeceras sensibles redactadas y su hash."""
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    # El objetivo expone /.git/config y manda una cookie de sesión.
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "[core]\n\trepositoryformatversion = 0\n",
+                     {"Server": "nginx", "Set-Cookie": "PHPSESSID=secret; HttpOnly"})
+            if path == "/.git/config" else Response(404, "", {}))
+    # Sin fingerprint ni TLS que enturbien.
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            findings = repo.get_findings_by_scan(escan.id)
+            git = next(f for f in findings if f.check_id == "lybra:git-config-exposure@1")
+            evidence = repo.get_evidence_for_finding(git.id)
+
+    assert len(evidence) == 1
+    row = evidence[0]
+    assert row.kind == "http_response"
+    assert row.payload["status"] == 200
+    assert "[core]" in row.payload["body"]
+    # El secreto no está: la cookie se redactó antes de persistir.
+    assert row.payload["headers"]["Set-Cookie"] == "[redacted]"
+    assert row.payload["headers"]["Server"] == "nginx"
+    assert len(row.content_hash) == 64
+
+
+def test_the_evidence_endpoint_returns_own_findings_and_404s_for_others(
+        client, monkeypatch, app, admin_user, regular_user, auth_headers):
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "[core]\n\trepositoryformatversion = 0\n", {"Server": "nginx"})
+            if path == "/.git/config" else Response(404, "", {}))
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            git = next(f for f in repo.get_findings_by_scan(escan.id)
+                       if f.check_id == "lybra:git-config-exposure@1")
+            finding_id = git.id
+
+    # El dueño ve su evidencia.
+    ok = client.get(f"/themis/findings/{finding_id}/evidence",
+                    headers=auth_headers(admin_user))
+    assert ok.status_code == 200
+    body = ok.get_json()
+    assert body["evidence"][0]["kind"] == "http_response"
+    assert body["evidence"][0]["contentHash"]
+
+    # Otro usuario recibe 404 (mismo criterio de propiedad que set_finding_state).
+    forbidden = client.get(f"/themis/findings/{finding_id}/evidence",
+                           headers=auth_headers(regular_user))
+    assert forbidden.status_code == 404

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -198,6 +198,7 @@ CONFIG_BLOCKS = [
     (CR.KnowledgeBaseConfig, CR.knowledge_base_config),
     (CR.LybraConfig, CR.lybra_config),
     (CR.LybraEngineConfig, CR.lybra_engine_config),
+    (CR.LybraEvidenceConfig, CR.lybra_evidence_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),

--- a/API/tests/unit/test_lybra_evidence.py
+++ b/API/tests/unit/test_lybra_evidence.py
@@ -1,0 +1,89 @@
+"""La evidencia cruda de un hallazgo: redacción, truncado y hash (L44).
+
+La parte pura, sin ORM ni red. La redacción es lo que separa «guardo lo que vi»
+de «me quedo con las llaves de casa del cliente», así que la mayoría de estos
+tests son sobre lo que **no** debe acabar en la base de datos.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.evidence import (
+    EvidenceRecorder,
+    build_recorder,
+    evidence_hash,
+    prepare_evidence,
+    redact_evidence,
+    redact_headers,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_sensitive_headers_lose_their_value_but_keep_their_name():
+    """Se conserva que la cabecera estaba —más honesto que fingir que no— y se
+    borra sólo el secreto."""
+    headers = {
+        "Server": "nginx",
+        "Set-Cookie": "PHPSESSID=deadbeef; HttpOnly",
+        "Authorization": "Bearer supersecret",
+        "X-Api-Key": "abc123",
+    }
+    redacted = redact_headers(headers)
+    assert redacted["Server"] == "nginx"
+    assert redacted["Set-Cookie"] == "[redacted]"
+    assert redacted["Authorization"] == "[redacted]"
+    assert redacted["X-Api-Key"] == "[redacted]"
+
+
+def test_redaction_is_case_insensitive_on_the_header_name():
+    assert redact_headers({"set-COOKIE": "x"})["set-COOKIE"] == "[redacted]"
+    assert redact_headers({"AUTHORIZATION": "x"})["AUTHORIZATION"] == "[redacted]"
+
+
+def test_the_body_is_truncated_to_the_configured_cap():
+    payload = {"body": "A" * 20000}
+    redacted = redact_evidence(payload, max_body_bytes=100)
+    assert len(redacted["body"].encode("utf-8")) == 100
+    assert redacted["body_truncated_bytes"] == 19900
+
+
+def test_a_short_body_is_left_alone():
+    payload = {"body": "corto"}
+    redacted = redact_evidence(payload, max_body_bytes=8192)
+    assert redacted["body"] == "corto"
+    assert "body_truncated_bytes" not in redacted
+
+
+def test_the_hash_is_stable_for_the_same_content():
+    payload = {"status": 200, "headers": {"b": "2", "a": "1"}, "body": "x"}
+    # El mismo contenido con las claves en otro orden produce el mismo hash.
+    other = {"body": "x", "status": 200, "headers": {"a": "1", "b": "2"}}
+    assert evidence_hash(payload) == evidence_hash(other)
+    assert len(evidence_hash(payload)) == 64
+
+
+def test_the_hash_changes_if_the_content_changes():
+    a = evidence_hash({"body": "hola"})
+    b = evidence_hash({"body": "adios"})
+    assert a != b
+
+
+def test_prepare_evidence_redacts_and_hashes_in_one_step():
+    payload = {"status": 200, "headers": {"Cookie": "secret"}, "body": "B" * 100}
+    prepared = prepare_evidence(payload, max_body_bytes=10)
+    assert prepared["payload"]["headers"]["Cookie"] == "[redacted]"
+    assert len(prepared["payload"]["body"].encode("utf-8")) == 10
+    # El hash es del contenido ya redactado, no del original.
+    assert prepared["content_hash"] == evidence_hash(prepared["payload"])
+
+
+def test_the_recorder_accumulates_records():
+    recorder = EvidenceRecorder()
+    recorder.record("k1", "http_response", {"status": 200})
+    recorder.record("k2", "http_response", {"status": 404})
+    assert [r.dedup_key for r in recorder.records] == ["k1", "k2"]
+
+
+def test_build_recorder_returns_none_when_disabled():
+    assert build_recorder(False) is None
+    assert isinstance(build_recorder(True), EvidenceRecorder)


### PR DESCRIPTION
## Resumen

Cierra #310.

Un hallazgo de Lybra dice **qué** encontró y **con qué regla**, pero no guardaba **lo que el objetivo respondió**. El roadmap lo formula bien: *«hoy `feed_version` + `check_id` dan reproducibilidad lógica, pero no guardan lo que el objetivo respondió»*.

Esa diferencia decide si un informe se puede defender. Cuando un cliente responde *«eso no es verdad, ese fichero no está expuesto»*, la respuesta útil es la respuesta HTTP con su cuerpo y su fecha, no *«nuestro check dice que sí»*. Sin evidencia, cada discusión se resuelve repitiendo el escaneo a mano. Y hay un segundo uso, interno y más frecuente: cuando el banco de precisión marca un falso positivo, sin la respuesta cruda no se puede saber **por qué** disparó el check.

## Qué se construye

- **Modelo `FindingEvidence`** (`finding_id`, `kind`, `payload` JSONB, `content_hash`, `captured_at`) con su migración. `ondelete=CASCADE`: la evidencia no tiene sentido sin su hallazgo.
- **Un recorder inyectable.** La capa pura `lybra/` **no puede tocar el ORM** (`test_lybra_package_invariants` lo fija), así que el runtime de checks adjunta la evidencia al hallazgo —viaja en la clave `_evidence` del dict— y es el manager quien la vuelca en la fase de persistencia. `evidence.py` sólo contiene lo que no depende de nada externo: redactar y hashear.
- **El endpoint `GET /themis/findings/<id>/evidence`**, con el mismo criterio de propiedad que `set_finding_state`: un hallazgo ajeno se reporta como `404`, sin revelar el `scan_id` de otro.

## Las tres precisiones que el issue pedía fijar

**1. Redacción obligatoria antes de persistir.** Una respuesta cruda puede traer cookies de sesión, cabeceras `Authorization`, tokens en el cuerpo o datos personales del objetivo. Guardar evidencia sin redactar convertiría la base de datos de Ellysia en un depósito de secretos ajenos —es la línea que separa «guardo lo que vi» de «me quedo con las llaves de casa del cliente»—. Se conserva el **nombre** de la cabecera sensible (dice que estaba) y se borra sólo su valor; el cuerpo se trunca a `maxBodyBytes` dejando constancia de cuántos bytes se recortaron. La lista de cabeceras sensibles cubre `Authorization`, `Cookie`/`Set-Cookie`, `WWW-Authenticate`, `X-Api-Key` y compañía, y se compara en minúsculas.

**2. El `content_hash` no es decorativo.** Es lo que permite decir «esta evidencia no se ha tocado desde que se capturó», la mitad del valor en un contexto de auditoría. Se calcula sobre el contenido **ya redactado** (no sobre el original, que no se guarda) y con las claves ordenadas, para que el mismo contenido produzca siempre el mismo hash.

**3. Retención configurable desde el primer día.** La evidencia crece rápido —KiB por hallazgo confirmado, por escaneo, por activo—. Cada escaneo que graba evidencia purga de paso la que ha pasado su `retentionDays`, así la tabla no crece sin fin **sin necesidad de un barredor aparte**. A 0 o menos, retención indefinida, para el caso de auditoría que exige conservarlo todo.

## Alcance de la captura

Se captura evidencia **de los hallazgos http confirmados** —los que van a un informe—, que es el caso que el criterio de cierre enfatiza (*«un hallazgo confirmado guarda la respuesta que lo provocó»*) y donde la respuesta cruda es más defendible. Los `kind` `ssh_banner`/`tls_cert`/`probe_output` quedan **declarados en el modelo** pero su captura desde el fingerprint es una pasada aparte: la evidencia del banner de un dissector es un recorder distinto, y meterlo aquí hincharía el PR sin cambiar el criterio de cierre.

## Configuración

Bloque `features.themis.scanners.lybra.evidence` con `enabled` (True), `maxBodyBytes` (8192) y `retentionDays` (90). Atado por `test_config_shape.py`.

## Validación

`pytest tests/unit -k "lybra or config"` y `tests/integration/test_lybra.py`: todo pasa, incluido `test_lybra_package_invariants` (`evidence.py` no toca el ORM). `pylint` sin avisos nuevos sobre la línea base (164 = 164), y `evidence.py` en 10,00/10.

- **`test_lybra_evidence.py`** (9 tests, sin red ni ORM): las cabeceras sensibles pierden el valor y conservan el nombre; la redacción es insensible a mayúsculas; el cuerpo se trunca al tope y deja la marca; el hash es estable ante el reordenamiento de claves y cambia con el contenido; y el recorder acumula.
- **Integración**: un escaneo que expone `/.git/config` y manda un `Set-Cookie` guarda la evidencia con la cookie **redactada** y el `Server` intacto, con su hash de 64 caracteres. Y el endpoint devuelve la evidencia al dueño (`200`) y `404` a otro usuario.

## Notas

- **La migración se apoya en `fd07fce5f920`** (la de `is_partial`, la última de la línea de Lybra). El repositorio tiene varios *heads* de Alembic por los merges recientes; no es algo que este PR introduzca ni corrija.
- El endpoint es nuevo, así que el **README** se actualizará en su commit propio al cierre de la fase, como manda `CLAUDE.md`.
