### PR TITLE
feat(themis): el DSL de checks encadena peticiones con variables extraídas y payloads

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -210,7 +210,8 @@
             "httpUserAgent": "Lybra/1.0",
             "networkTimeout": 5.0,
             "bannerTimeout": 2.0,
-            "maxBlindProbes": 2
+            "maxBlindProbes": 2,
+            "maxPayloadExpansions": 25
           },
           "evidence": {
             "enabled": true,

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -17,8 +17,14 @@ headers, and TLS/certificate hygiene (self-signed, expired, deprecated
 protocol — a ``type: "tls"`` check, evaluated against a handshake instead of an
 HTTP request/response), plus the raw protocol probes of ``type: "network"``
 (Fase N) and the first-party plugins of ``type: "script"`` (Fase R) for what no
-text matcher can express — a binary protocol, a multi-step negotiation. Request
-chaining and payloads/fuzzing are deliberate follow-ups.
+text matcher can express — a binary protocol, a multi-step negotiation. An
+``http`` check can also **chain** requests (L30): an ``extractors`` block pulls
+a variable out of one response — a session cookie, a CSRF token, a version
+string — and later requests in the same check reference it as ``{{name}}`` in
+their path, body or headers. **Payloads** (``payloads: {name: [v1, v2, ...]}``)
+expand a single check into several attempts, one per value substituted the
+same way, capped hard by ``lybra.engine.maxPayloadExpansions`` so a payload
+list never turns a check into a brute-force sweep.
 
 The runtime is pure given an injected ``fetch`` callable, so it can be
 unit-tested with hand-crafted responses and never touches the network in tests.
@@ -29,6 +35,7 @@ must wait on the authorized-targets register the roadmap calls for.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import re
@@ -61,7 +68,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-16"
+CHECKS_FEED_VERSION = "lybra-checks-17"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -253,11 +260,103 @@ class Matcher:
 
     def _part_text(self, response: Response) -> str:
         """Return the response text this matcher's ``part`` refers to."""
-        if self.part == "header":
-            return "\n".join(f"{k}: {v}" for k, v in response.headers.items())
-        if self.part == "status":
-            return str(response.status)
-        return response.body
+        return _part_text(response, self.part)
+
+
+def _part_text(response: Response, part: str) -> str:
+    """Return the text of a response ``part`` — ``body``, ``header`` or ``status``.
+
+    Shared by :class:`Matcher` and :class:`Extractor` so both name the same
+    three parts the same way; an unknown part falls back to the body.
+    """
+    if part == "header":
+        return "\n".join(f"{name}: {value}" for name, value in response.headers.items())
+    if part == "status":
+        return str(response.status)
+    return response.body
+
+
+# Un marcador de variable en el DSL: ``{{name}}``, la misma sintaxis que Nuclei,
+# con la que se aspira a mantener compatibilidad. El nombre admite letras,
+# dígitos, guion y guion bajo — lo justo para un identificador, sin abrir la
+# puerta a interpolar expresiones.
+_VARIABLE_RE = re.compile(r"\{\{\s*([A-Za-z0-9_-]+)\s*\}\}")
+
+
+def _substitute(text: str, variables: Dict[str, str]) -> str:
+    """Replace every ``{{name}}`` in ``text`` with its bound value.
+
+    A marker whose variable is not bound is left **verbatim**, not blanked: a
+    payload check with a typo'd ``{{fil}}`` should fail loudly by requesting a
+    literal ``{{fil}}`` path (a 404 that shows up), not silently probe ``/`` and
+    look like it ran. Substitution is single-pass, so a value that itself
+    contains ``{{...}}`` is not re-expanded — variables carry data from the
+    target, and re-expanding it would let a response steer later requests.
+
+    Args:
+        text: The template text (a path, body or header value).
+        variables: The bound variables.
+
+    Returns:
+        The rendered text.
+    """
+    return _VARIABLE_RE.sub(
+        lambda match: variables.get(match.group(1), match.group(0)), text)
+
+
+@dataclass(frozen=True)
+class Extractor:
+    """Pulls a named value out of a response, for the next request to reuse.
+
+    This is the piece that turns a check's requests from independent probes
+    into a *chain*: an extractor names a fragment of one response —a CSRF
+    token, a session id, a version string— and the runtime makes it available
+    as ``{{name}}`` in the ``path``, ``body`` and ``headers`` of every later
+    request in the **same** check. Without it there is no way to do
+    login → protected resource, because the second request cannot know what the
+    first one answered.
+
+    A single regular expression, matched against a chosen part of the response.
+    ``group`` selects which capture group is the value (``1`` by default, the
+    first parenthesised group; ``0`` is the whole match). When the pattern does
+    not match, the extractor yields nothing and the check is abandoned — a
+    chain whose link is missing cannot honestly claim to have fired.
+
+    Attributes:
+        name: The variable name the value is bound to (used as ``{{name}}``).
+        type: The extractor kind. Only ``"regex"`` exists today; the field is
+            here so the feed is explicit and a second kind is an added value,
+            not a reinterpretation.
+        part: Which part of the response to search — ``"body"``, ``"header"``
+            or ``"status"`` (same vocabulary as :class:`Matcher`).
+        pattern: The regular expression to search for.
+        group: Which capture group is the extracted value.
+    """
+    name: str
+    pattern: str
+    type: str = "regex"
+    part: str = "body"
+    group: int = 1
+
+    def extract(self, response: Response) -> Optional[str]:
+        """Return the value this extractor pulls from ``response``, or ``None``.
+
+        Args:
+            response: The response to search.
+
+        Returns:
+            The captured text, or ``None`` when the pattern does not match (or
+            names a group the pattern does not have) — the signal the runtime
+            reads as "this chain cannot continue".
+        """
+        text = _part_text(response, self.part)
+        match = re.search(self.pattern, text)
+        if match is None:
+            return None
+        try:
+            return match.group(self.group)
+        except IndexError:  # el patrón no tiene ese grupo — se trata como no-match
+            return None
 
 
 @dataclass(frozen=True)
@@ -285,6 +384,19 @@ class Request:
             own: where a reply stops is a fact about the protocol, so the feed
             declares it. Defaults to ``"line"``, the original behaviour.
             Unused by ``type: "http"``.
+        body: For ``type: "http"``, the request body — needed for anything
+            past a bare GET, a login POST above all. ``{{name}}`` placeholders
+            in it are substituted with variables the check has extracted or a
+            payload has bound. ``None`` sends no body.
+        headers: For ``type: "http"``, extra request headers as ``(name,
+            value)`` pairs (a tuple, not a dict, so the request stays a frozen
+            value). Their values also take ``{{name}}`` — the usual way a check
+            replays an extracted token is an ``Authorization`` or ``Cookie``
+            header on the next request.
+        extractors: The :class:`Extractor` s run against this request's
+            response, binding named values for the check's later requests. This
+            is what makes a check a chain rather than a set of independent
+            probes.
     """
     method: str = "GET"
     path: str = "/"
@@ -292,6 +404,9 @@ class Request:
     condition: str = "and"
     send: Optional[str] = None
     read: str = "line"
+    body: Optional[str] = None
+    headers: tuple = ()
+    extractors: tuple = ()
 
     def evaluate(self, response: Response) -> bool:
         """Return whether this request's matchers are satisfied by a response.
@@ -363,6 +478,15 @@ class Check:  # pylint: disable=too-many-instance-attributes
             given: they exist so a *selector* can decide which of thousands of
             ingested checks are worth running against a given service before
             the runtime ever sees them (see ``ingest.selector``).
+        payloads: Named lists of values the check fuzzes over, as ``(name,
+            values)`` pairs (a tuple of tuples, so the check stays a frozen
+            value). The runtime runs the whole request sequence once per
+            combination of payload values, substituting ``{{name}}`` in
+            ``path``/``body``/``headers`` each time — twenty backup-file names
+            probed by one check instead of twenty near-identical checks. The
+            cartesian product is **hard-capped** by the runtime
+            (``max_payload_expansions``) so a payload can never turn into an
+            hours-long brute force. Empty for a check that does not fuzz.
     """
     id: str
     version: int
@@ -380,6 +504,7 @@ class Check:  # pylint: disable=too-many-instance-attributes
     expect_banner: bool = False
     confirms: Optional[str] = None
     tags: tuple = ()
+    payloads: tuple = ()
 
     @property
     def check_id(self) -> str:
@@ -440,6 +565,18 @@ def _parse_check(c: dict) -> Check:
             condition=request.get("matchers-condition", "and"),
             send=request.get("send"),
             read=_parse_read_mode(request.get("read"), c.get("id")),
+            body=request.get("body"),
+            headers=tuple((str(name), str(value)) for name, value in (request.get("headers") or {}).items()),
+            extractors=tuple(
+                Extractor(
+                    name=extractor["name"],
+                    pattern=extractor.get("pattern") or extractor.get("regex") or "",
+                    type=extractor.get("type", "regex"),
+                    part=extractor.get("part", "body"),
+                    group=int(extractor.get("group", 1)),
+                )
+                for extractor in request.get("extractors", [])
+            ),
             matchers=tuple(
                 Matcher(
                     type=matcher["type"],
@@ -466,6 +603,10 @@ def _parse_check(c: dict) -> Check:
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
         confirms=c.get("confirms"),
+        payloads=tuple(
+            (str(name), tuple(str(value) for value in values))
+            for name, values in (c.get("payloads") or {}).items()
+        ),
     )
     _assert_service_is_reachable(check)
     return check
@@ -579,6 +720,12 @@ MATCHER_PARTS = ("body", "header", "status")
 # Forma de un identificador CVE, para validar el campo ``confirms``.
 _CVE_ID_RE = re.compile(r"^CVE-[0-9]{4}-[0-9]{4,}$")
 
+# Los tipos de extractor que :meth:`Extractor.extract` implementa. Sólo hay uno
+# hoy; validarlo evita que un ``type: xpath`` copiado de una plantilla de
+# Nuclei se cargue en silencio y no extraiga nunca nada — con lo que el
+# encadenamiento que dependa de esa variable se rompería sin decir por qué.
+EXTRACTOR_TYPES = ("regex",)
+
 
 def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=too-many-branches
     """Comprobar que ningún check está muerto por construcción.
@@ -659,6 +806,13 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=to
         if check.type in ("http", "network") and not check.requests:
             problems.append(f"Check {name!r}: de tipo {check.type!r} y sin ninguna petición")
 
+        # Un payload sin valores nunca expande nada, así que su ``{{name}}`` se
+        # queda literal en la petición: un check muerto que parece vivo.
+        for payload_name, values in check.payloads:
+            if not values:
+                problems.append(
+                    f"Check {name!r}: el payload {payload_name!r} no tiene ningún valor")
+
         for position, request in enumerate(check.requests):
             where = f"Check {name!r}, petición {position}"
             if request.read not in NETWORK_READ_MODES:
@@ -672,6 +826,25 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=to
                     problems.append(f"{where}: matcher sobre la parte {matcher.part!r}, que no existe")
                 if not matcher.values:
                     problems.append(f"{where}: matcher {matcher.type!r} sin valores que buscar")
+            for extractor in request.extractors:
+                if not extractor.name:
+                    problems.append(f"{where}: un extractor no declara 'name'")
+                if extractor.type not in EXTRACTOR_TYPES:
+                    problems.append(
+                        f"{where}: extractor de tipo {extractor.type!r} desconocido "
+                        f"(disponibles: {', '.join(EXTRACTOR_TYPES)})")
+                if extractor.part not in MATCHER_PARTS:
+                    problems.append(
+                        f"{where}: extractor sobre la parte {extractor.part!r}, que no existe")
+                if not extractor.pattern:
+                    problems.append(f"{where}: extractor {extractor.name!r} sin patrón")
+                else:
+                    try:
+                        re.compile(extractor.pattern)
+                    except re.error as compile_error:
+                        problems.append(
+                            f"{where}: extractor {extractor.name!r} con patrón inválido "
+                            f"({compile_error})")
 
     return problems
 
@@ -1098,6 +1271,7 @@ class CheckRuntime:
         script_plugins: Optional[Dict[str, object]] = None,
         mapper: Optional[Callable] = None,
         capture_evidence: bool = False,
+        max_payload_expansions: int = 25,
     ) -> None:
         self._checks = list(checks)
         self._fetch = fetch
@@ -1106,6 +1280,11 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
+        # El tope de expansiones de un payload (L30): un check que fuzzea corta
+        # aquí, pase lo que pase, para que no se vuelva un barrido de fuerza
+        # bruta. El manager lo inyecta desde la config; el default de 25 es el
+        # que un check declarativo espera si nadie lo toca.
+        self._max_payload_expansions = max(1, int(max_payload_expansions))
         # Cómo se recorren los servicios. Por defecto, el ``map`` de siempre:
         # uno detrás de otro. El manager inyecta aquí un pool acotado por host
         # (L23), igual que ya inyecta las sondas — este módulo no conoce la
@@ -1292,35 +1471,113 @@ class CheckRuntime:
     def _run_check(self, check: Check, host: str, service: Service) -> Optional[dict]:
         """Run one check against one service, returning a finding if it fired.
 
-        Every request in the check must fire (they are combined with AND). If any
-        request fails to reach the target or does not match, the check produces
-        nothing.
+        The check's requests run in sequence and are combined with AND: every
+        one must reach the target and match, or the check produces nothing. A
+        request can carry a ``body`` and ``headers``, and each request's
+        ``extractors`` bind ``{{name}}`` variables that later requests in the
+        same sequence substitute — that is the login → protected-resource chain.
+
+        When the check declares ``payloads``, the whole sequence runs once per
+        combination of payload values (``{{name}}`` substituted each time),
+        capped at ``max_payload_expansions``. The **first** combination that
+        fires wins: a check that probes twenty backup-file names is asking "is
+        *any* of these exposed?", and one hit answers it. Every finding still
+        carries a single ``check_id``, so twenty probes collapse to one finding.
         """
-        last_response = None
-        for request in check.requests:
-            response = self._probe_response(host, service, request.method, request.path)
-            if response is None or not request.evaluate(response):
-                return None
-            last_response = response
+        fired = None
+        for variables in self._payload_combinations(check):
+            fired = self._run_request_sequence(check, host, service, variables)
+            if fired is not None:
+                break
+        if fired is None:
+            return None
+        last_response, last_path = fired
         finding = self._finding(check, service)
         # Evidencia (Fase E): la respuesta que provocó el hallazgo. Sólo para
         # los confirmados —los que van a un informe— y sólo si la captura está
         # activada. El payload viaja en ``_evidence`` hasta la persistencia, que
-        # lo redacta y lo separa en su propia fila.
-        if (self._capture_evidence and last_response is not None
-                and finding.get("confirmed")):
+        # lo redacta y lo separa en su propia fila. La ruta es la ya sustituida
+        # (el payload o la variable que de verdad disparó), no la plantilla.
+        if self._capture_evidence and finding.get("confirmed"):
             finding["_evidence"] = {
                 "kind": "http_response",
                 "payload": {
                     "status": last_response.status,
                     "headers": dict(last_response.headers),
                     "body": last_response.body,
-                    "path": check.requests[-1].path,
+                    "path": last_path,
                 },
             }
         return finding
 
-    def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
+    def _payload_combinations(self, check: Check) -> List[Dict[str, str]]:
+        """Return the variable bindings to run the check's sequence under.
+
+        A check with no ``payloads`` runs once, with no bindings (``[{}]``): the
+        old behaviour, unchanged. A check *with* payloads runs once per element
+        of the cartesian product of its payload lists — ``{file: [a, b], ext:
+        [x, y]}`` yields four bindings — but never more than
+        ``max_payload_expansions`` of them. The cap is applied while the product
+        is generated (it is lazy), so a payload whose product is astronomically
+        large still costs only the capped number of iterations, not the full
+        expansion followed by a slice.
+        """
+        if not check.payloads:
+            return [{}]
+        names = [name for name, _ in check.payloads]
+        value_lists = [values for _, values in check.payloads]
+        combinations: List[Dict[str, str]] = []
+        for combination in itertools.product(*value_lists):
+            combinations.append(dict(zip(names, combination)))
+            if len(combinations) >= self._max_payload_expansions:
+                break
+        return combinations
+
+    def _run_request_sequence(
+        self, check: Check, host: str, service: Service, variables: Dict[str, str],
+    ) -> Optional[Tuple[Response, str]]:
+        """Run a check's requests once, threading extracted variables through.
+
+        Each request's ``path``/``body``/``headers`` are rendered with the
+        variables gathered so far (the payload binding this call started with,
+        plus whatever earlier requests extracted). Every request must match; a
+        request that fails to reach the target, does not match, **or whose
+        extractor finds nothing** abandons the whole sequence — a chain with a
+        missing link never fired.
+
+        Args:
+            check: The check being run.
+            host: The target host.
+            service: The service being probed.
+            variables: The initial variable bindings (a payload combination, or
+                empty).
+
+        Returns:
+            ``(last_response, last_path)`` if every request matched, else
+            ``None``. The path comes back rendered so the caller can record the
+            request that actually fired as evidence.
+        """
+        variables = dict(variables)
+        last: Optional[Tuple[Response, str]] = None
+        for request in check.requests:
+            path = _substitute(request.path, variables)
+            body = _substitute(request.body, variables) if request.body else None
+            headers = {name: _substitute(value, variables) for name, value in request.headers} or None
+            response = self._probe_response(host, service, request.method, path, body, headers)
+            if response is None or not request.evaluate(response):
+                return None
+            for extractor in request.extractors:
+                value = extractor.extract(response)
+                if value is None:
+                    return None
+                variables[extractor.name] = value
+            last = (response, path)
+        return last
+
+    def _probe_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, service: Service, method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Response]:
         """Return the response for one request, asking the target only once.
 
         Every check runs independently, which is what keeps them simple, but
@@ -1331,19 +1588,29 @@ class CheckRuntime:
 
         Noise on the target is not a side issue for a security scanner: it
         shows up in the SIEM of whoever hired us. So a response is fetched once
-        per ``(method, path)`` and shared by every check that asks for it,
-        within one :meth:`run`.
+        per ``(method, path, body, headers)`` and shared by every check that
+        asks for it, within one :meth:`run`.
+
+        The ``body``/``headers`` are optional so the vast majority of checks —
+        bare GETs — call the injected ``fetch`` with the same four positional
+        arguments it always took: a test ``fetch`` written as ``(host, port,
+        method, path)`` keeps working, and only a check that actually sends a
+        body or headers requires a ``fetch`` that accepts them.
 
         A transport failure is remembered too. Not caching it would mean three
         attempts against a service that is down — the case where retrying costs
         the most and informs the least.
         """
-        key = (host, service.port, method, path)
+        header_key = tuple(sorted(headers.items())) if headers else None
+        key = (host, service.port, method, path, body, header_key)
         if key in self._responses:
             return self._responses[key]
         if self._rl is not None:
             self._rl.acquire(host)
-        response = self._fetch(host, service.port, method, path)
+        if body is None and headers is None:
+            response = self._fetch(host, service.port, method, path)
+        else:
+            response = self._fetch(host, service.port, method, path, body, headers)
         self._responses[key] = response
         return response
 
@@ -1613,7 +1880,10 @@ class HttpProbe:
             urllib.request.HTTPSHandler(context=ssl._create_unverified_context())
         )
 
-    def fetch(self, host: str, port: Optional[int], method: str, path: str) -> Optional[Response]:
+    def fetch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, port: Optional[int], method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Response]:
         """Make a request and return it as a :class:`Response`.
 
         Args:
@@ -1621,15 +1891,20 @@ class HttpProbe:
             port: The target port (decides http vs https).
             method: The HTTP method.
             path: The request path.
+            body: The request body (L30), or ``None`` for none. A non-GET check
+                — a login POST above all — needs this.
+            headers: Extra request headers (L30), or ``None``. The way a chained
+                check replays an extracted token: an ``Authorization`` or
+                ``Cookie`` header on the follow-up request.
 
         Returns:
             The response, or ``None`` on a transport failure.
         """
-        result = self._request(host, port, method, path)
+        result = self._request(host, port, method, path, body, headers)
         if result is None:
             return None
-        status, body, headers = result
-        return self._to_response(status, body, headers)
+        status, response_body, response_headers = result
+        return self._to_response(status, response_body, response_headers)
 
     def fetch_bytes(self, host: str, port: Optional[int], path: str) -> Optional[bytes]:
         """Fetch raw bytes for binary content such as a favicon.
@@ -1652,18 +1927,29 @@ class HttpProbe:
         status, body, _headers = result
         return body if status == 200 else None
 
-    def _request(self, host: str, port: Optional[int], method: str, path: str) -> Optional[tuple]:
+    def _request(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, port: Optional[int], method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[tuple]:
         """Perform the raw HTTP request, returning ``(status, body, headers)``.
 
         A 4xx/5xx is returned normally; only a transport failure returns ``None``.
         HTTPS uses an unverified TLS context, since we are scanning arbitrary
         hosts whose certificates we do not control.
+
+        The check-supplied ``headers`` are layered over the probe's own
+        ``User-Agent`` (a check may deliberately override it), and ``body`` is
+        sent UTF-8 encoded. Both are absent for the common read-only GET.
         """
         scheme = self._scheme_for(host, port)
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
+        request_headers = {"User-Agent": self._user_agent}
+        if headers:
+            request_headers.update({str(name): str(value) for name, value in headers.items()})
+        data = body.encode("utf-8") if body is not None else None
         try:
-            request = urllib.request.Request(url, method=method, headers={"User-Agent": self._user_agent})
+            request = urllib.request.Request(url, method=method, headers=request_headers, data=data)
             with self._opener.open(request, timeout=self._timeout) as response:
                 return response.status, response.read(self._max_bytes), dict(response.headers)
         except urllib.error.HTTPError as err:

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -1395,3 +1395,45 @@ checks:
       title: 'Apache path traversal confirmado (CVE-2021-42013): /etc/passwd legible'
       qod: 99
       confirmed: true
+  # ---------------------------------------------------------------------------
+  # PAYLOADS (L30) — una lista de valores sustituidos en la ruta, en vez de un
+  # check por variación. Este busca un volcado de base de datos olvidado bajo
+  # la raíz web: los nombres de fichero de copia de seguridad más habituales,
+  # probados con una sola entrada de feed. El motor expande ``{{name}}`` una
+  # vez por valor y corta en ``maxPayloadExpansions``, así que la lista puede
+  # crecer sin volverse un barrido. Cualquiera que devuelva 200 con pinta de
+  # volcado SQL dispara; un solo hallazgo, sea cual sea el que picó.
+  - id: sql-dump-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    payloads:
+      name:
+        - backup.sql
+        - dump.sql
+        - database.sql
+        - db.sql
+        - backup.sql.gz
+        - www.sql
+        - site.sql
+    requests:
+      - method: GET
+        path: /{{name}}
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'CREATE TABLE'
+              - 'INSERT INTO'
+              - 'DROP TABLE'
+    finding:
+      title: Volcado de base de datos SQL expuesto bajo la raíz web
+      qod: 99
+      confirmed: true

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -484,6 +484,7 @@ class LybraEngineManager(ScanManager):
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
                 capture_evidence=CR.lybra_evidence_config().enabled,
+                max_payload_expansions=engine.max_payload_expansions,
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
                 # red servicio a servicio— y el mismo motivo para no hacerla en

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -898,6 +898,16 @@ class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
     presupuesto que separa "prueba lo que ya sabes leer" de un escaneo de
     servicios completo. A cero, la cascada se queda sólo en el saludo."""
 
+    # --- DSL de checks: payloads/fuzzing (checks.CheckRuntime)
+    max_payload_expansions: int = 25
+    """Tope duro de peticiones que un check con ``payloads`` puede expandir
+    (L30). Un payload es una lista de valores —veinte nombres de fichero de
+    copia de seguridad, pongamos— que se sustituyen en la petición, y sin un
+    tope el producto cartesiano de varias listas convierte un check en un
+    barrido de fuerza bruta de horas. El motor corta en cuanto alcanza este
+    número, así que es la diferencia entre "prueba unas cuantas variaciones" y
+    "prueba el diccionario entero"."""
+
 
 @config_block("features.themis.scanners.lybra.ingest")
 @dataclass(frozen=True)

--- a/API/tests/unit/test_lybra_dsl_chaining.py
+++ b/API/tests/unit/test_lybra_dsl_chaining.py
@@ -1,0 +1,251 @@
+"""El DSL de checks: variables extraídas, encadenamiento y payloads (L30).
+
+El motor sabía hacer una petición y mirar la respuesta, y nada más. No podía
+leer un dato de una respuesta y usarlo en la siguiente (login → recurso
+protegido), ni probar la misma ruta con veinte nombres de fichero sin escribir
+veinte checks. Esto añade las tres piezas que faltaban —**extractores**,
+**cuerpo/cabeceras** y **payloads con tope**— y aquí se prueban las tres, más
+las dos reglas que las hacen seguras: un extractor que no casa **aborta** la
+cadena, y un payload **nunca** supera el tope de expansiones.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    Check,
+    CheckRuntime,
+    Extractor,
+    Matcher,
+    Request,
+    Response,
+    Service,
+    _substitute,
+    load_checks,
+    validate_checks,
+)
+
+pytestmark = pytest.mark.unit
+
+_SVC = Service(80, "tcp", "http", None, None, None)
+
+
+def _run(check, fetch, **kwargs):
+    return CheckRuntime([check], fetch, **kwargs).run("10.0.0.1", [_SVC])
+
+
+# =============================================== sustitución de variables (unidad)
+
+
+def test_substitute_replaces_a_bound_variable():
+    assert _substitute("/user/{{id}}", {"id": "42"}) == "/user/42"
+
+
+def test_substitute_leaves_an_unbound_marker_verbatim():
+    """Un marcador sin valor se deja tal cual —no se borra— para que un typo
+    falle a la vista (una ruta con ``{{fil}}`` literal da un 404 visible) en vez
+    de sondear ``/`` en silencio y parecer que corrió."""
+    assert _substitute("/{{fil}}", {"name": "x"}) == "/{{fil}}"
+
+
+def test_substitute_does_not_re_expand_a_value():
+    """Una sola pasada: un valor que a su vez trae ``{{...}}`` no se vuelve a
+    expandir. El valor viene del objetivo, y re-expandirlo dejaría que una
+    respuesta dirigiera las peticiones siguientes."""
+    assert _substitute("{{a}}", {"a": "{{b}}", "b": "x"}) == "{{b}}"
+
+
+# =============================================== extractores + encadenamiento
+
+
+def test_an_extractor_binds_a_value_for_the_next_request():
+    """La pieza que convierte dos peticiones sueltas en una cadena: la primera
+    extrae un token, la segunda lo usa en la ruta."""
+    first = Request(
+        path="/token",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="tok", pattern=r"TOKEN=([A-Z0-9]+)"),),
+    )
+    second = Request(
+        path="/resource/{{tok}}",
+        matchers=(Matcher(type="status", values=(200,)),),
+    )
+    check = Check(id="chain", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(first, second), finding={"title": "x"})
+
+    requested = []
+
+    def fetch(host, port, method, path, *args):
+        requested.append(path)
+        if path == "/token":
+            return Response(200, "TOKEN=ABC123", {})
+        if path == "/resource/ABC123":
+            return Response(200, "ok", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:chain@1"]
+    assert requested == ["/token", "/resource/ABC123"]
+
+
+def test_a_login_chain_uses_body_and_headers():
+    """El criterio de cierre entero: login (POST con cuerpo) → recurso protegido
+    (GET con el token de sesión en una cabecera), encadenados por una variable
+    extraída de la respuesta del login."""
+    login = Request(
+        method="POST", path="/login", body="user=admin&pass={{pw}}",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="sid", pattern=r"sid: ([A-Za-z0-9]+)", part="header"),),
+    )
+    protected = Request(
+        method="GET", path="/admin", headers=(("Cookie", "session={{sid}}"),),
+        matchers=(Matcher(type="word", part="body", values=("bienvenido",)),),
+    )
+    # ``pw`` llega como payload de un solo valor: prueba de paso que payload y
+    # extracción conviven en la misma cadena.
+    check = Check(id="login", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  payloads=(("pw", ("s3cret",)),),
+                  requests=(login, protected), finding={"title": "x"})
+
+    def fetch(host, port, method, path, body=None, headers=None):
+        if method == "POST" and path == "/login":
+            assert body == "user=admin&pass=s3cret", body
+            return Response(200, "", {"sid": "Tok9"})
+        if method == "GET" and path == "/admin":
+            assert headers == {"Cookie": "session=Tok9"}, headers
+            return Response(200, "bienvenido", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:login@1"]
+
+
+def test_an_extractor_that_does_not_match_aborts_the_check():
+    """La regla que hace fiable el encadenamiento: si el extractor no encuentra
+    su valor, la cadena no puede continuar honestamente, así que el check no
+    dispara —ni siquiera lanza la petición siguiente."""
+    first = Request(
+        path="/token",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="tok", pattern=r"NO_APARECE=([0-9]+)"),),
+    )
+    second = Request(path="/resource/{{tok}}",
+                     matchers=(Matcher(type="status", values=(200,)),))
+    check = Check(id="chain", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(first, second), finding={"title": "x"})
+
+    requested = []
+
+    def fetch(host, port, method, path, *args):
+        requested.append(path)
+        return Response(200, "sin token aquí", {})
+
+    assert _run(check, fetch) == []
+    assert requested == ["/token"]        # la segunda petición nunca se lanza
+
+
+def test_a_backward_compatible_fetch_still_works_for_plain_checks():
+    """Un check sin cuerpo ni cabeceras llama al ``fetch`` con los cuatro
+    argumentos posicionales de siempre, así que un ``fetch`` de test escrito
+    ``(host, port, method, path)`` sigue valiendo —sólo los checks que de
+    verdad mandan cuerpo o cabeceras necesitan un ``fetch`` que los acepte."""
+    check = Check(id="plain", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(Request(path="/.git/config",
+                                    matchers=(Matcher(type="status", values=(200,)),)),),
+                  finding={"title": "x"})
+
+    def four_arg_fetch(host, port, method, path):     # exactamente cuatro
+        return Response(200, "", {})
+
+    assert [f["check_id"] for f in _run(check, four_arg_fetch)] == ["lybra:plain@1"]
+
+
+# =============================================== payloads + tope
+
+
+def _sql_dump_check():
+    return [c for c in load_checks() if c.id == "sql-dump-exposure"][0]
+
+
+def test_a_payload_expands_one_request_over_many_values():
+    """Un check con payloads prueba cada valor sin escribir un check por
+    valor: aquí, siete nombres de volcado SQL con una sola entrada de feed."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        if path == "/db.sql":
+            return Response(200, "INSERT INTO users VALUES (1);", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:sql-dump-exposure@1"]
+    assert "/backup.sql" in tried and "/db.sql" in tried
+
+
+def test_a_payload_never_exceeds_the_expansion_cap():
+    """El tope no es opcional: es lo que impide que un payload se convierta en
+    un barrido. Con el tope en 2, sólo se prueban dos valores —aunque un valor
+    posterior sí existiría, no se llega a él y el check no dispara."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        # database.sql es el tercer payload: existiría, pero el tope lo deja fuera
+        return Response(200, "CREATE TABLE x", {}) if path == "/database.sql" else Response(404, "", {})
+
+    findings = _run(check, fetch, max_payload_expansions=2)
+    assert findings == []
+    assert len(tried) == 2
+
+
+def test_the_first_matching_payload_wins_as_a_single_finding():
+    """Veinte sondas colapsan en un hallazgo: en cuanto un valor pica, el check
+    dispara una vez y no sigue probando el resto."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        return Response(200, "CREATE TABLE x", {})       # todos "existen"
+
+    findings = _run(check, fetch)
+    assert len(findings) == 1
+    assert len(tried) == 1                                # paró en el primero
+
+
+# =============================================== validación de forma (CI, #275)
+
+
+def test_the_shipped_feed_including_the_payload_check_is_well_formed():
+    assert validate_checks(load_checks()) == []
+
+
+def test_an_extractor_with_an_invalid_regex_is_reported():
+    bad = Request(path="/", matchers=(Matcher(type="status", values=(200,)),),
+                  extractors=(Extractor(name="x", pattern="(sin cerrar"),))
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(bad,), finding={})
+    assert any("patrón inválido" in problem for problem in validate_checks([check]))
+
+
+def test_an_extractor_without_a_name_is_reported():
+    bad = Request(path="/", matchers=(Matcher(type="status", values=(200,)),),
+                  extractors=(Extractor(name="", pattern="x"),))
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(bad,), finding={})
+    assert any("'name'" in problem for problem in validate_checks([check]))
+
+
+def test_a_payload_with_no_values_is_reported():
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  payloads=(("name", ()),),
+                  requests=(Request(path="/{{name}}",
+                                    matchers=(Matcher(type="status", values=(200,)),)),),
+                  finding={})
+    assert any("no tiene ningún valor" in problem for problem in validate_checks([check]))


### PR DESCRIPTION
## Resumen

Cierra #300. El DSL de checks sabía hacer una petición y mirar la respuesta, y nada más — el propio módulo lo admitía desde su primera línea: *"el encadenamiento de peticiones y los payloads/fuzzing son seguimientos deliberados"*. Este PR entrega los tres.

## El problema, en dos escenarios reales

**Sin variables entre peticiones**, un check no puede expresar "haz login, y con lo que te devuelva, pide el recurso protegido". Cada petición del check es ciega a lo que respondieron las anteriores. Eso deja fuera cualquier flujo con estado: login → panel, token CSRF → formulario, "lee un id de la respuesta A y úsalo en la B".

**Sin payloads**, probar la misma ruta con veinte nombres de fichero de copia de seguridad —`backup.sql`, `dump.sql`, `db.sql`...— cuesta veinte entradas casi idénticas en el feed. El feed que #296 hizo crecer a más de sesenta checks se vuelve difícil de mantener así.

## Las tres piezas, y cómo encajan

**Extractores.** Un `Request` puede llevar `extractors: [{name: tok, pattern: "TOKEN=([A-Z0-9]+)"}]`. Cuando esa petición responde, el runtime busca el patrón —sobre el `body`, una cabecera o el status, igual que un matcher— y, si casa, liga el valor capturado a `{{tok}}`. Cualquier petición **posterior del mismo check** puede referenciar `{{tok}}` en su `path`, su `body` o sus cabeceras, y el runtime lo sustituye antes de disparar la petición. Esto es lo que convierte una lista de peticiones sueltas en una cadena.

**Cuerpo y cabeceras.** Hasta ahora un `Request` sólo tenía `method`/`path` — no había forma de mandar un POST de login con sus credenciales, ni de reenviar un token en una cabecera `Authorization` o `Cookie`. Ambos campos aceptan `{{name}}` igual que el `path`.

**Payloads, con tope duro.** Un `Check` puede declarar `payloads: {name: [backup.sql, dump.sql, db.sql, ...]}`. El runtime corre la secuencia de peticiones **una vez por valor** —o por combinación, si hay varias listas: el producto cartesiano—, sustituyendo `{{name}}` cada vez, y para en cuanto una combinación dispara: veinte sondas colapsan en un único hallazgo. El tope (`lybra.engine.maxPayloadExpansions`, 25 por defecto) se aplica generando el producto de forma perezosa, así que una combinatoria enorme cuesta como mucho el tope, nunca la expansión completa. **No es opcional**: es lo único que impide que una lista de payloads se convierta en un barrido de fuerza bruta por accidente.

## La regla que hace fiable la cadena

**Un extractor que no encuentra su patrón aborta el check entero**, sin lanzar la petición siguiente. Una cadena con un eslabón que falta no puede afirmar honestamente que disparó — así que ni lo intenta. Es la garantía simétrica a la que ya llevaba `confirms` en #298 (un confirmador que no confirma nada no dispara): aquí, una cadena que no puede continuar no sigue adelante fingiendo que sí.

## Compatibilidad hacia atrás

El cambio más delicado técnicamente: el `fetch` que el runtime inyecta pasó de recibir siempre cuatro argumentos (`host, port, method, path`) a poder recibir también `body`/`headers`. Para no romper los más de sesenta tests existentes —cada uno con su propio `fetch` de prueba escrito con la firma de cuatro argumentos— el runtime llama al `fetch` con la firma **corta** cuando el check no manda cuerpo ni cabeceras (el caso de siempre, un GET simple), y sólo añade `body`/`headers` cuando el check de verdad los declara. Un `fetch` de test escrito `(host, port, method, path)` sigue funcionando sin tocarlo; sólo un check que use las piezas nuevas necesita un `fetch` que las acepte. Hay un test dedicado a esta garantía (`test_a_backward_compatible_fetch_still_works_for_plain_checks`).

## Validación de forma

Un extractor sin `name`, con un `type` que no sea `regex`, sobre una `part` que no existe, o con un patrón que no compila como regex — los cuatro casos se detectan en `validate_checks` y se listan como problemas legibles, no se lanzan a mitad de un escaneo. Igual para un payload sin ningún valor: expandiría a nada y el `{{name}}` se quedaría literal en la petición, un check muerto que parece vivo.

## Ejemplo real en el feed

`sql-dump-exposure`: un solo check con siete nombres habituales de volcado SQL (`backup.sql`, `dump.sql`, `database.sql`, ...) en vez de siete entradas casi idénticas. Es exactamente el ahorro que el diagnóstico del issue nombra.

## Validación

`pytest tests/unit -k lybra` y `tests/integration/test_lybra.py` (sin Docker): todo pasa. `pylint src`: 10.00/10.

`tests/unit/test_lybra_dsl_chaining.py`, 14 tests. Los que sostienen el diseño:

- `test_an_extractor_binds_a_value_for_the_next_request` — la cadena mínima: la primera petición extrae, la segunda usa.
- `test_a_login_chain_uses_body_and_headers` — el criterio de cierre completo: login (POST con cuerpo) → recurso protegido (GET con el token en una cabecera), con un payload de un solo valor conviviendo en la misma cadena.
- `test_an_extractor_that_does_not_match_aborts_the_check` — la garantía de fiabilidad: sin el token, la segunda petición **ni se lanza**.
- `test_a_backward_compatible_fetch_still_works_for_plain_checks` — ningún check existente paga nada por esto.
- `test_a_payload_never_exceeds_the_expansion_cap` — con el tope en 2, el tercer valor (que sí dispararía) nunca se prueba.
- `test_the_first_matching_payload_wins_as_a_single_finding` — veinte sondas, un hallazgo.
- Más la sustitución de variables en aislamiento (`_substitute`) y la validación de forma de extractores y payloads mal construidos.

## Notas

- Sólo `type: "http"` recibe estas tres piezas — es el ámbito exacto que el issue marca (`Request`, `Check`, `_load_request`, `CheckRuntime._run_check`); `type: "network"` sigue sin tocarse.
- `feedVersion` sube a `lybra-checks-17`: es capacidad nueva del esquema, no el arreglo de un check.
- Habilita la Fase A (#317, exposición de APIs, que pide explícitamente "variables de sesión para encadenar login → endpoint") y hace mantenible el crecimiento futuro de #296.
- No se toca el banco `oracle`.
