### PR TITLE
feat(themis): motor de credenciales por defecto tras la doble puerta del modo agresivo

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -218,6 +218,9 @@
             "maxBodyBytes": 8192,
             "retentionDays": 90
           },
+          "credentials": {
+            "maxAttempts": 3
+          },
           "fingerprintingEnabled": true,
           "ingest": {
             "enabled": false,

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -388,7 +388,8 @@ def start_lybra_scan(data):
         user_id=user.id,
         target=target,
         discover_ports=discover_ports,
-        timeout=timeout
+        timeout=timeout,
+        aggressive=data.get("aggressive", False),
     )
     logger.info(f"Lybra lanzado: ID={scan_id} autodescubrimiento target={target} user={user.username}")
 

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -104,6 +104,14 @@ from .script_checks import (
     SnmpDefaultCommunityPlugin,
     default_script_plugins,
 )
+from .credentials import (
+    load_credentials,
+    validate_credentials,
+    CredentialRuntime,
+    CredentialEntry,
+    CredentialPair,
+    CREDENTIALS_FEED_VERSION,
+)
 from .correlation import (
     classify_exposure,
     compute_dedup_key,
@@ -257,6 +265,12 @@ __all__ = [
     "SmbSigningNotRequiredPlugin",
     "SnmpDefaultCommunityPlugin",
     "default_script_plugins",
+    "load_credentials",
+    "validate_credentials",
+    "CredentialRuntime",
+    "CredentialEntry",
+    "CredentialPair",
+    "CREDENTIALS_FEED_VERSION",
     "classify_exposure",
     "compute_dedup_key",
     "merge_findings",

--- a/API/src/modules/features/themis/lybra/credentials.py
+++ b/API/src/modules/features/themis/lybra/credentials.py
@@ -1,0 +1,357 @@
+"""El motor de credenciales por defecto — Fase D del roadmap (L31).
+
+Es la **única** familia de detección de Lybra que escribe en el objetivo: cada
+intento es un login real contra un servicio real. El roadmap lo dice sin
+rodeos — *"es una operación que escribe en el objetivo, que puede bloquear
+cuentas, que genera ruido en el SIEM del objetivo y que exige un control de
+tasa y un presupuesto muy distintos a un GET de .git/config"* — y por eso vive
+en su propio módulo, con sus propias guardas, en vez de ser un ``Check`` más
+del DSL declarativo de :mod:`checks`.
+
+**Las guardas no son opcionales, y son del llamante, no de aquí.** Este
+runtime no decide si debe correr: el manager lo invoca sólo bajo la doble
+puerta del modo agresivo (L40) — objetivo en el registro de autorización *y*
+petición explícita del usuario —, exactamente igual que cualquier otro check
+``mode: aggressive``. Lo que sí es responsabilidad de este módulo es el
+presupuesto de intentos: **por cuenta, no por servicio** — tres contraseñas
+distintas contra ``admin`` cuentan tres intentos para ``admin``, sin que
+probar además ``root`` en el mismo servicio consuma ese mismo cupo. Es la
+cuenta, no el servicio, la que un proveedor bloquea tras demasiados fallos.
+
+**El plaintext nunca sale de este módulo.** Una vez usada para construir la
+cabecera ``Authorization``, una contraseña no vuelve a aparecer en ningún
+dict que este módulo produzca — ni en el hallazgo, ni en su evidencia, ni en
+un log. Sólo el *nombre de usuario* que funcionó se recuerda, porque decir
+"la cuenta admin tiene la contraseña de fábrica" es información útil para
+quien recibe el informe; decir cuál era la contraseña no lo es, y guardarla
+convertiría la base de datos de un cliente en un depósito de las contraseñas
+del propio cliente.
+
+Reutiliza deliberadamente piezas de :mod:`checks` en vez de duplicarlas: el
+mismo :class:`~.checks.Matcher` decide si una respuesta demuestra que el login
+funcionó, el mismo :class:`~.checks.Response` es lo que un matcher evalúa, y
+el ``fetch`` inyectado es la misma forma que :class:`~.checks.HttpProbe.fetch`
+ya expone desde L30 (``host, port, method, path, body, headers``) — un intento
+de credenciales *es* una petición HTTP con una cabecera ``Authorization``,
+nada más.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+from .checks import HostRateLimiter, Matcher, Response, is_http_service
+
+logger = logging.getLogger(__name__)
+
+# El feed shipped junto al de checks.py, mismo directorio, mismo trato: JSON
+# porque estos pares no necesitan comentarios extensos por entrada como el
+# feed de checks (una lista de pares usuario/contraseña se explica sola), y
+# porque no aspira a compatibilidad con ningún formato externo (a diferencia
+# de checks_feed.yaml, que sí la busca con Nuclei).
+_BUNDLED_FEED = Path(__file__).parent / "feeds" / "credentials_feed.json"
+
+CREDENTIALS_FEED_VERSION = "lybra-credentials-1"
+QOD_CONFIRMED = 99
+
+# Servicios candidatos hoy. Sólo HTTP: es donde vive Tomcat Manager, Jenkins y
+# la mayoría de paneles de administración con credenciales de fábrica
+# conocidas, y es el único protocolo para el que ``HttpProbe.fetch`` ya sabe
+# mandar una cabecera ``Authorization`` (L30). Ampliar a FTP/SSH es straight-
+# forward por el mismo camino que las familias ``network`` de checks.py —
+# inyectar un ``attempt`` en vez de un ``fetch`` HTTP—, pero no hay ninguna
+# entrada del feed que lo necesite todavía.
+_SERVICE_MATCHERS: Dict[str, Callable] = {
+    "http": is_http_service,
+}
+
+
+@dataclass(frozen=True)
+class CredentialPair:
+    """Un par usuario/contraseña de fábrica a probar.
+
+    Attributes:
+        username: El nombre de usuario.
+        password: La contraseña. Vive únicamente aquí y en la cabecera HTTP
+            que :class:`CredentialRuntime` construye con ella — nunca en un
+            hallazgo, en su evidencia, ni en un log.
+    """
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class CredentialEntry:  # pylint: disable=too-many-instance-attributes
+    """Un producto con credenciales de fábrica conocidas y cómo probarlas.
+
+    Attributes:
+        id: Identificador corto, p. ej. ``"tomcat-manager-default"``.
+        version: Versión de la entrada — misma convención que
+            :attr:`~.checks.Check.version`: sube cuando cambia qué prueba o
+            cómo, no cuando sólo se añade un par a la lista.
+        service: Qué servicio reclama esta entrada (``"http"`` hoy — ver
+            :data:`_SERVICE_MATCHERS`).
+        method: El método HTTP de la sonda.
+        path: La ruta a la que se manda cada intento (p. ej.
+            ``"/manager/html"`` para Tomcat Manager).
+        accounts: Los pares a probar, en orden. El mismo usuario puede
+            aparecer varias veces con contraseñas distintas — así es como el
+            presupuesto "por cuenta" tiene sentido: agota primero las
+            contraseñas de una cuenta antes de pasar a la siguiente.
+        matchers: Las condiciones que demuestran que el intento entró — el
+            mismo :class:`~.checks.Matcher` que usa el DSL declarativo,
+            combinadas con AND. Un ``status: 200`` solo no basta contra un
+            servidor que sirve sin autenticar; el feed añade además una
+            palabra del cuerpo esperado tras entrar.
+        finding: Plantilla de campos del hallazgo (``title`` sobre todo).
+        feed_version: Versión del feed de origen, o ``None`` para usar
+            :data:`CREDENTIALS_FEED_VERSION`.
+    """
+    id: str
+    version: int
+    service: str
+    path: str
+    accounts: tuple
+    matchers: tuple
+    method: str = "GET"
+    finding: dict = field(default_factory=dict)
+    feed_version: Optional[str] = None
+
+    @property
+    def check_id(self) -> str:
+        """El identificador versionado, p. ej. ``lybra-credentials:tomcat-manager-default@1``."""
+        return f"lybra-credentials:{self.id}@{self.version}"
+
+
+# =========================================================================
+# FEED LOADING
+# =========================================================================
+
+def load_credentials(path: Optional[str] = None) -> List[CredentialEntry]:
+    """Cargar y parsear el feed de credenciales por defecto.
+
+    Args:
+        path: Ruta a un feed JSON. Por defecto, el empaquetado con el módulo.
+
+    Returns:
+        Las entradas parseadas.
+    """
+    feed_path = Path(path) if path else _BUNDLED_FEED
+    document = json.loads(feed_path.read_text(encoding="utf-8"))
+    return [_parse_entry(entry) for entry in document.get("entries", [])]
+
+
+def _parse_entry(raw: dict) -> CredentialEntry:
+    """Construir una :class:`CredentialEntry` desde su representación JSON."""
+    return CredentialEntry(
+        id=raw["id"],
+        version=raw.get("version", 1),
+        service=raw.get("service", "http"),
+        method=raw.get("method", "GET"),
+        path=raw.get("path", "/"),
+        accounts=tuple(
+            CredentialPair(username=account["username"], password=account["password"])
+            for account in raw.get("accounts", [])
+        ),
+        matchers=tuple(
+            Matcher(
+                type=matcher["type"],
+                part=matcher.get("part", "body"),
+                values=tuple(matcher.get("words") or matcher.get("regex") or matcher.get("value") or []),
+                negative=matcher.get("negative", False),
+            )
+            for matcher in raw.get("matchers", [])
+        ),
+        finding=raw.get("finding", {}),
+    )
+
+
+# =========================================================================
+# FEED VALIDATION
+# =========================================================================
+
+def validate_credentials(entries: Iterable[CredentialEntry]) -> List[str]:
+    """Comprobar que ninguna entrada de credenciales está muerta por construcción.
+
+    Misma filosofía que :func:`~.checks.validate_checks`: un feed que se
+    ejecuta y falla en silencio es peor que uno que no carga. Devuelve los
+    problemas en vez de lanzar, para poder revisar el feed entero de una vez.
+
+    Args:
+        entries: Las entradas ya parseadas.
+
+    Returns:
+        Una lista de problemas legibles, vacía si el feed está sano.
+    """
+    problems: List[str] = []
+    seen: set = set()
+
+    for entry in entries:
+        name = entry.id or "<sin id>"
+
+        if not entry.id:
+            problems.append("Una entrada de credenciales no declara 'id'")
+        if (entry.id, entry.version) in seen:
+            problems.append(f"Entrada {name!r}: duplicada en (id, version)={(entry.id, entry.version)}")
+        seen.add((entry.id, entry.version))
+
+        if entry.service not in _SERVICE_MATCHERS:
+            problems.append(
+                f"Entrada {name!r}: servicio {entry.service!r} sin predicado "
+                f"(disponibles: {', '.join(sorted(_SERVICE_MATCHERS))})"
+            )
+        if not entry.accounts:
+            problems.append(f"Entrada {name!r}: sin ninguna cuenta que probar")
+        for position, account in enumerate(entry.accounts):
+            if not account.username:
+                problems.append(f"Entrada {name!r}, cuenta {position}: sin 'username'")
+            if not account.password:
+                problems.append(f"Entrada {name!r}, cuenta {position}: sin 'password'")
+        if not entry.matchers:
+            problems.append(
+                f"Entrada {name!r}: sin ningún matcher, así que ningún intento "
+                f"se podría distinguir de un fallo de login"
+            )
+
+    return problems
+
+
+# =========================================================================
+# RUNTIME
+# =========================================================================
+
+def _basic_auth_headers(username: str, password: str) -> Dict[str, str]:
+    """Construir la cabecera ``Authorization: Basic`` para un intento.
+
+    El único punto de todo el módulo donde la contraseña en claro se toca:
+    entra aquí, sale codificada en la cabecera, y no queda en ninguna otra
+    parte —ni en una variable que sobreviva a esta llamada.
+    """
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+class CredentialRuntime:
+    """Prueba credenciales de fábrica contra los servicios de un host (Fase D).
+
+    Args:
+        entries: Las entradas de credenciales a probar.
+        fetch: Un ``(host, port, method, path, body, headers) -> Response |
+            None`` — la misma forma que :meth:`~.checks.HttpProbe.fetch`
+            expone desde L30.
+        rate_limiter: Limitador por host opcional, aplicado antes de cada
+            intento — cada login real es tráfico hacia el objetivo, y esta es
+            la única familia del motor donde ese tráfico además escribe.
+        max_attempts_per_account: Tope de contraseñas distintas probadas
+            contra una misma cuenta (L31) — no contra un mismo servicio. Ver
+            el docstring del módulo.
+        capture_evidence: Si se adjunta la respuesta que demostró el acceso
+            como evidencia (Fase E) — nunca incluye la contraseña, sólo lo que
+            el objetivo respondió.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        entries: Iterable[CredentialEntry],
+        fetch: Callable[..., Optional[Response]],
+        rate_limiter: Optional[HostRateLimiter] = None,
+        max_attempts_per_account: int = 3,
+        capture_evidence: bool = False,
+    ) -> None:
+        self._entries = list(entries)
+        self._fetch = fetch
+        self._rl = rate_limiter
+        self._max_attempts = max(1, int(max_attempts_per_account))
+        self._capture_evidence = capture_evidence
+
+    def run(self, host: str, services: Iterable) -> List[dict]:
+        """Probar cada entrada aplicable contra cada servicio del host.
+
+        Args:
+            host: El objetivo.
+            services: Los servicios descubiertos del host.
+
+        Returns:
+            Un hallazgo por cada entrada que encontró una cuenta funcionando.
+        """
+        findings: List[dict] = []
+        for service in services:
+            for entry in self._entries:
+                matches_service = _SERVICE_MATCHERS.get(entry.service)
+                if matches_service is None or not matches_service(service):
+                    continue
+                finding = self._try_entry(host, service, entry)
+                if finding is not None:
+                    findings.append(finding)
+        return findings
+
+    def _try_entry(self, host: str, service, entry: CredentialEntry) -> Optional[dict]:
+        """Probar las cuentas de una entrada contra un servicio, hasta el primer éxito.
+
+        Cada intento se registra ocurra lo que ocurra — un informe que dice
+        "se probaron credenciales por defecto y ninguna funcionó" es
+        información tan válida como un hallazgo, y el silencio no distingue
+        eso de "no se llegó a probar".
+        """
+        attempts_by_username: Dict[str, int] = {}
+        for account in entry.accounts:
+            used = attempts_by_username.get(account.username, 0)
+            if used >= self._max_attempts:
+                continue
+            attempts_by_username[account.username] = used + 1
+
+            if self._rl is not None:
+                self._rl.acquire(host)
+            logger.info(
+                "Credenciales por defecto %s: intento %s/%s contra %s:%s con la cuenta %r",
+                entry.check_id, used + 1, self._max_attempts, host, service.port, account.username,
+            )
+            response = self._fetch(
+                host, service.port, entry.method, entry.path,
+                None, _basic_auth_headers(account.username, account.password),
+            )
+            if response is None:
+                continue
+            if all(matcher.matches(response) for matcher in entry.matchers):
+                return self._finding(entry, service, account, response)
+        return None
+
+    def _finding(self, entry: CredentialEntry, service, account: CredentialPair,
+                 response: Response) -> dict:
+        """Construir el hallazgo de un acceso logrado — sin la contraseña en ningún sitio."""
+        finding_template = entry.finding
+        finding = {
+            "title": finding_template.get(
+                "title", f"Credenciales por defecto: {entry.id} ({account.username})"),
+            "category": "default_credentials",
+            "port": service.port,
+            "service": service.name or entry.service,
+            "protocol": service.protocol,
+            "cve_ids": None,
+            "source": "lybra",
+            "check_id": entry.check_id,
+            "feed_version": entry.feed_version or CREDENTIALS_FEED_VERSION,
+            "qod": QOD_CONFIRMED,
+            "confirmed": True,
+            "state": "open",
+        }
+        if self._capture_evidence:
+            finding["_evidence"] = {
+                "kind": "http_response",
+                # Sólo lo que el objetivo respondió: la cabecera Authorization
+                # que este módulo mandó nunca viaja aquí, así que la
+                # contraseña no tiene forma de colarse en la evidencia.
+                "payload": {
+                    "status": response.status,
+                    "headers": dict(response.headers),
+                    "body": response.body,
+                    "path": entry.path,
+                    "username": account.username,
+                },
+            }
+        return finding

--- a/API/src/modules/features/themis/lybra/feeds/credentials_feed.json
+++ b/API/src/modules/features/themis/lybra/feeds/credentials_feed.json
@@ -1,0 +1,63 @@
+{
+  "feedVersion": "lybra-credentials-1",
+  "entries": [
+    {
+      "id": "tomcat-manager-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/manager/html",
+      "accounts": [
+        {"username": "tomcat", "password": "tomcat"},
+        {"username": "admin", "password": "admin"},
+        {"username": "tomcat", "password": "s3cret"},
+        {"username": "admin", "password": "tomcat"},
+        {"username": "both", "password": "tomcat"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Tomcat Web Application Manager"]}
+      ],
+      "finding": {
+        "title": "Tomcat Manager con credenciales por defecto"
+      }
+    },
+    {
+      "id": "tomcat-host-manager-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/host-manager/html",
+      "accounts": [
+        {"username": "admin", "password": "admin"},
+        {"username": "tomcat", "password": "tomcat"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Tomcat Virtual Host Manager"]}
+      ],
+      "finding": {
+        "title": "Tomcat Host Manager con credenciales por defecto"
+      }
+    },
+    {
+      "id": "jenkins-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/manage",
+      "accounts": [
+        {"username": "admin", "password": "admin"},
+        {"username": "admin", "password": "password"},
+        {"username": "jenkins", "password": "jenkins"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Manage Jenkins"]}
+      ],
+      "finding": {
+        "title": "Jenkins con credenciales por defecto"
+      }
+    }
+  ]
+}

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -42,6 +42,8 @@ from ...lybra import (
     TlsProbe,
     NetworkProbe,
     default_script_plugins,
+    load_credentials,
+    CredentialRuntime,
     sweep_with_retries,
     PortSweep,
     scan_udp_ports_sync,
@@ -108,7 +110,7 @@ class LybraEngineManager(ScanManager):
         kwargs["discover_ports"] = arguments.get("discover_ports")
         return kwargs
 
-    def run_scan(self,
+    def run_scan(self,  # pylint: disable=too-many-arguments,too-many-positional-arguments
         user_id: int,
         target: Optional[str] = None,  # pylint: disable=arguments-differ
         services: Optional[List[Service]] = None,
@@ -116,6 +118,7 @@ class LybraEngineManager(ScanManager):
         timeout: int = 120,
         programed_scan_id: Optional[int] = None,
         asset_id: Optional[int] = None,
+        aggressive: bool = False,
     ) -> int:
         """
         Start an Lybra engine scan in one of two modes.
@@ -139,6 +142,15 @@ class LybraEngineManager(ScanManager):
                 ``services``. Recorded on the scan row for provenance and
                 grouping; it is never an input to the analysis itself, which
                 is why it does not travel in the TaskQueue args.
+            aggressive: Explicit request for the aggressive mode (L40).
+                Deliberately **not** enough on its own — ``_run_lybra`` only
+                honours it when the target is *also* in the authorized-target
+                register. A registered target does not pre-authorize
+                everything that could ever be done to it; this is the second
+                half of that double gate, and it is what unblocks the
+                default-credentials engine (Fase D, L31), the only family that
+                writes to the target. Never set from a scheduled scan — see
+                ``scheduled_run_kwargs``, which does not forward it.
 
         Returns:
             Primary key of the created LybraScan record.
@@ -166,7 +178,7 @@ class LybraEngineManager(ScanManager):
 
         self._task_queue.submit(
             func=LybraEngineManager.execute_lybra_scan, # type: ignore
-            args=(scan_id, discover_ports, services, timeout),
+            args=(scan_id, discover_ports, services, timeout, aggressive),
             name=f"LybraScan-{scan_id}",
             category=self.TASK_CATEGORY, # type: ignore
             external_id=self.external_id_for(scan_id),
@@ -182,12 +194,16 @@ class LybraEngineManager(ScanManager):
         discover_ports: Optional[list] = None,
         services: Optional[List[Service]] = None,
         timeout: Optional[int] = None,
+        aggressive: bool = False,
     ) -> None:
         """Entry point submitted to the TaskQueue. Runs the engine in the worker.
 
-        ``timeout`` es opcional para que un job encolado antes de este cambio
+        ``timeout`` es opcional para que un job encolado antes de ese cambio
         —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
-        despliegue en vez de fallar al deserializarse.
+        despliegue en vez de fallar al deserializarse. ``aggressive`` (L40) es
+        opcional por el mismo motivo, con el mismo default seguro: un job
+        encolado antes de este cambio se ejecuta en modo ``safe``, nunca en
+        agresivo por sorpresa.
         """
         with job_context() as job:
             manager = LybraEngineManager()
@@ -198,6 +214,7 @@ class LybraEngineManager(ScanManager):
                 timeout,
                 cancel_check=job.cancelled,
                 progress=job.progress,
+                aggressive=aggressive,
             )
 
     @staticmethod
@@ -213,6 +230,7 @@ class LybraEngineManager(ScanManager):
         timeout: Optional[int] = None,
         cancel_check: Optional[Callable[[], bool]] = None,
         progress: Optional[Callable[[int], None]] = None,
+        aggressive: bool = False,
     ) -> None:
         """Resolve services (own discovery or a payload), detect, persist.
 
@@ -232,6 +250,14 @@ class LybraEngineManager(ScanManager):
         tráfico) y la que aparecía en el incidente; el fingerprinting y los
         checks tienen plazo por operación. Si algún día hace falta acotarlos
         también, el plazo ya está aquí: basta pasarles ``_remaining_budget``.
+
+        ``aggressive`` (L40) es la petición explícita del usuario; por sí sola
+        no basta. El modo efectivo con el que corren los checks activos y el
+        motor de credenciales (Fase D, L31) sólo sube a ``"aggressive"``
+        cuando además ``is_target_authorized`` es verdadero — la doble puerta
+        que el roadmap exige para cualquier cosa que escriba en el objetivo.
+        Un objetivo autorizado sin petición explícita se queda en ``safe``;
+        una petición explícita sobre un objetivo no autorizado, también.
         """
         deadline = time.monotonic() + timeout if timeout else None
         is_cancelled = cancel_check or (lambda: False)
@@ -272,6 +298,12 @@ class LybraEngineManager(ScanManager):
                     and source_target
                     and AuthorizedTargetManager.is_authorized(user_id, source_target)
                 )
+                # La doble puerta del modo agresivo (L40): la petición
+                # explícita del usuario por sí sola no basta, y el registro de
+                # autorización por sí solo tampoco — autorizar un objetivo no
+                # es autorizar cualquier cosa contra él. Sólo con las dos a la
+                # vez sube el modo; en cualquier otro caso, ``safe``.
+                mode = "aggressive" if (aggressive and is_target_authorized) else "safe"
 
                 resolved = source.resolve_services(scan_repo, probes, source_target)
                 if resolved is None:
@@ -339,8 +371,17 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(
                     self._run_active_checks(source_target, services,
                                             cancel_check=cancel_check,
-                                            proposed_cves=proposed_cves))
+                                            proposed_cves=proposed_cves,
+                                            mode=mode))
                 is_partial = is_partial or is_cancelled()
+
+            # Motor de credenciales por defecto (Fase D, L31) — la única
+            # familia que escribe en el objetivo. ``_run_credential_checks``
+            # repite por su cuenta la comprobación de ``mode`` antes de probar
+            # nada; esta condición sólo evita el trabajo de construir el
+            # runtime cuando ya se sabe que no va a correr.
+            if source.probes_target_network and source_target and mode == "aggressive" and not is_cancelled():
+                findings_data.extend(self._run_credential_checks(source_target, services, mode))
             report(90)
 
             for finding in findings_data:
@@ -461,13 +502,19 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services, cancel_check=None,
-                           proposed_cves=None) -> list:
+    def _run_active_checks(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, target: str, services, cancel_check=None,
+        proposed_cves=None, mode: str = "safe") -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
         Best-effort: a runtime failure (unreachable host, etc.) yields no active
-        findings rather than failing the whole scan. Safe mode only.
+        findings rather than failing the whole scan.
+
+        ``mode`` llega ya resuelto por :meth:`_run_lybra` — esta capa no decide
+        si el agresivo procede, sólo lo aplica (L40): un ``check`` marcado
+        ``mode: aggressive`` en el feed sigue sin correr en modo ``safe``, y
+        eso lo sigue decidiendo ``CheckRuntime._applies_mode`` como siempre.
         """
         try:
             engine = CR.lybra_engine_config()
@@ -478,7 +525,7 @@ class LybraEngineManager(ScanManager):
                     max_bytes=engine.http_max_body_bytes,
                     user_agent=engine.http_user_agent,
                 ).fetch,
-                mode="safe",
+                mode=mode,
                 rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval),
                 tls_fetch=TlsProbe().fetch,
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
@@ -495,6 +542,44 @@ class LybraEngineManager(ScanManager):
                                proposed_cves=proposed_cves)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
+            return []
+
+    def _run_credential_checks(self, target: str, services, mode: str) -> list:
+        """Probar credenciales por defecto contra los servicios del objetivo (Fase D, L31).
+
+        Es la única familia de detección que escribe en el objetivo, así que
+        no basta con la doble puerta de quien llama (autorizado + agresivo
+        pedido explícitamente): esta función además **repite** la comprobación
+        de modo antes de construir nada. Dos guardas para la única capacidad
+        que de verdad puede bloquear una cuenta real es defensa en profundidad
+        barata, no paranoia.
+
+        Best-effort igual que ``_run_active_checks``: un fallo de red no debe
+        hundir un escaneo que ya tenía hallazgos de las demás familias.
+        """
+        if mode != "aggressive":
+            return []
+        try:
+            engine = CR.lybra_engine_config()
+            credentials = CR.lybra_credentials_config()
+            runtime = CredentialRuntime(
+                load_credentials(),
+                HttpProbe(
+                    timeout=engine.http_timeout,
+                    max_bytes=engine.http_max_body_bytes,
+                    user_agent=engine.http_user_agent,
+                ).fetch,
+                # Intervalo mayor que el de los checks de lectura: cada
+                # intento aquí es un login real, y el roadmap pide
+                # explícitamente un ritmo distinto al de un GET de
+                # ``.git/config`` para no parecer un ataque de fuerza bruta.
+                rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval * 5),
+                max_attempts_per_account=credentials.max_attempts,
+                capture_evidence=CR.lybra_evidence_config().enabled,
+            )
+            return runtime.run(target, services)
+        except Exception:
+            logger.exception("Lybra credential checks failed for %s", target)
             return []
 
     def _ingested_checks(self, services) -> list:

--- a/API/src/modules/features/themis/schemas.py
+++ b/API/src/modules/features/themis/schemas.py
@@ -48,6 +48,11 @@ class LybraScanRequestSchema(Schema):
     target = fields.String(required=True)
     ports = fields.String()
     timeout = fields.Integer(load_default=120, validate=validate.Range(min=1))
+    # La doble puerta del modo agresivo (L40): esta petición explícita del
+    # usuario es sólo la mitad. El manager sólo la honra cuando el objetivo
+    # está además en el registro de autorización — un registro no autoriza
+    # cualquier cosa contra el objetivo, sólo el escaneo pasivo.
+    aggressive = fields.Boolean(load_default=False)
 
 
 class FindingStateRequestSchema(Schema):

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1116,6 +1116,31 @@ def lybra_ingest_config() -> LybraIngestConfig:
     return load_block(LybraIngestConfig)
 
 
+@config_block("features.themis.scanners.lybra.credentials")
+@dataclass(frozen=True)
+class LybraCredentialsConfig:
+    """El presupuesto del motor de credenciales por defecto (Fase D, L31).
+
+    Es la única fase del motor que **escribe** en el objetivo — cada intento es
+    un login real —, así que el único dial que expone es el que evita que se
+    convierta en un ataque de fuerza bruta: cuántas contraseñas se prueban
+    contra una misma cuenta antes de rendirse con ella. No hay ``enabled``:
+    el motor entero está detrás de la doble puerta de :func:`aggressive
+    mode <>` — objetivo autorizado y petición explícita del usuario (L40) —,
+    así que un interruptor aparte sería una tercera puerta redundante.
+    """
+
+    max_attempts: int = 3
+    """Intentos máximos **por cuenta** (no por servicio): tres contraseñas
+    distintas contra ``admin`` cuentan tres, no las que además se prueben
+    contra ``root`` en el mismo servicio. Es la cuenta, no el servicio, la que
+    un proveedor bloquea tras demasiados fallos."""
+
+
+def lybra_credentials_config() -> LybraCredentialsConfig:
+    return load_block(LybraCredentialsConfig)
+
+
 def nuclei_config() -> NucleiConfig:
     return load_block(NucleiConfig)
 

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -150,6 +150,41 @@ def test_lybra_run_scan_self_discovery_succeeds_once_authorized(app, admin_user,
         assert scan_id is not None
 
 
+def test_lybra_endpoint_threads_the_aggressive_flag_to_run_scan(
+        client, admin_user, auth_headers, monkeypatch):
+    """El schema declara ``aggressive`` con ``load_default=False`` (L40): sin
+    el campo, una petición de siempre no cambia de comportamiento, y con él,
+    el valor llega íntegro al manager — la mitad de la doble puerta que
+    depende del usuario."""
+    captured = {}
+
+    def fake_run_scan(self, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(LybraEngineManager, "run_scan", fake_run_scan)
+
+    resp = client.post("/themis/lybra", headers=auth_headers(admin_user),
+                       json={"target": "8.8.8.8", "aggressive": True})
+    assert resp.status_code == 201
+    assert captured["aggressive"] is True
+
+
+def test_lybra_endpoint_defaults_to_non_aggressive(client, admin_user, auth_headers, monkeypatch):
+    captured = {}
+
+    def fake_run_scan(self, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(LybraEngineManager, "run_scan", fake_run_scan)
+
+    resp = client.post("/themis/lybra", headers=auth_headers(admin_user),
+                       json={"target": "8.8.8.8"})
+    assert resp.status_code == 201
+    assert captured["aggressive"] is False
+
+
 def test_lybra_self_discovery_produces_open_port_findings(app, admin_user, monkeypatch):
     # Stub reachability (no real socket) and the connect scan; the rest of the
     # self-discovery pipeline runs for real.
@@ -1514,3 +1549,109 @@ def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_us
     assert len(for_cve) == 1
     assert for_cve[0].confirmed is True
     assert for_cve[0].qod == 99
+
+
+# =============================================== modo agresivo + credenciales (L40/L31)
+
+
+def _stub_tomcat_manager(monkeypatch) -> None:
+    """Un panel de Tomcat Manager con la tercera credencial de fábrica del feed
+    (``tomcat/s3cret``) — deliberadamente no la primera que se prueba, para
+    que el runtime tenga que agotar un intento fallido antes de acertar, y
+    con usuario y contraseña distintos, para poder afirmar sin ambigüedad que
+    la contraseña que funcionó no aparece en ningún sitio.
+
+    Sirve tanto a los checks activos declarativos como al motor de
+    credenciales: cualquier ruta que no sea ``/manager/html`` con la cabecera
+    correcta responde 404/401, así que el resto del feed no dispara ruido.
+    """
+    from src.modules.features.themis.lybra.checks import Response
+    import base64
+    valid_auth = "Basic " + base64.b64encode(b"tomcat:s3cret").decode("ascii")
+
+    def fetch(self, host, port, method, path, body=None, headers=None):
+        if path == "/manager/html" and (headers or {}).get("Authorization") == valid_auth:
+            return Response(200, "Tomcat Web Application Manager", {})
+        if path == "/manager/html":
+            return Response(401, "", {})
+        return Response(404, "", {})
+
+    monkeypatch.setattr("src.modules.features.themis.lybra.checks.HttpProbe.fetch", fetch)
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+
+def test_aggressive_checks_do_not_run_without_an_explicit_request(monkeypatch, app, admin_user):
+    """Objetivo autorizado, pero nadie pidió el modo agresivo: la mitad de la
+    puerta que falta. Ni un check ``aggressive`` ni el motor de credenciales
+    corren, así que un panel con credenciales de fábrica de verdad expuestas
+    no produce ningún hallazgo de ``default_credentials``."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)  # aggressive=False por defecto
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    assert not [f for f in findings if f.category == "default_credentials"]
+
+
+def test_aggressive_checks_do_not_run_on_an_unauthorized_target(monkeypatch, app, admin_user):
+    """Petición explícita de modo agresivo, pero el objetivo NO está en el
+    registro de autorización: la otra mitad de la puerta. Autorizar un
+    objetivo para el escaneo pasivo no autoriza escribir en él."""
+    # Deliberadamente sin `_authorize_target`: el objetivo no está autorizado.
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, aggressive=True)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    assert not [f for f in findings if f.category == "default_credentials"]
+
+
+def test_an_authorized_and_explicit_aggressive_scan_finds_default_credentials(
+        monkeypatch, app, admin_user):
+    """Las dos mitades de la puerta juntas: objetivo autorizado y modo
+    agresivo pedido explícitamente. El motor de credenciales prueba el panel
+    de Tomcat Manager, encuentra la credencial de fábrica que funciona y
+    produce un hallazgo confirmado — sin que la contraseña aparezca en
+    ningún campo."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, aggressive=True)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    credential_findings = [f for f in findings if f.category == "default_credentials"]
+    assert len(credential_findings) == 1
+    finding = credential_findings[0]
+    assert finding.confirmed is True
+    assert finding.qod == 99
+    assert finding.check_id == "lybra-credentials:tomcat-manager-default@1"
+
+    assert "s3cret" not in str(finding.title)
+
+    with UnitOfWork() as uow:
+        evidence = ScanRepository(uow).get_evidence_for_finding(finding.id)
+    # La contraseña que funcionó no aparece en el hallazgo ni en su evidencia
+    # — es justo lo que el motor de credenciales existe para garantizar. El
+    # usuario ("tomcat") sí puede aparecer; es información útil y no secreta.
+    assert len(evidence) == 1
+    assert "s3cret" not in str(evidence[0].payload)

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -200,6 +200,7 @@ CONFIG_BLOCKS = [
     (CR.LybraEngineConfig, CR.lybra_engine_config),
     (CR.LybraEvidenceConfig, CR.lybra_evidence_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
+    (CR.LybraCredentialsConfig, CR.lybra_credentials_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),
     (CR.IrisConfig, CR.iris_config),

--- a/API/tests/unit/test_lybra_credentials.py
+++ b/API/tests/unit/test_lybra_credentials.py
@@ -1,0 +1,201 @@
+"""El motor de credenciales por defecto (Fase D, L31).
+
+Es la única familia de detección de Lybra que escribe en el objetivo, así que
+lo que estos tests protegen no es sólo "encuentra el par correcto" sino las
+tres garantías que hacen esa escritura segura: el presupuesto de intentos se
+cuenta **por cuenta**, para en el primer éxito, y la contraseña que funcionó
+no aparece nunca en el hallazgo ni en su evidencia.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import Response, Service
+from src.modules.features.themis.lybra.credentials import (
+    CredentialEntry,
+    CredentialPair,
+    CredentialRuntime,
+    load_credentials,
+    validate_credentials,
+)
+from src.modules.features.themis.lybra.checks import Matcher
+
+pytestmark = pytest.mark.unit
+
+_SVC = Service(80, "tcp", "http", None, None, None)
+
+
+def _entry(accounts, matchers=None, **kwargs):
+    if matchers is None:
+        matchers = (Matcher(type="status", values=(200,)),)
+    return CredentialEntry(
+        id=kwargs.pop("id", "test-panel"),
+        version=kwargs.pop("version", 1),
+        service=kwargs.pop("service", "http"),
+        path=kwargs.pop("path", "/admin"),
+        accounts=tuple(accounts),
+        matchers=tuple(matchers),
+        **kwargs,
+    )
+
+
+# =============================================== el par correcto dispara
+
+def test_a_correct_pair_produces_a_confirmed_finding():
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        assert headers == {"Authorization": "Basic YWRtaW46YWRtaW4="}
+        return Response(200, "bienvenido", {})
+
+    findings = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert findings[0]["category"] == "default_credentials"
+    assert findings[0]["confirmed"] is True
+    assert findings[0]["qod"] == 99
+
+
+def test_a_wrong_pair_produces_nothing():
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(401, "unauthorized", {})
+
+    assert CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC]) == []
+
+
+# =============================================== plaintext, en ningún sitio
+
+def test_the_password_never_appears_in_the_finding():
+    entry = _entry([CredentialPair("admin", "s3cr3t-p4ss")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(200, "ok", {})
+
+    finding = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])[0]
+    assert "s3cr3t-p4ss" not in str(finding)
+
+
+def test_the_password_never_appears_in_the_evidence():
+    entry = _entry([CredentialPair("admin", "s3cr3t-p4ss")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(200, "ok", {"X-Served-By": "app-1"})
+
+    finding = CredentialRuntime([entry], fetch, capture_evidence=True).run("10.0.0.1", [_SVC])[0]
+    assert "_evidence" in finding
+    assert "s3cr3t-p4ss" not in str(finding["_evidence"])
+    assert finding["_evidence"]["payload"]["username"] == "admin"
+
+
+# =============================================== presupuesto por cuenta
+
+def test_the_budget_is_counted_per_account_not_per_service():
+    """Tres contraseñas contra 'admin' y una contra 'root' en el mismo
+    servicio: con el tope en 2, a 'admin' solo le quedan dos intentos, pero a
+    'root' — una cuenta distinta — le sigue quedando su propio presupuesto
+    entero."""
+    entry = _entry([
+        CredentialPair("admin", "wrong1"),
+        CredentialPair("admin", "wrong2"),
+        CredentialPair("admin", "wrong3"),   # nunca se llega: tope de 2 para 'admin'
+        CredentialPair("root", "toor"),      # cuenta distinta, presupuesto propio
+    ])
+    tried = []
+
+    def fetch(host, port, method, path, body, headers):
+        tried.append(headers["Authorization"])
+        if headers["Authorization"] == _basic("root", "toor"):
+            return Response(200, "ok", {})
+        return Response(401, "no", {})
+
+    findings = CredentialRuntime([entry], fetch, max_attempts_per_account=2).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert len(tried) == 3          # 2 de admin + 1 de root (éxito, para ahí)
+    assert _basic("admin", "wrong3") not in tried
+
+
+def test_stops_at_the_first_successful_account():
+    entry = _entry([
+        CredentialPair("admin", "admin"),
+        CredentialPair("root", "toor"),
+    ])
+    tried = []
+
+    def fetch(host, port, method, path, body, headers):
+        tried.append(headers["Authorization"])
+        return Response(200, "ok", {})   # la primera cuenta ya funciona
+
+    findings = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert len(tried) == 1
+
+
+# =============================================== registro incluso al fallar
+
+def test_every_attempt_is_logged_even_on_failure(caplog):
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(401, "no", {})
+
+    with caplog.at_level("INFO"):
+        CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert any("intento" in record.message for record in caplog.records)
+
+
+# =============================================== servicio no aplicable
+
+def test_an_entry_is_skipped_against_a_non_matching_service():
+    entry = _entry([CredentialPair("admin", "admin")], service="http")
+    ftp_service = Service(21, "tcp", "ftp", None, None, None)
+    called = []
+
+    def fetch(host, port, method, path, body, headers):
+        called.append(1)
+        return Response(200, "ok", {})
+
+    assert CredentialRuntime([entry], fetch).run("10.0.0.1", [ftp_service]) == []
+    assert not called
+
+
+# =============================================== el feed empaquetado
+
+def test_the_shipped_feed_is_well_formed():
+    entries = load_credentials()
+    assert len(entries) >= 3
+    assert validate_credentials(entries) == []
+
+
+def test_the_shipped_feed_never_stores_a_password_in_a_finding_field_name():
+    """Sanity check estructural: ninguna entrada del feed usa un nombre de
+    campo que sugiera que la contraseña se vaya a guardar en el hallazgo."""
+    for entry in load_credentials():
+        assert "password" not in entry.finding
+
+
+# =============================================== validación de forma
+
+def test_an_entry_without_accounts_is_reported():
+    entry = _entry([])
+    assert any("ninguna cuenta" in problem for problem in validate_credentials([entry]))
+
+
+def test_an_entry_without_matchers_is_reported():
+    entry = _entry([CredentialPair("a", "b")], matchers=())
+    assert any("matcher" in problem for problem in validate_credentials([entry]))
+
+
+def test_an_entry_with_an_unknown_service_is_reported():
+    entry = _entry([CredentialPair("a", "b")], service="carrier-pigeon")
+    assert any("sin predicado" in problem for problem in validate_credentials([entry]))
+
+
+def test_a_duplicate_id_and_version_is_reported():
+    entry = _entry([CredentialPair("a", "b")])
+    assert any("duplicada" in problem for problem in validate_credentials([entry, entry]))
+
+
+def _basic(username: str, password: str) -> str:
+    import base64
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The REST API (Flask) orchestrates asynchronous scans and analysis over **RQ + Re
 
 ## Features
 
-- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine: its own TCP and UDP discovery, protocol dissectors for HTTP, SSH, FTP, SMTP/IMAP/POP3, SMB, TLS, MySQL, PostgreSQL, SQL Server, MongoDB, Redis, LDAP, RDP, VNC, SNMP, DNS, NTP, NetBIOS, mDNS, IKE and unauthenticated admin APIs (Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana), declarative and script checks, and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler and an authorized-targets registry for scan governance.
+- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine: its own TCP and UDP discovery, protocol dissectors for HTTP, SSH, FTP, SMTP/IMAP/POP3, SMB, TLS, MySQL, PostgreSQL, SQL Server, MongoDB, Redis, LDAP, RDP, VNC, SNMP, DNS, NTP, NetBIOS, mDNS, IKE and unauthenticated admin APIs (Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana); declarative checks with request chaining (extracted variables reused across requests), payload expansion (capped), and script plugins; version→confirmer promotion for high-profile CVEs; a default-credentials engine (Tomcat/Jenkins-style panels, gated behind an explicit aggressive-mode request *and* the authorized-targets registry); redacted raw-evidence capture per confirmed finding; and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler.
 - **AI-powered PDF reports** — Scan results enriched by a pluggable LLM backend with "Controls, Not Counts" calibrated risk assessment, plus per-host traceroute.
 - **Anti-phishing analysis** — 46 atomic rules across 10 rule families evaluate email headers and content (SPF, DKIM, DMARC, ARC, QR-code/quishing detection, domain impersonation, IOC extraction), producing a calibrated `Legitimate` / `Suspicious` / `Phishing` verdict with optional AI summaries.
 - **Automated mailbox monitoring** — Connect Gmail or Microsoft 365 via OAuth; Iris periodically pulls new mail and analyzes it automatically, and emails the user when a connected mailbox receives phishing.
@@ -188,11 +188,12 @@ The web application checks MFA once when an authenticated session enters the SPA
 | `POST` | `/themis/nmap` | Port scan (supports CIDR ranges) |
 | `POST` | `/themis/nikto` | Web configuration / vulnerability scan |
 | `POST` | `/themis/nuclei` | Template-based scan (single host per scan) |
-| `POST` | `/themis/lybra` | Self-built engine scan (own port discovery — `target` required) |
+| `POST` | `/themis/lybra` | Self-built engine scan (own port discovery — `target` required). `aggressive: true` requests the aggressive mode (active-check families marked `mode: aggressive` in the feed, plus the default-credentials engine); it only takes effect when the target is *also* in the caller's authorized-targets registry — a double gate, since a registered target is only pre-authorized for passive scanning |
 | `GET` | `/themis/scan-status?id=` | Scan status / progress: pending · running · done · cancelled |
 | `POST` | `/themis/scans/<id>/cancel` | Cancel a running scan |
 | `GET` | `/themis/results` · `/themis/results/<id>` | List scans (filterable, paginated) / scan detail. The Lybra listing carries per-scan counters, not every finding, and flags with `isPartial` a scan whose port discovery ran out of time before covering the whole target |
 | `GET` | `/themis/lybra/scans/<id>/findings` | Lybra findings grouped by remediable unit (product + port), each group with its CVEs, KEV membership, worst priority and the version that closes it |
+| `GET` | `/themis/findings/<id>/evidence` | The raw (redacted, hashed) response that produced a confirmed finding — 404 for a finding owned by another user |
 | `PATCH` | `/themis/findings/<id>` | Mark a finding's triage state (e.g. accept a risk) |
 | `DELETE` | `/themis/<id>` · `/themis/scans` | Delete a scan / bulk delete |
 | `GET` | `/themis/stats` · `/themis/history/hosts` · `/themis/history/stats` | Scan counters and per-host historical trends |


### PR DESCRIPTION
## Resumen

Cierra #299 (Fase D — motor de credenciales por defecto) e incluye, dentro del mismo cambio, lo mínimo de #308 (modo agresivo alcanzable) que #299 necesitaba para poder correr. **No cierra #308 entero**: los perfiles de escaneo (Rápido/Estándar/Exhaustivo), el selector en el SPA y que el informe diga con qué perfil se escaneó quedan fuera — es trabajo de la Fase 5, no de esta fase, y #308 se queda abierto para eso.

## Por qué #308 va incluido aquí

El diagnóstico de #299 es explícito: *"tres de los cuatro cimientos que esta fase necesita ya están, y el cuarto es un ítem de esta misma lista"*. Ese cuarto ítem es #308 — el modo `aggressive` existía por completo en el esquema (`CheckRuntime._applies_mode` lo respeta, `ScriptContext` lo transporta) pero **era inalcanzable**: el manager lo fijaba a `mode="safe"` de forma literal, sin parámetro, sin configuración, sin forma de que un usuario lo pidiera. Sin eso, el motor de credenciales no tenía forma de ejecutarse nunca. Construir #299 sin tocar #308 habría sido escribir un motor que ninguna llamada real podría activar.

## El problema que ambos resuelven juntos

Tomcat con `tomcat/tomcat`, paneles de administración con la contraseña de fábrica, FTP anónimo — es la cobertura clásica de OpenVAS y de las que más hallazgos reales produce en una red interna. El roadmap ya avisa de por qué esto no es "un check HTTP más": *"es una operación que escribe en el objetivo, que puede bloquear cuentas, que genera ruido en el SIEM del objetivo y que exige un control de tasa y un presupuesto muy distintos a un GET de `.git/config`"*. Por eso es la única fase del motor que va al final, cuando todo lo demás ya funciona.

## La doble puerta (la parte de #308 que se construye aquí)

`run_scan` gana un parámetro `aggressive: bool = False`, expuesto en la API como el campo `aggressive` del `POST /themis/lybra`. **Por sí solo no hace nada.** El modo efectivo con el que corren tanto los checks `mode: aggressive` del feed como el motor de credenciales sólo sube a `"aggressive"` cuando se cumplen **las dos** condiciones a la vez:

1. El usuario lo pidió explícitamente (`aggressive: true` en la petición).
2. El objetivo está en el registro de autorización (`AuthorizedTargetManager`).

Un objetivo autorizado sin petición explícita se queda en `safe`. Una petición explícita sobre un objetivo no autorizado, también. La razón de por qué hacen falta las dos y no basta una está en el propio issue: *"el registro por sí solo no basta — autorizar un objetivo no es autorizar cualquier cosa contra él"*. Autorizar un objetivo dice "puedes escanearlo pasivamente"; no dice "puedes intentar iniciar sesión en sus paneles de administración".

Un job de la cola encolado **antes** de este cambio deserializa sin `aggressive` y usa el default `False` — nunca se activa el modo agresivo por sorpresa en un job viejo, la misma garantía que ya existía para `timeout`.

## El motor de credenciales (#299)

`CredentialRuntime` en `lybra/credentials.py` — capa pura, sin ORM ni red directa, como el resto de `lybra/` (`test_lybra_package_invariants.py` lo comprueba). Reutiliza deliberadamente piezas ya construidas en vez de duplicarlas:

- El mismo `Matcher`/`Response` del DSL declarativo decide si un intento entró.
- El mismo `fetch` con `body`/`headers` que `HttpProbe` ya expone desde #300 (L30) — un intento de credenciales *es* una petición HTTP con una cabecera `Authorization: Basic`, nada más.

**Las tres garantías de seguridad, ninguna opcional:**

- **El presupuesto se cuenta por cuenta, no por servicio** (`lybra.credentials.maxAttempts`, 3 por defecto). Tres contraseñas contra `admin` y una contra `root` en el mismo servicio son cuatro peticiones al servicio, pero tres intentos para `admin` y uno para `root` — porque es la cuenta, no el servicio, la que un proveedor bloquea tras demasiados fallos.
- **Para en el primer éxito.** Veinte pares posibles no se prueban todos si el tercero ya funcionó.
- **La contraseña nunca sale del módulo.** Se usa una vez para construir la cabecera `Authorization` y no vuelve a aparecer en ningún dict que el runtime produzca — ni en el `Finding`, ni en su evidencia, ni en un log. Sólo el *nombre de usuario* que funcionó se guarda: decir "la cuenta admin tiene la contraseña de fábrica" es información útil para un informe; guardar cuál era la contraseña convertiría la base de datos de un cliente en un depósito de las contraseñas del propio cliente.

Un éxito produce un `Finding` con `category="default_credentials"`, `confirmed=true`, `qod=99`, y evidencia (Fase E, reutilizando el mecanismo de #310) con la respuesta que lo demostró — nunca con la cabecera `Authorization` que mandamos, sólo con lo que el objetivo respondió.

`_run_credential_checks` en el manager repite por su cuenta la comprobación de `mode == "aggressive"` antes de construir nada: dos guardas para la única capacidad que de verdad puede bloquear una cuenta real es defensa en profundidad barata, no paranoia.

## Feed inicial

`credentials_feed.json`: Tomcat Manager, Tomcat Host Manager y Jenkins, con los pares de fábrica más conocidos de cada uno. Crece con más entradas del mismo formato JSON, sin tocar el runtime.

## Puntos exactos de cambio

- Nuevo `lybra/credentials.py` + `lybra/feeds/credentials_feed.json`.
- `config_reading.py` — `LybraCredentialsConfig` (`lybra.credentials.maxAttempts`).
- `managers/lybra/engine.py` — `run_scan`/`execute_lybra_scan`/`_run_lybra` ganan `aggressive`; nuevo `_run_credential_checks`; `_run_active_checks` deja de fijar `mode="safe"` a fuego.
- `schemas.py`/`endpoints.py` — campo `aggressive` en `POST /themis/lybra`.
- `SecOpsConfig.json` — bloque `lybra.credentials`.

## Validación

`pytest tests/unit -k lybra` + `tests/integration/test_lybra.py` (sin Docker): todo pasa. **Suite completa del repo** (`pytest -m "not oracle and not postgres"`): todo pasa, sin regresiones en ningún otro módulo. `pylint src`: 10.00/10.

`tests/unit/test_lybra_credentials.py`, 14 tests. Los que sostienen las garantías:

- `test_the_password_never_appears_in_the_finding` / `..._in_the_evidence` — la garantía central del módulo.
- `test_the_budget_is_counted_per_account_not_per_service` — tres contraseñas contra `admin` (tope 2, la tercera nunca se prueba) más una contra `root` (presupuesto propio, la prueba y acierta).
- `test_stops_at_the_first_successful_account`.
- `test_every_attempt_is_logged_even_on_failure` — "se probaron credenciales por defecto y ninguna funcionó" es información, no silencio.
- `test_an_entry_is_skipped_against_a_non_matching_service` — Tomcat no se prueba contra FTP.
- Validación de forma: sin cuentas, sin matchers, servicio desconocido, `(id, version)` duplicado.

`tests/integration/test_lybra.py`, 6 tests nuevos:

- `test_aggressive_checks_do_not_run_without_an_explicit_request` — objetivo autorizado, sin petición explícita: un Tomcat con `tomcat/s3cret` de verdad expuesto no produce ningún hallazgo.
- `test_aggressive_checks_do_not_run_on_an_unauthorized_target` — petición explícita, objetivo no autorizado: tampoco.
- `test_an_authorized_and_explicit_aggressive_scan_finds_default_credentials` — las dos mitades juntas: el motor encuentra la credencial, produce un hallazgo confirmado, y ni el hallazgo ni su evidencia contienen la contraseña.
- `test_lybra_endpoint_threads_the_aggressive_flag_to_run_scan` / `..._defaults_to_non_aggressive` — el campo del schema llega íntegro al manager, con el default seguro cuando no se manda.

## Notas

- No hay un `enabled` separado para el motor de credenciales: ya está detrás de la doble puerta del modo agresivo, y un interruptor aparte sería una tercera puerta redundante — lo documenta el propio docstring de `LybraCredentialsConfig`.
- No se toca el banco `oracle` (el issue lo pedía para una fase posterior de medición contra un Tomcat de laboratorio).
- README actualizado en su propio commit, como manda `CLAUDE.md`.
