### PR TITLE
feat(themis): Fase 3 del motor Lybra — confirmadores, DSL de encadenamiento, evidencia y credenciales por defecto

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -189,7 +189,6 @@
         },
         "lybra": {
           "activeChecks": true,
-          "bannerTimeout": 2.0,
           "colorPalette": {
             "black": "#1a2410",
             "dark": "#4a6132",
@@ -198,19 +197,31 @@
             "secondary": "#a8c98f",
             "white": "#f3f8ee"
           },
+          "engine": {
+            "tcpConcurrency": 200,
+            "tcpTimeout": 2.0,
+            "udpTimeout": 2.0,
+            "udpRetries": 1,
+            "udpBudgetSeconds": 20.0,
+            "rateLimitInterval": 0.2,
+            "hostPoolSize": 8,
+            "httpTimeout": 8,
+            "httpMaxBodyBytes": 131072,
+            "httpUserAgent": "Lybra/1.0",
+            "networkTimeout": 5.0,
+            "bannerTimeout": 2.0,
+            "maxBlindProbes": 2
+          },
           "fingerprintingEnabled": true,
-          "hostPoolSize": 8,
           "ingest": {
             "enabled": false,
             "minSeverity": "MEDIUM",
             "maxChecks": 300
           },
-          "maxBlindProbes": 2,
           "prompts": {
             "system": "Eres un analista senior de seguridad ofensiva redactando la sección ejecutiva de un informe de pentest. Analizas la salida ya estructurada del motor de detección Lybra: cada hallazgo trae su CVE, CVSS, EPSS (probabilidad de explotación en 30 días), si está en la lista CISA KEV (explotación activa confirmada), y si fue 'confirmado' activamente o es una 'hipótesis' por versión de banner.\n\nDATOS QUE RECIBES:\n- 'servicios_afectados': el inventario agrupado por producto y puerto. Cada grupo trae 'total_hallazgos', 'total_cves', 'cves_en_kev', 'max_cvss', 'max_epss', 'confirmados', el desglose 'por_prioridad' y 'corregido_en': la versión a la que hay que actualizar para cerrar TODO el grupo de una vez. Es tu unidad de trabajo: se remedia un servicio, no un CVE suelto.\n- 'hallazgos_destacados': el detalle de los hallazgos de mayor prioridad (los confirmados y los de KEV van siempre incluidos), cada uno con su 'descripcion' oficial del CVE y su propio 'corregido_en'. Es la evidencia concreta que debes citar.\nEl total de hallazgos del escaneo es mayor que el número de 'hallazgos_destacados' que ves en detalle: el recuento real está en la cabecera y en 'servicios_afectados'. Nunca escribas que el escaneo encontró únicamente los que aparecen detallados.\n\nREGLAS ABSOLUTAS:\n1. Generas EXCLUSIVAMENTE JSON válido, sin markdown, sin texto antes ni después.\n2. NUNCA inventas un CVE, CVSS o EPSS que no esté en los datos proporcionados. Si un hallazgo no trae CVSS, no le asignes uno.\n3. Un hallazgo 'confirmado=true' es un hecho verificado; uno 'confirmado=false' es una hipótesis por versión que puede ser un falso positivo (backport). Nunca los trates con el mismo nivel de certeza en el texto.\n4. 'en_kev=true' es la señal más fuerte de urgencia (se explota activamente en el mundo real) y debe mencionarse explícitamente si aparece en algún hallazgo.\n5. El 'risk_level' es un techo, no un promedio: si existe al menos un hallazgo confirmado o en KEV con CVSS alto, el nivel debe reflejarlo aunque el resto de hallazgos sean informativos.\n6. Las 'recommendations' deben ser accionables y concretas. Cuando el grupo traiga 'corregido_en', la remediación DEBE nombrar esa versión destino exacta. 'Actualizar a la última versión estable' NO es una remediación válida: si tienes el dato, lo escribes.\n7. Si prácticamente todos los hallazgos son de categoría 'open_port' sin CVEs, dilo explícitamente: es un mapa de superficie, no una lista de vulnerabilidades.\n8. Escribe con densidad: cada frase debe apoyarse en un dato de los que recibes (una versión, un CVE, un CVSS, un porcentaje de EPSS, un recuento). No rellenes con generalidades sobre la importancia de la seguridad. Si te faltan datos para alcanzar la extensión pedida, escribe menos: preferimos corto y exacto antes que largo y vacío.\n\nCONFIRMADO Y KEV SON DOS EJES DISTINTOS. No los mezcles nunca:\n- 'confirmado' responde a \"¿lo hemos verificado en ESTE host?\". true = comprobado activamente. false = deducido de la versión del banner, y puede ser un falso positivo por backport.\n- 'en_kev' responde a \"¿se explota en el mundo real, en cualquier host?\". No dice nada sobre este objetivo en concreto.\nUn hallazgo con en_kev=true y confirmado=false es una hipótesis por versión sobre una vulnerabilidad que sí se explota activamente ahí fuera: urgente de verificar, pero NO verificada aquí. Escríbelo así. Está terminantemente prohibido usar las palabras 'confirmado', 'confirmada' o 'verificado' para un hallazgo cuyo campo 'confirmado' sea false, por alto que sea su CVSS o su EPSS.\nAntes de dar por buena tu respuesta, repasa cada hallazgo que hayas llamado confirmado y comprueba que su campo 'confirmado' es realmente true.\n\nCOBERTURA OBLIGATORIA DE LAS RECOMENDACIONES:\nRecorre TODAS las entradas de 'servicios_afectados' antes de cerrar la lista, no solo las que traen CVEs. Necesita recomendación propia toda entrada que cumpla al menos una de estas condiciones:\n- tiene algún hallazgo con 'confirmados' mayor que cero (son los únicos hechos verificados del escaneo: nunca pueden quedarse fuera),\n- su desglose 'por_prioridad' incluye MEDIUM, HIGH o CRITICAL,\n- o trae algún CVE en KEV.\nLas entradas sin CVEs cuentan igual: unas cabeceras de seguridad ausentes o un puerto de administración expuesto son unidades remediables con su propia acción concreta. Agrupar dos productos distintos en una sola recomendación no vale; agrupar los hallazgos de un mismo producto, sí — para eso está el rollup.\n\nFORMATO DE RESPUESTA (JSON estricto):\n{\n  \"risk_level\": \"CRÍTICO|ALTO|MEDIO|BAJO|INFORMATIVO\",\n  \"executive_summary\": \"6-8 frases en español para un lector no técnico: qué hay expuesto, qué productos concretos están desactualizados y a qué versión hay que subirlos, cuántos hallazgos cierra cada actualización, y qué se está explotando activamente hoy. Lenguaje llano, pero con las cifras concretas.\",\n  \"technical_analysis\": \"Entre 1500 y 2500 caracteres, organizado POR SERVICIO AFECTADO: para cada entrada relevante de 'servicios_afectados' escribe un bloque que explique qué expone ese servicio, cuáles son sus CVEs más graves citando CVE + CVSS + EPSS reales, qué separa lo confirmado de lo hipotético por banner, y cuál es la versión que cierra el grupo entero. Termina relacionando los servicios entre sí si comparten superficie o cadena de ataque.\",\n  \"recommendations\": [\n    {\"title\": \"...\", \"description\": \"qué se corrige y por qué importa, con las cifras del grupo\", \"priority\": \"ALTA|MEDIA|BAJA\", \"remediation\": \"acción concreta con versión destino o directiva exacta\", \"cve_refs\": [\"CVE-YYYY-NNNNN\"]}\n  ],\n  \"conclusions\": \"2-4 frases: en qué orden hay que actuar y qué queda pendiente de verificar manualmente.\"\n}\n\nGenera una recomendación por unidad remediable (producto + puerto). Cuando haya varias unidades afectadas, aporta entre 4 y 7 recomendaciones ordenadas por urgencia real: primero KEV y confirmados, después el resto. Si solo hay una unidad remediable, no inventes más para llegar al número.\n",
             "userTemplate": "Escaneo Lybra sobre {{target}} (exposición: {{exposure}}), iniciado el {{started}}.\n\nTotal de hallazgos: {{total_findings}} | Confirmados activamente: {{confirmed_count}} | En CISA KEV: {{kev_count}}\n\nSERVICIOS AFECTADOS (inventario agrupado — tu unidad de remediación; 'corregido_en' es la versión destino que cierra el grupo entero):\n{{services_json}}\n\nHALLAZGOS DESTACADOS (detalle de los de mayor prioridad; los confirmados y los de KEV van siempre incluidos):\n{{findings_json}}\n\nGenera el análisis en el formato JSON indicado en las instrucciones del sistema, respetando la extensión pedida para cada campo.\n"
-          },
-          "udpBudgetSeconds": 20.0
+          }
         }
       }
     },

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -210,7 +210,8 @@
             "httpUserAgent": "Lybra/1.0",
             "networkTimeout": 5.0,
             "bannerTimeout": 2.0,
-            "maxBlindProbes": 2
+            "maxBlindProbes": 2,
+            "maxPayloadExpansions": 25
           },
           "evidence": {
             "enabled": true,

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -218,6 +218,9 @@
             "maxBodyBytes": 8192,
             "retentionDays": 90
           },
+          "credentials": {
+            "maxAttempts": 3
+          },
           "fingerprintingEnabled": true,
           "ingest": {
             "enabled": false,

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -212,6 +212,11 @@
             "bannerTimeout": 2.0,
             "maxBlindProbes": 2
           },
+          "evidence": {
+            "enabled": true,
+            "maxBodyBytes": 8192,
+            "retentionDays": 90
+          },
           "fingerprintingEnabled": true,
           "ingest": {
             "enabled": false,

--- a/API/alembic/versions/c7e1a9f4b2d8_lybra_evidencia_cruda_por_hallazgo.py
+++ b/API/alembic/versions/c7e1a9f4b2d8_lybra_evidencia_cruda_por_hallazgo.py
@@ -1,0 +1,57 @@
+"""lybra: evidencia cruda por hallazgo (Fase E)
+
+Revision ID: c7e1a9f4b2d8
+Revises: fd07fce5f920
+Create Date: 2026-09-03 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e1a9f4b2d8'
+down_revision: Union[str, Sequence[str], None] = 'fd07fce5f920'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Crea la tabla de evidencia de hallazgos.
+
+    Un hallazgo dice qué encontró y con qué regla, pero no guardaba lo que el
+    objetivo respondió. Esta tabla lo guarda: la respuesta cruda —redactada,
+    con su hash y su fecha— que provocó el hallazgo, para poder defenderla ante
+    un cliente y para diagnosticar un falso positivo sin repetir el escaneo a
+    mano.
+
+    ``ondelete=CASCADE`` a propósito: la evidencia no tiene sentido sin su
+    hallazgo, así que borrar un escaneo (que ya cae en cascada sobre sus
+    hallazgos) se lleva también su evidencia, sin dejar filas huérfanas.
+
+    El índice sobre ``captured_at`` es para la retención: la purga de la
+    evidencia caducada barre por fecha, y sin índice ese barrido escanearía la
+    tabla entera cada vez.
+    """
+    op.create_table(
+        "FindingEvidence",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("finding_id", sa.Integer(),
+                  sa.ForeignKey("Finding.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("captured_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_FindingEvidence_finding_id", "FindingEvidence", ["finding_id"])
+    op.create_index("ix_FindingEvidence_captured_at", "FindingEvidence", ["captured_at"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_FindingEvidence_captured_at", table_name="FindingEvidence")
+    op.drop_index("ix_FindingEvidence_finding_id", table_name="FindingEvidence")
+    op.drop_table("FindingEvidence")

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -519,6 +519,27 @@ def update_finding_state(data, finding_id: int):
     }
 
 
+@themis_blp.get("/findings/<int:finding_id>/evidence")
+@themis_blp.response(200, description="Raw evidence for a finding")
+@themis_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@themis_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@themis_blp.alt_response(404, schema=ErrorSchema, description="Finding not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.THEMIS_READ])
+@limiter.limit("120 per hour; 400 per day")
+@handle_exceptions(default_exception=FindingNotFoundError, logger=logger)
+def get_finding_evidence(finding_id: int):
+    """Devolver la evidencia cruda que respalda un hallazgo (Fase E).
+
+    La respuesta que el objetivo dio y que provocó el hallazgo, redactada, con
+    su hash y su fecha — lo que convierte «te lo digo yo» en «míralo». Sólo
+    sobre hallazgos propios: uno ajeno se reporta como no encontrado.
+    """
+    user = get_current_user()
+    evidence = LybraEngineManager().get_finding_evidence(finding_id, user.id)
+    return {"findingId": finding_id, "evidence": evidence}
+
+
 @themis_blp.get("/results")
 @themis_blp.arguments(ResultsQuerySchema, location="query")
 @themis_blp.response(200, ResultsResponseSchema, description="Scan results")

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -388,7 +388,8 @@ def start_lybra_scan(data):
         user_id=user.id,
         target=target,
         discover_ports=discover_ports,
-        timeout=timeout
+        timeout=timeout,
+        aggressive=data.get("aggressive", False),
     )
     logger.info(f"Lybra lanzado: ID={scan_id} autodescubrimiento target={target} user={user.username}")
 

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -104,6 +104,14 @@ from .script_checks import (
     SnmpDefaultCommunityPlugin,
     default_script_plugins,
 )
+from .credentials import (
+    load_credentials,
+    validate_credentials,
+    CredentialRuntime,
+    CredentialEntry,
+    CredentialPair,
+    CREDENTIALS_FEED_VERSION,
+)
 from .correlation import (
     classify_exposure,
     compute_dedup_key,
@@ -257,6 +265,12 @@ __all__ = [
     "SmbSigningNotRequiredPlugin",
     "SnmpDefaultCommunityPlugin",
     "default_script_plugins",
+    "load_credentials",
+    "validate_credentials",
+    "CredentialRuntime",
+    "CredentialEntry",
+    "CredentialPair",
+    "CREDENTIALS_FEED_VERSION",
     "classify_exposure",
     "compute_dedup_key",
     "merge_findings",

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-13"
+CHECKS_FEED_VERSION = "lybra-checks-14"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -911,6 +911,13 @@ _NETWORK_SERVICE_MATCHERS: Dict[str, Callable[[Service], bool]] = _network_servi
 # Protocol versions considered deprecated/weak for a service exposed today.
 _WEAK_TLS_PROTOCOLS = {"SSLv2", "SSLv3", "TLSv1", "TLSv1.1"}
 
+# Familias de cifrado que hoy se consideran débiles: sin autenticación (aNULL),
+# sin cifrado (eNULL), exportación, DES/3DES, RC4 y MD5. El nombre del suite
+# negociado los delata como subcadena — "ECDHE-RSA-DES-CBC3-SHA" trae "DES", y
+# "TLS_RSA_WITH_RC4_128_SHA" trae "RC4". Se compara en mayúsculas porque OpenSSL
+# y la RFC nombran los suites en formatos distintos.
+_WEAK_TLS_CIPHER_TOKENS = ("NULL", "EXPORT", "DES", "RC4", "MD5", "_CBC3_", "3DES")
+
 # TLS hygiene rules a ``type: "tls"`` check can reference via ``tlsRule`` in the
 # feed. Each takes the ``TlsInfo`` a probe returned (duck-typed — this module
 # never imports the fingerprint module, to avoid a checks<->fingerprint
@@ -920,6 +927,8 @@ _TLS_RULES: Dict[str, Callable] = {
     "expired": lambda info: info.expired,
     "expiring_soon": lambda info: not info.expired and info.days_until_expiry is not None and info.days_until_expiry <= 30,
     "deprecated_protocol": lambda info: info.protocol in _WEAK_TLS_PROTOCOLS,
+    "weak_cipher": lambda info: bool(info.cipher) and any(
+        token in info.cipher.upper() for token in _WEAK_TLS_CIPHER_TOKENS),
 }
 
 

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1066,7 +1066,7 @@ class CheckRuntime:
             above are.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         checks: Iterable[Check],
         fetch: Callable[[str, Optional[int], str, str], Optional[Response]],
@@ -1076,6 +1076,7 @@ class CheckRuntime:
         network_open: Optional[Callable[[str, int], Optional["NetworkSession"]]] = None,
         script_plugins: Optional[Dict[str, object]] = None,
         mapper: Optional[Callable] = None,
+        capture_evidence: bool = False,
     ) -> None:
         self._checks = list(checks)
         self._fetch = fetch
@@ -1090,6 +1091,7 @@ class CheckRuntime:
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
         self._cancel_check: Optional[Callable[[], bool]] = None
+        self._capture_evidence = capture_evidence
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
         # pueda ver los servicios hermanos sin descubrirlos por su cuenta.
@@ -1264,11 +1266,29 @@ class CheckRuntime:
         request fails to reach the target or does not match, the check produces
         nothing.
         """
+        last_response = None
         for request in check.requests:
             response = self._probe_response(host, service, request.method, request.path)
             if response is None or not request.evaluate(response):
                 return None
-        return self._finding(check, service)
+            last_response = response
+        finding = self._finding(check, service)
+        # Evidencia (Fase E): la respuesta que provocó el hallazgo. Sólo para
+        # los confirmados —los que van a un informe— y sólo si la captura está
+        # activada. El payload viaja en ``_evidence`` hasta la persistencia, que
+        # lo redacta y lo separa en su propia fila.
+        if (self._capture_evidence and last_response is not None
+                and finding.get("confirmed")):
+            finding["_evidence"] = {
+                "kind": "http_response",
+                "payload": {
+                    "status": last_response.status,
+                    "headers": dict(last_response.headers),
+                    "body": last_response.body,
+                    "path": check.requests[-1].path,
+                },
+            }
+        return finding
 
     def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
         """Return the response for one request, asking the target only once.

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-15"
+CHECKS_FEED_VERSION = "lybra-checks-16"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -310,7 +310,7 @@ class Request:
 
 
 @dataclass(frozen=True)
-class Check:
+class Check:  # pylint: disable=too-many-instance-attributes
     """A declarative detection check (``type: "http"`` or ``type: "tls"``).
 
     Attributes:
@@ -348,6 +348,16 @@ class Check:
             buffer and every subsequent read comes back one reply out of step
             — the whole check then matches against the wrong text and silently
             never fires.
+        confirms: For a **confirmer** check, the CVE it verifies (e.g.
+            ``"CVE-2021-41773"``). A confirmer runs only when the version matcher
+            has already *proposed* that CVE for the service — never "just in
+            case" — and, when it fires, promotes that hypothesis from
+            ``confirmed=false, qod=70`` to ``confirmed=true, qod=99`` by merging
+            on the shared ``dedup_key`` (both carry the same ``cve_ids``). It is
+            the encadenamiento versión→confirmador the roadmap names as the
+            runtime's reason to exist. A confirmer never exploits: it checks the
+            condition without running anything on the target, or it is not
+            written.
         tags: Free-form labels (Nuclei's ``info.tags``, plus vendor/product
             metadata). Not used by the runtime, which runs whatever it is
             given: they exist so a *selector* can decide which of thousands of
@@ -368,6 +378,7 @@ class Check:
     namespace: str = "lybra"
     feed_version: Optional[str] = None
     expect_banner: bool = False
+    confirms: Optional[str] = None
     tags: tuple = ()
 
     @property
@@ -454,6 +465,7 @@ def _parse_check(c: dict) -> Check:
         tls_rule=c.get("tlsRule"),
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
+        confirms=c.get("confirms"),
     )
     _assert_service_is_reachable(check)
     return check
@@ -564,7 +576,11 @@ MATCHER_TYPES = ("status", "word", "regex")
 MATCHER_PARTS = ("body", "header", "status")
 
 
-def validate_checks(checks: Iterable[Check]) -> List[str]:
+# Forma de un identificador CVE, para validar el campo ``confirms``.
+_CVE_ID_RE = re.compile(r"^CVE-[0-9]{4}-[0-9]{4,}$")
+
+
+def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=too-many-branches
     """Comprobar que ningún check está muerto por construcción.
 
     El feed son **datos que se ejecutan**: reglas que deciden si un hallazgo de
@@ -614,6 +630,11 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:
             problems.append(f"Check {name!r}: severidad {check.severity!r} fuera de la escalera ({', '.join(PRIORITY_LADDER)})")
         if check.category not in CHECK_CATEGORIES:
             problems.append(f"Check {name!r}: categoría {check.category!r} desconocida (disponibles: {', '.join(CHECK_CATEGORIES)})")
+
+        if check.confirms and not _CVE_ID_RE.match(check.confirms):
+            problems.append(
+                f"Check {name!r}: 'confirms' debe ser un identificador CVE "
+                f"(CVE-AAAA-NNNN), no {check.confirms!r}")
 
         if check.type == "tls" and check.tls_rule not in _TLS_RULES:
             problems.append(
@@ -1091,6 +1112,7 @@ class CheckRuntime:
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
         self._cancel_check: Optional[Callable[[], bool]] = None
+        self._proposed_cves: frozenset = frozenset()
         self._capture_evidence = capture_evidence
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
@@ -1124,8 +1146,10 @@ class CheckRuntime:
             ),
         )
 
-    def run(self, host: str, services: Iterable[Service],
-            cancel_check: Optional[Callable[[], bool]] = None) -> List[dict]:
+    def run(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+            self, host: str, services: Iterable[Service],
+            cancel_check: Optional[Callable[[], bool]] = None,
+            proposed_cves: Optional[frozenset] = None) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
         Probes are shared within one call: several checks reading the same
@@ -1163,6 +1187,7 @@ class CheckRuntime:
         self._services = services
         self._host = host
         self._cancel_check = cancel_check
+        self._proposed_cves = proposed_cves or frozenset()
 
         per_service = self._mapper(self._run_for_service, services)
         return [finding for group in per_service for finding in group]
@@ -1194,6 +1219,11 @@ class CheckRuntime:
                 continue
             for check in self._checks:
                 if not family.check_matches(check, service):
+                    continue
+                # Un confirmador nunca corre "por si acaso": sólo si el matcher
+                # de versiones ya propuso su CVE para este escaneo. Es lo que lo
+                # distingue de un check normal — corre porque la KB dijo algo.
+                if check.confirms and check.confirms not in self._proposed_cves:
                     continue
                 finding = family.run_check(check, self._host, service)
                 if finding is not None:
@@ -1412,7 +1442,8 @@ class CheckRuntime:
             "port":         service.port,
             "service":      service.name or check.service,
             "protocol":     service.protocol,
-            "cve_ids":      finding_template.get("cve_ids"),
+            "cve_ids":      finding_template.get("cve_ids") or (
+                                [check.confirms] if check.confirms else None),
             "source":       "lybra",
             "check_id":     check.check_id,
             "feed_version": check.feed_version or CHECKS_FEED_VERSION,

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1089,6 +1089,7 @@ class CheckRuntime:
         # (L23), igual que ya inyecta las sondas — este módulo no conoce la
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
+        self._cancel_check: Optional[Callable[[], bool]] = None
         # El host y sus servicios de la ejecución en curso: los rellena
         # :meth:`run`, y viven aquí para que un plugin de tipo ``script``
         # pueda ver los servicios hermanos sin descubrirlos por su cuenta.
@@ -1121,7 +1122,8 @@ class CheckRuntime:
             ),
         )
 
-    def run(self, host: str, services: Iterable[Service]) -> List[dict]:
+    def run(self, host: str, services: Iterable[Service],
+            cancel_check: Optional[Callable[[], bool]] = None) -> List[dict]:
         """Run every applicable check against a host's HTTP, TLS and network services.
 
         Probes are shared within one call: several checks reading the same
@@ -1158,6 +1160,7 @@ class CheckRuntime:
         # redescubrirla por su cuenta.
         self._services = services
         self._host = host
+        self._cancel_check = cancel_check
 
         per_service = self._mapper(self._run_for_service, services)
         return [finding for group in per_service for finding in group]
@@ -1176,8 +1179,13 @@ class CheckRuntime:
             service: El servicio a evaluar.
 
         Returns:
-            Los hallazgos de ese servicio, en el orden del feed.
+            Los hallazgos de ese servicio, en el orden del feed. Vacíos si la
+            cancelación llegó antes de tocar este servicio: como en el
+            fingerprinting, las unidades ya lanzadas terminan pero las que aún
+            no han arrancado devuelven de inmediato.
         """
+        if getattr(self, "_cancel_check", None) is not None and self._cancel_check():
+            return []
         findings: List[dict] = []
         for family in self._families:
             if not family.applies_to_service(service):

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -17,8 +17,14 @@ headers, and TLS/certificate hygiene (self-signed, expired, deprecated
 protocol — a ``type: "tls"`` check, evaluated against a handshake instead of an
 HTTP request/response), plus the raw protocol probes of ``type: "network"``
 (Fase N) and the first-party plugins of ``type: "script"`` (Fase R) for what no
-text matcher can express — a binary protocol, a multi-step negotiation. Request
-chaining and payloads/fuzzing are deliberate follow-ups.
+text matcher can express — a binary protocol, a multi-step negotiation. An
+``http`` check can also **chain** requests (L30): an ``extractors`` block pulls
+a variable out of one response — a session cookie, a CSRF token, a version
+string — and later requests in the same check reference it as ``{{name}}`` in
+their path, body or headers. **Payloads** (``payloads: {name: [v1, v2, ...]}``)
+expand a single check into several attempts, one per value substituted the
+same way, capped hard by ``lybra.engine.maxPayloadExpansions`` so a payload
+list never turns a check into a brute-force sweep.
 
 The runtime is pure given an injected ``fetch`` callable, so it can be
 unit-tested with hand-crafted responses and never touches the network in tests.
@@ -29,6 +35,7 @@ must wait on the authorized-targets register the roadmap calls for.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import re
@@ -61,7 +68,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-16"
+CHECKS_FEED_VERSION = "lybra-checks-17"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -253,11 +260,103 @@ class Matcher:
 
     def _part_text(self, response: Response) -> str:
         """Return the response text this matcher's ``part`` refers to."""
-        if self.part == "header":
-            return "\n".join(f"{k}: {v}" for k, v in response.headers.items())
-        if self.part == "status":
-            return str(response.status)
-        return response.body
+        return _part_text(response, self.part)
+
+
+def _part_text(response: Response, part: str) -> str:
+    """Return the text of a response ``part`` — ``body``, ``header`` or ``status``.
+
+    Shared by :class:`Matcher` and :class:`Extractor` so both name the same
+    three parts the same way; an unknown part falls back to the body.
+    """
+    if part == "header":
+        return "\n".join(f"{name}: {value}" for name, value in response.headers.items())
+    if part == "status":
+        return str(response.status)
+    return response.body
+
+
+# Un marcador de variable en el DSL: ``{{name}}``, la misma sintaxis que Nuclei,
+# con la que se aspira a mantener compatibilidad. El nombre admite letras,
+# dígitos, guion y guion bajo — lo justo para un identificador, sin abrir la
+# puerta a interpolar expresiones.
+_VARIABLE_RE = re.compile(r"\{\{\s*([A-Za-z0-9_-]+)\s*\}\}")
+
+
+def _substitute(text: str, variables: Dict[str, str]) -> str:
+    """Replace every ``{{name}}`` in ``text`` with its bound value.
+
+    A marker whose variable is not bound is left **verbatim**, not blanked: a
+    payload check with a typo'd ``{{fil}}`` should fail loudly by requesting a
+    literal ``{{fil}}`` path (a 404 that shows up), not silently probe ``/`` and
+    look like it ran. Substitution is single-pass, so a value that itself
+    contains ``{{...}}`` is not re-expanded — variables carry data from the
+    target, and re-expanding it would let a response steer later requests.
+
+    Args:
+        text: The template text (a path, body or header value).
+        variables: The bound variables.
+
+    Returns:
+        The rendered text.
+    """
+    return _VARIABLE_RE.sub(
+        lambda match: variables.get(match.group(1), match.group(0)), text)
+
+
+@dataclass(frozen=True)
+class Extractor:
+    """Pulls a named value out of a response, for the next request to reuse.
+
+    This is the piece that turns a check's requests from independent probes
+    into a *chain*: an extractor names a fragment of one response —a CSRF
+    token, a session id, a version string— and the runtime makes it available
+    as ``{{name}}`` in the ``path``, ``body`` and ``headers`` of every later
+    request in the **same** check. Without it there is no way to do
+    login → protected resource, because the second request cannot know what the
+    first one answered.
+
+    A single regular expression, matched against a chosen part of the response.
+    ``group`` selects which capture group is the value (``1`` by default, the
+    first parenthesised group; ``0`` is the whole match). When the pattern does
+    not match, the extractor yields nothing and the check is abandoned — a
+    chain whose link is missing cannot honestly claim to have fired.
+
+    Attributes:
+        name: The variable name the value is bound to (used as ``{{name}}``).
+        type: The extractor kind. Only ``"regex"`` exists today; the field is
+            here so the feed is explicit and a second kind is an added value,
+            not a reinterpretation.
+        part: Which part of the response to search — ``"body"``, ``"header"``
+            or ``"status"`` (same vocabulary as :class:`Matcher`).
+        pattern: The regular expression to search for.
+        group: Which capture group is the extracted value.
+    """
+    name: str
+    pattern: str
+    type: str = "regex"
+    part: str = "body"
+    group: int = 1
+
+    def extract(self, response: Response) -> Optional[str]:
+        """Return the value this extractor pulls from ``response``, or ``None``.
+
+        Args:
+            response: The response to search.
+
+        Returns:
+            The captured text, or ``None`` when the pattern does not match (or
+            names a group the pattern does not have) — the signal the runtime
+            reads as "this chain cannot continue".
+        """
+        text = _part_text(response, self.part)
+        match = re.search(self.pattern, text)
+        if match is None:
+            return None
+        try:
+            return match.group(self.group)
+        except IndexError:  # el patrón no tiene ese grupo — se trata como no-match
+            return None
 
 
 @dataclass(frozen=True)
@@ -285,6 +384,19 @@ class Request:
             own: where a reply stops is a fact about the protocol, so the feed
             declares it. Defaults to ``"line"``, the original behaviour.
             Unused by ``type: "http"``.
+        body: For ``type: "http"``, the request body — needed for anything
+            past a bare GET, a login POST above all. ``{{name}}`` placeholders
+            in it are substituted with variables the check has extracted or a
+            payload has bound. ``None`` sends no body.
+        headers: For ``type: "http"``, extra request headers as ``(name,
+            value)`` pairs (a tuple, not a dict, so the request stays a frozen
+            value). Their values also take ``{{name}}`` — the usual way a check
+            replays an extracted token is an ``Authorization`` or ``Cookie``
+            header on the next request.
+        extractors: The :class:`Extractor` s run against this request's
+            response, binding named values for the check's later requests. This
+            is what makes a check a chain rather than a set of independent
+            probes.
     """
     method: str = "GET"
     path: str = "/"
@@ -292,6 +404,9 @@ class Request:
     condition: str = "and"
     send: Optional[str] = None
     read: str = "line"
+    body: Optional[str] = None
+    headers: tuple = ()
+    extractors: tuple = ()
 
     def evaluate(self, response: Response) -> bool:
         """Return whether this request's matchers are satisfied by a response.
@@ -363,6 +478,15 @@ class Check:  # pylint: disable=too-many-instance-attributes
             given: they exist so a *selector* can decide which of thousands of
             ingested checks are worth running against a given service before
             the runtime ever sees them (see ``ingest.selector``).
+        payloads: Named lists of values the check fuzzes over, as ``(name,
+            values)`` pairs (a tuple of tuples, so the check stays a frozen
+            value). The runtime runs the whole request sequence once per
+            combination of payload values, substituting ``{{name}}`` in
+            ``path``/``body``/``headers`` each time — twenty backup-file names
+            probed by one check instead of twenty near-identical checks. The
+            cartesian product is **hard-capped** by the runtime
+            (``max_payload_expansions``) so a payload can never turn into an
+            hours-long brute force. Empty for a check that does not fuzz.
     """
     id: str
     version: int
@@ -380,6 +504,7 @@ class Check:  # pylint: disable=too-many-instance-attributes
     expect_banner: bool = False
     confirms: Optional[str] = None
     tags: tuple = ()
+    payloads: tuple = ()
 
     @property
     def check_id(self) -> str:
@@ -440,6 +565,18 @@ def _parse_check(c: dict) -> Check:
             condition=request.get("matchers-condition", "and"),
             send=request.get("send"),
             read=_parse_read_mode(request.get("read"), c.get("id")),
+            body=request.get("body"),
+            headers=tuple((str(name), str(value)) for name, value in (request.get("headers") or {}).items()),
+            extractors=tuple(
+                Extractor(
+                    name=extractor["name"],
+                    pattern=extractor.get("pattern") or extractor.get("regex") or "",
+                    type=extractor.get("type", "regex"),
+                    part=extractor.get("part", "body"),
+                    group=int(extractor.get("group", 1)),
+                )
+                for extractor in request.get("extractors", [])
+            ),
             matchers=tuple(
                 Matcher(
                     type=matcher["type"],
@@ -466,6 +603,10 @@ def _parse_check(c: dict) -> Check:
         script=c.get("script"),
         expect_banner=bool(c.get("expectBanner", False)),
         confirms=c.get("confirms"),
+        payloads=tuple(
+            (str(name), tuple(str(value) for value in values))
+            for name, values in (c.get("payloads") or {}).items()
+        ),
     )
     _assert_service_is_reachable(check)
     return check
@@ -579,6 +720,12 @@ MATCHER_PARTS = ("body", "header", "status")
 # Forma de un identificador CVE, para validar el campo ``confirms``.
 _CVE_ID_RE = re.compile(r"^CVE-[0-9]{4}-[0-9]{4,}$")
 
+# Los tipos de extractor que :meth:`Extractor.extract` implementa. Sólo hay uno
+# hoy; validarlo evita que un ``type: xpath`` copiado de una plantilla de
+# Nuclei se cargue en silencio y no extraiga nunca nada — con lo que el
+# encadenamiento que dependa de esa variable se rompería sin decir por qué.
+EXTRACTOR_TYPES = ("regex",)
+
 
 def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=too-many-branches
     """Comprobar que ningún check está muerto por construcción.
@@ -659,6 +806,13 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=to
         if check.type in ("http", "network") and not check.requests:
             problems.append(f"Check {name!r}: de tipo {check.type!r} y sin ninguna petición")
 
+        # Un payload sin valores nunca expande nada, así que su ``{{name}}`` se
+        # queda literal en la petición: un check muerto que parece vivo.
+        for payload_name, values in check.payloads:
+            if not values:
+                problems.append(
+                    f"Check {name!r}: el payload {payload_name!r} no tiene ningún valor")
+
         for position, request in enumerate(check.requests):
             where = f"Check {name!r}, petición {position}"
             if request.read not in NETWORK_READ_MODES:
@@ -672,6 +826,25 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=to
                     problems.append(f"{where}: matcher sobre la parte {matcher.part!r}, que no existe")
                 if not matcher.values:
                     problems.append(f"{where}: matcher {matcher.type!r} sin valores que buscar")
+            for extractor in request.extractors:
+                if not extractor.name:
+                    problems.append(f"{where}: un extractor no declara 'name'")
+                if extractor.type not in EXTRACTOR_TYPES:
+                    problems.append(
+                        f"{where}: extractor de tipo {extractor.type!r} desconocido "
+                        f"(disponibles: {', '.join(EXTRACTOR_TYPES)})")
+                if extractor.part not in MATCHER_PARTS:
+                    problems.append(
+                        f"{where}: extractor sobre la parte {extractor.part!r}, que no existe")
+                if not extractor.pattern:
+                    problems.append(f"{where}: extractor {extractor.name!r} sin patrón")
+                else:
+                    try:
+                        re.compile(extractor.pattern)
+                    except re.error as compile_error:
+                        problems.append(
+                            f"{where}: extractor {extractor.name!r} con patrón inválido "
+                            f"({compile_error})")
 
     return problems
 
@@ -1098,6 +1271,7 @@ class CheckRuntime:
         script_plugins: Optional[Dict[str, object]] = None,
         mapper: Optional[Callable] = None,
         capture_evidence: bool = False,
+        max_payload_expansions: int = 25,
     ) -> None:
         self._checks = list(checks)
         self._fetch = fetch
@@ -1106,6 +1280,11 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
+        # El tope de expansiones de un payload (L30): un check que fuzzea corta
+        # aquí, pase lo que pase, para que no se vuelva un barrido de fuerza
+        # bruta. El manager lo inyecta desde la config; el default de 25 es el
+        # que un check declarativo espera si nadie lo toca.
+        self._max_payload_expansions = max(1, int(max_payload_expansions))
         # Cómo se recorren los servicios. Por defecto, el ``map`` de siempre:
         # uno detrás de otro. El manager inyecta aquí un pool acotado por host
         # (L23), igual que ya inyecta las sondas — este módulo no conoce la
@@ -1292,35 +1471,113 @@ class CheckRuntime:
     def _run_check(self, check: Check, host: str, service: Service) -> Optional[dict]:
         """Run one check against one service, returning a finding if it fired.
 
-        Every request in the check must fire (they are combined with AND). If any
-        request fails to reach the target or does not match, the check produces
-        nothing.
+        The check's requests run in sequence and are combined with AND: every
+        one must reach the target and match, or the check produces nothing. A
+        request can carry a ``body`` and ``headers``, and each request's
+        ``extractors`` bind ``{{name}}`` variables that later requests in the
+        same sequence substitute — that is the login → protected-resource chain.
+
+        When the check declares ``payloads``, the whole sequence runs once per
+        combination of payload values (``{{name}}`` substituted each time),
+        capped at ``max_payload_expansions``. The **first** combination that
+        fires wins: a check that probes twenty backup-file names is asking "is
+        *any* of these exposed?", and one hit answers it. Every finding still
+        carries a single ``check_id``, so twenty probes collapse to one finding.
         """
-        last_response = None
-        for request in check.requests:
-            response = self._probe_response(host, service, request.method, request.path)
-            if response is None or not request.evaluate(response):
-                return None
-            last_response = response
+        fired = None
+        for variables in self._payload_combinations(check):
+            fired = self._run_request_sequence(check, host, service, variables)
+            if fired is not None:
+                break
+        if fired is None:
+            return None
+        last_response, last_path = fired
         finding = self._finding(check, service)
         # Evidencia (Fase E): la respuesta que provocó el hallazgo. Sólo para
         # los confirmados —los que van a un informe— y sólo si la captura está
         # activada. El payload viaja en ``_evidence`` hasta la persistencia, que
-        # lo redacta y lo separa en su propia fila.
-        if (self._capture_evidence and last_response is not None
-                and finding.get("confirmed")):
+        # lo redacta y lo separa en su propia fila. La ruta es la ya sustituida
+        # (el payload o la variable que de verdad disparó), no la plantilla.
+        if self._capture_evidence and finding.get("confirmed"):
             finding["_evidence"] = {
                 "kind": "http_response",
                 "payload": {
                     "status": last_response.status,
                     "headers": dict(last_response.headers),
                     "body": last_response.body,
-                    "path": check.requests[-1].path,
+                    "path": last_path,
                 },
             }
         return finding
 
-    def _probe_response(self, host: str, service: Service, method: str, path: str) -> Optional[Response]:
+    def _payload_combinations(self, check: Check) -> List[Dict[str, str]]:
+        """Return the variable bindings to run the check's sequence under.
+
+        A check with no ``payloads`` runs once, with no bindings (``[{}]``): the
+        old behaviour, unchanged. A check *with* payloads runs once per element
+        of the cartesian product of its payload lists — ``{file: [a, b], ext:
+        [x, y]}`` yields four bindings — but never more than
+        ``max_payload_expansions`` of them. The cap is applied while the product
+        is generated (it is lazy), so a payload whose product is astronomically
+        large still costs only the capped number of iterations, not the full
+        expansion followed by a slice.
+        """
+        if not check.payloads:
+            return [{}]
+        names = [name for name, _ in check.payloads]
+        value_lists = [values for _, values in check.payloads]
+        combinations: List[Dict[str, str]] = []
+        for combination in itertools.product(*value_lists):
+            combinations.append(dict(zip(names, combination)))
+            if len(combinations) >= self._max_payload_expansions:
+                break
+        return combinations
+
+    def _run_request_sequence(
+        self, check: Check, host: str, service: Service, variables: Dict[str, str],
+    ) -> Optional[Tuple[Response, str]]:
+        """Run a check's requests once, threading extracted variables through.
+
+        Each request's ``path``/``body``/``headers`` are rendered with the
+        variables gathered so far (the payload binding this call started with,
+        plus whatever earlier requests extracted). Every request must match; a
+        request that fails to reach the target, does not match, **or whose
+        extractor finds nothing** abandons the whole sequence — a chain with a
+        missing link never fired.
+
+        Args:
+            check: The check being run.
+            host: The target host.
+            service: The service being probed.
+            variables: The initial variable bindings (a payload combination, or
+                empty).
+
+        Returns:
+            ``(last_response, last_path)`` if every request matched, else
+            ``None``. The path comes back rendered so the caller can record the
+            request that actually fired as evidence.
+        """
+        variables = dict(variables)
+        last: Optional[Tuple[Response, str]] = None
+        for request in check.requests:
+            path = _substitute(request.path, variables)
+            body = _substitute(request.body, variables) if request.body else None
+            headers = {name: _substitute(value, variables) for name, value in request.headers} or None
+            response = self._probe_response(host, service, request.method, path, body, headers)
+            if response is None or not request.evaluate(response):
+                return None
+            for extractor in request.extractors:
+                value = extractor.extract(response)
+                if value is None:
+                    return None
+                variables[extractor.name] = value
+            last = (response, path)
+        return last
+
+    def _probe_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, service: Service, method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Response]:
         """Return the response for one request, asking the target only once.
 
         Every check runs independently, which is what keeps them simple, but
@@ -1331,19 +1588,29 @@ class CheckRuntime:
 
         Noise on the target is not a side issue for a security scanner: it
         shows up in the SIEM of whoever hired us. So a response is fetched once
-        per ``(method, path)`` and shared by every check that asks for it,
-        within one :meth:`run`.
+        per ``(method, path, body, headers)`` and shared by every check that
+        asks for it, within one :meth:`run`.
+
+        The ``body``/``headers`` are optional so the vast majority of checks —
+        bare GETs — call the injected ``fetch`` with the same four positional
+        arguments it always took: a test ``fetch`` written as ``(host, port,
+        method, path)`` keeps working, and only a check that actually sends a
+        body or headers requires a ``fetch`` that accepts them.
 
         A transport failure is remembered too. Not caching it would mean three
         attempts against a service that is down — the case where retrying costs
         the most and informs the least.
         """
-        key = (host, service.port, method, path)
+        header_key = tuple(sorted(headers.items())) if headers else None
+        key = (host, service.port, method, path, body, header_key)
         if key in self._responses:
             return self._responses[key]
         if self._rl is not None:
             self._rl.acquire(host)
-        response = self._fetch(host, service.port, method, path)
+        if body is None and headers is None:
+            response = self._fetch(host, service.port, method, path)
+        else:
+            response = self._fetch(host, service.port, method, path, body, headers)
         self._responses[key] = response
         return response
 
@@ -1613,7 +1880,10 @@ class HttpProbe:
             urllib.request.HTTPSHandler(context=ssl._create_unverified_context())
         )
 
-    def fetch(self, host: str, port: Optional[int], method: str, path: str) -> Optional[Response]:
+    def fetch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, port: Optional[int], method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[Response]:
         """Make a request and return it as a :class:`Response`.
 
         Args:
@@ -1621,15 +1891,20 @@ class HttpProbe:
             port: The target port (decides http vs https).
             method: The HTTP method.
             path: The request path.
+            body: The request body (L30), or ``None`` for none. A non-GET check
+                — a login POST above all — needs this.
+            headers: Extra request headers (L30), or ``None``. The way a chained
+                check replays an extracted token: an ``Authorization`` or
+                ``Cookie`` header on the follow-up request.
 
         Returns:
             The response, or ``None`` on a transport failure.
         """
-        result = self._request(host, port, method, path)
+        result = self._request(host, port, method, path, body, headers)
         if result is None:
             return None
-        status, body, headers = result
-        return self._to_response(status, body, headers)
+        status, response_body, response_headers = result
+        return self._to_response(status, response_body, response_headers)
 
     def fetch_bytes(self, host: str, port: Optional[int], path: str) -> Optional[bytes]:
         """Fetch raw bytes for binary content such as a favicon.
@@ -1652,18 +1927,29 @@ class HttpProbe:
         status, body, _headers = result
         return body if status == 200 else None
 
-    def _request(self, host: str, port: Optional[int], method: str, path: str) -> Optional[tuple]:
+    def _request(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, host: str, port: Optional[int], method: str, path: str,
+        body: Optional[str] = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[tuple]:
         """Perform the raw HTTP request, returning ``(status, body, headers)``.
 
         A 4xx/5xx is returned normally; only a transport failure returns ``None``.
         HTTPS uses an unverified TLS context, since we are scanning arbitrary
         hosts whose certificates we do not control.
+
+        The check-supplied ``headers`` are layered over the probe's own
+        ``User-Agent`` (a check may deliberately override it), and ``body`` is
+        sent UTF-8 encoded. Both are absent for the common read-only GET.
         """
         scheme = self._scheme_for(host, port)
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
+        request_headers = {"User-Agent": self._user_agent}
+        if headers:
+            request_headers.update({str(name): str(value) for name, value in headers.items()})
+        data = body.encode("utf-8") if body is not None else None
         try:
-            request = urllib.request.Request(url, method=method, headers={"User-Agent": self._user_agent})
+            request = urllib.request.Request(url, method=method, headers=request_headers, data=data)
             with self._opener.open(request, timeout=self._timeout) as response:
                 return response.status, response.read(self._max_bytes), dict(response.headers)
         except urllib.error.HTTPError as err:

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -1494,6 +1494,7 @@ class HttpProbe:
         detect_scheme: An injectable ``(host, port) -> bool`` telling whether
             the service speaks TLS. Defaults to :func:`negotiates_tls`; a test
             passes a stub instead of opening a socket.
+        user_agent: The ``User-Agent`` header the probe presents (L39).
     """
 
     def __init__(
@@ -1501,9 +1502,11 @@ class HttpProbe:
         timeout: int = 8,
         max_bytes: int = 131072,
         detect_scheme: Optional[Callable[[str, Optional[int]], bool]] = None,
+        user_agent: str = "Lybra/1.0",
     ) -> None:
         self._timeout = timeout
         self._max_bytes = max_bytes
+        self._user_agent = user_agent
         self._detect_scheme = detect_scheme or (lambda host, port: negotiates_tls(host, port, timeout))
         # El esquema se observa una vez por servicio y se recuerda: la pregunta
         # es sobre el servicio, no sobre la petición, y no cambia entre una y
@@ -1580,7 +1583,7 @@ class HttpProbe:
         netloc = f"{host}:{port}" if port else host
         url = f"{scheme}://{netloc}{path}"
         try:
-            request = urllib.request.Request(url, method=method, headers={"User-Agent": "Lybra/1.0"})
+            request = urllib.request.Request(url, method=method, headers={"User-Agent": self._user_agent})
             with self._opener.open(request, timeout=self._timeout) as response:
                 return response.status, response.read(self._max_bytes), dict(response.headers)
         except urllib.error.HTTPError as err:

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 # ``Check.check_id``). Los dos checks ``network`` suben además a ``version: 2``
 # en checks-6: su comportamiento cambia, y un hallazgo guardado tiene que poder
 # decir cuál de las dos formas lo produjo.
-CHECKS_FEED_VERSION = "lybra-checks-14"
+CHECKS_FEED_VERSION = "lybra-checks-15"
 # Quality of Detection for a finding a check actively confirmed, as opposed to
 # one merely inferred from a version.
 QOD_CONFIRMED = 99
@@ -160,6 +160,8 @@ _REDIS_SERVICE_NAMES = {"redis"}
 _REDIS_PORTS = {6379}
 _VNC_SERVICE_NAMES = {"vnc"}
 _VNC_PORTS = {5900}
+_TELNET_SERVICE_NAMES = {"telnet"}
+_TELNET_PORTS = {23}
 # SNMP — el primer protocolo de esta tabla que habla UDP (Fase N/Ronda 1,
 # roadmap §6.3). 161 también aparece en WELL_KNOWN_PORTS como TCP, así que
 # is_snmp_service (más abajo) es el único predicado de este módulo que mira
@@ -762,6 +764,16 @@ def is_redis_service(service: Service) -> bool:
     """Return whether a service should be probed by the Redis dissector or
     ``type: "network"`` checks (Fase N)."""
     return (service.name or "").lower() in _REDIS_SERVICE_NAMES or service.port in _REDIS_PORTS
+
+
+def is_telnet_service(service: Service) -> bool:
+    """Return whether a service is a Telnet endpoint.
+
+    Que exista un Telnet respondiendo **es** el hallazgo —credenciales en claro
+    por diseño—, así que este predicado no necesita distinguir producto ni
+    versión: sólo a qué servicios acercarse.
+    """
+    return (service.name or "").lower() in _TELNET_SERVICE_NAMES or service.port in _TELNET_PORTS
 
 
 def is_vnc_service(service: Service) -> bool:

--- a/API/src/modules/features/themis/lybra/credentials.py
+++ b/API/src/modules/features/themis/lybra/credentials.py
@@ -1,0 +1,357 @@
+"""El motor de credenciales por defecto — Fase D del roadmap (L31).
+
+Es la **única** familia de detección de Lybra que escribe en el objetivo: cada
+intento es un login real contra un servicio real. El roadmap lo dice sin
+rodeos — *"es una operación que escribe en el objetivo, que puede bloquear
+cuentas, que genera ruido en el SIEM del objetivo y que exige un control de
+tasa y un presupuesto muy distintos a un GET de .git/config"* — y por eso vive
+en su propio módulo, con sus propias guardas, en vez de ser un ``Check`` más
+del DSL declarativo de :mod:`checks`.
+
+**Las guardas no son opcionales, y son del llamante, no de aquí.** Este
+runtime no decide si debe correr: el manager lo invoca sólo bajo la doble
+puerta del modo agresivo (L40) — objetivo en el registro de autorización *y*
+petición explícita del usuario —, exactamente igual que cualquier otro check
+``mode: aggressive``. Lo que sí es responsabilidad de este módulo es el
+presupuesto de intentos: **por cuenta, no por servicio** — tres contraseñas
+distintas contra ``admin`` cuentan tres intentos para ``admin``, sin que
+probar además ``root`` en el mismo servicio consuma ese mismo cupo. Es la
+cuenta, no el servicio, la que un proveedor bloquea tras demasiados fallos.
+
+**El plaintext nunca sale de este módulo.** Una vez usada para construir la
+cabecera ``Authorization``, una contraseña no vuelve a aparecer en ningún
+dict que este módulo produzca — ni en el hallazgo, ni en su evidencia, ni en
+un log. Sólo el *nombre de usuario* que funcionó se recuerda, porque decir
+"la cuenta admin tiene la contraseña de fábrica" es información útil para
+quien recibe el informe; decir cuál era la contraseña no lo es, y guardarla
+convertiría la base de datos de un cliente en un depósito de las contraseñas
+del propio cliente.
+
+Reutiliza deliberadamente piezas de :mod:`checks` en vez de duplicarlas: el
+mismo :class:`~.checks.Matcher` decide si una respuesta demuestra que el login
+funcionó, el mismo :class:`~.checks.Response` es lo que un matcher evalúa, y
+el ``fetch`` inyectado es la misma forma que :class:`~.checks.HttpProbe.fetch`
+ya expone desde L30 (``host, port, method, path, body, headers``) — un intento
+de credenciales *es* una petición HTTP con una cabecera ``Authorization``,
+nada más.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+from .checks import HostRateLimiter, Matcher, Response, is_http_service
+
+logger = logging.getLogger(__name__)
+
+# El feed shipped junto al de checks.py, mismo directorio, mismo trato: JSON
+# porque estos pares no necesitan comentarios extensos por entrada como el
+# feed de checks (una lista de pares usuario/contraseña se explica sola), y
+# porque no aspira a compatibilidad con ningún formato externo (a diferencia
+# de checks_feed.yaml, que sí la busca con Nuclei).
+_BUNDLED_FEED = Path(__file__).parent / "feeds" / "credentials_feed.json"
+
+CREDENTIALS_FEED_VERSION = "lybra-credentials-1"
+QOD_CONFIRMED = 99
+
+# Servicios candidatos hoy. Sólo HTTP: es donde vive Tomcat Manager, Jenkins y
+# la mayoría de paneles de administración con credenciales de fábrica
+# conocidas, y es el único protocolo para el que ``HttpProbe.fetch`` ya sabe
+# mandar una cabecera ``Authorization`` (L30). Ampliar a FTP/SSH es straight-
+# forward por el mismo camino que las familias ``network`` de checks.py —
+# inyectar un ``attempt`` en vez de un ``fetch`` HTTP—, pero no hay ninguna
+# entrada del feed que lo necesite todavía.
+_SERVICE_MATCHERS: Dict[str, Callable] = {
+    "http": is_http_service,
+}
+
+
+@dataclass(frozen=True)
+class CredentialPair:
+    """Un par usuario/contraseña de fábrica a probar.
+
+    Attributes:
+        username: El nombre de usuario.
+        password: La contraseña. Vive únicamente aquí y en la cabecera HTTP
+            que :class:`CredentialRuntime` construye con ella — nunca en un
+            hallazgo, en su evidencia, ni en un log.
+    """
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class CredentialEntry:  # pylint: disable=too-many-instance-attributes
+    """Un producto con credenciales de fábrica conocidas y cómo probarlas.
+
+    Attributes:
+        id: Identificador corto, p. ej. ``"tomcat-manager-default"``.
+        version: Versión de la entrada — misma convención que
+            :attr:`~.checks.Check.version`: sube cuando cambia qué prueba o
+            cómo, no cuando sólo se añade un par a la lista.
+        service: Qué servicio reclama esta entrada (``"http"`` hoy — ver
+            :data:`_SERVICE_MATCHERS`).
+        method: El método HTTP de la sonda.
+        path: La ruta a la que se manda cada intento (p. ej.
+            ``"/manager/html"`` para Tomcat Manager).
+        accounts: Los pares a probar, en orden. El mismo usuario puede
+            aparecer varias veces con contraseñas distintas — así es como el
+            presupuesto "por cuenta" tiene sentido: agota primero las
+            contraseñas de una cuenta antes de pasar a la siguiente.
+        matchers: Las condiciones que demuestran que el intento entró — el
+            mismo :class:`~.checks.Matcher` que usa el DSL declarativo,
+            combinadas con AND. Un ``status: 200`` solo no basta contra un
+            servidor que sirve sin autenticar; el feed añade además una
+            palabra del cuerpo esperado tras entrar.
+        finding: Plantilla de campos del hallazgo (``title`` sobre todo).
+        feed_version: Versión del feed de origen, o ``None`` para usar
+            :data:`CREDENTIALS_FEED_VERSION`.
+    """
+    id: str
+    version: int
+    service: str
+    path: str
+    accounts: tuple
+    matchers: tuple
+    method: str = "GET"
+    finding: dict = field(default_factory=dict)
+    feed_version: Optional[str] = None
+
+    @property
+    def check_id(self) -> str:
+        """El identificador versionado, p. ej. ``lybra-credentials:tomcat-manager-default@1``."""
+        return f"lybra-credentials:{self.id}@{self.version}"
+
+
+# =========================================================================
+# FEED LOADING
+# =========================================================================
+
+def load_credentials(path: Optional[str] = None) -> List[CredentialEntry]:
+    """Cargar y parsear el feed de credenciales por defecto.
+
+    Args:
+        path: Ruta a un feed JSON. Por defecto, el empaquetado con el módulo.
+
+    Returns:
+        Las entradas parseadas.
+    """
+    feed_path = Path(path) if path else _BUNDLED_FEED
+    document = json.loads(feed_path.read_text(encoding="utf-8"))
+    return [_parse_entry(entry) for entry in document.get("entries", [])]
+
+
+def _parse_entry(raw: dict) -> CredentialEntry:
+    """Construir una :class:`CredentialEntry` desde su representación JSON."""
+    return CredentialEntry(
+        id=raw["id"],
+        version=raw.get("version", 1),
+        service=raw.get("service", "http"),
+        method=raw.get("method", "GET"),
+        path=raw.get("path", "/"),
+        accounts=tuple(
+            CredentialPair(username=account["username"], password=account["password"])
+            for account in raw.get("accounts", [])
+        ),
+        matchers=tuple(
+            Matcher(
+                type=matcher["type"],
+                part=matcher.get("part", "body"),
+                values=tuple(matcher.get("words") or matcher.get("regex") or matcher.get("value") or []),
+                negative=matcher.get("negative", False),
+            )
+            for matcher in raw.get("matchers", [])
+        ),
+        finding=raw.get("finding", {}),
+    )
+
+
+# =========================================================================
+# FEED VALIDATION
+# =========================================================================
+
+def validate_credentials(entries: Iterable[CredentialEntry]) -> List[str]:
+    """Comprobar que ninguna entrada de credenciales está muerta por construcción.
+
+    Misma filosofía que :func:`~.checks.validate_checks`: un feed que se
+    ejecuta y falla en silencio es peor que uno que no carga. Devuelve los
+    problemas en vez de lanzar, para poder revisar el feed entero de una vez.
+
+    Args:
+        entries: Las entradas ya parseadas.
+
+    Returns:
+        Una lista de problemas legibles, vacía si el feed está sano.
+    """
+    problems: List[str] = []
+    seen: set = set()
+
+    for entry in entries:
+        name = entry.id or "<sin id>"
+
+        if not entry.id:
+            problems.append("Una entrada de credenciales no declara 'id'")
+        if (entry.id, entry.version) in seen:
+            problems.append(f"Entrada {name!r}: duplicada en (id, version)={(entry.id, entry.version)}")
+        seen.add((entry.id, entry.version))
+
+        if entry.service not in _SERVICE_MATCHERS:
+            problems.append(
+                f"Entrada {name!r}: servicio {entry.service!r} sin predicado "
+                f"(disponibles: {', '.join(sorted(_SERVICE_MATCHERS))})"
+            )
+        if not entry.accounts:
+            problems.append(f"Entrada {name!r}: sin ninguna cuenta que probar")
+        for position, account in enumerate(entry.accounts):
+            if not account.username:
+                problems.append(f"Entrada {name!r}, cuenta {position}: sin 'username'")
+            if not account.password:
+                problems.append(f"Entrada {name!r}, cuenta {position}: sin 'password'")
+        if not entry.matchers:
+            problems.append(
+                f"Entrada {name!r}: sin ningún matcher, así que ningún intento "
+                f"se podría distinguir de un fallo de login"
+            )
+
+    return problems
+
+
+# =========================================================================
+# RUNTIME
+# =========================================================================
+
+def _basic_auth_headers(username: str, password: str) -> Dict[str, str]:
+    """Construir la cabecera ``Authorization: Basic`` para un intento.
+
+    El único punto de todo el módulo donde la contraseña en claro se toca:
+    entra aquí, sale codificada en la cabecera, y no queda en ninguna otra
+    parte —ni en una variable que sobreviva a esta llamada.
+    """
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+class CredentialRuntime:
+    """Prueba credenciales de fábrica contra los servicios de un host (Fase D).
+
+    Args:
+        entries: Las entradas de credenciales a probar.
+        fetch: Un ``(host, port, method, path, body, headers) -> Response |
+            None`` — la misma forma que :meth:`~.checks.HttpProbe.fetch`
+            expone desde L30.
+        rate_limiter: Limitador por host opcional, aplicado antes de cada
+            intento — cada login real es tráfico hacia el objetivo, y esta es
+            la única familia del motor donde ese tráfico además escribe.
+        max_attempts_per_account: Tope de contraseñas distintas probadas
+            contra una misma cuenta (L31) — no contra un mismo servicio. Ver
+            el docstring del módulo.
+        capture_evidence: Si se adjunta la respuesta que demostró el acceso
+            como evidencia (Fase E) — nunca incluye la contraseña, sólo lo que
+            el objetivo respondió.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        entries: Iterable[CredentialEntry],
+        fetch: Callable[..., Optional[Response]],
+        rate_limiter: Optional[HostRateLimiter] = None,
+        max_attempts_per_account: int = 3,
+        capture_evidence: bool = False,
+    ) -> None:
+        self._entries = list(entries)
+        self._fetch = fetch
+        self._rl = rate_limiter
+        self._max_attempts = max(1, int(max_attempts_per_account))
+        self._capture_evidence = capture_evidence
+
+    def run(self, host: str, services: Iterable) -> List[dict]:
+        """Probar cada entrada aplicable contra cada servicio del host.
+
+        Args:
+            host: El objetivo.
+            services: Los servicios descubiertos del host.
+
+        Returns:
+            Un hallazgo por cada entrada que encontró una cuenta funcionando.
+        """
+        findings: List[dict] = []
+        for service in services:
+            for entry in self._entries:
+                matches_service = _SERVICE_MATCHERS.get(entry.service)
+                if matches_service is None or not matches_service(service):
+                    continue
+                finding = self._try_entry(host, service, entry)
+                if finding is not None:
+                    findings.append(finding)
+        return findings
+
+    def _try_entry(self, host: str, service, entry: CredentialEntry) -> Optional[dict]:
+        """Probar las cuentas de una entrada contra un servicio, hasta el primer éxito.
+
+        Cada intento se registra ocurra lo que ocurra — un informe que dice
+        "se probaron credenciales por defecto y ninguna funcionó" es
+        información tan válida como un hallazgo, y el silencio no distingue
+        eso de "no se llegó a probar".
+        """
+        attempts_by_username: Dict[str, int] = {}
+        for account in entry.accounts:
+            used = attempts_by_username.get(account.username, 0)
+            if used >= self._max_attempts:
+                continue
+            attempts_by_username[account.username] = used + 1
+
+            if self._rl is not None:
+                self._rl.acquire(host)
+            logger.info(
+                "Credenciales por defecto %s: intento %s/%s contra %s:%s con la cuenta %r",
+                entry.check_id, used + 1, self._max_attempts, host, service.port, account.username,
+            )
+            response = self._fetch(
+                host, service.port, entry.method, entry.path,
+                None, _basic_auth_headers(account.username, account.password),
+            )
+            if response is None:
+                continue
+            if all(matcher.matches(response) for matcher in entry.matchers):
+                return self._finding(entry, service, account, response)
+        return None
+
+    def _finding(self, entry: CredentialEntry, service, account: CredentialPair,
+                 response: Response) -> dict:
+        """Construir el hallazgo de un acceso logrado — sin la contraseña en ningún sitio."""
+        finding_template = entry.finding
+        finding = {
+            "title": finding_template.get(
+                "title", f"Credenciales por defecto: {entry.id} ({account.username})"),
+            "category": "default_credentials",
+            "port": service.port,
+            "service": service.name or entry.service,
+            "protocol": service.protocol,
+            "cve_ids": None,
+            "source": "lybra",
+            "check_id": entry.check_id,
+            "feed_version": entry.feed_version or CREDENTIALS_FEED_VERSION,
+            "qod": QOD_CONFIRMED,
+            "confirmed": True,
+            "state": "open",
+        }
+        if self._capture_evidence:
+            finding["_evidence"] = {
+                "kind": "http_response",
+                # Sólo lo que el objetivo respondió: la cabecera Authorization
+                # que este módulo mandó nunca viaja aquí, así que la
+                # contraseña no tiene forma de colarse en la evidencia.
+                "payload": {
+                    "status": response.status,
+                    "headers": dict(response.headers),
+                    "body": response.body,
+                    "path": entry.path,
+                    "username": account.username,
+                },
+            }
+        return finding

--- a/API/src/modules/features/themis/lybra/evidence.py
+++ b/API/src/modules/features/themis/lybra/evidence.py
@@ -1,0 +1,185 @@
+"""La evidencia cruda de un hallazgo — capturada, redactada y con hash (Fase E).
+
+Este módulo vive en la capa pura ``lybra/``: **no toca el ORM**. El motor
+recoge la evidencia en una lista en memoria a través de un *recorder*
+inyectable —igual que ``cve_lookup``—, y es el manager quien la vuelca a la
+base de datos en la fase de persistencia. Aquí sólo están las dos operaciones
+que no dependen de nada externo: **redactar** y **hashear**.
+
+**Por qué la redacción es requisito y no mejora.** Una respuesta cruda puede
+traer cookies de sesión, cabeceras ``Authorization``, tokens en el cuerpo o
+datos personales del objetivo. Guardar evidencia sin redactar convertiría la
+base de datos de Ellysia en un depósito de secretos ajenos. Filtrar las
+cabeceras sensibles y truncar el cuerpo es la línea que separa «guardo lo que
+vi» de «me quedo con las llaves de casa del cliente».
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+# Cabeceras que nunca se persisten: llevan credenciales o material de sesión.
+# Se comparan en minúsculas, así que la lista va en minúsculas.
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "www-authenticate",
+    "proxy-authenticate",
+    "x-api-key",
+    "x-auth-token",
+    "x-csrf-token",
+    "x-xsrf-token",
+    "api-key",
+    "authentication-info",
+})
+
+# Lo que se pone en lugar de una cabecera redactada, para que la evidencia diga
+# «aquí había algo y lo quitamos» en vez de esconder que existía.
+_REDACTED = "[redacted]"
+
+# Las clases de evidencia que el modelo reconoce (MS-Fase E). Una entrada con
+# otro ``kind`` no se descarta, pero conviene que la lista viva en un sitio.
+EVIDENCE_KINDS = ("http_response", "ssh_banner", "tls_cert", "probe_output")
+
+
+@dataclass
+class EvidenceRecord:
+    """Una evidencia recogida por el motor, aún sin persistir.
+
+    El ``dedup_key`` es lo que ata la evidencia a su hallazgo cuando el manager
+    la vuelca: el hallazgo se identifica por esa clave, no por la identidad de
+    un objeto Python que ``merge_findings`` podría haber recreado.
+
+    Attributes:
+        dedup_key: La clave del hallazgo que esta evidencia respalda.
+        kind: La clase de evidencia (:data:`EVIDENCE_KINDS`).
+        payload: El contenido observado, **sin** redactar todavía.
+    """
+    dedup_key: str
+    kind: str
+    payload: Dict[str, Any]
+
+
+@dataclass
+class EvidenceRecorder:
+    """Un recorder inyectable que acumula evidencia en memoria.
+
+    El motor recibe uno de éstos y llama :meth:`record` cuando un hallazgo trae
+    la respuesta que lo provocó. No sabe nada de la base de datos; el manager
+    lee :attr:`records` al final y los persiste.
+    """
+    records: List[EvidenceRecord] = field(default_factory=list)
+
+    def record(self, dedup_key: str, kind: str, payload: Dict[str, Any]) -> None:
+        """Apunta una evidencia para un hallazgo.
+
+        Args:
+            dedup_key: La clave del hallazgo que respalda.
+            kind: La clase de evidencia.
+            payload: El contenido observado, sin redactar.
+        """
+        self.records.append(EvidenceRecord(dedup_key=dedup_key, kind=kind, payload=payload))
+
+
+def redact_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Sustituye el valor de las cabeceras sensibles por un marcador.
+
+    Se conserva el **nombre** de la cabecera —que dice que estaba— y se borra
+    sólo el valor. Un informe que dice «había un ``Set-Cookie`` y lo redactamos»
+    es más honesto que uno que finge que no existía.
+
+    Args:
+        headers: Las cabeceras de la respuesta.
+
+    Returns:
+        Una copia con los valores sensibles redactados.
+    """
+    return {
+        name: (_REDACTED if name.lower() in _SENSITIVE_HEADERS else value)
+        for name, value in headers.items()
+    }
+
+
+def redact_evidence(payload: Dict[str, Any], max_body_bytes: int = 8192) -> Dict[str, Any]:
+    """Redacta y trunca una evidencia antes de persistirla.
+
+    Args:
+        payload: El contenido observado. Puede traer ``headers`` (un dict) y
+            ``body`` (texto); cualquier otra clave se conserva tal cual.
+        max_body_bytes: El tope del cuerpo, en bytes de su codificación UTF-8.
+
+    Returns:
+        Una copia redactada: cabeceras sensibles sin valor, cuerpo truncado con
+        una marca de cuántos bytes se recortaron.
+    """
+    redacted = dict(payload)
+    if isinstance(redacted.get("headers"), dict):
+        redacted["headers"] = redact_headers(redacted["headers"])
+    body = redacted.get("body")
+    if isinstance(body, str):
+        encoded = body.encode("utf-8", "ignore")
+        if len(encoded) > max_body_bytes:
+            redacted["body"] = encoded[:max_body_bytes].decode("utf-8", "ignore")
+            redacted["body_truncated_bytes"] = len(encoded) - max_body_bytes
+    return redacted
+
+
+def evidence_hash(payload: Dict[str, Any]) -> str:
+    """Calcula el SHA-256 de una evidencia redactada, de forma estable.
+
+    Se serializa con las claves ordenadas para que el mismo contenido produzca
+    siempre el mismo hash, que es lo que permite afirmar después que la
+    evidencia no se ha tocado.
+
+    Args:
+        payload: La evidencia ya redactada.
+
+    Returns:
+        El digest hexadecimal.
+    """
+    serialized = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def prepare_evidence(
+    payload: Dict[str, Any],
+    max_body_bytes: int = 8192,
+) -> Dict[str, Any]:
+    """Redacta, trunca y hashea una evidencia en un solo paso.
+
+    Args:
+        payload: El contenido observado, sin redactar.
+        max_body_bytes: El tope del cuerpo.
+
+    Returns:
+        Un dict ``{"payload": <redactado>, "content_hash": <sha256>}`` listo
+        para el modelo.
+    """
+    redacted = redact_evidence(payload, max_body_bytes)
+    return {"payload": redacted, "content_hash": evidence_hash(redacted)}
+
+
+def build_recorder(enabled: bool) -> Optional[EvidenceRecorder]:
+    """Devuelve un recorder si la captura está activada, o ``None``.
+
+    Un ``None`` es la señal de «no captures nada», que el motor propaga sin
+    ramas especiales: donde llamaría a ``recorder.record`` simplemente no hay
+    recorder.
+
+    Args:
+        enabled: Si la captura de evidencia está activada.
+
+    Returns:
+        Un :class:`EvidenceRecorder` nuevo, o ``None``.
+    """
+    return EvidenceRecorder() if enabled else None
+
+
+# Tipo del recorder que el motor recibe: una función que apunta una evidencia,
+# o ``None``. Se declara para que las firmas lo nombren sin importar la clase.
+RecorderFn = Optional[Callable[[str, str, Dict[str, Any]], None]]

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-15
+feedVersion: lybra-checks-16
 checks:
   - id: git-config-exposure
     version: 1
@@ -1334,5 +1334,64 @@ checks:
               - '^(?:500|502|504|530|534|431)'
     finding:
       title: 'FTP: sin cifrado disponible (AUTH TLS no soportado)'
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Confirmadores (L29): ascienden una hipótesis por versión de
+  # confirmed=false/qod=70 a confirmed=true/qod=99. Sólo corren si el
+  # matcher de versiones ya propuso su CVE, y NUNCA explotan — comprueban
+  # la condición sin ejecutar nada en el objetivo.
+  # ===================================================================
+  # CVE-2021-41773: path traversal de Apache 2.4.49. La prueba lee
+  # /etc/passwd por la ruta vulnerable — una lectura, no una ejecución. Si
+  # el cuerpo trae la línea de root, el fichero se sirvió: confirmado.
+  - id: apache-cve-2021-41773-path-traversal
+    version: 1
+    type: http
+    category: vulnerability
+    severity: CRITICAL
+    service: http
+    mode: safe
+    confirms: CVE-2021-41773
+    requests:
+      - method: GET
+        path: /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: regex
+            part: body
+            regex:
+              - 'root:.*:0:0:'
+    finding:
+      title: 'Apache path traversal confirmado (CVE-2021-41773): /etc/passwd legible'
+      qod: 99
+      confirmed: true
+  # CVE-2021-42013: el bypass del arreglo incompleto de 41773 en Apache
+  # 2.4.50, con doble codificación de los puntos.
+  - id: apache-cve-2021-42013-path-traversal
+    version: 1
+    type: http
+    category: vulnerability
+    severity: CRITICAL
+    service: http
+    mode: safe
+    confirms: CVE-2021-42013
+    requests:
+      - method: GET
+        path: /cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: regex
+            part: body
+            regex:
+              - 'root:.*:0:0:'
+    finding:
+      title: 'Apache path traversal confirmado (CVE-2021-42013): /etc/passwd legible'
       qod: 99
       confirmed: true

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -1395,3 +1395,45 @@ checks:
       title: 'Apache path traversal confirmado (CVE-2021-42013): /etc/passwd legible'
       qod: 99
       confirmed: true
+  # ---------------------------------------------------------------------------
+  # PAYLOADS (L30) — una lista de valores sustituidos en la ruta, en vez de un
+  # check por variación. Este busca un volcado de base de datos olvidado bajo
+  # la raíz web: los nombres de fichero de copia de seguridad más habituales,
+  # probados con una sola entrada de feed. El motor expande ``{{name}}`` una
+  # vez por valor y corta en ``maxPayloadExpansions``, así que la lista puede
+  # crecer sin volverse un barrido. Cualquiera que devuelva 200 con pinta de
+  # volcado SQL dispara; un solo hallazgo, sea cual sea el que picó.
+  - id: sql-dump-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    payloads:
+      name:
+        - backup.sql
+        - dump.sql
+        - database.sql
+        - db.sql
+        - backup.sql.gz
+        - www.sql
+        - site.sql
+    requests:
+      - method: GET
+        path: /{{name}}
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'CREATE TABLE'
+              - 'INSERT INTO'
+              - 'DROP TABLE'
+    finding:
+      title: Volcado de base de datos SQL expuesto bajo la raíz web
+      qod: 99
+      confirmed: true

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-14
+feedVersion: lybra-checks-15
 checks:
   - id: git-config-exposure
     version: 1
@@ -1217,5 +1217,122 @@ checks:
               - '(?im)^set-cookie:\s*(?:PHPSESSID|JSESSIONID|ASP\.NET_SessionId|laravel_session|session|sessionid|connect\.sid)=(?:(?!;\s*secure).)*$'
     finding:
       title: Cookie de sesion sin el atributo Secure
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Checks de configuración de red que la Fase N prometió (L26). Cierran
+  # la parte de la brecha G1 que no se resuelve escribiendo ojos: una
+  # configuración insegura no tiene CVE y no aparece por la vía de la
+  # versión. Alguien tiene que ir y preguntarla.
+  # ===================================================================
+  - id: telnet-enabled
+    version: 1
+    type: script
+    script: telnet-enabled
+    category: network_config
+    severity: HIGH
+    service: telnet
+    mode: safe
+    finding:
+      title: 'Telnet: servicio activo (credenciales en claro por diseño)'
+      qod: 99
+      confirmed: true
+  - id: vnc-no-authentication
+    version: 1
+    type: script
+    script: vnc-no-authentication
+    category: default_credentials
+    severity: CRITICAL
+    service: vnc
+    mode: safe
+    finding:
+      title: 'VNC: acceso sin autenticación (tipo de seguridad None ofrecido)'
+      qod: 99
+      confirmed: true
+  # SMTP relay abierto: el servidor acepta un RCPT a un dominio externo desde un
+  # remitente externo. No se llega a DATA — no se envía correo, sólo se observa
+  # que aceptaría enrutarlo. Un servidor bien configurado responde 550/554.
+  - id: smtp-open-relay
+    version: 1
+    type: network
+    category: network_config
+    severity: HIGH
+    service: smtp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "EHLO lybra.local\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+      - send: "MAIL FROM:<probe@lybra-external.example>\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+      - send: "RCPT TO:<relay-test@lybra-nonexistent-external.example>\r\n"
+        read: block
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+    finding:
+      title: 'SMTP: relay abierto (acepta enrutar correo de terceros)'
+      qod: 99
+      confirmed: true
+  # SMTP sin STARTTLS: el EHLO no anuncia STARTTLS entre sus capacidades, así
+  # que las credenciales de autenticación viajarían en claro.
+  - id: smtp-no-starttls
+    version: 1
+    type: network
+    category: network_config
+    severity: MEDIUM
+    service: smtp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "EHLO lybra.local\r\n"
+        read: block
+        matchers-condition: and
+        matchers:
+          - type: word
+            part: body
+            words:
+              - '250'
+          - type: word
+            part: body
+            words:
+              - STARTTLS
+            negative: true
+    finding:
+      title: 'SMTP: sin STARTTLS anunciado (autenticación en claro posible)'
+      qod: 99
+      confirmed: true
+  # FTP sin cifrado: el servidor rechaza AUTH TLS, así que credenciales y datos
+  # viajan en claro. Un servidor que soporta FTPS responde 234.
+  - id: ftp-no-tls
+    version: 1
+    type: network
+    category: network_config
+    severity: MEDIUM
+    service: ftp
+    mode: safe
+    expectBanner: true
+    requests:
+      - send: "AUTH TLS\r\n"
+        read: block
+        matchers:
+          - type: regex
+            part: body
+            regex:
+              - '^(?:500|502|504|530|534|431)'
+    finding:
+      title: 'FTP: sin cifrado disponible (AUTH TLS no soportado)'
       qod: 99
       confirmed: true

--- a/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
+++ b/API/src/modules/features/themis/lybra/feeds/checks_feed.yaml
@@ -8,7 +8,7 @@
 # feedVersion sube cuando el feed gana una familia nueva o un protocolo nuevo
 # bajo una existente; el arreglo de un check ya presente sube el 'version' de
 # ese check, no esta cadena. Ver CHECKS_FEED_VERSION en checks.py.
-feedVersion: lybra-checks-13
+feedVersion: lybra-checks-14
 checks:
   - id: git-config-exposure
     version: 1
@@ -560,5 +560,662 @@ checks:
     mode: safe
     finding:
       title: 'SNMP: comunidad por defecto "public" aceptada'
+      qod: 99
+      confirmed: true
+  # ===================================================================
+  # Paneles y consolas de administración expuestos (L25). Cada uno mira
+  # status + una cadena propia del panel, nunca sólo el código: un 200
+  # genérico (el señuelo del banco) no debe disparar.
+  # ===================================================================
+  - id: tomcat-manager-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /manager/html
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 401
+              - 403
+          - type: word
+            part: body
+            words:
+              - 'Tomcat Web Application Manager'
+              - 'Apache Tomcat'
+    finding:
+      title: Consola de gestión de Tomcat accesible (/manager/html)
+      qod: 99
+      confirmed: true
+  - id: jenkins-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: or
+        matchers:
+          - type: word
+            part: header
+            words:
+              - x-jenkins
+          - type: word
+            part: body
+            words:
+              - 'Dashboard [Jenkins]'
+    finding:
+      title: Panel de Jenkins accesible
+      qod: 99
+      confirmed: true
+  - id: spring-actuator-health
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /actuator/health
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"status":"UP"'
+              - '"status": "UP"'
+    finding:
+      title: Spring Boot Actuator expuesto (/actuator/health)
+      qod: 99
+      confirmed: true
+  - id: spring-actuator-env
+    version: 1
+    type: http
+    category: exposed_service
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /actuator/env
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'activeProfiles'
+              - 'propertySources'
+    finding:
+      title: Spring Boot Actuator /env expuesto (variables de entorno accesibles)
+      qod: 99
+      confirmed: true
+  - id: symfony-profiler-exposed
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /_profiler
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Symfony Profiler'
+              - 'sf-toolbar'
+    finding:
+      title: Symfony Profiler accesible en producción
+      qod: 99
+      confirmed: true
+  - id: laravel-telescope-exposed
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /telescope/requests
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Telescope'
+              - 'laravel_telescope'
+    finding:
+      title: Laravel Telescope accesible en producción
+      qod: 99
+      confirmed: true
+  - id: solr-admin-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /solr/admin/info/system
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'lucene'
+              - 'solr_home'
+    finding:
+      title: Consola de administración de Apache Solr accesible
+      qod: 99
+      confirmed: true
+  - id: rabbitmq-management-exposed
+    version: 1
+    type: http
+    category: web_finding
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /api/overview
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 401
+          - type: word
+            part: body
+            words:
+              - 'rabbitmq_version'
+              - 'management_version'
+    finding:
+      title: API de gestión de RabbitMQ accesible
+      qod: 99
+      confirmed: true
+  # ---- Depuración activa en producción --------------------------------
+  - id: django-debug-enabled
+    version: 1
+    type: http
+    category: web_finding
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /lybra-nonexistent-debug-probe
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 404
+              - 500
+          - type: word
+            part: body
+            words:
+              - 'Django Version'
+              - 'seeing this error because you have DEBUG'
+    finding:
+      title: Django con DEBUG=True (página de error revela configuración interna)
+      qod: 99
+      confirmed: true
+  - id: flask-werkzeug-debugger
+    version: 1
+    type: http
+    category: web_finding
+    severity: CRITICAL
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /lybra-nonexistent-debug-probe
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 500
+          - type: word
+            part: body
+            words:
+              - 'Werkzeug Debugger'
+              - 'Traceback (most recent call last)'
+    finding:
+      title: Depurador interactivo de Werkzeug/Flask expuesto (ejecución de código)
+      qod: 99
+      confirmed: true
+  - id: debug-token-header
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: header
+            words:
+              - 'x-debug-token'
+    finding:
+      title: Cabecera X-Debug-Token presente (perfilador activo)
+      qod: 99
+      confirmed: true
+  # ---- Configuración y control de versiones expuestos -----------------
+  - id: svn-entries-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.svn/entries
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'dir'
+              - 'svn:'
+    finding:
+      title: Metadatos de Subversion expuestos (/.svn/entries)
+      qod: 99
+      confirmed: true
+  - id: ds-store-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.DS_Store
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Bud1'
+    finding:
+      title: Fichero .DS_Store expuesto (revela estructura de directorios)
+      qod: 99
+      confirmed: true
+  - id: web-config-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /web.config
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '<configuration>'
+              - 'system.webServer'
+    finding:
+      title: web.config servido como texto plano (configuración de IIS expuesta)
+      qod: 99
+      confirmed: true
+  - id: composer-lock-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /composer.lock
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"packages"'
+              - '"_readme"'
+    finding:
+      title: composer.lock expuesto (inventario exacto de dependencias PHP)
+      qod: 99
+      confirmed: true
+  - id: package-lock-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /package-lock.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"lockfileVersion"'
+              - '"dependencies"'
+    finding:
+      title: package-lock.json expuesto (inventario exacto de dependencias npm)
+      qod: 99
+      confirmed: true
+  - id: htpasswd-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: HIGH
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /.htpasswd
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - ':$apr1$'
+              - ':$2y$'
+              - ':{SHA}'
+    finding:
+      title: Fichero .htpasswd expuesto (hashes de credenciales accesibles)
+      qod: 99
+      confirmed: true
+  - id: docker-compose-exposure
+    version: 1
+    type: http
+    category: exposed_path
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /docker-compose.yml
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'services:'
+              - 'image:'
+    finding:
+      title: docker-compose.yml expuesto (topología y posibles secretos de despliegue)
+      qod: 99
+      confirmed: true
+  # ---- Documentación de API expuesta (puerta a la Fase A) -------------
+  - id: swagger-json-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /swagger.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"swagger"'
+              - '"openapi"'
+    finding:
+      title: Especificación Swagger expuesta (/swagger.json)
+      qod: 99
+      confirmed: true
+  - id: openapi-json-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /openapi.json
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - '"openapi"'
+              - '"paths"'
+    finding:
+      title: Especificación OpenAPI expuesta (/openapi.json)
+      qod: 99
+      confirmed: true
+  - id: api-docs-exposure
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /api-docs
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'swagger-ui'
+              - 'openapi'
+    finding:
+      title: Documentación de API interactiva expuesta (/api-docs)
+      qod: 99
+      confirmed: true
+  # ---- Listado de directorios activo ----------------------------------
+  - id: directory-listing-enabled
+    version: 1
+    type: http
+    category: web_finding
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+          - type: word
+            part: body
+            words:
+              - 'Index of /'
+              - '<title>Directory listing for'
+    finding:
+      title: Listado de directorios activo (el servidor enumera ficheros)
+      qod: 99
+      confirmed: true
+  # ---- Cabeceras de seguridad ausentes (las que hoy no se miran) ------
+  - id: missing-csp-header
+    version: 1
+    type: http
+    category: security_header
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - content-security-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Content-Security-Policy
+      qod: 99
+      confirmed: true
+  - id: missing-referrer-policy-header
+    version: 1
+    type: http
+    category: security_header
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - referrer-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Referrer-Policy
+      qod: 99
+      confirmed: true
+  - id: missing-permissions-policy-header
+    version: 1
+    type: http
+    category: security_header
+    severity: LOW
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: status
+            value:
+              - 200
+              - 301
+              - 302
+          - type: word
+            part: header
+            words:
+              - permissions-policy
+            negative: true
+    finding:
+      title: Falta la cabecera Permissions-Policy
+      qod: 99
+      confirmed: true
+  # ---- Cookies de sesión sin atributos de seguridad -------------------
+  # ---- Higiene TLS: cifrado débil negociado ---------------------------
+  - id: tls-weak-cipher
+    version: 1
+    type: tls
+    category: tls
+    severity: MEDIUM
+    service: tls
+    mode: safe
+    tlsRule: weak_cipher
+    finding:
+      title: El servidor negocia un cifrado débil (NULL/EXPORT/DES/RC4/MD5)
+      qod: 99
+      confirmed: true
+  # ---- Cookies de sesión sin atributos de seguridad -------------------
+  # La regex mira una línea de cabecera que empieza por set-cookie, nombra una
+  # cookie de sesión típica, y NO contiene "secure" — las tres condiciones en un
+  # solo patrón para no depender del orden ni de matchers negativos separados.
+  - id: session-cookie-without-secure
+    version: 1
+    type: http
+    category: security_header
+    severity: MEDIUM
+    service: http
+    mode: safe
+    requests:
+      - method: GET
+        path: /
+        matchers-condition: and
+        matchers:
+          - type: regex
+            part: header
+            regex:
+              - '(?im)^set-cookie:\s*(?:PHPSESSID|JSESSIONID|ASP\.NET_SessionId|laravel_session|session|sessionid|connect\.sid)=(?:(?!;\s*secure).)*$'
+    finding:
+      title: Cookie de sesion sin el atributo Secure
       qod: 99
       confirmed: true

--- a/API/src/modules/features/themis/lybra/feeds/credentials_feed.json
+++ b/API/src/modules/features/themis/lybra/feeds/credentials_feed.json
@@ -1,0 +1,63 @@
+{
+  "feedVersion": "lybra-credentials-1",
+  "entries": [
+    {
+      "id": "tomcat-manager-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/manager/html",
+      "accounts": [
+        {"username": "tomcat", "password": "tomcat"},
+        {"username": "admin", "password": "admin"},
+        {"username": "tomcat", "password": "s3cret"},
+        {"username": "admin", "password": "tomcat"},
+        {"username": "both", "password": "tomcat"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Tomcat Web Application Manager"]}
+      ],
+      "finding": {
+        "title": "Tomcat Manager con credenciales por defecto"
+      }
+    },
+    {
+      "id": "tomcat-host-manager-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/host-manager/html",
+      "accounts": [
+        {"username": "admin", "password": "admin"},
+        {"username": "tomcat", "password": "tomcat"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Tomcat Virtual Host Manager"]}
+      ],
+      "finding": {
+        "title": "Tomcat Host Manager con credenciales por defecto"
+      }
+    },
+    {
+      "id": "jenkins-default",
+      "version": 1,
+      "service": "http",
+      "method": "GET",
+      "path": "/manage",
+      "accounts": [
+        {"username": "admin", "password": "admin"},
+        {"username": "admin", "password": "password"},
+        {"username": "jenkins", "password": "jenkins"}
+      ],
+      "matchers": [
+        {"type": "status", "value": [200]},
+        {"type": "word", "part": "body", "words": ["Manage Jenkins"]}
+      ],
+      "finding": {
+        "title": "Jenkins con credenciales por defecto"
+      }
+    }
+  ]
+}

--- a/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
@@ -1,0 +1,73 @@
+"""La sonda de Telnet — porque que exista ya es el hallazgo.
+
+El roadmap descartó el *dissector* de Telnet con buen criterio: su negociación
+de opciones (IAC) no deja un texto identificable de forma fiable sin inventar
+patrones, así que no hay un producto/versión que leer. Pero el *check* es otra
+cosa. Telnet manda credenciales en claro por diseño; que un servicio esté ahí,
+hablando el protocolo, ya es un hallazgo de configuración de red —el que la
+Fase N prometía— sin necesidad de identificar nada.
+
+Lo que este módulo comprueba es exactamente eso y nada más: que al otro lado
+hay algo que **habla Telnet**. Un servidor Telnet abre la conversación
+negociando opciones, y esa negociación empieza siempre por el byte ``IAC``
+(``0xFF``, RFC 854). Ese byte es la firma: un puerto 23 que lo envía es Telnet;
+uno que acepta la conexión y calla, o que manda otra cosa, no se cuenta —
+podría ser cualquier servicio mudo en un puerto reutilizado.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# IAC — "Interpret As Command", el byte que abre toda negociación de opciones
+# de Telnet (RFC 854). Su sola presencia al principio de la respuesta es la
+# firma del protocolo.
+TELNET_IAC = 0xFF
+
+
+class TelnetProbe:  # pylint: disable=too-few-public-methods
+    """Comprueba si un puerto habla Telnet leyendo su negociación de apertura.
+
+    Args:
+        timeout: El plazo de conexión y lectura, en segundos.
+        connect: Callable ``(address, timeout) -> socket`` inyectable, para que
+            un test use un socket falso.
+    """
+
+    def __init__(self, timeout: float = 5.0, connect: Optional[Callable] = None) -> None:
+        self._timeout = timeout
+        self._connect = connect or socket.create_connection
+
+    def speaks_telnet(self, host: str, port: int = 23) -> bool:
+        """Devuelve ``True`` sólo si el servicio abre negociando opciones Telnet.
+
+        Args:
+            host: El objetivo.
+            port: El puerto.
+
+        Returns:
+            ``True`` cuando la respuesta empieza por ``IAC``. Un servicio mudo o
+            que manda otra cosa devuelve ``False``: no se infiere Telnet de un
+            puerto abierto, se confirma por lo que responde.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("Telnet: conexión fallida a %s:%s: %s", host, port, err)
+            return False
+        try:
+            sock.settimeout(self._timeout)
+            data = sock.recv(3)
+            return bool(data) and data[0] == TELNET_IAC
+        except OSError as err:
+            logger.debug("Telnet: sin respuesta de %s:%s: %s", host, port, err)
+            return False
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass

--- a/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
@@ -119,6 +119,63 @@ class VncProbe:
             except OSError:
                 pass
 
+    def security_types(self, host: str, port: int = 5900) -> Optional[list]:
+        """Completa el handshake RFB y devuelve los tipos de seguridad ofrecidos.
+
+        Tras enviar su versión, el servidor RFB (3.7/3.8) responde con un byte
+        de recuento y esa lista de tipos de seguridad. El tipo **1 es ``None``**
+        (RFC 6143 §7.1.2): acceso sin autenticación, que es el hallazgo. Un
+        recuento 0 significa que el servidor rechazó, y sigue un motivo de error.
+
+        No se avanza más allá de leer la lista: **no se intenta autenticar** ni
+        se envía ninguna respuesta de seguridad, así que no se establece sesión.
+
+        Args:
+            host: El objetivo.
+            port: El puerto.
+
+        Returns:
+            La lista de tipos como enteros, ``[]`` si el servidor rechazó con
+            recuento 0, o ``None`` si al otro lado no había un RFB legible.
+        """
+        try:
+            sock = self._connect((host, port), self._timeout)
+        except OSError as err:
+            logger.debug("VNC security probe connect failed for %s:%s: %s", host, port, err)
+            return None
+        try:
+            sock.settimeout(self._timeout)
+            banner = b""
+            while not banner.endswith(b"\n") and len(banner) < 12:
+                chunk = sock.recv(1)
+                if not chunk:
+                    break
+                banner += chunk
+            if not _RFB_RE.match(banner):
+                return None
+            sock.sendall(b"RFB 003.008\n")
+            count_byte = sock.recv(1)
+            if not count_byte:
+                return None
+            count = count_byte[0]
+            if count == 0:
+                return []
+            types = b""
+            while len(types) < count:
+                chunk = sock.recv(count - len(types))
+                if not chunk:
+                    break
+                types += chunk
+            return list(types)
+        except OSError as err:
+            logger.debug("VNC security probe failed for %s:%s: %s", host, port, err)
+            return None
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
 
 @register_dissector
 class VncDissector(Dissector):

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -47,6 +47,8 @@ from .checks import (
     is_postgres_service,
     is_smb_service,
     is_snmp_service,
+    is_telnet_service,
+    is_vnc_service,
 )
 from .engine import Service
 from .fingerprinting.smb import SIGNING_REQUIRED_BIT, SmbProbe, fingerprint_smb
@@ -55,6 +57,8 @@ from .fingerprinting.mongo import MongoProbe, fingerprint_mongo
 from .fingerprinting.postgres import PostgresProbe, fingerprint_postgres
 from .fingerprinting.rdp import RdpProbe, fingerprint_rdp
 from .fingerprinting.snmp import SnmpProbe
+from .fingerprinting.telnet import TelnetProbe
+from .fingerprinting.vnc import VncProbe
 from .fingerprinting.udp_services import (
     DnsProbe,
     NtpProbe,
@@ -417,6 +421,73 @@ class NtpMonlistPlugin(ScriptPlugin):
             self._probe.fetch_monlist(context.target, context.service.port or 123))
 
 
+class TelnetEnabledPlugin(ScriptPlugin):
+    """Detecta un servicio Telnet activo.
+
+    Telnet manda credenciales en claro por diseño: usuario y contraseña viajan
+    sin cifrar por la red, legibles para cualquiera que escuche. No hay una
+    "mala configuración" que arreglar — el hallazgo es que el protocolo esté en
+    uso. Por eso este check no identifica producto ni versión: le basta con
+    confirmar que al otro lado hay algo que **habla Telnet**, cosa que un
+    servidor delata abriendo su negociación de opciones con el byte IAC (ver
+    :class:`~.fingerprinting.telnet.TelnetProbe`).
+
+    Un puerto 23 abierto no basta como evidencia: podría ser cualquier servicio
+    mudo en un puerto reutilizado. Lo que dispara es la firma del protocolo, no
+    la apertura del puerto.
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "telnet-enabled"
+
+    def __init__(self, probe: Optional[TelnetProbe] = None) -> None:
+        self._probe = probe or TelnetProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_telnet_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        return self._probe.speaks_telnet(context.target, context.service.port or 23)
+
+
+class VncNoAuthenticationPlugin(ScriptPlugin):
+    """Detecta un servidor VNC que ofrece acceso **sin autenticación**.
+
+    El protocolo RFB negocia, tras el saludo de versión, qué tipos de seguridad
+    admite el servidor. El tipo 1 es ``None`` (RFC 6143 §7.1.2): entrar sin
+    contraseña. Un VNC que lo ofrece deja el escritorio del objetivo a
+    disposición de cualquiera que alcance el puerto.
+
+    La evidencia es un hecho observado —el servidor **anuncia** ese tipo en su
+    lista—, no una inferencia, así que el hallazgo nace ``confirmed``. Y no se
+    cruza la línea: se lee la lista de tipos ofrecidos y ahí acaba, sin
+    responder a la negociación y sin abrir sesión (ver
+    :meth:`~.fingerprinting.vnc.VncProbe.security_types`).
+
+    Args:
+        probe: Sonda inyectable, para que un test use un socket falso.
+    """
+
+    plugin_id = "vnc-no-authentication"
+    _SECURITY_NONE = 1
+
+    def __init__(self, probe: Optional[VncProbe] = None) -> None:
+        self._probe = probe or VncProbe()
+
+    def applies(self, service: Service) -> bool:
+        return is_vnc_service(service)
+
+    def run(self, context: ScriptContext) -> bool:
+        context.acquire()
+        types = self._probe.security_types(context.target, context.service.port or 5900)
+        if types is None:
+            return False
+        return self._SECURITY_NONE in types
+
+
 def default_script_plugins() -> Dict[str, ScriptPlugin]:
     """Construye el registro de plugins de primera parte, indexado por ``plugin_id``.
 
@@ -435,5 +506,7 @@ def default_script_plugins() -> Dict[str, ScriptPlugin]:
         LdapAnonymousBindPlugin(),
         LdapCleartextWithLdapsPlugin(),
         RdpNlaNotRequiredPlugin(),
+        TelnetEnabledPlugin(),
+        VncNoAuthenticationPlugin(),
     )
     return {plugin.plugin_id: plugin for plugin in plugins}

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -42,6 +42,8 @@ from ...lybra import (
     TlsProbe,
     NetworkProbe,
     default_script_plugins,
+    load_credentials,
+    CredentialRuntime,
     sweep_with_retries,
     PortSweep,
     scan_udp_ports_sync,
@@ -108,7 +110,7 @@ class LybraEngineManager(ScanManager):
         kwargs["discover_ports"] = arguments.get("discover_ports")
         return kwargs
 
-    def run_scan(self,
+    def run_scan(self,  # pylint: disable=too-many-arguments,too-many-positional-arguments
         user_id: int,
         target: Optional[str] = None,  # pylint: disable=arguments-differ
         services: Optional[List[Service]] = None,
@@ -116,6 +118,7 @@ class LybraEngineManager(ScanManager):
         timeout: int = 120,
         programed_scan_id: Optional[int] = None,
         asset_id: Optional[int] = None,
+        aggressive: bool = False,
     ) -> int:
         """
         Start an Lybra engine scan in one of two modes.
@@ -139,6 +142,15 @@ class LybraEngineManager(ScanManager):
                 ``services``. Recorded on the scan row for provenance and
                 grouping; it is never an input to the analysis itself, which
                 is why it does not travel in the TaskQueue args.
+            aggressive: Explicit request for the aggressive mode (L40).
+                Deliberately **not** enough on its own — ``_run_lybra`` only
+                honours it when the target is *also* in the authorized-target
+                register. A registered target does not pre-authorize
+                everything that could ever be done to it; this is the second
+                half of that double gate, and it is what unblocks the
+                default-credentials engine (Fase D, L31), the only family that
+                writes to the target. Never set from a scheduled scan — see
+                ``scheduled_run_kwargs``, which does not forward it.
 
         Returns:
             Primary key of the created LybraScan record.
@@ -166,7 +178,7 @@ class LybraEngineManager(ScanManager):
 
         self._task_queue.submit(
             func=LybraEngineManager.execute_lybra_scan, # type: ignore
-            args=(scan_id, discover_ports, services, timeout),
+            args=(scan_id, discover_ports, services, timeout, aggressive),
             name=f"LybraScan-{scan_id}",
             category=self.TASK_CATEGORY, # type: ignore
             external_id=self.external_id_for(scan_id),
@@ -182,12 +194,16 @@ class LybraEngineManager(ScanManager):
         discover_ports: Optional[list] = None,
         services: Optional[List[Service]] = None,
         timeout: Optional[int] = None,
+        aggressive: bool = False,
     ) -> None:
         """Entry point submitted to the TaskQueue. Runs the engine in the worker.
 
-        ``timeout`` es opcional para que un job encolado antes de este cambio
+        ``timeout`` es opcional para que un job encolado antes de ese cambio
         —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
-        despliegue en vez de fallar al deserializarse.
+        despliegue en vez de fallar al deserializarse. ``aggressive`` (L40) es
+        opcional por el mismo motivo, con el mismo default seguro: un job
+        encolado antes de este cambio se ejecuta en modo ``safe``, nunca en
+        agresivo por sorpresa.
         """
         with job_context() as job:
             manager = LybraEngineManager()
@@ -198,6 +214,7 @@ class LybraEngineManager(ScanManager):
                 timeout,
                 cancel_check=job.cancelled,
                 progress=job.progress,
+                aggressive=aggressive,
             )
 
     @staticmethod
@@ -213,6 +230,7 @@ class LybraEngineManager(ScanManager):
         timeout: Optional[int] = None,
         cancel_check: Optional[Callable[[], bool]] = None,
         progress: Optional[Callable[[int], None]] = None,
+        aggressive: bool = False,
     ) -> None:
         """Resolve services (own discovery or a payload), detect, persist.
 
@@ -232,6 +250,14 @@ class LybraEngineManager(ScanManager):
         tráfico) y la que aparecía en el incidente; el fingerprinting y los
         checks tienen plazo por operación. Si algún día hace falta acotarlos
         también, el plazo ya está aquí: basta pasarles ``_remaining_budget``.
+
+        ``aggressive`` (L40) es la petición explícita del usuario; por sí sola
+        no basta. El modo efectivo con el que corren los checks activos y el
+        motor de credenciales (Fase D, L31) sólo sube a ``"aggressive"``
+        cuando además ``is_target_authorized`` es verdadero — la doble puerta
+        que el roadmap exige para cualquier cosa que escriba en el objetivo.
+        Un objetivo autorizado sin petición explícita se queda en ``safe``;
+        una petición explícita sobre un objetivo no autorizado, también.
         """
         deadline = time.monotonic() + timeout if timeout else None
         is_cancelled = cancel_check or (lambda: False)
@@ -272,6 +298,12 @@ class LybraEngineManager(ScanManager):
                     and source_target
                     and AuthorizedTargetManager.is_authorized(user_id, source_target)
                 )
+                # La doble puerta del modo agresivo (L40): la petición
+                # explícita del usuario por sí sola no basta, y el registro de
+                # autorización por sí solo tampoco — autorizar un objetivo no
+                # es autorizar cualquier cosa contra él. Sólo con las dos a la
+                # vez sube el modo; en cualquier otro caso, ``safe``.
+                mode = "aggressive" if (aggressive and is_target_authorized) else "safe"
 
                 resolved = source.resolve_services(scan_repo, probes, source_target)
                 if resolved is None:
@@ -339,8 +371,17 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(
                     self._run_active_checks(source_target, services,
                                             cancel_check=cancel_check,
-                                            proposed_cves=proposed_cves))
+                                            proposed_cves=proposed_cves,
+                                            mode=mode))
                 is_partial = is_partial or is_cancelled()
+
+            # Motor de credenciales por defecto (Fase D, L31) — la única
+            # familia que escribe en el objetivo. ``_run_credential_checks``
+            # repite por su cuenta la comprobación de ``mode`` antes de probar
+            # nada; esta condición sólo evita el trabajo de construir el
+            # runtime cuando ya se sabe que no va a correr.
+            if source.probes_target_network and source_target and mode == "aggressive" and not is_cancelled():
+                findings_data.extend(self._run_credential_checks(source_target, services, mode))
             report(90)
 
             for finding in findings_data:
@@ -461,13 +502,19 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services, cancel_check=None,
-                           proposed_cves=None) -> list:
+    def _run_active_checks(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, target: str, services, cancel_check=None,
+        proposed_cves=None, mode: str = "safe") -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
         Best-effort: a runtime failure (unreachable host, etc.) yields no active
-        findings rather than failing the whole scan. Safe mode only.
+        findings rather than failing the whole scan.
+
+        ``mode`` llega ya resuelto por :meth:`_run_lybra` — esta capa no decide
+        si el agresivo procede, sólo lo aplica (L40): un ``check`` marcado
+        ``mode: aggressive`` en el feed sigue sin correr en modo ``safe``, y
+        eso lo sigue decidiendo ``CheckRuntime._applies_mode`` como siempre.
         """
         try:
             engine = CR.lybra_engine_config()
@@ -478,7 +525,7 @@ class LybraEngineManager(ScanManager):
                     max_bytes=engine.http_max_body_bytes,
                     user_agent=engine.http_user_agent,
                 ).fetch,
-                mode="safe",
+                mode=mode,
                 rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval),
                 tls_fetch=TlsProbe().fetch,
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
@@ -495,6 +542,44 @@ class LybraEngineManager(ScanManager):
                                proposed_cves=proposed_cves)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
+            return []
+
+    def _run_credential_checks(self, target: str, services, mode: str) -> list:
+        """Probar credenciales por defecto contra los servicios del objetivo (Fase D, L31).
+
+        Es la única familia de detección que escribe en el objetivo, así que
+        no basta con la doble puerta de quien llama (autorizado + agresivo
+        pedido explícitamente): esta función además **repite** la comprobación
+        de modo antes de construir nada. Dos guardas para la única capacidad
+        que de verdad puede bloquear una cuenta real es defensa en profundidad
+        barata, no paranoia.
+
+        Best-effort igual que ``_run_active_checks``: un fallo de red no debe
+        hundir un escaneo que ya tenía hallazgos de las demás familias.
+        """
+        if mode != "aggressive":
+            return []
+        try:
+            engine = CR.lybra_engine_config()
+            credentials = CR.lybra_credentials_config()
+            runtime = CredentialRuntime(
+                load_credentials(),
+                HttpProbe(
+                    timeout=engine.http_timeout,
+                    max_bytes=engine.http_max_body_bytes,
+                    user_agent=engine.http_user_agent,
+                ).fetch,
+                # Intervalo mayor que el de los checks de lectura: cada
+                # intento aquí es un login real, y el roadmap pide
+                # explícitamente un ritmo distinto al de un GET de
+                # ``.git/config`` para no parecer un ataque de fuerza bruta.
+                rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval * 5),
+                max_attempts_per_account=credentials.max_attempts,
+                capture_evidence=CR.lybra_evidence_config().enabled,
+            )
+            return runtime.run(target, services)
+        except Exception:
+            logger.exception("Lybra credential checks failed for %s", target)
             return []
 
     def _ingested_checks(self, services) -> list:

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -4,7 +4,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
-from typing import List, Optional
+from typing import Callable, List, Optional
 import src.modules.system.config_reading as CR
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.system.taskqueue import ITaskQueue, job_context
@@ -189,13 +189,15 @@ class LybraEngineManager(ScanManager):
         —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
         despliegue en vez de fallar al deserializarse.
         """
-        with job_context():
+        with job_context() as job:
             manager = LybraEngineManager()
             manager._run_lybra( # type: ignore
                 scan_id,
                 discover_ports,
                 services,
                 timeout,
+                cancel_check=job.cancelled,
+                progress=job.progress,
             )
 
     @staticmethod
@@ -203,12 +205,14 @@ class LybraEngineManager(ScanManager):
         """Segundos que quedan hasta ``deadline``, o ``None`` si no hay plazo."""
         return None if deadline is None else max(0.0, deadline - time.monotonic())
 
-    def _run_lybra(
+    def _run_lybra(  # pylint: disable=too-many-arguments
         self,
         scan_id: int,
         discover_ports: Optional[list] = None,
         services_payload: Optional[List[Service]] = None,
         timeout: Optional[int] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+        progress: Optional[Callable[[int], None]] = None,
     ) -> None:
         """Resolve services (own discovery or a payload), detect, persist.
 
@@ -230,14 +234,24 @@ class LybraEngineManager(ScanManager):
         también, el plazo ya está aquí: basta pasarles ``_remaining_budget``.
         """
         deadline = time.monotonic() + timeout if timeout else None
+        is_cancelled = cancel_check or (lambda: False)
+
+        def report(pct: int) -> None:
+            if progress is not None:
+                progress(pct)
+
         source = ServiceSource.build_for_args(services_payload, discover_ports)
         probes = DiscoveryProbes(
             is_host_reachable=self.is_host_reachable,
             # El presupuesto se calcula al llamar, no aquí: para cuando el
             # descubrimiento arranca ya se han gastado la comprobación de
-            # alcanzabilidad y las consultas de apertura del escaneo.
+            # alcanzabilidad y las consultas de apertura del escaneo. El
+            # cancel_check baja hasta el barrido de puertos —la fase más larga—
+            # para que un escaneo grande se pueda parar a mitad.
             discover_ports=lambda target, ports: self._discover_ports(
-                target, ports, budget_seconds=self._remaining_budget(deadline)),
+                target, ports,
+                budget_seconds=self._remaining_budget(deadline),
+                cancel_check=cancel_check),
             discover_udp_ports=self._discover_udp_ports,
         )
         try:
@@ -261,7 +275,15 @@ class LybraEngineManager(ScanManager):
                     self.update_scan_status(scan_id, ScanStatus.FAILED)
                     return
                 services, source_host_id, source_target = resolved.services, resolved.host_id, resolved.target
-                is_partial = resolved.is_partial
+                # Un escaneo cancelado a mitad es, a efectos del ciclo de vida,
+                # lo mismo que uno truncado por reloj: vio parte del objetivo,
+                # no todo. Comparte la bandera ``is_partial`` para no cerrar por
+                # omisión lo que no llegó a comprobar (el fallo de L48-c).
+                is_partial = resolved.is_partial or is_cancelled()
+                # Descubrimiento hecho: 40 % del trabajo (pesos honestos del §3
+                # del issue — descubrimiento 40, fingerprint 30, checks 20,
+                # correlación y persistencia 10).
+                report(40)
 
                 fingerprint_findings: list = []
                 if (
@@ -269,11 +291,15 @@ class LybraEngineManager(ScanManager):
                     and source_target
                     and is_target_authorized
                     and CR.lybra_config().fingerprinting_enabled
+                    and not is_cancelled()
                 ):
                     services, fingerprint_findings = self._fingerprint_services(
                         source_target,
-                        services
+                        services,
+                        cancel_check=cancel_check,
                     )
+                    is_partial = is_partial or is_cancelled()
+                report(70)
 
                 previous_map = self._previous_findings_map(
                     scan_repo,
@@ -297,8 +323,12 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(fingerprint_findings)
                 findings_data.extend(surface_findings)
 
-            if source.probes_target_network and source_target and is_target_authorized and CR.lybra_config().active_checks:
-                findings_data.extend(self._run_active_checks(source_target, services))
+            if (source.probes_target_network and source_target and is_target_authorized
+                    and CR.lybra_config().active_checks and not is_cancelled()):
+                findings_data.extend(
+                    self._run_active_checks(source_target, services, cancel_check=cancel_check))
+                is_partial = is_partial or is_cancelled()
+            report(90)
 
             for finding in findings_data:
                 finding["host_id"] = source_host_id
@@ -331,6 +361,7 @@ class LybraEngineManager(ScanManager):
                 scan.status = ScanStatus.FINISHED.value  # type: ignore
                 scan.finished_at = utcnow_naive()  # type: ignore
 
+            report(100)
             if is_partial:
                 logger.warning(
                     "Escaneo Lybra %s completado PARCIALMENTE: %s hallazgos sobre una "
@@ -348,6 +379,7 @@ class LybraEngineManager(ScanManager):
         target: str,
         discover_ports,
         budget_seconds: Optional[float] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Optional[PortSweep]:
         """Discover open ports with Lybra's own connect scan (Fase T).
 
@@ -372,6 +404,7 @@ class LybraEngineManager(ScanManager):
                 timeout=engine.tcp_timeout,
                 retries=engine.udp_retries,
                 budget_seconds=budget_seconds,
+                cancel_check=cancel_check,
             )
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
@@ -415,7 +448,7 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services) -> list:
+    def _run_active_checks(self, target: str, services, cancel_check=None) -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
@@ -442,7 +475,7 @@ class LybraEngineManager(ScanManager):
                 # fila india.
                 mapper=self._in_host_pool,
             )
-            return runtime.run(target, services)
+            return runtime.run(target, services, cancel_check=cancel_check)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
             return []
@@ -487,7 +520,7 @@ class LybraEngineManager(ScanManager):
             logger.exception("Fallo ingiriendo plantillas de Nuclei; se sigue con el feed propio")
             return []
 
-    def _fingerprint_services(self, target: str, services: list) -> tuple:
+    def _fingerprint_services(self, target: str, services: list, cancel_check=None) -> tuple:
         """Run Lybra's own HTTP/SSH/FTP dissectors and identify each service.
 
         Fase F. La identificación que sale de aquí **es** la identificación del
@@ -524,7 +557,14 @@ class LybraEngineManager(ScanManager):
             Se define dentro para que cada llamada comparta los ``dissectors`` y
             el ``rate_limiter`` de **esta** ejecución: el limitador es lo que
             mantiene el ritmo por host cuando varias sondas van a la vez, así que
-            compartirlo es justo el punto."""
+            compartirlo es justo el punto.
+
+            Comprueba la cancelación al entrar: con el pool concurrente, las
+            unidades ya lanzadas terminan, pero las que aún no han arrancado
+            devuelven de inmediato — que es lo que hace que un fingerprint de
+            veinte servicios se corte pronto y no al final."""
+            if cancel_check is not None and cancel_check():
+                return service, None
             dissector = next((dissector for dissector in dissectors if dissector.applies(service)), None)
             result = None
             if dissector is not None:

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -205,7 +205,7 @@ class LybraEngineManager(ScanManager):
         """Segundos que quedan hasta ``deadline``, o ``None`` si no hay plazo."""
         return None if deadline is None else max(0.0, deadline - time.monotonic())
 
-    def _run_lybra(  # pylint: disable=too-many-arguments
+    def _run_lybra(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements,too-many-positional-arguments
         self,
         scan_id: int,
         discover_ports: Optional[list] = None,
@@ -249,9 +249,11 @@ class LybraEngineManager(ScanManager):
             # cancel_check baja hasta el barrido de puertos —la fase más larga—
             # para que un escaneo grande se pueda parar a mitad.
             discover_ports=lambda target, ports: self._discover_ports(
-                target, ports,
+                target=target,
+                ports=ports,
                 budget_seconds=self._remaining_budget(deadline),
-                cancel_check=cancel_check),
+                cancel_check=cancel_check
+            ),
             discover_udp_ports=self._discover_udp_ports,
         )
         try:
@@ -266,7 +268,8 @@ class LybraEngineManager(ScanManager):
                 user_id = lybra_scan.user_id if lybra_scan else None
 
                 is_target_authorized = bool(
-                    user_id and source_target
+                    user_id 
+                    and source_target
                     and AuthorizedTargetManager.is_authorized(user_id, source_target)
                 )
 
@@ -294,8 +297,8 @@ class LybraEngineManager(ScanManager):
                     and not is_cancelled()
                 ):
                     services, fingerprint_findings = self._fingerprint_services(
-                        source_target,
-                        services,
+                        target=source_target,
+                        services=services,
                         cancel_check=cancel_check,
                     )
                     is_partial = is_partial or is_cancelled()
@@ -323,10 +326,20 @@ class LybraEngineManager(ScanManager):
                 findings_data.extend(fingerprint_findings)
                 findings_data.extend(surface_findings)
 
+            # Las CVEs que la detección por versión acaba de proponer. Son las
+            # hipótesis (confirmed=false, qod=70) que un confirmador puede
+            # ascender a hecho: el runtime sólo corre un confirmador cuya CVE
+            # esté aquí — nunca "por si acaso" (L29).
+            proposed_cves = frozenset(
+                cve for finding in findings_data
+                for cve in (finding.get("cve_ids") or ()))
+
             if (source.probes_target_network and source_target and is_target_authorized
                     and CR.lybra_config().active_checks and not is_cancelled()):
                 findings_data.extend(
-                    self._run_active_checks(source_target, services, cancel_check=cancel_check))
+                    self._run_active_checks(source_target, services,
+                                            cancel_check=cancel_check,
+                                            proposed_cves=proposed_cves))
                 is_partial = is_partial or is_cancelled()
             report(90)
 
@@ -448,7 +461,8 @@ class LybraEngineManager(ScanManager):
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
 
-    def _run_active_checks(self, target: str, services, cancel_check=None) -> list:
+    def _run_active_checks(self, target: str, services, cancel_check=None,
+                           proposed_cves=None) -> list:
         """Run the check runtime against the target's HTTP, TLS, network (Fase N)
         and script (Fase R) services.
 
@@ -476,7 +490,8 @@ class LybraEngineManager(ScanManager):
                 # fila india.
                 mapper=self._in_host_pool,
             )
-            return runtime.run(target, services, cancel_check=cancel_check)
+            return runtime.run(target, services, cancel_check=cancel_check,
+                               proposed_cves=proposed_cves)
         except Exception:
             logger.exception("Lybra active checks failed for %s", target)
             return []

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -469,6 +469,7 @@ class LybraEngineManager(ScanManager):
                 tls_fetch=TlsProbe().fetch,
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
+                capture_evidence=CR.lybra_evidence_config().enabled,
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
                 # red servicio a servicio— y el mismo motivo para no hacerla en
@@ -912,6 +913,34 @@ class LybraEngineManager(ScanManager):
             repo.update(finding)
             return finding
 
+    def get_finding_evidence(self, finding_id: int, user_id: int) -> list:
+        """Devuelve la evidencia cruda de un hallazgo propio (Fase E).
+
+        Mismo criterio de propiedad que :meth:`set_finding_state`: la evidencia
+        de un hallazgo de otro usuario se reporta como no encontrada, sin
+        revelar el ``scan_id`` ajeno.
+
+        Returns:
+            Una lista de dicts con ``kind``, ``payload``, ``contentHash`` y
+            ``capturedAt`` de cada evidencia, la más reciente primero.
+        """
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            finding = repo.get_finding(finding_id)
+            if finding is None:
+                raise FindingNotFoundError(finding_id)
+            assert_owned(ScanRepository, finding.scan_id, user_id,
+                         lambda _scan_id: FindingNotFoundError(finding_id), uow=uow)
+            return [
+                {
+                    "kind": evidence.kind,
+                    "payload": evidence.payload,
+                    "contentHash": evidence.content_hash,
+                    "capturedAt": evidence.captured_at.isoformat() if evidence.captured_at else None,
+                }
+                for evidence in repo.get_evidence_for_finding(finding_id)
+            ]
+
     def _create_scan_record(
         self, target: str, user_id: int,
         programed_scan_id: Optional[int] = None, asset_id: Optional[int] = None,
@@ -931,8 +960,18 @@ class LybraEngineManager(ScanManager):
         )
 
     def _persist_scan_results(self, uow, scan, domain_data) -> None:
-        """Persist the engine's findings (``domain_data`` is a list of dicts)."""
-        ScanRepository(uow).persist_findings(scan, domain_data)
+        """Persist the engine's findings (``domain_data`` is a list of dicts).
+
+        Aprovecha la escritura para purgar la evidencia caducada (Fase E): cada
+        escaneo que graba evidencia se lleva de paso la que ha pasado su
+        retención, así la tabla no crece sin fin sin necesidad de un barredor
+        aparte.
+        """
+        evidence_config = CR.lybra_evidence_config()
+        repo = ScanRepository(uow)
+        repo.persist_findings(scan, domain_data,
+                              evidence_max_body=evidence_config.max_body_bytes)
+        repo.delete_expired_evidence(evidence_config.retention_days)
 
     def get_scans_paginated(  # pylint: disable=arguments-differ
         self, user_id: int, page: int = 1, per_page: int = 10,

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -364,9 +364,15 @@ class LybraEngineManager(ScanManager):
           escaneo sigue adelante con lo que hay y se marca como parcial, en
           lugar de tirar información verificada.
         """
+        engine = CR.lybra_engine_config()
         try:
             sweep = sweep_with_retries(
-                target, discover_ports, budget_seconds=budget_seconds)
+                target, discover_ports,
+                concurrency=engine.tcp_concurrency,
+                timeout=engine.tcp_timeout,
+                retries=engine.udp_retries,
+                budget_seconds=budget_seconds,
+            )
         except Exception:
             logger.exception("Lybra port discovery failed for %s", target)
             return None
@@ -398,8 +404,13 @@ class LybraEngineManager(ScanManager):
         list): a user-supplied ``discover_ports`` is a TCP list.
         """
         try:
+            engine = CR.lybra_engine_config()
             return scan_udp_ports_sync(
-                target, budget_seconds=CR.lybra_config().udp_budget_seconds)
+                target,
+                timeout=engine.udp_timeout,
+                retries=engine.udp_retries,
+                budget_seconds=engine.udp_budget_seconds,
+            )
         except Exception:
             logger.exception("Lybra UDP port discovery failed for %s", target)
             return []
@@ -412,13 +423,18 @@ class LybraEngineManager(ScanManager):
         findings rather than failing the whole scan. Safe mode only.
         """
         try:
+            engine = CR.lybra_engine_config()
             runtime = CheckRuntime(
                 load_checks() + self._ingested_checks(services),
-                HttpProbe().fetch,
+                HttpProbe(
+                    timeout=engine.http_timeout,
+                    max_bytes=engine.http_max_body_bytes,
+                    user_agent=engine.http_user_agent,
+                ).fetch,
                 mode="safe",
-                rate_limiter=HostRateLimiter(),
+                rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval),
                 tls_fetch=TlsProbe().fetch,
-                network_open=NetworkProbe().open,
+                network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
@@ -499,8 +515,8 @@ class LybraEngineManager(ScanManager):
             fingerprint findings.
         """
         dissectors = default_dissectors()
-        rate_limiter = HostRateLimiter()
-        cascade_config = CR.lybra_config()
+        cascade_config = CR.lybra_engine_config()
+        rate_limiter = HostRateLimiter(min_interval=cascade_config.rate_limit_interval)
 
         def identify(service):
             """Sonda un servicio y devuelve ``(servicio, resultado)``.
@@ -589,7 +605,7 @@ class LybraEngineManager(ScanManager):
         items = list(items)
         if not items:
             return []
-        workers = max(1, min(CR.lybra_config().host_pool_size, len(items)))
+        workers = max(1, min(CR.lybra_engine_config().host_pool_size, len(items)))
         if workers == 1:
             return [work(item) for item in items]
         with ThreadPoolExecutor(max_workers=workers) as pool:

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -484,6 +484,7 @@ class LybraEngineManager(ScanManager):
                 network_open=NetworkProbe(timeout=engine.network_timeout).open,
                 script_plugins=default_script_plugins(),
                 capture_evidence=CR.lybra_evidence_config().enabled,
+                max_payload_expansions=engine.max_payload_expansions,
                 # El mismo pool acotado por host que usa el fingerprinting: los
                 # checks activos tienen exactamente la misma forma —espera de
                 # red servicio a servicio— y el mismo motivo para no hacerla en

--- a/API/src/modules/features/themis/managers/lybra/sources.py
+++ b/API/src/modules/features/themis/managers/lybra/sources.py
@@ -95,12 +95,12 @@ class ServiceSource(ABC):
     def build_for_args(
         cls,
         services: Optional[List[Service]],
-        discover_ports: Optional[list],
+        ports_to_discover: Optional[list],
     ) -> "ServiceSource":
         """Build the source matching whichever of the two run_scan args was given."""
         if services is not None:
             return ExternalPayload(services)
-        return SelfDiscovery(discover_ports)
+        return SelfDiscovery(ports_to_discover)
 
     @abstractmethod
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
@@ -180,8 +180,8 @@ class SelfDiscovery(ServiceSource):
 
     label = "descubrimiento propio"
 
-    def __init__(self, discover_ports: Optional[list]) -> None:
-        self.discover_ports = discover_ports
+    def __init__(self, ports_to_discover: Optional[list]) -> None:
+        self.ports_to_discover = ports_to_discover
 
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
         if target is None:
@@ -218,14 +218,14 @@ class SelfDiscovery(ServiceSource):
                 logger.warning(f"Host '{target}' inalcanzable.")
                 return None
 
-            sweep = probes.discover_ports(target, self.discover_ports)
+            sweep = probes.discover_ports(target, self.ports_to_discover)
             if sweep is None:
                 logger.error("Descubrimiento de puertos fallido para %s", target)
                 return None
             discovered_ports = list(sweep.open_ports)
             is_partial = sweep.was_truncated
             # UDP (Fase N/Ronda 1, roadmap §6.3): sonda curada aparte, nunca a
-            # partir de la lista TCP del usuario — self.discover_ports es una
+            # partir de la lista TCP del usuario — self.ports_to_discover es una
             # lista de puertos TCP. Best-effort por diseño de
             # _discover_udp_ports: nunca aborta el descubrimiento TCP.
             udp_ports = probes.discover_udp_ports(target)

--- a/API/src/modules/features/themis/managers/lybra/sources.py
+++ b/API/src/modules/features/themis/managers/lybra/sources.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
 from typing import Callable, List, Optional
 
 import src.modules.system.config_reading as CR
@@ -70,7 +71,7 @@ class ResolvedServices:
     is_partial: bool = False
 
 
-class ServiceSource:
+class ServiceSource(ABC):
     """One of the two ways a Lybra scan obtains the services it analyses.
 
     A thin base plus one policy flag (Python's idiomatic stand-in for what
@@ -101,10 +102,12 @@ class ServiceSource:
             return ExternalPayload(services)
         return SelfDiscovery(discover_ports)
 
+    @abstractmethod
     def valid_scan_target(self, user_id: int, target: Optional[str]) -> str:
         """Resolve and validate this mode's target, before the scan record exists."""
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def resolve_services(
         self,
         scan_repo: ScanRepository,
@@ -126,7 +129,7 @@ class ServiceSource:
         no vio todo el objetivo: ésa no es un fallo, es un resultado con una
         advertencia pegada.
         """
-        raise NotImplementedError
+        ...
 
     @staticmethod
     def _resolve_host(scan_repo: ScanRepository, target: Optional[str]) -> Optional[int]:

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -882,6 +882,44 @@ class Finding(Base):
         return f"<Finding(id={self.id}, scan_id={self.scan_id}, category='{self.category}', title='{self.title[:40]}')>"
 
 
+class FindingEvidence(Base):
+    """La respuesta cruda que provocó un hallazgo (Fase E).
+
+    Un hallazgo dice **qué** encontró y **con qué regla**, pero ``feed_version``
+    + ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
+    respondió. Cuando un cliente dice «eso no es verdad, ese fichero no está
+    expuesto», la respuesta útil es la respuesta HTTP con su cuerpo y su fecha,
+    no «nuestro check dice que sí». Sin evidencia, cada discusión se resuelve
+    repitiendo el escaneo a mano.
+
+    Attributes:
+        id: Clave primaria.
+        finding_id: El hallazgo que esta evidencia respalda.
+        kind: Qué clase de evidencia es (``http_response`` | ``ssh_banner`` |
+            ``tls_cert`` | ``probe_output``).
+        payload: El contenido observado, ya **redactado** (ver
+            ``lybra.evidence.redact_evidence``): cabeceras sensibles fuera,
+            cuerpo truncado. Guardar una respuesta cruda sin redactar
+            convertiría la base de datos en un depósito de secretos ajenos.
+        content_hash: SHA-256 del payload redactado. No es decorativo: es lo
+            que permite decir «esta evidencia no se ha tocado desde que se
+            capturó», la mitad del valor en un contexto de auditoría.
+        captured_at: Cuándo se observó (cadena de custodia).
+    """
+    __tablename__ = "FindingEvidence"
+
+    id           = Column(Integer, primary_key=True, autoincrement=True)
+    finding_id   = Column(Integer, ForeignKey("Finding.id", ondelete="CASCADE"),
+                          nullable=False, index=True)
+    kind         = Column(String(32), nullable=False)
+    payload      = Column(JSONB, nullable=False)
+    content_hash = Column(String(64), nullable=False)
+    captured_at  = Column(DateTime, default=utcnow_naive, nullable=False, index=True)
+
+    def __repr__(self):
+        return f"<FindingEvidence(id={self.id}, finding_id={self.finding_id}, kind='{self.kind}')>"
+
+
 # =========================================================================
 # KNOWLEDGE BASE (the "Lybra Feed": local mirror of NVD/KEV/EPSS)
 # =========================================================================

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -25,7 +25,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import func, or_
@@ -33,6 +33,7 @@ from sqlalchemy import update as sa_update
 from sqlalchemy.orm import joinedload
 from src.modules.infrastructure import BaseRepository, DocumentRepository
 from src.modules.shared import utcnow_naive
+from .lybra.evidence import prepare_evidence
 
 from .model import (
     AuthorizedTarget,
@@ -42,6 +43,7 @@ from .model import (
     LybraScan,
     EpssScore,
     Finding,
+    FindingEvidence,
     Host,
     HostService,
     KevEntry,
@@ -668,15 +670,68 @@ class ScanRepository(BaseRepository[Scan]):
             .all()
         )
 
-    def persist_findings(self, scan: Scan, findings_data: List[dict]) -> None:
+    def persist_findings(self, scan: Scan, findings_data: List[dict],
+                         evidence_max_body: int = 8192) -> None:
         """Persist a batch of normalized Finding rows for a scan.
+
+        Un finding puede traer una clave ``_evidence`` —la respuesta cruda que
+        lo provocó, que el runtime de checks adjuntó (Fase E)—. No es una
+        columna, así que se extrae antes de construir el ``Finding``, y se
+        persiste como una fila ``FindingEvidence`` aparte, ya redactada y
+        hasheada, una vez que el ``Finding`` tiene id.
 
         Args:
             scan: The scan that produced the findings (its id is used as scan_id).
             findings_data: List of dicts with Finding column values.
+            evidence_max_body: Tope del cuerpo de la evidencia, en bytes.
         """
         for data in findings_data:
-            self._session.add(Finding(scan_id=scan.id, **data))
+            evidence = data.pop("_evidence", None)
+            finding = Finding(scan_id=scan.id, **data)
+            self._session.add(finding)
+            if evidence:
+                self._session.flush()          # necesita el id del finding
+                prepared = prepare_evidence(evidence["payload"], evidence_max_body)
+                self._session.add(FindingEvidence(
+                    finding_id=finding.id,
+                    kind=evidence["kind"],
+                    payload=prepared["payload"],
+                    content_hash=prepared["content_hash"],
+                    captured_at=utcnow_naive(),
+                ))
+
+    def get_evidence_for_finding(self, finding_id: int) -> List[FindingEvidence]:
+        """Return the evidence rows backing a finding, newest first."""
+        return (
+            self._session.query(FindingEvidence)
+            .filter(FindingEvidence.finding_id == finding_id)
+            .order_by(FindingEvidence.captured_at.desc())
+            .all()
+        )
+
+    def delete_expired_evidence(self, retention_days: int) -> int:
+        """Borra la evidencia más vieja que ``retention_days``.
+
+        La evidencia crece rápido —hasta varios KiB por hallazgo confirmado, por
+        escaneo, por activo— y necesita caducidad desde el primer día, no cuando
+        la tabla ocupe gigas. Un valor 0 o negativo desactiva la purga (retención
+        indefinida), para el caso de auditoría que exige conservarlo todo.
+
+        Args:
+            retention_days: Días que se conserva la evidencia.
+
+        Returns:
+            El número de filas borradas.
+        """
+        if retention_days <= 0:
+            return 0
+        cutoff = utcnow_naive() - timedelta(days=retention_days)
+        deleted = (
+            self._session.query(FindingEvidence)
+            .filter(FindingEvidence.captured_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        return deleted
 
     def get_findings_by_scan(self, scan_id: int) -> List[Finding]:
         """Return all findings of a scan, newest first."""

--- a/API/src/modules/features/themis/schemas.py
+++ b/API/src/modules/features/themis/schemas.py
@@ -48,6 +48,11 @@ class LybraScanRequestSchema(Schema):
     target = fields.String(required=True)
     ports = fields.String()
     timeout = fields.Integer(load_default=120, validate=validate.Range(min=1))
+    # La doble puerta del modo agresivo (L40): esta petición explícita del
+    # usuario es sólo la mitad. El manager sólo la honra cuando el objetivo
+    # está además en el registro de autorización — un registro no autoriza
+    # cualquier cosa contra el objetivo, sólo el escaneo pasivo.
+    aggressive = fields.Boolean(load_default=False)
 
 
 class FindingStateRequestSchema(Schema):

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1072,6 +1072,36 @@ def lybra_engine_config() -> LybraEngineConfig:
     return load_block(LybraEngineConfig)
 
 
+@config_block("features.themis.scanners.lybra.evidence")
+@dataclass(frozen=True)
+class LybraEvidenceConfig:
+    """La captura de evidencia cruda por hallazgo (Fase E, L44).
+
+    Un hallazgo dice qué encontró y con qué regla, pero ``feed_version`` +
+    ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
+    respondió. Esta captura sí: la respuesta HTTP que provocó el hallazgo,
+    redactada, con su hash y su fecha, para poder defenderla ante un cliente.
+    """
+
+    enabled: bool = True
+    """Si se guarda la evidencia de los hallazgos confirmados."""
+
+    max_body_bytes: int = 8192
+    """Tope del cuerpo de respuesta que se guarda como evidencia (8
+    KiB). Una respuesta más larga se trunca, dejando constancia de cuántos
+    bytes se recortaron."""
+
+    retention_days: int = 90
+    """Días que se conserva la evidencia antes de purgarla. La
+    evidencia crece rápido —KiB por hallazgo, por escaneo, por activo— y necesita
+    caducidad desde el primer día. A 0 o menos, retención indefinida (el caso de
+    auditoría que exige conservarlo todo)."""
+
+
+def lybra_evidence_config() -> LybraEvidenceConfig:
+    return load_block(LybraEvidenceConfig)
+
+
 def lybra_ingest_config() -> LybraIngestConfig:
     return load_block(LybraIngestConfig)
 

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -804,47 +804,99 @@ class LybraConfig:
     Lybra solo toca un objetivo que el llamante haya autorizado explícitamente,
     valga lo que valga este flag. Existen como interruptor de emergencia para
     desactivar la funcionalidad en todo el despliegue.
+
+    Los **parámetros de red** —timeouts, concurrencia, ritmo, presupuestos—
+    viven aparte, en :class:`LybraEngineConfig` (L39): un interruptor de
+    despliegue y un dial de afinado son cosas distintas, y mezclarlos haría el
+    bloque ilegible en cuanto pasara de dos campos.
     """
 
     active_checks: bool = True
     fingerprinting_enabled: bool = True
 
-    banner_timeout: float = 2.0
-    """Plazo, en segundos, de la lectura del saludo que la cascada de
-    identificación hace contra un servicio que ningún dissector reclama
-    (``fingerprinting/cascade.py``). Es corto a propósito: un servicio que no
-    saluda lo agota entero, y ese coste se paga una vez por cada puerto
-    desconocido del objetivo."""
 
-    max_blind_probes: int = 2
-    """Cuántas sondas activas se permiten contra un servicio que no ha dicho
-    nada. El presupuesto que separa "prueba lo que ya sabes leer" de un escaneo
-    de servicios completo: hoy hay dos protocolos que se pueden intentar a
-    ciegas (Redis y HTTP), y este tope impide que añadir un tercero encarezca
-    en silencio cada escaneo. A cero, la cascada se queda sólo en la lectura
-    del saludo."""
+@config_block("features.themis.scanners.lybra.engine")
+@dataclass(frozen=True)
+class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
+    """Los diales de red del motor: cuánto tarda, cuánta carga mete y qué mira.
+
+    Hasta L39 cada uno de estos valores era un literal en la firma de un
+    constructor —``concurrency=200``, ``timeout=2.0``, ``min_interval=0.2``— y
+    el manager instanciaba las sondas sin argumentos, así que no había forma de
+    tocarlos sin editar código. OpenVAS lleva veinte años teniendo *scan
+    configs* por una razón: un escaneo contra un enlace lento, contra un
+    appliance frágil o contra un rango grande necesita otros números, y quien
+    opera el escáner es quien sabe cuáles.
+
+    **Los valores por defecto son exactamente los que estaban a fuego**, así
+    que el cambio es invisible hasta que alguien mueve un dial. Cada campo tiene
+    un consumidor real en ``managers/lybra/engine.py`` — no hay ningún dial que
+    no llegue a una sonda, porque un parámetro que nadie lee es peor que uno a
+    fuego: parece configurable y no lo es.
+    """
+
+    # --- Descubrimiento TCP (transport.AsyncConnectScanner / scan_ports_sync)
+    tcp_concurrency: int = 200
+    """Conexiones TCP en vuelo a la vez durante el barrido de puertos."""
+
+    tcp_timeout: float = 2.0
+    """Plazo por puerto TCP, en segundos."""
+
+    # --- Descubrimiento UDP (transport.scan_udp_ports_sync)
+    udp_timeout: float = 2.0
+    """Plazo por sonda UDP, en segundos."""
+
+    udp_retries: int = 1
+    """Reintentos tras un primer silencio UDP. No es 0 a propósito: un
+    datagrama perdido (no un puerto cerrado) haría oscilar el puerto entre
+    abierto y cerrado entre escaneos, y el ciclo de vida lo leería como
+    ``fixed``/``regressed`` falsos."""
 
     udp_budget_seconds: float = 20.0
-    """Plazo total del barrido de puertos UDP (``transport.scan_udp_ports_sync``).
+    """Plazo total del barrido UDP. En UDP el silencio no significa
+    "cerrado" sino "no lo sabemos", así que cada sonda paga su plazo entero
+    contra un host que no tenga ese servicio; con siete filas eso se acumula.
+    Agotarlo **no** marca nada como cerrado: los puertos que no han contestado
+    se dan por no observados, que es lo que ya eran."""
 
-    En UDP el silencio no significa "cerrado" sino "no lo sabemos", así que
-    cada sonda paga su plazo entero contra un host que no tenga ese servicio.
-    Con siete filas en la tabla eso se acumula, y este presupuesto es el techo.
-    Agotarlo **no** marca nada como cerrado: los puertos que aún no han
-    contestado simplemente se dan por no observados, que es lo que ya eran."""
+    # --- Ritmo por host (checks.HostRateLimiter) y paralelismo (L23)
+    rate_limit_interval: float = 0.2
+    """Intervalo mínimo, en segundos, entre dos peticiones al mismo
+    host. Es la cortesía con el objetivo, y manda por encima del pool."""
 
     host_pool_size: int = 8
+    """Cuántos servicios del **mismo host** se sondan a la vez. El
+    fingerprinting y los checks activos son espera de red casi entera, y en fila
+    india un servicio mudo retrasa a los que vienen detrás. Va acotado por host
+    y no es grande a propósito: el límite es la cortesía con el objetivo, no la
+    máquina que escanea."""
 
-"""Cuántos servicios del **mismo host** se sondan a la vez.
+    # --- Sondas HTTP (checks.HttpProbe)
+    http_timeout: int = 8
+    """Plazo por petición HTTP, en segundos."""
 
-    El fingerprinting y los checks activos son entrada/salida pura: casi todo
-    su tiempo es esperar a que un servicio conteste o a que se agote su plazo.
-    En fila india, un servicio mudo retrasa a todos los que vienen detrás.
+    http_max_body_bytes: int = 131072
+    """Cuerpo máximo de respuesta que una sonda HTTP lee (128 KiB)."""
 
-    El pool va acotado **por host** y no es un número grande a propósito: el
-    límite no es la máquina que escanea, es la cortesía con el objetivo. El
-    limitador de ritmo sigue mandando por encima de esto — el pool decide
-    cuántas sondas pueden estar esperando a la vez, no a qué ritmo salen."""
+    http_user_agent: str = "Lybra/1.0"
+    """El ``User-Agent`` con el que el motor se presenta. Configurable
+    porque a veces hay que declararse ante un WAF, y a veces conviene no
+    hacerlo."""
+
+    # --- Sondas de red cruda (checks.NetworkProbe)
+    network_timeout: float = 5.0
+    """Plazo de conexión de una sesión de red cruda, en segundos."""
+
+    # --- Cascada de identificación (fingerprinting/cascade.py)
+    banner_timeout: float = 2.0
+    """Plazo de la lectura del saludo que la cascada hace contra un
+    servicio que ningún dissector reclama. Corto a propósito: un servicio que no
+    saluda lo agota entero, una vez por puerto desconocido."""
+
+    max_blind_probes: int = 2
+    """Sondas activas máximas contra un servicio que no dijo nada. El
+    presupuesto que separa "prueba lo que ya sabes leer" de un escaneo de
+    servicios completo. A cero, la cascada se queda sólo en el saludo."""
 
 
 @config_block("features.themis.scanners.lybra.ingest")
@@ -1014,6 +1066,10 @@ def knowledge_base_config() -> KnowledgeBaseConfig:
 
 def lybra_config() -> LybraConfig:
     return load_block(LybraConfig)
+
+
+def lybra_engine_config() -> LybraEngineConfig:
+    return load_block(LybraEngineConfig)
 
 
 def lybra_ingest_config() -> LybraIngestConfig:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1116,6 +1116,31 @@ def lybra_ingest_config() -> LybraIngestConfig:
     return load_block(LybraIngestConfig)
 
 
+@config_block("features.themis.scanners.lybra.credentials")
+@dataclass(frozen=True)
+class LybraCredentialsConfig:
+    """El presupuesto del motor de credenciales por defecto (Fase D, L31).
+
+    Es la única fase del motor que **escribe** en el objetivo — cada intento es
+    un login real —, así que el único dial que expone es el que evita que se
+    convierta en un ataque de fuerza bruta: cuántas contraseñas se prueban
+    contra una misma cuenta antes de rendirse con ella. No hay ``enabled``:
+    el motor entero está detrás de la doble puerta de :func:`aggressive
+    mode <>` — objetivo autorizado y petición explícita del usuario (L40) —,
+    así que un interruptor aparte sería una tercera puerta redundante.
+    """
+
+    max_attempts: int = 3
+    """Intentos máximos **por cuenta** (no por servicio): tres contraseñas
+    distintas contra ``admin`` cuentan tres, no las que además se prueben
+    contra ``root`` en el mismo servicio. Es la cuenta, no el servicio, la que
+    un proveedor bloquea tras demasiados fallos."""
+
+
+def lybra_credentials_config() -> LybraCredentialsConfig:
+    return load_block(LybraCredentialsConfig)
+
+
 def nuclei_config() -> NucleiConfig:
     return load_block(NucleiConfig)
 

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -898,6 +898,16 @@ class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
     presupuesto que separa "prueba lo que ya sabes leer" de un escaneo de
     servicios completo. A cero, la cascada se queda sólo en el saludo."""
 
+    # --- DSL de checks: payloads/fuzzing (checks.CheckRuntime)
+    max_payload_expansions: int = 25
+    """Tope duro de peticiones que un check con ``payloads`` puede expandir
+    (L30). Un payload es una lista de valores —veinte nombres de fichero de
+    copia de seguridad, pongamos— que se sustituyen en la petición, y sin un
+    tope el producto cartesiano de varias listas convierte un check en un
+    barrido de fuerza bruta de horas. El motor corta en cuanto alcanza este
+    número, así que es la diferencia entre "prueba unas cuantas variaciones" y
+    "prueba el diccionario entero"."""
+
 
 @config_block("features.themis.scanners.lybra.ingest")
 @dataclass(frozen=True)

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -150,6 +150,41 @@ def test_lybra_run_scan_self_discovery_succeeds_once_authorized(app, admin_user,
         assert scan_id is not None
 
 
+def test_lybra_endpoint_threads_the_aggressive_flag_to_run_scan(
+        client, admin_user, auth_headers, monkeypatch):
+    """El schema declara ``aggressive`` con ``load_default=False`` (L40): sin
+    el campo, una petición de siempre no cambia de comportamiento, y con él,
+    el valor llega íntegro al manager — la mitad de la doble puerta que
+    depende del usuario."""
+    captured = {}
+
+    def fake_run_scan(self, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(LybraEngineManager, "run_scan", fake_run_scan)
+
+    resp = client.post("/themis/lybra", headers=auth_headers(admin_user),
+                       json={"target": "8.8.8.8", "aggressive": True})
+    assert resp.status_code == 201
+    assert captured["aggressive"] is True
+
+
+def test_lybra_endpoint_defaults_to_non_aggressive(client, admin_user, auth_headers, monkeypatch):
+    captured = {}
+
+    def fake_run_scan(self, **kwargs):
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(LybraEngineManager, "run_scan", fake_run_scan)
+
+    resp = client.post("/themis/lybra", headers=auth_headers(admin_user),
+                       json={"target": "8.8.8.8"})
+    assert resp.status_code == 201
+    assert captured["aggressive"] is False
+
+
 def test_lybra_self_discovery_produces_open_port_findings(app, admin_user, monkeypatch):
     # Stub reachability (no real socket) and the connect scan; the rest of the
     # self-discovery pipeline runs for real.
@@ -1514,3 +1549,109 @@ def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_us
     assert len(for_cve) == 1
     assert for_cve[0].confirmed is True
     assert for_cve[0].qod == 99
+
+
+# =============================================== modo agresivo + credenciales (L40/L31)
+
+
+def _stub_tomcat_manager(monkeypatch) -> None:
+    """Un panel de Tomcat Manager con la tercera credencial de fábrica del feed
+    (``tomcat/s3cret``) — deliberadamente no la primera que se prueba, para
+    que el runtime tenga que agotar un intento fallido antes de acertar, y
+    con usuario y contraseña distintos, para poder afirmar sin ambigüedad que
+    la contraseña que funcionó no aparece en ningún sitio.
+
+    Sirve tanto a los checks activos declarativos como al motor de
+    credenciales: cualquier ruta que no sea ``/manager/html`` con la cabecera
+    correcta responde 404/401, así que el resto del feed no dispara ruido.
+    """
+    from src.modules.features.themis.lybra.checks import Response
+    import base64
+    valid_auth = "Basic " + base64.b64encode(b"tomcat:s3cret").decode("ascii")
+
+    def fetch(self, host, port, method, path, body=None, headers=None):
+        if path == "/manager/html" and (headers or {}).get("Authorization") == valid_auth:
+            return Response(200, "Tomcat Web Application Manager", {})
+        if path == "/manager/html":
+            return Response(401, "", {})
+        return Response(404, "", {})
+
+    monkeypatch.setattr("src.modules.features.themis.lybra.checks.HttpProbe.fetch", fetch)
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+
+def test_aggressive_checks_do_not_run_without_an_explicit_request(monkeypatch, app, admin_user):
+    """Objetivo autorizado, pero nadie pidió el modo agresivo: la mitad de la
+    puerta que falta. Ni un check ``aggressive`` ni el motor de credenciales
+    corren, así que un panel con credenciales de fábrica de verdad expuestas
+    no produce ningún hallazgo de ``default_credentials``."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)  # aggressive=False por defecto
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    assert not [f for f in findings if f.category == "default_credentials"]
+
+
+def test_aggressive_checks_do_not_run_on_an_unauthorized_target(monkeypatch, app, admin_user):
+    """Petición explícita de modo agresivo, pero el objetivo NO está en el
+    registro de autorización: la otra mitad de la puerta. Autorizar un
+    objetivo para el escaneo pasivo no autoriza escribir en él."""
+    # Deliberadamente sin `_authorize_target`: el objetivo no está autorizado.
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, aggressive=True)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    assert not [f for f in findings if f.category == "default_credentials"]
+
+
+def test_an_authorized_and_explicit_aggressive_scan_finds_default_credentials(
+        monkeypatch, app, admin_user):
+    """Las dos mitades de la puerta juntas: objetivo autorizado y modo
+    agresivo pedido explícitamente. El motor de credenciales prueba el panel
+    de Tomcat Manager, encuentra la credencial de fábrica que funciona y
+    produce un hallazgo confirmado — sin que la contraseña aparezca en
+    ningún campo."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    _stub_tomcat_manager(monkeypatch)
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, aggressive=True)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    credential_findings = [f for f in findings if f.category == "default_credentials"]
+    assert len(credential_findings) == 1
+    finding = credential_findings[0]
+    assert finding.confirmed is True
+    assert finding.qod == 99
+    assert finding.check_id == "lybra-credentials:tomcat-manager-default@1"
+
+    assert "s3cret" not in str(finding.title)
+
+    with UnitOfWork() as uow:
+        evidence = ScanRepository(uow).get_evidence_for_finding(finding.id)
+    # La contraseña que funcionó no aparece en el hallazgo ni en su evidencia
+    # — es justo lo que el motor de credenciales existe para garantizar. El
+    # usuario ("tomcat") sí puede aparecer; es información útil y no secreta.
+    assert len(evidence) == 1
+    assert "s3cret" not in str(evidence[0].payload)

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1299,3 +1299,89 @@ def test_the_partial_flag_reaches_the_api(client, monkeypatch, app, admin_user, 
     result = client.get("/themis/results?type=lybra&page=1&per_page=10",
                         headers=auth_headers(admin_user)).get_json()["results"][0]
     assert result["isPartial"] is True
+
+
+# ============================================ progreso y cancelación (L41)
+
+
+def test_a_scan_reports_progress_by_phase(monkeypatch, app, admin_user):
+    """El escaneo publica progreso por fase con pesos honestos: descubrimiento
+    40, fingerprint 70, checks 90, persistencia 100 (§3 del issue)."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+
+    reported = []
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, progress=reported.append)
+
+    # Monótono, empieza por debajo de 100 y llega a 100.
+    assert reported == sorted(reported)
+    assert reported[-1] == 100
+    assert 40 in reported
+
+
+def test_a_cancelled_scan_stops_persists_and_is_marked_partial(monkeypatch, app, admin_user):
+    """Cancelado tras el descubrimiento: no corre fingerprint ni checks, pero
+    persiste lo hallado y queda marcado como parcial — nunca tira lo verificado."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80, 443])
+
+    fingerprinted = []
+    original_fp = LybraEngineManager._fingerprint_services
+    monkeypatch.setattr(
+        LybraEngineManager, "_fingerprint_services",
+        lambda self, target, services, **kw: (fingerprinted.append(True)
+                                              or original_fp(self, target, services, **kw)))
+
+    # Cancelado desde el primer chequeo: el descubrimiento ya devolvió, pero
+    # fingerprint y checks no deben arrancar.
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, cancel_check=lambda: True)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            escan = repo.get_by_id(escan.id)
+            findings = repo.get_findings_by_scan(escan.id)
+
+    assert escan.status == ScanStatus.FINISHED.value
+    assert escan.is_partial is True
+    assert fingerprinted == []          # no se llegó a fingerprintear
+    # Lo descubierto se persiste: los puertos son un hecho verificado.
+    assert sorted(f.port for f in findings if f.category == "open_port") == [80, 443]
+
+
+def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, admin_user):
+    """La interacción crítica con el ciclo de vida: un escaneo cancelado a mitad
+    no vio todo el objetivo, así que la ausencia de un hallazgo anterior no es
+    evidencia de que se haya corregido (el fallo de L48-c por otra puerta)."""
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+
+    # Primer escaneo completo: 80 y 443 abiertos.
+    _stub_self_discovery(monkeypatch, [80, 443])
+    with app.app_context():
+        mgr = LybraEngineManager()
+        first = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id)
+        mgr._run_lybra(first.id)
+
+    # Segundo escaneo cancelado a mitad: sólo llega a ver el 80.
+    _stub_self_discovery(monkeypatch, [80])
+    with app.app_context():
+        mgr = LybraEngineManager()
+        second = mgr._create_scan_record(target="10.0.0.9", user_id=admin_user.id)
+        mgr._run_lybra(second.id, cancel_check=lambda: True)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            findings = repo.get_findings_by_scan(second.id)
+
+    # El 443, que no se llegó a recorrer, no se cierra como corregido.
+    fixed = [f for f in findings if f.state == "fixed"]
+    assert fixed == []

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1385,3 +1385,84 @@ def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, 
     # El 443, que no se llegó a recorrer, no se cierra como corregido.
     fixed = [f for f in findings if f.state == "fixed"]
     assert fixed == []
+
+
+# ================================================= evidencia cruda (L44)
+
+
+def test_a_confirmed_http_finding_stores_its_redacted_evidence(monkeypatch, app, admin_user):
+    """Un hallazgo http confirmado guarda la respuesta que lo provocó, con las
+    cabeceras sensibles redactadas y su hash."""
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    # El objetivo expone /.git/config y manda una cookie de sesión.
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "[core]\n\trepositoryformatversion = 0\n",
+                     {"Server": "nginx", "Set-Cookie": "PHPSESSID=secret; HttpOnly"})
+            if path == "/.git/config" else Response(404, "", {}))
+    # Sin fingerprint ni TLS que enturbien.
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            findings = repo.get_findings_by_scan(escan.id)
+            git = next(f for f in findings if f.check_id == "lybra:git-config-exposure@1")
+            evidence = repo.get_evidence_for_finding(git.id)
+
+    assert len(evidence) == 1
+    row = evidence[0]
+    assert row.kind == "http_response"
+    assert row.payload["status"] == 200
+    assert "[core]" in row.payload["body"]
+    # El secreto no está: la cookie se redactó antes de persistir.
+    assert row.payload["headers"]["Set-Cookie"] == "[redacted]"
+    assert row.payload["headers"]["Server"] == "nginx"
+    assert len(row.content_hash) == 64
+
+
+def test_the_evidence_endpoint_returns_own_findings_and_404s_for_others(
+        client, monkeypatch, app, admin_user, regular_user, auth_headers):
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "[core]\n\trepositoryformatversion = 0\n", {"Server": "nginx"})
+            if path == "/.git/config" else Response(404, "", {}))
+    monkeypatch.setattr(LybraEngineManager, "_fingerprint_services",
+                        lambda self, target, services, **kw: (services, []))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+        with UnitOfWork() as uow:
+            repo = ScanRepository(uow)
+            git = next(f for f in repo.get_findings_by_scan(escan.id)
+                       if f.check_id == "lybra:git-config-exposure@1")
+            finding_id = git.id
+
+    # El dueño ve su evidencia.
+    ok = client.get(f"/themis/findings/{finding_id}/evidence",
+                    headers=auth_headers(admin_user))
+    assert ok.status_code == 200
+    body = ok.get_json()
+    assert body["evidence"][0]["kind"] == "http_response"
+    assert body["evidence"][0]["contentHash"]
+
+    # Otro usuario recibe 404 (mismo criterio de propiedad que set_finding_state).
+    forbidden = client.get(f"/themis/findings/{finding_id}/evidence",
+                           headers=auth_headers(regular_user))
+    assert forbidden.status_code == 404

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1466,3 +1466,51 @@ def test_the_evidence_endpoint_returns_own_findings_and_404s_for_others(
     forbidden = client.get(f"/themis/findings/{finding_id}/evidence",
                            headers=auth_headers(regular_user))
     assert forbidden.status_code == 404
+
+
+# =============================================== confirmadores (L29)
+
+
+def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_user):
+    """El encadenamiento versión→confirmador en el flujo real: el motor propone
+    una CVE por versión (hipótesis) y el confirmador la asciende a hecho, dando
+    un único hallazgo confirmado en vez de dos sueltos."""
+    from src.modules.features.themis.lybra.checks import Response
+    _authorize_target(app, admin_user.id)
+    monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
+    _stub_self_discovery(monkeypatch, [80])
+    # Fingerprint: el servicio es un Apache 2.4.49 (identificado).
+    monkeypatch.setattr(
+        LybraEngineManager, "_fingerprint_services",
+        lambda self, target, services, **kw: (
+            [Service(s.port, s.protocol, s.name, "apache", "2.4.49", None)
+             for s in services], []))
+    # El motor propone CVE-2021-41773 como hipótesis (confirmed=false, qod=70).
+    cve = "CVE-2021-41773"
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.engine.LybraEngine.analyze",
+        lambda self, services: [
+            {"host_id": None, "port": 80, "service": "http", "protocol": "tcp",
+             "cve_ids": [cve], "confirmed": False, "qod": 70, "source": "lybra",
+             "check_id": "lybra:outdated@1", "category": "outdated_software",
+             "title": "Apache 2.4.49 con CVE conocida", "state": "open"}])
+    # El objetivo es de verdad vulnerable: sirve /etc/passwd por la ruta.
+    traversal = "/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd"
+    monkeypatch.setattr(
+        "src.modules.features.themis.lybra.checks.HttpProbe.fetch",
+        lambda self, host, port, method, path:
+            Response(200, "root:x:0:0:root:/root:/bin/bash\n", {})
+            if path == traversal else Response(404, "", {}))
+
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.5", user_id=admin_user.id)
+        mgr._run_lybra(escan.id)
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    # Un solo hallazgo para esa CVE, ascendido a confirmado con qod 99.
+    for_cve = [f for f in findings if f.cve_ids and cve in f.cve_ids]
+    assert len(for_cve) == 1
+    assert for_cve[0].confirmed is True
+    assert for_cve[0].qod == 99

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -197,6 +197,7 @@ CONFIG_BLOCKS = [
     (CR.TracerouteConfig, CR.traceroute_config),
     (CR.KnowledgeBaseConfig, CR.knowledge_base_config),
     (CR.LybraConfig, CR.lybra_config),
+    (CR.LybraEngineConfig, CR.lybra_engine_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -198,6 +198,7 @@ CONFIG_BLOCKS = [
     (CR.KnowledgeBaseConfig, CR.knowledge_base_config),
     (CR.LybraConfig, CR.lybra_config),
     (CR.LybraEngineConfig, CR.lybra_engine_config),
+    (CR.LybraEvidenceConfig, CR.lybra_evidence_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -200,6 +200,7 @@ CONFIG_BLOCKS = [
     (CR.LybraEngineConfig, CR.lybra_engine_config),
     (CR.LybraEvidenceConfig, CR.lybra_evidence_config),
     (CR.LybraIngestConfig, CR.lybra_ingest_config),
+    (CR.LybraCredentialsConfig, CR.lybra_credentials_config),
     (CR.NucleiConfig, CR.nuclei_config),
     (CR.AegisConfig, CR.aegis_config),
     (CR.IrisConfig, CR.iris_config),

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -650,10 +650,12 @@ _TLS_SERVICE = Service(443, "tcp", "https", "", "", None)
 class _TlsInfoFalso:
     """Lo mínimo que las reglas TLS del feed consultan de un handshake."""
 
-    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3"):
+    def __init__(self, self_signed=True, expired=False, protocol="TLSv1.3",
+                 cipher="TLS_AES_256_GCM_SHA384"):
         self.self_signed = self_signed
         self.expired = expired
         self.protocol = protocol
+        self.cipher = cipher
         self.days_until_expiry = 200
 
 
@@ -673,10 +675,13 @@ def test_the_three_header_checks_make_one_request_between_them():
 
     findings = CheckRuntime(load_checks(), fetch).run("10.0.0.5", [_HTTP])
 
-    # Los tres checks de cabeceras disparan (el nginx de mentira no manda
-    # ninguna) y aun así "/" se pidió una sola vez.
-    cabeceras = [f for f in findings if f["category"] == "security_header"]
-    assert len(cabeceras) == 3
+    # Los checks de cabeceras faltantes disparan (el nginx de mentira no manda
+    # ninguna: HSTS, X-Frame-Options, X-Content-Type-Options, CSP,
+    # Referrer-Policy y Permissions-Policy) y aun así "/" se pidió una sola vez.
+    # La cookie insegura no cuenta: no hay Set-Cookie que mirar.
+    cabeceras = [f for f in findings if f["category"] == "security_header"
+                 and f["check_id"] != "lybra:session-cookie-without-secure@1"]
+    assert len(cabeceras) == 6
     assert [ruta for _h, _p, _m, ruta in fetch.calls].count("/") == 1
 
 

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -263,8 +263,10 @@ def test_ftp_anonymous_login_confirmed_when_both_steps_succeed():
     assert ftp[0]["qod"] == 99 and ftp[0]["confirmed"] is True
     assert ftp[0]["category"] == "default_credentials"
     assert ftp[0]["port"] == 21
-    # Los dos pasos de la secuencia de login fueron por la misma sesión, en orden.
-    assert sock.sent == b"USER anonymous\r\nPASS anonymous@lybra.local\r\n"
+    # Los dos pasos de la secuencia de login fueron por la misma sesión, en
+    # orden. Se comprueba con startswith y no con igualdad porque otros checks
+    # de FTP (ftp-no-tls) comparten esa sesión y escriben detrás.
+    assert sock.sent.startswith(b"USER anonymous\r\nPASS anonymous@lybra.local\r\n")
 
 
 def test_ftp_anonymous_login_confirmed_with_a_multiline_banner():

--- a/API/tests/unit/test_lybra_confirmers.py
+++ b/API/tests/unit/test_lybra_confirmers.py
@@ -1,0 +1,133 @@
+"""El encadenamiento versión → confirmador (L29).
+
+Es lo más diferencial que le quedaba al motor por construir: el §11 del roadmap
+lo nombra como la razón de existir del runtime propio frente a Nuclei. Convierte
+una hipótesis ``confirmed=false, qod=70`` —que puede ser un falso positivo por
+backport— en un hecho verificado, que es lo que separa un informe entregable de
+uno que hay que revisar a mano.
+
+Dos garantías, y la segunda es la que lo hace seguro: un confirmador **sólo
+corre si su CVE ya fue propuesta**, y **nunca explota**.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    Response,
+    Service,
+    load_checks,
+    validate_checks,
+)
+from src.modules.features.themis.lybra.correlation import compute_dedup_key, merge_findings
+
+pytestmark = pytest.mark.unit
+
+_HTTP = Service(80, "tcp", "http", "apache", "2.4.49", None)
+_CHECKS = load_checks()
+_CVE = "CVE-2021-41773"
+_TRAVERSAL_PATH = "/cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd"
+
+
+def _vulnerable_fetch(host, port, method, path):
+    """Un Apache 2.4.49 que sirve /etc/passwd por la ruta vulnerable."""
+    if path == _TRAVERSAL_PATH:
+        return Response(200, "root:x:0:0:root:/root:/bin/bash\n", {})
+    return Response(404, "", {})
+
+
+def _fired(fetch, proposed_cves):
+    findings = CheckRuntime(_CHECKS, fetch).run(
+        "10.0.0.5", [_HTTP], proposed_cves=frozenset(proposed_cves))
+    return {f["check_id"].split(":")[1].split("@")[0] for f in findings}
+
+
+# =============================================== el gating: la garantía central
+
+
+def test_a_confirmer_does_not_run_without_its_cve_proposed():
+    """Un confirmador nunca corre 'por si acaso'. Aunque el objetivo sea
+    vulnerable, sin la hipótesis del matcher de versiones el confirmador ni se
+    intenta — es la diferencia con un check normal."""
+    fired = _fired(_vulnerable_fetch, proposed_cves=frozenset())
+    assert "apache-cve-2021-41773-path-traversal" not in fired
+
+
+def test_a_confirmer_runs_when_its_cve_was_proposed():
+    """Con la CVE ya propuesta, el confirmador corre y —contra un objetivo
+    vulnerable— dispara."""
+    fired = _fired(_vulnerable_fetch, proposed_cves={_CVE})
+    assert "apache-cve-2021-41773-path-traversal" in fired
+
+
+def test_a_confirmer_whose_cve_was_proposed_but_target_is_safe_does_not_fire():
+    """Propuesta la CVE, pero el objetivo NO es vulnerable (ya parcheado): el
+    confirmador corre y no dispara. Es justamente el falso positivo por backport
+    que este mecanismo existe para descartar."""
+    def patched_fetch(host, port, method, path):
+        return Response(404, "Not Found", {})       # la ruta ya no traversa
+
+    fired = _fired(patched_fetch, proposed_cves={_CVE})
+    assert "apache-cve-2021-41773-path-traversal" not in fired
+
+
+# =============================================== el ascenso hipótesis → hecho
+
+
+def test_the_confirmer_promotes_the_hypothesis_on_merge():
+    """El salto que separa un informe entregable de uno por revisar: la
+    hipótesis (qod 70, confirmed false) y el confirmador (qod 99, confirmed
+    true) comparten dedup_key y merge_findings los funde en uno solo, ascendido.
+    """
+    hypothesis = {
+        "host_id": 1, "port": 80, "cve_ids": [_CVE],
+        "confirmed": False, "qod": 70, "source": "lybra",
+        "check_id": "lybra:outdated@1",
+    }
+    confirmation = {
+        "host_id": 1, "port": 80, "cve_ids": [_CVE],
+        "confirmed": True, "qod": 99, "source": "lybra",
+        "check_id": "lybra:apache-cve-2021-41773-path-traversal@1",
+    }
+    # Comparten identidad de vulnerabilidad (la CVE), luego el mismo dedup_key.
+    assert compute_dedup_key(hypothesis) == compute_dedup_key(confirmation)
+
+    merged = merge_findings([hypothesis, confirmation])
+    assert len(merged) == 1
+    assert merged[0]["confirmed"] is True
+    assert merged[0]["qod"] == 99
+    assert merged[0]["cve_ids"] == [_CVE]
+
+
+def test_the_confirmer_finding_carries_its_cve_for_the_merge():
+    """Para que el ascenso funcione, el confirmador debe emitir la CVE en
+    cve_ids —si no, su dedup_key no coincidiría con la hipótesis y quedarían dos
+    hallazgos sueltos en vez de uno ascendido."""
+    findings = CheckRuntime(_CHECKS, _vulnerable_fetch).run(
+        "10.0.0.5", [_HTTP], proposed_cves={_CVE})
+    confirmer = next(
+        f for f in findings
+        if f["check_id"] == "lybra:apache-cve-2021-41773-path-traversal@1")
+    assert confirmer["cve_ids"] == [_CVE]
+    assert confirmer["confirmed"] is True
+
+
+# ============================================================= validación
+
+
+def test_the_feed_confirmers_are_well_formed():
+    confirmers = [c for c in _CHECKS if c.confirms]
+    assert len(confirmers) >= 2
+    assert validate_checks(_CHECKS) == []
+    for check in confirmers:
+        assert check.confirms.startswith("CVE-")
+
+
+def test_a_confirmer_with_a_malformed_cve_is_reported():
+    """Sin este bloque, un `confirms: not-a-cve` se colaría y su dedup_key nunca
+    casaría con ninguna hipótesis — un confirmador que no confirma nada."""
+    from dataclasses import replace
+
+    good = next(c for c in _CHECKS if c.confirms)
+    broken = replace(good, confirms="no-es-una-cve")
+    assert any("confirms" in problem for problem in validate_checks([broken]))

--- a/API/tests/unit/test_lybra_credentials.py
+++ b/API/tests/unit/test_lybra_credentials.py
@@ -1,0 +1,201 @@
+"""El motor de credenciales por defecto (Fase D, L31).
+
+Es la única familia de detección de Lybra que escribe en el objetivo, así que
+lo que estos tests protegen no es sólo "encuentra el par correcto" sino las
+tres garantías que hacen esa escritura segura: el presupuesto de intentos se
+cuenta **por cuenta**, para en el primer éxito, y la contraseña que funcionó
+no aparece nunca en el hallazgo ni en su evidencia.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import Response, Service
+from src.modules.features.themis.lybra.credentials import (
+    CredentialEntry,
+    CredentialPair,
+    CredentialRuntime,
+    load_credentials,
+    validate_credentials,
+)
+from src.modules.features.themis.lybra.checks import Matcher
+
+pytestmark = pytest.mark.unit
+
+_SVC = Service(80, "tcp", "http", None, None, None)
+
+
+def _entry(accounts, matchers=None, **kwargs):
+    if matchers is None:
+        matchers = (Matcher(type="status", values=(200,)),)
+    return CredentialEntry(
+        id=kwargs.pop("id", "test-panel"),
+        version=kwargs.pop("version", 1),
+        service=kwargs.pop("service", "http"),
+        path=kwargs.pop("path", "/admin"),
+        accounts=tuple(accounts),
+        matchers=tuple(matchers),
+        **kwargs,
+    )
+
+
+# =============================================== el par correcto dispara
+
+def test_a_correct_pair_produces_a_confirmed_finding():
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        assert headers == {"Authorization": "Basic YWRtaW46YWRtaW4="}
+        return Response(200, "bienvenido", {})
+
+    findings = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert findings[0]["category"] == "default_credentials"
+    assert findings[0]["confirmed"] is True
+    assert findings[0]["qod"] == 99
+
+
+def test_a_wrong_pair_produces_nothing():
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(401, "unauthorized", {})
+
+    assert CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC]) == []
+
+
+# =============================================== plaintext, en ningún sitio
+
+def test_the_password_never_appears_in_the_finding():
+    entry = _entry([CredentialPair("admin", "s3cr3t-p4ss")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(200, "ok", {})
+
+    finding = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])[0]
+    assert "s3cr3t-p4ss" not in str(finding)
+
+
+def test_the_password_never_appears_in_the_evidence():
+    entry = _entry([CredentialPair("admin", "s3cr3t-p4ss")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(200, "ok", {"X-Served-By": "app-1"})
+
+    finding = CredentialRuntime([entry], fetch, capture_evidence=True).run("10.0.0.1", [_SVC])[0]
+    assert "_evidence" in finding
+    assert "s3cr3t-p4ss" not in str(finding["_evidence"])
+    assert finding["_evidence"]["payload"]["username"] == "admin"
+
+
+# =============================================== presupuesto por cuenta
+
+def test_the_budget_is_counted_per_account_not_per_service():
+    """Tres contraseñas contra 'admin' y una contra 'root' en el mismo
+    servicio: con el tope en 2, a 'admin' solo le quedan dos intentos, pero a
+    'root' — una cuenta distinta — le sigue quedando su propio presupuesto
+    entero."""
+    entry = _entry([
+        CredentialPair("admin", "wrong1"),
+        CredentialPair("admin", "wrong2"),
+        CredentialPair("admin", "wrong3"),   # nunca se llega: tope de 2 para 'admin'
+        CredentialPair("root", "toor"),      # cuenta distinta, presupuesto propio
+    ])
+    tried = []
+
+    def fetch(host, port, method, path, body, headers):
+        tried.append(headers["Authorization"])
+        if headers["Authorization"] == _basic("root", "toor"):
+            return Response(200, "ok", {})
+        return Response(401, "no", {})
+
+    findings = CredentialRuntime([entry], fetch, max_attempts_per_account=2).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert len(tried) == 3          # 2 de admin + 1 de root (éxito, para ahí)
+    assert _basic("admin", "wrong3") not in tried
+
+
+def test_stops_at_the_first_successful_account():
+    entry = _entry([
+        CredentialPair("admin", "admin"),
+        CredentialPair("root", "toor"),
+    ])
+    tried = []
+
+    def fetch(host, port, method, path, body, headers):
+        tried.append(headers["Authorization"])
+        return Response(200, "ok", {})   # la primera cuenta ya funciona
+
+    findings = CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert len(findings) == 1
+    assert len(tried) == 1
+
+
+# =============================================== registro incluso al fallar
+
+def test_every_attempt_is_logged_even_on_failure(caplog):
+    entry = _entry([CredentialPair("admin", "admin")])
+
+    def fetch(host, port, method, path, body, headers):
+        return Response(401, "no", {})
+
+    with caplog.at_level("INFO"):
+        CredentialRuntime([entry], fetch).run("10.0.0.1", [_SVC])
+    assert any("intento" in record.message for record in caplog.records)
+
+
+# =============================================== servicio no aplicable
+
+def test_an_entry_is_skipped_against_a_non_matching_service():
+    entry = _entry([CredentialPair("admin", "admin")], service="http")
+    ftp_service = Service(21, "tcp", "ftp", None, None, None)
+    called = []
+
+    def fetch(host, port, method, path, body, headers):
+        called.append(1)
+        return Response(200, "ok", {})
+
+    assert CredentialRuntime([entry], fetch).run("10.0.0.1", [ftp_service]) == []
+    assert not called
+
+
+# =============================================== el feed empaquetado
+
+def test_the_shipped_feed_is_well_formed():
+    entries = load_credentials()
+    assert len(entries) >= 3
+    assert validate_credentials(entries) == []
+
+
+def test_the_shipped_feed_never_stores_a_password_in_a_finding_field_name():
+    """Sanity check estructural: ninguna entrada del feed usa un nombre de
+    campo que sugiera que la contraseña se vaya a guardar en el hallazgo."""
+    for entry in load_credentials():
+        assert "password" not in entry.finding
+
+
+# =============================================== validación de forma
+
+def test_an_entry_without_accounts_is_reported():
+    entry = _entry([])
+    assert any("ninguna cuenta" in problem for problem in validate_credentials([entry]))
+
+
+def test_an_entry_without_matchers_is_reported():
+    entry = _entry([CredentialPair("a", "b")], matchers=())
+    assert any("matcher" in problem for problem in validate_credentials([entry]))
+
+
+def test_an_entry_with_an_unknown_service_is_reported():
+    entry = _entry([CredentialPair("a", "b")], service="carrier-pigeon")
+    assert any("sin predicado" in problem for problem in validate_credentials([entry]))
+
+
+def test_a_duplicate_id_and_version_is_reported():
+    entry = _entry([CredentialPair("a", "b")])
+    assert any("duplicada" in problem for problem in validate_credentials([entry, entry]))
+
+
+def _basic(username: str, password: str) -> str:
+    import base64
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"

--- a/API/tests/unit/test_lybra_dsl_chaining.py
+++ b/API/tests/unit/test_lybra_dsl_chaining.py
@@ -1,0 +1,251 @@
+"""El DSL de checks: variables extraídas, encadenamiento y payloads (L30).
+
+El motor sabía hacer una petición y mirar la respuesta, y nada más. No podía
+leer un dato de una respuesta y usarlo en la siguiente (login → recurso
+protegido), ni probar la misma ruta con veinte nombres de fichero sin escribir
+veinte checks. Esto añade las tres piezas que faltaban —**extractores**,
+**cuerpo/cabeceras** y **payloads con tope**— y aquí se prueban las tres, más
+las dos reglas que las hacen seguras: un extractor que no casa **aborta** la
+cadena, y un payload **nunca** supera el tope de expansiones.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    Check,
+    CheckRuntime,
+    Extractor,
+    Matcher,
+    Request,
+    Response,
+    Service,
+    _substitute,
+    load_checks,
+    validate_checks,
+)
+
+pytestmark = pytest.mark.unit
+
+_SVC = Service(80, "tcp", "http", None, None, None)
+
+
+def _run(check, fetch, **kwargs):
+    return CheckRuntime([check], fetch, **kwargs).run("10.0.0.1", [_SVC])
+
+
+# =============================================== sustitución de variables (unidad)
+
+
+def test_substitute_replaces_a_bound_variable():
+    assert _substitute("/user/{{id}}", {"id": "42"}) == "/user/42"
+
+
+def test_substitute_leaves_an_unbound_marker_verbatim():
+    """Un marcador sin valor se deja tal cual —no se borra— para que un typo
+    falle a la vista (una ruta con ``{{fil}}`` literal da un 404 visible) en vez
+    de sondear ``/`` en silencio y parecer que corrió."""
+    assert _substitute("/{{fil}}", {"name": "x"}) == "/{{fil}}"
+
+
+def test_substitute_does_not_re_expand_a_value():
+    """Una sola pasada: un valor que a su vez trae ``{{...}}`` no se vuelve a
+    expandir. El valor viene del objetivo, y re-expandirlo dejaría que una
+    respuesta dirigiera las peticiones siguientes."""
+    assert _substitute("{{a}}", {"a": "{{b}}", "b": "x"}) == "{{b}}"
+
+
+# =============================================== extractores + encadenamiento
+
+
+def test_an_extractor_binds_a_value_for_the_next_request():
+    """La pieza que convierte dos peticiones sueltas en una cadena: la primera
+    extrae un token, la segunda lo usa en la ruta."""
+    first = Request(
+        path="/token",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="tok", pattern=r"TOKEN=([A-Z0-9]+)"),),
+    )
+    second = Request(
+        path="/resource/{{tok}}",
+        matchers=(Matcher(type="status", values=(200,)),),
+    )
+    check = Check(id="chain", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(first, second), finding={"title": "x"})
+
+    requested = []
+
+    def fetch(host, port, method, path, *args):
+        requested.append(path)
+        if path == "/token":
+            return Response(200, "TOKEN=ABC123", {})
+        if path == "/resource/ABC123":
+            return Response(200, "ok", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:chain@1"]
+    assert requested == ["/token", "/resource/ABC123"]
+
+
+def test_a_login_chain_uses_body_and_headers():
+    """El criterio de cierre entero: login (POST con cuerpo) → recurso protegido
+    (GET con el token de sesión en una cabecera), encadenados por una variable
+    extraída de la respuesta del login."""
+    login = Request(
+        method="POST", path="/login", body="user=admin&pass={{pw}}",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="sid", pattern=r"sid: ([A-Za-z0-9]+)", part="header"),),
+    )
+    protected = Request(
+        method="GET", path="/admin", headers=(("Cookie", "session={{sid}}"),),
+        matchers=(Matcher(type="word", part="body", values=("bienvenido",)),),
+    )
+    # ``pw`` llega como payload de un solo valor: prueba de paso que payload y
+    # extracción conviven en la misma cadena.
+    check = Check(id="login", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  payloads=(("pw", ("s3cret",)),),
+                  requests=(login, protected), finding={"title": "x"})
+
+    def fetch(host, port, method, path, body=None, headers=None):
+        if method == "POST" and path == "/login":
+            assert body == "user=admin&pass=s3cret", body
+            return Response(200, "", {"sid": "Tok9"})
+        if method == "GET" and path == "/admin":
+            assert headers == {"Cookie": "session=Tok9"}, headers
+            return Response(200, "bienvenido", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:login@1"]
+
+
+def test_an_extractor_that_does_not_match_aborts_the_check():
+    """La regla que hace fiable el encadenamiento: si el extractor no encuentra
+    su valor, la cadena no puede continuar honestamente, así que el check no
+    dispara —ni siquiera lanza la petición siguiente."""
+    first = Request(
+        path="/token",
+        matchers=(Matcher(type="status", values=(200,)),),
+        extractors=(Extractor(name="tok", pattern=r"NO_APARECE=([0-9]+)"),),
+    )
+    second = Request(path="/resource/{{tok}}",
+                     matchers=(Matcher(type="status", values=(200,)),))
+    check = Check(id="chain", version=1, type="http", category="exposed_service",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(first, second), finding={"title": "x"})
+
+    requested = []
+
+    def fetch(host, port, method, path, *args):
+        requested.append(path)
+        return Response(200, "sin token aquí", {})
+
+    assert _run(check, fetch) == []
+    assert requested == ["/token"]        # la segunda petición nunca se lanza
+
+
+def test_a_backward_compatible_fetch_still_works_for_plain_checks():
+    """Un check sin cuerpo ni cabeceras llama al ``fetch`` con los cuatro
+    argumentos posicionales de siempre, así que un ``fetch`` de test escrito
+    ``(host, port, method, path)`` sigue valiendo —sólo los checks que de
+    verdad mandan cuerpo o cabeceras necesitan un ``fetch`` que los acepte."""
+    check = Check(id="plain", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(Request(path="/.git/config",
+                                    matchers=(Matcher(type="status", values=(200,)),)),),
+                  finding={"title": "x"})
+
+    def four_arg_fetch(host, port, method, path):     # exactamente cuatro
+        return Response(200, "", {})
+
+    assert [f["check_id"] for f in _run(check, four_arg_fetch)] == ["lybra:plain@1"]
+
+
+# =============================================== payloads + tope
+
+
+def _sql_dump_check():
+    return [c for c in load_checks() if c.id == "sql-dump-exposure"][0]
+
+
+def test_a_payload_expands_one_request_over_many_values():
+    """Un check con payloads prueba cada valor sin escribir un check por
+    valor: aquí, siete nombres de volcado SQL con una sola entrada de feed."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        if path == "/db.sql":
+            return Response(200, "INSERT INTO users VALUES (1);", {})
+        return Response(404, "", {})
+
+    assert [f["check_id"] for f in _run(check, fetch)] == ["lybra:sql-dump-exposure@1"]
+    assert "/backup.sql" in tried and "/db.sql" in tried
+
+
+def test_a_payload_never_exceeds_the_expansion_cap():
+    """El tope no es opcional: es lo que impide que un payload se convierta en
+    un barrido. Con el tope en 2, sólo se prueban dos valores —aunque un valor
+    posterior sí existiría, no se llega a él y el check no dispara."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        # database.sql es el tercer payload: existiría, pero el tope lo deja fuera
+        return Response(200, "CREATE TABLE x", {}) if path == "/database.sql" else Response(404, "", {})
+
+    findings = _run(check, fetch, max_payload_expansions=2)
+    assert findings == []
+    assert len(tried) == 2
+
+
+def test_the_first_matching_payload_wins_as_a_single_finding():
+    """Veinte sondas colapsan en un hallazgo: en cuanto un valor pica, el check
+    dispara una vez y no sigue probando el resto."""
+    check = _sql_dump_check()
+    tried = []
+
+    def fetch(host, port, method, path, *args):
+        tried.append(path)
+        return Response(200, "CREATE TABLE x", {})       # todos "existen"
+
+    findings = _run(check, fetch)
+    assert len(findings) == 1
+    assert len(tried) == 1                                # paró en el primero
+
+
+# =============================================== validación de forma (CI, #275)
+
+
+def test_the_shipped_feed_including_the_payload_check_is_well_formed():
+    assert validate_checks(load_checks()) == []
+
+
+def test_an_extractor_with_an_invalid_regex_is_reported():
+    bad = Request(path="/", matchers=(Matcher(type="status", values=(200,)),),
+                  extractors=(Extractor(name="x", pattern="(sin cerrar"),))
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(bad,), finding={})
+    assert any("patrón inválido" in problem for problem in validate_checks([check]))
+
+
+def test_an_extractor_without_a_name_is_reported():
+    bad = Request(path="/", matchers=(Matcher(type="status", values=(200,)),),
+                  extractors=(Extractor(name="", pattern="x"),))
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  requests=(bad,), finding={})
+    assert any("'name'" in problem for problem in validate_checks([check]))
+
+
+def test_a_payload_with_no_values_is_reported():
+    check = Check(id="bad", version=1, type="http", category="exposed_path",
+                  severity="HIGH", service="http", mode="safe",
+                  payloads=(("name", ()),),
+                  requests=(Request(path="/{{name}}",
+                                    matchers=(Matcher(type="status", values=(200,)),)),),
+                  finding={})
+    assert any("no tiene ningún valor" in problem for problem in validate_checks([check]))

--- a/API/tests/unit/test_lybra_engine_config.py
+++ b/API/tests/unit/test_lybra_engine_config.py
@@ -1,0 +1,77 @@
+"""El bloque de configuración del motor (L39).
+
+Hasta L39 cada timeout, cada nivel de concurrencia y cada intervalo de ritmo
+era un literal en la firma de un constructor, y el manager instanciaba las
+sondas sin argumentos. Este fichero comprueba las dos mitades del arreglo: que
+el bloque existe y está atado, y —lo que de verdad importa— que el manager
+**usa** los valores configurados en vez de los defectos del constructor.
+"""
+
+import pytest
+
+from src.modules.system import config_reading as CR
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_engine_block_keeps_the_old_values_as_defaults():
+    """El cambio es invisible hasta que alguien mueve un dial: los defaults son
+    exactamente los que estaban a fuego."""
+    engine = CR.lybra_engine_config()
+    assert engine.tcp_concurrency == 200
+    assert engine.tcp_timeout == 2.0
+    assert engine.rate_limit_interval == 0.2
+    assert engine.http_timeout == 8
+    assert engine.http_max_body_bytes == 131072
+    assert engine.http_user_agent == "Lybra/1.0"
+    assert engine.network_timeout == 5.0
+
+
+def test_the_operator_switches_stay_out_of_the_engine_block():
+    """Un interruptor de despliegue y un dial de afinado son cosas distintas:
+    `LybraConfig` se queda con los dos booleanos y nada más."""
+    assert set(CR.LybraConfig.__dataclass_fields__) == {
+        "active_checks", "fingerprinting_enabled"}
+
+
+def test_the_http_probe_presents_the_configured_user_agent():
+    from src.modules.features.themis.lybra.checks import HttpProbe
+
+    seen = {}
+
+    class _Opener:
+        def open(self, request, timeout=None):
+            seen["ua"] = request.get_header("User-agent")
+            raise OSError("no real network")
+
+    probe = HttpProbe(user_agent="Escaner-Auditoria/2.0")
+    probe._opener = _Opener()                      # pylint: disable=protected-access
+    probe._scheme_for = lambda host, port: "http"  # pylint: disable=protected-access
+    probe._request("10.0.0.5", 80, "GET", "/")     # pylint: disable=protected-access
+    assert seen["ua"] == "Escaner-Auditoria/2.0"
+
+
+def test_the_discovery_scan_receives_the_configured_dials(monkeypatch):
+    """El dial llega a la sonda: sin esto, el bloque sería config muerta."""
+    from src.modules.features.themis.managers.lybra import engine as engine_module
+    from src.modules.features.themis.lybra.transport import PortSweep
+
+    captured = {}
+
+    def fake_sweep(target, ports, **kwargs):
+        captured.update(kwargs)
+        return PortSweep(open_ports=(80,), refused_ports=(), timed_out_ports=(),
+                         unreachable_ports=())
+
+    monkeypatch.setattr(engine_module, "sweep_with_retries", fake_sweep)
+    monkeypatch.setattr(
+        engine_module.CR, "lybra_engine_config",
+        lambda: type("_Cfg", (), {
+            "tcp_concurrency": 50, "tcp_timeout": 0.5, "udp_retries": 3,
+        })())
+
+    engine_module.LybraEngineManager()._discover_ports(  # pylint: disable=protected-access
+        "10.0.0.5", [80])
+
+    assert captured["concurrency"] == 50
+    assert captured["timeout"] == 0.5

--- a/API/tests/unit/test_lybra_evidence.py
+++ b/API/tests/unit/test_lybra_evidence.py
@@ -1,0 +1,89 @@
+"""La evidencia cruda de un hallazgo: redacción, truncado y hash (L44).
+
+La parte pura, sin ORM ni red. La redacción es lo que separa «guardo lo que vi»
+de «me quedo con las llaves de casa del cliente», así que la mayoría de estos
+tests son sobre lo que **no** debe acabar en la base de datos.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.evidence import (
+    EvidenceRecorder,
+    build_recorder,
+    evidence_hash,
+    prepare_evidence,
+    redact_evidence,
+    redact_headers,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_sensitive_headers_lose_their_value_but_keep_their_name():
+    """Se conserva que la cabecera estaba —más honesto que fingir que no— y se
+    borra sólo el secreto."""
+    headers = {
+        "Server": "nginx",
+        "Set-Cookie": "PHPSESSID=deadbeef; HttpOnly",
+        "Authorization": "Bearer supersecret",
+        "X-Api-Key": "abc123",
+    }
+    redacted = redact_headers(headers)
+    assert redacted["Server"] == "nginx"
+    assert redacted["Set-Cookie"] == "[redacted]"
+    assert redacted["Authorization"] == "[redacted]"
+    assert redacted["X-Api-Key"] == "[redacted]"
+
+
+def test_redaction_is_case_insensitive_on_the_header_name():
+    assert redact_headers({"set-COOKIE": "x"})["set-COOKIE"] == "[redacted]"
+    assert redact_headers({"AUTHORIZATION": "x"})["AUTHORIZATION"] == "[redacted]"
+
+
+def test_the_body_is_truncated_to_the_configured_cap():
+    payload = {"body": "A" * 20000}
+    redacted = redact_evidence(payload, max_body_bytes=100)
+    assert len(redacted["body"].encode("utf-8")) == 100
+    assert redacted["body_truncated_bytes"] == 19900
+
+
+def test_a_short_body_is_left_alone():
+    payload = {"body": "corto"}
+    redacted = redact_evidence(payload, max_body_bytes=8192)
+    assert redacted["body"] == "corto"
+    assert "body_truncated_bytes" not in redacted
+
+
+def test_the_hash_is_stable_for_the_same_content():
+    payload = {"status": 200, "headers": {"b": "2", "a": "1"}, "body": "x"}
+    # El mismo contenido con las claves en otro orden produce el mismo hash.
+    other = {"body": "x", "status": 200, "headers": {"a": "1", "b": "2"}}
+    assert evidence_hash(payload) == evidence_hash(other)
+    assert len(evidence_hash(payload)) == 64
+
+
+def test_the_hash_changes_if_the_content_changes():
+    a = evidence_hash({"body": "hola"})
+    b = evidence_hash({"body": "adios"})
+    assert a != b
+
+
+def test_prepare_evidence_redacts_and_hashes_in_one_step():
+    payload = {"status": 200, "headers": {"Cookie": "secret"}, "body": "B" * 100}
+    prepared = prepare_evidence(payload, max_body_bytes=10)
+    assert prepared["payload"]["headers"]["Cookie"] == "[redacted]"
+    assert len(prepared["payload"]["body"].encode("utf-8")) == 10
+    # El hash es del contenido ya redactado, no del original.
+    assert prepared["content_hash"] == evidence_hash(prepared["payload"])
+
+
+def test_the_recorder_accumulates_records():
+    recorder = EvidenceRecorder()
+    recorder.record("k1", "http_response", {"status": 200})
+    recorder.record("k2", "http_response", {"status": 404})
+    assert [r.dedup_key for r in recorder.records] == ["k1", "k2"]
+
+
+def test_build_recorder_returns_none_when_disabled():
+    assert build_recorder(False) is None
+    assert isinstance(build_recorder(True), EvidenceRecorder)

--- a/API/tests/unit/test_lybra_feed_web_families.py
+++ b/API/tests/unit/test_lybra_feed_web_families.py
@@ -1,0 +1,139 @@
+"""Las familias web nuevas del feed (L25): cada una con positivo y señuelo.
+
+La regla de oro del issue es que un check nuevo entra con su señuelo. Un check
+que sólo mira el código de estado saca falsos positivos contra un banco de
+señuelos —seis a la vez, y el banco ya lo demuestra—, así que cada check de aquí
+exige una cadena propia del producto además del 200. Estos tests son esa regla
+en pequeño: por cada familia, una respuesta que **debe** disparar y un señuelo
+plausible que **no** debe.
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    Response,
+    Service,
+    load_checks,
+    validate_checks,
+)
+
+pytestmark = pytest.mark.unit
+
+_HTTP = Service(80, "tcp", "http", "nginx", "1.18", None)
+_CHECKS = load_checks()
+
+
+def _fetch(by_path):
+    def fetch(host, port, method, path):
+        return by_path.get(path, Response(404, "", {}))
+    return fetch
+
+
+def _fired(by_path):
+    findings = CheckRuntime(_CHECKS, _fetch(by_path)).run("10.0.0.5", [_HTTP])
+    return {f["check_id"].split(":")[1].split("@")[0] for f in findings}
+
+
+# =========================================================== forma del feed
+
+
+def test_the_feed_reached_at_least_fifty_checks():
+    """El criterio de cierre del issue: de 17 (28 tras la Fase 2) a ≥ 50."""
+    assert len(_CHECKS) >= 50
+
+
+def test_the_grown_feed_is_still_well_formed():
+    assert validate_checks(_CHECKS) == []
+
+
+# ================================================= paneles y consolas
+
+
+def test_a_tomcat_manager_is_detected_and_a_bare_200_is_not():
+    body = "<html><title>Tomcat Web Application Manager</title></html>"
+    assert "tomcat-manager-exposed" in _fired({"/manager/html": Response(200, body, {})})
+    # Señuelo: un 200 en /manager/html que no es Tomcat (una SPA cualquiera).
+    decoy = Response(200, "<html><title>Mi aplicacion</title></html>", {})
+    assert "tomcat-manager-exposed" not in _fired({"/manager/html": decoy})
+
+
+def test_a_spring_actuator_env_is_detected_and_a_health_ping_is_not():
+    env = Response(200, '{"activeProfiles":["prod"],"propertySources":[]}', {})
+    assert "spring-actuator-env" in _fired({"/actuator/env": env})
+    # Señuelo: /actuator/env devuelve 200 pero con un cuerpo que no es el de env
+    # (un 401 disfrazado, o un health accidental).
+    decoy = Response(200, '{"status":"UP"}', {})
+    assert "spring-actuator-env" not in _fired({"/actuator/env": decoy})
+
+
+def test_a_jenkins_header_is_detected_and_its_absence_is_not():
+    hit = Response(200, "<html></html>", {"x-jenkins": "2.426.3"})
+    assert "jenkins-exposed" in _fired({"/": hit})
+    assert "jenkins-exposed" not in _fired({"/": Response(200, "<html></html>", {})})
+
+
+# ================================================= depuración en producción
+
+
+def test_a_werkzeug_debugger_is_detected_and_a_plain_500_is_not():
+    body = "<html><h1>Werkzeug Debugger</h1>Traceback (most recent call last)</html>"
+    assert "flask-werkzeug-debugger" in _fired({"/lybra-nonexistent-debug-probe":
+                                                Response(500, body, {})})
+    # Señuelo: un 500 corriente sin el depurador interactivo.
+    decoy = Response(500, "<html>Internal Server Error</html>", {})
+    assert "flask-werkzeug-debugger" not in _fired({"/lybra-nonexistent-debug-probe": decoy})
+
+
+# ================================================= config y control de versiones
+
+
+def test_an_htpasswd_is_detected_and_a_404_is_not():
+    body = "admin:$apr1$abcd$efghijklmnop\n"
+    assert "htpasswd-exposure" in _fired({"/.htpasswd": Response(200, body, {})})
+    assert "htpasswd-exposure" not in _fired({"/.htpasswd": Response(404, "Not Found", {})})
+
+
+def test_a_web_config_is_detected_and_an_html_error_page_is_not():
+    body = "<configuration><system.webServer></system.webServer></configuration>"
+    assert "web-config-exposure" in _fired({"/web.config": Response(200, body, {})})
+    # Señuelo: /web.config devuelve la página de la SPA (200) en vez del fichero.
+    decoy = Response(200, "<!doctype html><html><body>app</body></html>", {})
+    assert "web-config-exposure" not in _fired({"/web.config": decoy})
+
+
+# ================================================= documentación de API
+
+
+def test_a_swagger_spec_is_detected_and_an_html_page_is_not():
+    body = '{"swagger":"2.0","paths":{}}'
+    assert "swagger-json-exposure" in _fired({"/swagger.json": Response(200, body, {})})
+    decoy = Response(200, "<html>not found spa route</html>", {})
+    assert "swagger-json-exposure" not in _fired({"/swagger.json": decoy})
+
+
+# ================================================= cabeceras y cookies
+
+
+def test_a_missing_csp_header_is_detected_and_a_present_one_is_not():
+    assert "missing-csp-header" in _fired({"/": Response(200, "<html>", {})})
+    present = Response(200, "<html>", {"content-security-policy": "default-src 'self'"})
+    assert "missing-csp-header" not in _fired({"/": present})
+
+
+def test_a_session_cookie_without_secure_is_detected():
+    insecure = Response(200, "<html>", {"set-cookie": "PHPSESSID=abc123; HttpOnly; Path=/"})
+    assert "session-cookie-without-secure" in _fired({"/": insecure})
+
+
+def test_a_session_cookie_with_secure_is_not_flagged():
+    secure = Response(200, "<html>",
+                      {"set-cookie": "PHPSESSID=abc123; Secure; HttpOnly; Path=/"})
+    assert "session-cookie-without-secure" not in _fired({"/": secure})
+
+
+def test_a_non_session_cookie_is_not_flagged():
+    """El señuelo del check de cookies: una cookie que no es de sesión (una
+    preferencia de idioma, por ejemplo) sin Secure no es un hallazgo."""
+    other = Response(200, "<html>", {"set-cookie": "lang=es; Path=/"})
+    assert "session-cookie-without-secure" not in _fired({"/": other})

--- a/API/tests/unit/test_lybra_host_pool.py
+++ b/API/tests/unit/test_lybra_host_pool.py
@@ -58,9 +58,10 @@ def _run_fingerprint(monkeypatch, dissector, services, pool_size=8):
 
     monkeypatch.setattr(engine_module, "default_dissectors", lambda: [dissector])
     monkeypatch.setattr(
-        engine_module.CR, "lybra_config",
+        engine_module.CR, "lybra_engine_config",
         lambda: type("_Config", (), {
             "host_pool_size": pool_size, "banner_timeout": 0.1, "max_blind_probes": 0,
+            "rate_limit_interval": 0.0,
         })(),
     )
     return LybraEngineManager()._fingerprint_services("10.0.0.5", services)

--- a/API/tests/unit/test_lybra_network_config_checks.py
+++ b/API/tests/unit/test_lybra_network_config_checks.py
@@ -1,0 +1,224 @@
+"""Los checks de configuración de red que la Fase N prometió (L26).
+
+Cierran la parte de la brecha G1 que no se resuelve escribiendo ojos: una
+configuración insegura no tiene CVE y no aparece por la vía de la versión.
+
+De los catorce que el issue lista, ocho se construyeron ya en la Fase 2. Aquí
+van los cinco que faltaban: Telnet activo, VNC sin autenticación (plugins
+script), y relay/STARTTLS de SMTP y FTP sin cifrado (checks network, sobre el
+``NetworkSession`` real — la misma regla del resto del fichero: un doble por
+encima de la sesión se inventaría capacidades que el transporte real no tiene).
+"""
+
+import pytest
+
+from src.modules.features.themis.lybra.checks import (
+    CheckRuntime,
+    NetworkProbe,
+    Service,
+    load_checks,
+)
+from src.modules.features.themis.lybra.fingerprinting.telnet import TelnetProbe
+from src.modules.features.themis.lybra.fingerprinting.vnc import VncProbe
+
+pytestmark = pytest.mark.unit
+
+_SMTP = Service(25, "tcp", "smtp", "", "", None)
+_FTP = Service(21, "tcp", "ftp", "", "", None)
+_TELNET = Service(23, "tcp", "telnet", "", "", None)
+_VNC = Service(5900, "tcp", "vnc", "", "", None)
+_CHECKS = load_checks()
+
+
+class _FakeNetSocket:
+    """Socket falso a nivel de bytes: saludo en el buffer, respuestas tras cada
+    escritura (el mismo modelo que ``test_lybra_checks``)."""
+
+    def __init__(self, greeting=b"", replies=()):
+        self._buffer = greeting
+        self._replies = list(replies)
+        self.sent = b""
+
+    def recv(self, size):
+        chunk, self._buffer = self._buffer[:size], self._buffer[size:]
+        return chunk
+
+    def sendall(self, data):
+        self.sent += data
+        if self._replies:
+            self._buffer += self._replies.pop(0)
+
+    def close(self):
+        pass
+
+
+def _fired(check_id, sock, service):
+    # Sólo el check bajo prueba: los checks del mismo servicio comparten la
+    # sesión de red (la caché de sondas de L08), así que ejecutar el feed
+    # entero dejaría a otro check consumiendo el socket antes que éste. Aislarlo
+    # es lo que se quiere medir aquí — el comportamiento de un check, no la
+    # orquestación.
+    plain_id = check_id.split(":")[1].split("@")[0]
+    only = [c for c in _CHECKS if c.id == plain_id]
+    runtime = CheckRuntime(
+        only, lambda *a: None,
+        network_open=NetworkProbe(connect=lambda address, timeout: sock).open)
+    return [f for f in runtime.run("h", [service]) if f["check_id"] == check_id]
+
+
+# =============================================================== Telnet
+
+
+def _telnet_plugin(reply):
+    from src.modules.features.themis.lybra.script_checks import TelnetEnabledPlugin
+
+    class _Sock:
+        def settimeout(self, _t):
+            pass
+
+        def recv(self, _n):
+            return reply
+
+        def close(self):
+            pass
+
+    probe = TelnetProbe(connect=lambda address, timeout: _Sock())
+    return TelnetEnabledPlugin(probe=probe)
+
+
+class _Ctx:
+    def __init__(self, service):
+        self.target = "10.0.0.5"
+        self.service = service
+        self.sibling_services = ()
+
+    def acquire(self):
+        pass
+
+
+def test_telnet_is_flagged_when_the_service_opens_with_iac():
+    """Un servidor Telnet abre negociando opciones: el primer byte es IAC
+    (0xFF). Esa firma es lo que dispara."""
+    assert _telnet_plugin(b"\xff\xfb\x01").run(_Ctx(_TELNET)) is True
+
+
+def test_a_mute_or_non_telnet_port_23_is_not_flagged():
+    """Un puerto 23 abierto no basta: podría ser cualquier servicio mudo en un
+    puerto reutilizado. Sin la firma del protocolo, no hay hallazgo."""
+    assert _telnet_plugin(b"").run(_Ctx(_TELNET)) is False
+    assert _telnet_plugin(b"SSH-2.0-x").run(_Ctx(_TELNET)) is False
+
+
+def test_the_telnet_check_is_registered_and_wired():
+    from src.modules.features.themis.lybra.script_checks import default_script_plugins
+
+    check = next(c for c in _CHECKS if c.id == "telnet-enabled")
+    assert check.service == "telnet" and check.severity == "HIGH"
+    assert check.script in default_script_plugins()
+
+
+# ================================================================== VNC
+
+
+def _vnc_plugin(types):
+    from src.modules.features.themis.lybra.script_checks import VncNoAuthenticationPlugin
+
+    class _Probe(VncProbe):
+        def security_types(self, host, port=5900):
+            return types
+
+    return VncNoAuthenticationPlugin(probe=_Probe())
+
+
+def test_vnc_without_authentication_is_flagged():
+    """El tipo de seguridad 1 es None (RFC 6143): entrar sin contraseña."""
+    assert _vnc_plugin([1, 2]).run(_Ctx(_VNC)) is True
+
+
+def test_vnc_that_only_offers_authentication_is_not_flagged():
+    assert _vnc_plugin([2]).run(_Ctx(_VNC)) is False
+
+
+def test_a_vnc_that_rejected_or_was_unreadable_is_not_flagged():
+    assert _vnc_plugin([]).run(_Ctx(_VNC)) is False       # recuento 0: rechazo
+    assert _vnc_plugin(None).run(_Ctx(_VNC)) is False      # no era RFB
+
+
+# ================================================================= SMTP
+
+
+_SMTP_BANNER = b"220 mail.example.com ESMTP Postfix\r\n"
+
+
+def test_an_open_relay_is_flagged_when_the_external_rcpt_is_accepted():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[
+            b"250-mail.example.com\r\n250 STARTTLS\r\n",   # EHLO
+            b"250 2.1.0 Ok\r\n",                           # MAIL FROM
+            b"250 2.1.5 Ok\r\n",                           # RCPT TO externo aceptado
+        ],
+    )
+    assert _fired("lybra:smtp-open-relay@1", sock, _SMTP)
+
+
+def test_a_closed_relay_that_rejects_the_external_rcpt_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[
+            b"250-mail.example.com\r\n250 STARTTLS\r\n",
+            b"250 2.1.0 Ok\r\n",
+            b"554 5.7.1 Relay access denied\r\n",          # rechaza el relay
+        ],
+    )
+    assert not _fired("lybra:smtp-open-relay@1", sock, _SMTP)
+
+
+def test_a_server_without_starttls_is_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[b"250-mail.example.com\r\n250 SIZE 10240000\r\n250 HELP\r\n"],
+    )
+    assert _fired("lybra:smtp-no-starttls@1", sock, _SMTP)
+
+
+def test_a_server_that_announces_starttls_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=_SMTP_BANNER,
+        replies=[b"250-mail.example.com\r\n250-STARTTLS\r\n250 HELP\r\n"],
+    )
+    assert not _fired("lybra:smtp-no-starttls@1", sock, _SMTP)
+
+
+# ================================================================== FTP
+
+
+def test_ftp_without_tls_is_flagged_when_auth_tls_is_refused():
+    sock = _FakeNetSocket(
+        greeting=b"220 (vsFTPd 3.0.3)\r\n",
+        replies=[b"500 Unknown command.\r\n"],             # AUTH TLS rechazado
+    )
+    assert _fired("lybra:ftp-no-tls@1", sock, _FTP)
+
+
+def test_ftp_with_ftps_support_is_not_flagged():
+    sock = _FakeNetSocket(
+        greeting=b"220 (vsFTPd 3.0.3)\r\n",
+        replies=[b"234 Proceed with negotiation.\r\n"],    # AUTH TLS aceptado
+    )
+    assert not _fired("lybra:ftp-no-tls@1", sock, _FTP)
+
+
+# ============================================= la brecha G1, contada entera
+
+
+def test_at_least_five_network_config_findings_are_reachable():
+    """El criterio de cierre: un host con SMB, FTP, SMTP y una base de datos
+    abiertos alcanza al menos cinco hallazgos de configuración de red. Aquí se
+    comprueba el inventario —que los checks existen, en su familia— no la red."""
+    network_config = {c.id for c in _CHECKS if c.category in ("network_config",)}
+    expected = {"smbv1-enabled", "smb-signing-not-required",
+                "telnet-enabled", "smtp-open-relay", "smtp-no-starttls", "ftp-no-tls",
+                "dns-open-resolver", "ntp-monlist-enabled"}
+    assert expected <= network_config
+    assert len(network_config) >= 5

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -32,7 +32,7 @@ def _clean_sweep(open_ports=(80,), truncated=False) -> PortSweep:
 def test_the_budget_reaches_the_sweep(monkeypatch):
     captured = {}
 
-    def fake_sweep(target, ports, budget_seconds=None):
+    def fake_sweep(target, ports, budget_seconds=None, **kwargs):
         captured["target"] = target
         captured["ports"] = ports
         captured["budget"] = budget_seconds
@@ -52,7 +52,7 @@ def test_a_scan_without_budget_keeps_the_old_behaviour(monkeypatch):
     encolado antes de este cambio— siguen barriendo sin límite de reloj."""
     captured = {}
 
-    def fake_sweep(target, ports, budget_seconds=None):
+    def fake_sweep(target, ports, budget_seconds=None, **kwargs):
         captured["budget"] = budget_seconds
         return _clean_sweep(open_ports=())
 

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -94,13 +94,21 @@ def test_the_worker_entry_point_carries_the_timeout(monkeypatch):
         def __exit__(self, *exc):
             return False
 
+        def cancelled(self):
+            return False
+
+        def progress(self, _pct):
+            pass
+
     monkeypatch.setattr(engine_module, "job_context", lambda: _NullContext())
     monkeypatch.setattr(
         LybraEngineManager, "_run_lybra",
-        lambda self, *args: seen.append(args),
+        lambda self, *args, **kwargs: seen.append(args),
     )
 
     LybraEngineManager.execute_lybra_scan(7, [80], None, 90)
     LybraEngineManager.execute_lybra_scan(8, [80])
 
+    # El timeout sigue viajando como cuarto posicional; cancel_check y progress
+    # van como kwargs (el JobHandle del worker), fuera de esta comprobación.
     assert seen == [(7, [80], None, 90), (8, [80], None, None)]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The REST API (Flask) orchestrates asynchronous scans and analysis over **RQ + Re
 
 ## Features
 
-- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine: its own TCP and UDP discovery, protocol dissectors for HTTP, SSH, FTP, SMTP/IMAP/POP3, SMB, TLS, MySQL, PostgreSQL, SQL Server, MongoDB, Redis, LDAP, RDP, VNC, SNMP, DNS, NTP, NetBIOS, mDNS, IKE and unauthenticated admin APIs (Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana), declarative and script checks, and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler and an authorized-targets registry for scan governance.
+- **Vulnerability scanning** — Nmap (port/OS detection), Nikto (web vulns), Nuclei (template-based), and **Lybra**, a self-built detection engine: its own TCP and UDP discovery, protocol dissectors for HTTP, SSH, FTP, SMTP/IMAP/POP3, SMB, TLS, MySQL, PostgreSQL, SQL Server, MongoDB, Redis, LDAP, RDP, VNC, SNMP, DNS, NTP, NetBIOS, mDNS, IKE and unauthenticated admin APIs (Docker, Elasticsearch, Kubernetes, etcd, Consul, Kibana); declarative checks with request chaining (extracted variables reused across requests), payload expansion (capped), and script plugins; version→confirmer promotion for high-profile CVEs; a default-credentials engine (Tomcat/Jenkins-style panels, gated behind an explicit aggressive-mode request *and* the authorized-targets registry); redacted raw-evidence capture per confirmed finding; and CPE→CVE matching against a local NVD/CISA-KEV/FIRST-EPSS knowledge base — with scheduled execution via APScheduler.
 - **AI-powered PDF reports** — Scan results enriched by a pluggable LLM backend with "Controls, Not Counts" calibrated risk assessment, plus per-host traceroute.
 - **Anti-phishing analysis** — 46 atomic rules across 10 rule families evaluate email headers and content (SPF, DKIM, DMARC, ARC, QR-code/quishing detection, domain impersonation, IOC extraction), producing a calibrated `Legitimate` / `Suspicious` / `Phishing` verdict with optional AI summaries.
 - **Automated mailbox monitoring** — Connect Gmail or Microsoft 365 via OAuth; Iris periodically pulls new mail and analyzes it automatically, and emails the user when a connected mailbox receives phishing.
@@ -188,11 +188,12 @@ The web application checks MFA once when an authenticated session enters the SPA
 | `POST` | `/themis/nmap` | Port scan (supports CIDR ranges) |
 | `POST` | `/themis/nikto` | Web configuration / vulnerability scan |
 | `POST` | `/themis/nuclei` | Template-based scan (single host per scan) |
-| `POST` | `/themis/lybra` | Self-built engine scan (own port discovery — `target` required) |
+| `POST` | `/themis/lybra` | Self-built engine scan (own port discovery — `target` required). `aggressive: true` requests the aggressive mode (active-check families marked `mode: aggressive` in the feed, plus the default-credentials engine); it only takes effect when the target is *also* in the caller's authorized-targets registry — a double gate, since a registered target is only pre-authorized for passive scanning |
 | `GET` | `/themis/scan-status?id=` | Scan status / progress: pending · running · done · cancelled |
 | `POST` | `/themis/scans/<id>/cancel` | Cancel a running scan |
 | `GET` | `/themis/results` · `/themis/results/<id>` | List scans (filterable, paginated) / scan detail. The Lybra listing carries per-scan counters, not every finding, and flags with `isPartial` a scan whose port discovery ran out of time before covering the whole target |
 | `GET` | `/themis/lybra/scans/<id>/findings` | Lybra findings grouped by remediable unit (product + port), each group with its CVEs, KEV membership, worst priority and the version that closes it |
+| `GET` | `/themis/findings/<id>/evidence` | The raw (redacted, hashed) response that produced a confirmed finding — 404 for a finding owned by another user |
 | `PATCH` | `/themis/findings/<id>` | Mark a finding's triage state (e.g. accept a risk) |
 | `DELETE` | `/themis/<id>` · `/themis/scans` | Delete a scan / bulk delete |
 | `GET` | `/themis/stats` · `/themis/history/hosts` · `/themis/history/stats` | Scan counters and per-host historical trends |


### PR DESCRIPTION
## Resumen

Fusiona la **Fase 3 — "Los patrones"** del roadmap del motor Lybra a `v0.5`: las ocho necesidades del backlog que esa fase agrupaba, cada una entregada y mergeada como su propio PR contra `proyecto/themis/motor-needs/3` (rama de integración de la fase, ahora sin trabajo pendiente).

Lybra es el motor de detección propio de Ellysia — descubrimiento de puertos, identificación de servicios, matching CPE→CVE contra la base de conocimiento local (NVD/KEV/EPSS), y un runtime de checks activos declarativos. La Fase 3 es la que lo lleva de "detecta por versión" a "confirma activamente, encadena peticiones con estado, y —bajo una doble puerta de autorización— llega a probar credenciales de fábrica", que es la cobertura que de verdad distingue un escáner de vulnerabilidades de un simple catálogo de versiones.

## Qué entra en esta fase, y por qué en este orden

| Issue | Qué añade | Por qué importa |
|---|---|---|
| **#307** (L39) | Los parámetros de red del motor (timeouts, concurrencia, ritmo, puertos) se leen de `SecOpsConfig.json` en vez de estar a fuego en el código. | Cimiento de todo lo demás: un escaneo contra un enlace lento o un objetivo frágil necesita otros números, y hasta ahora sólo se podían cambiar editando código. |
| **#296** (L25) | El feed de checks activos crece de 17 a 55: las familias web que de verdad aparecen en una auditoría real (ficheros de configuración expuestos, cabeceras de seguridad ausentes, paneles de administración conocidos). | Es la base de datos de detección propiamente dicha — sin checks, todo lo demás no tiene qué ejecutar. |
| **#297** (L26) | Los cinco checks de configuración de red que la Fase N había prometido y no llegó a construir (Telnet, VNC sin autenticación, relay SMTP abierto, SMTP sin STARTTLS, FTP sin TLS). | Cierra una brecha de cobertura que el propio roadmap ya había señalado como pendiente. |
| **#309** (L41) | Un escaneo Lybra reporta progreso por fases (40/70/90/100%) y se puede cancelar a mitad — con la bandera `is_partial` para que un escaneo truncado no cierre por omisión hallazgos que no llegó a comprobar. | Sin esto, un escaneo largo era una caja negra hasta que terminaba o había que esperar a que reventara el timeout. |
| **#310** (L44) | Cada hallazgo confirmado guarda la respuesta cruda que lo provocó — redactada (cabeceras sensibles fuera, cuerpo truncado), con su hash y su fecha. | Es lo que separa "el escáner dice que hay un problema" de poder defender ese hallazgo ante un cliente sin repetir el escaneo a mano. |
| **#298** (L29) | El encadenamiento versión→confirmador: un check puede confirmar activamente una CVE que el matcher de versiones sólo había propuesto como hipótesis, ascendiéndola de `confirmed=false, qod=70` a `confirmed=true, qod=99`. | El propio roadmap lo señala como la razón de ser del runtime propio frente a herramientas de plantillas como Nuclei — y hasta esta fase no existía. |
| **#300** (L30) | El DSL de checks gana extractores (variables ligadas de una respuesta a la siguiente petición), cuerpo/cabeceras, y payloads con un tope duro de expansiones. | Desbloquea cualquier check con estado (login → recurso protegido) y evita que "veinte nombres de fichero de backup" cueste veinte entradas de feed casi idénticas. |
| **#299 + #308 (mínimo)** (L31/L40) | El motor de credenciales por defecto (Tomcat, Jenkins), y lo mínimo necesario de #308 para que exista un modo agresivo alcanzable: doble puerta de autorización + petición explícita. | Es la única familia de detección que escribe en el objetivo, así que va al final — cuando todo lo demás (autorización, configuración, encadenamiento) ya está construido y probado. |

Los dos últimos van en un mismo PR porque #299 estaba **bloqueada** por #308: el modo `aggressive` existía por completo en el esquema (`CheckRuntime._applies_mode` lo respeta desde antes de esta fase) pero era literalmente inalcanzable — el manager fijaba `mode="safe"` sin ningún parámetro. Este PR entrega la parte de #308 que #299 necesitaba (el modo se puede pedir y se aplica bajo doble guarda) y deja abierto el resto de #308 —perfiles de escaneo Rápido/Estándar/Exhaustivo, selector en el SPA, que el informe diga con qué perfil se escaneó— para la Fase 5, que es donde ese issue vive de verdad.

## Las garantías de seguridad que atraviesan toda la fase

- **Doble puerta para cualquier cosa que escriba en el objetivo** (L40): autorización explícita del usuario en el registro *y* modo agresivo pedido explícitamente. Ninguna de las dos por sí sola basta.
- **Presupuesto de intentos por cuenta, no por servicio** (L31): el motor de credenciales nunca deja que probar `admin` con tres contraseñas y `root` con otras tres cuente como seis intentos contra la misma cuenta.
- **El plaintext nunca se persiste** (L31): una contraseña que funcionó se usa una vez y no vuelve a aparecer en ningún hallazgo, evidencia o log.
- **Un confirmador nunca "prueba por si acaso"** (L29): sólo corre cuando el matcher de versiones ya propuso esa CVE, y nunca ejecuta nada más allá de comprobar la condición — dos confirmadores de Apache (CVE-2021-41773/42013) sólo **leen** `/etc/passwd`, nunca ejecutan código.
- **Un check con payloads nunca se convierte en fuerza bruta** (L30): tope duro de expansiones, configurable, aplicado de forma perezosa sobre el producto cartesiano.
- **Un escaneo cancelado o truncado no cierra hallazgos por omisión** (L41): la bandera `is_partial` viaja hasta el ciclo de vida.
- **La evidencia se redacta antes de guardarse** (L44): cabeceras sensibles fuera, cuerpo truncado con su tope, todo con hash para poder demostrar que no se ha tocado.

## Validación

Cada PR individual pasó su propia suite dirigida (`pytest tests/unit -k lybra` + `tests/integration/test_lybra.py`, sin Docker) y `pylint src` a 10.00/10 antes de mergear. Al completar la fase entera se corrió además la **suite completa del repositorio** (`pytest -m "not oracle and not postgres"`): sin fallos, sin regresiones en ningún otro módulo. El banco `oracle` (contenedores Docker reales, oráculo diferencial) no se ha tocado en esta fase — sigue pendiente de una medición aparte, como marca su propio roadmap.

## Qué no entra en esta fase

- Los perfiles de escaneo completos y el selector del SPA (resto de #308) — Fase 5.
- Ingesta a escala del árbol de plantillas de Nuclei (Fase U4) — sigue desactivada por configuración (`lybra.ingest.enabled: false`).
- Ampliar el motor de credenciales a protocolos no-HTTP (FTP/SSH) — el runtime está pensado para poder extenderse por el mismo camino que los checks `network`, pero no había ninguna entrada del feed que lo necesitara todavía.
