### PR TITLE
La frescura de la KB deja de ser invisible (y una fuente rota deja de congelar las otras dos)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -131,7 +131,12 @@
           "kev": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
           "nvd": "https://services.nvd.nist.gov/rest/json/cves/2.0"
         },
-        "syncCron": "0 3 * * *"
+        "syncCron": "0 3 * * *",
+        "maxAgeDays": {
+          "nvd": 3,
+          "kev": 7,
+          "epss": 7
+        }
       },
       "scanners": {
         "nmap": {

--- a/API/alembic/versions/d421740891b4_kb_registrar_el_estado_de_.py
+++ b/API/alembic/versions/d421740891b4_kb_registrar_el_estado_de_.py
@@ -1,0 +1,58 @@
+"""kb: registrar el estado de sincronizacion por fuente
+
+Revision ID: d421740891b4
+Revises: c7e1a9f4b2d8
+Create Date: 2026-09-03 19:11:39.703210
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd421740891b4'
+down_revision: Union[str, Sequence[str], None] = 'c7e1a9f4b2d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Una fila por fuente de la KB (NVD, KEV, EPSS) con cuándo se intentó
+    sincronizar por última vez, cuándo funcionó, cuántas filas escribió y qué
+    error dio si falló.
+
+    Sin esto, una sincronización rota es invisible: los escaneos siguen
+    saliendo en verde contra un catálogo congelado porque el motor no tiene
+    forma de saber que dejó de aprender. La tabla nace vacía y se rellena en la
+    primera sincronización de cada fuente; hasta entonces, "nunca sincronizada"
+    es la respuesta correcta y no un hueco.
+
+    ``source`` es único porque esto es un estado, no un historial: una fila por
+    fuente, sobrescrita en cada intento. El historial vive en los logs.
+    """
+    op.create_table(
+        "KbSyncStatus",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("last_attempt_at", sa.DateTime(), nullable=True),
+        sa.Column("last_success_at", sa.DateTime(), nullable=True),
+        sa.Column("rows_upserted", sa.Integer(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_KbSyncStatus_source"), "KbSyncStatus", ["source"], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde el registro de sincronizaciones, que es observabilidad y no
+    datos: la KB en sí —CVEs, KEV, EPSS— no se toca, y la siguiente subida
+    vuelve a empezar a registrar desde cero.
+    """
+    op.drop_index(op.f("ix_KbSyncStatus_source"), table_name="KbSyncStatus")
+    op.drop_table("KbSyncStatus")

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -35,6 +35,7 @@ from .managers import (
     ScanHistoryManager,
     TracerouteManager,
     AuthorizedTargetManager,
+    KbSyncManager,
 )
 from .model import ScanType
 from .exceptions import (
@@ -465,6 +466,35 @@ def delete_authorized_target(target_id: int):
         "message": "Objetivo autorizado eliminado correctamente",
         "targetId": target_id,
         "target": target,
+        "user": user.username,
+    }
+
+
+@themis_blp.get("/kb/status")
+@themis_blp.response(200, description="Knowledge-base freshness per source")
+@themis_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@themis_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.THEMIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=ScanError, logger=logger)
+def get_kb_status():
+    """Cuándo se sincronizó por última vez cada fuente de la base de conocimiento.
+
+    Toda la detección por versión depende de un espejo local de NVD, KEV y
+    EPSS. Si ese espejo deja de refrescarse, los escaneos siguen saliendo en
+    verde contra un catálogo congelado y nada lo dice: un CVE publicado ayer no
+    existe para el motor, y el informe afirma que el host está limpio.
+
+    Responde a las dos preguntas por separado, porque son distintas: cuándo se
+    intentó sincronizar cada fuente y si funcionó, y cuán reciente es lo que
+    de hecho sabemos.
+    """
+    user = get_current_user()
+    status = KbSyncManager().status()
+    return {
+        "message": "Estado de la base de conocimiento obtenido correctamente",
+        **status,
         "user": user.username,
     }
 

--- a/API/src/modules/features/themis/managers/kb_sync.py
+++ b/API/src/modules/features/themis/managers/kb_sync.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 import src.modules.system.config_reading as CR
 from src.modules.infrastructure import UnitOfWork
-from src.modules.shared import utcnow_naive
+from src.modules.shared import isoformat_utc, utcnow_naive
 from ..repositories import KbRepository
 
 
@@ -148,32 +148,152 @@ class KbSyncManager:
 
         return index
 
+    def _record(self, source: str, rows_upserted: Optional[int] = None,
+                error: Optional[str] = None) -> None:
+        """Dejar constancia del intento en su propia transacción.
+
+        Aparte de la de la sincronización a propósito: si la escritura de datos
+        falló y su transacción se deshizo, el registro del fallo tiene que
+        sobrevivir — es lo único que va a quedar de ese intento.
+        """
+        try:
+            with UnitOfWork() as uow:
+                KbRepository(uow).record_sync(source, rows_upserted, error)
+        except Exception:  # noqa: BLE001
+            # Observabilidad que no puede tumbar aquello que observa.
+            logger.exception("KB: no se pudo registrar el estado de '%s'", source)
+
+    def _sync_source(self, source: str, run) -> Optional[int]:
+        """Ejecutar la sincronización de una fuente y anotar cómo salió.
+
+        Devuelve las filas escritas, o ``None`` si falló. **La excepción no se
+        propaga**, y ésa es la razón de que este método exista: ``sync_all``
+        encadenaba las tres fuentes en línea recta, así que un fallo de KEV
+        —una URL caída, un formato cambiado— se llevaba por delante a EPSS y a
+        NVD, que no tienen nada que ver. Una fuente rota debe costar una
+        fuente, no tres.
+        """
+        try:
+            rows = run()
+        except Exception as e:  # noqa: BLE001
+            logger.exception("KB: la sincronización de '%s' falló", source)
+            self._record(source, error=f"{type(e).__name__}: {e}")
+            return None
+        self._record(source, rows_upserted=rows)
+        return rows
+
     def sync_all(self) -> dict:
-        """Run every configured source once; return a per-source count summary."""
-        sources = CR.knowledge_base_config().sources
+        """Run every configured source once; return a per-source count summary.
+
+        Cada fuente se sincroniza y se anota por separado: una que falle deja su
+        error registrado y las demás siguen. El resumen trae ``None`` en la
+        fuente que falló, que es distinto de un 0 (sincronizó bien y no había
+        nada nuevo).
+        """
+        config = CR.knowledge_base_config()
+        sources = config.sources
         summary: dict = {}
         if sources.get("kev"):
-            summary["kev"] = self.sync_kev(sources["kev"])
+            summary["kev"] = self._sync_source("kev", lambda: self.sync_kev(sources["kev"]))
         if sources.get("epss"):
-            summary["epss"] = self.sync_epss(sources["epss"])
+            summary["epss"] = self._sync_source("epss", lambda: self.sync_epss(sources["epss"]))
         if sources.get("nvd"):
-            summary["nvd"] = self.sync_nvd(
+            summary["nvd"] = self._sync_source("nvd", lambda: self.sync_nvd(
                 sources["nvd"],
-                window_days=CR.knowledge_base_config().nvd_window_days,
-                api_key=CR.knowledge_base_config().nvd_api_key,
-            )
-            # Only worth rebuilding when NVD's CpeMatch rows might have
-            # changed — the index is entirely derived from that table.
-            summary["cpeProductAliases"] = self.rebuild_cpe_product_index()
+                window_days=config.nvd_window_days,
+                api_key=config.nvd_api_key,
+            ))
+            if summary["nvd"] is not None:
+                # Only worth rebuilding when NVD's CpeMatch rows might have
+                # changed — the index is entirely derived from that table.
+                summary["cpeProductAliases"] = self.rebuild_cpe_product_index()
         logger.info("KB sync complete: %s", summary)
         return summary
+
+    def status(self) -> dict:
+        """Qué sabe la KB y cuándo lo aprendió, en una sola respuesta.
+
+        Junta las dos preguntas que hay que hacerse sobre un espejo local y que
+        no son la misma:
+
+        - **¿cuándo preguntamos, y funcionó?** — de ``KbSyncStatus``. Es lo que
+          detecta un job roto: sin esto, tres semanas de sincronizaciones
+          fallidas no dejan más rastro que unas líneas de log que nadie lee, y
+          los escaneos siguen saliendo en verde contra un catálogo congelado.
+        - **¿cuán reciente es lo que sabemos?** — de
+          :meth:`KbRepository.knowledge_state`, leyendo la fecha más nueva de
+          los propios datos.
+
+        Se recorren las fuentes **configuradas**, no las filas de la tabla: una
+        fuente que no se ha sincronizado nunca no tiene fila, y es justo la que
+        más importa reportar. Aparece con ``neverSynced`` y cuenta como vieja.
+
+        Returns:
+            ``{"sources": [...], "isStale": bool, "feedVersion": str}``, con
+            una entrada por fuente configurada.
+        """
+        from ..lybra import kb_feed_version
+
+        config = CR.knowledge_base_config()
+        max_age = config.max_age_days
+        now = utcnow_naive()
+
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            rows = {row.source: row for row in repo.sync_status()}
+            content_state = repo.knowledge_state()
+            feed_version = kb_feed_version(content_state)
+
+        sources = []
+        for name in sorted(config.sources):
+            row = rows.get(name)
+            limit_days = max_age.get(name)
+            age_days = None
+            if row is not None and row.last_success_at is not None:
+                age_days = round((now - row.last_success_at).total_seconds() / 86400, 2)
+            # Nunca sincronizada cuenta como vieja: no saber nada de una fuente
+            # es peor que saber que lleva días parada, no mejor.
+            is_stale = age_days is None or (limit_days is not None and age_days > limit_days)
+            newest = content_state.get(name)
+            sources.append({
+                "source": name,
+                "lastAttemptAt": isoformat_utc(row.last_attempt_at) if row else None,
+                "lastSuccessAt": isoformat_utc(row.last_success_at) if row else None,
+                "rowsUpserted": row.rows_upserted if row else None,
+                "error": row.error if row else None,
+                "neverSynced": row is None or row.last_success_at is None,
+                "ageDays": age_days,
+                "maxAgeDays": limit_days,
+                "isStale": is_stale,
+                "newestContentAt": isoformat_utc(newest) if newest else None,
+            })
+
+        return {
+            "sources": sources,
+            "isStale": any(entry["isStale"] for entry in sources),
+            "feedVersion": feed_version,
+        }
 
     @staticmethod
     def execute_kb_sync() -> None:
         """Scheduled entry point (APScheduler). Runs the full sync, best-effort."""
         from src.modules.infrastructure.unit_of_work import close_all
         try:
-            KbSyncManager().sync_all()
+            manager = KbSyncManager()
+            manager.sync_all()
+            # El aviso se emite justo después de sincronizar porque es cuando
+            # de verdad significa algo: si tras un intento la fuente sigue
+            # vieja, es que no se ha podido arreglar sola.
+            for entry in manager.status()["sources"]:
+                if entry["isStale"]:
+                    logger.warning(
+                        "KB: la fuente '%s' está desactualizada (%s, límite %s días)%s",
+                        entry["source"],
+                        "nunca sincronizada" if entry["neverSynced"]
+                        else f"{entry['ageDays']} días",
+                        entry["maxAgeDays"],
+                        f" — último error: {entry['error']}" if entry["error"] else "",
+                    )
         except Exception:
             logger.exception("KB sync failed")
         finally:

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -1046,6 +1046,51 @@ class EpssScore(Base):
         return f"<EpssScore(cve_id='{self.cve_id}', score={self.score})>"
 
 
+class KbSyncStatus(Base):
+    """Cuándo se intentó sincronizar cada fuente de la KB, y cómo salió.
+
+    Toda la detección por versión depende de este espejo local de NVD, KEV y
+    EPSS, y hasta ahora no había **nada** que registrara cuándo se refrescó. Los
+    modos de fallo eran todos silenciosos y todos igual de malos: el job lleva
+    tres semanas fallando y los escaneos siguen saliendo en verde contra un
+    catálogo congelado; un CVE crítico publicado ayer no está, así que para el
+    motor no existe; KEV lleva un mes parado justo en la señal que más pesa al
+    priorizar. Un log de `INFO` no es un estado consultable.
+
+    No sustituye a :meth:`KbRepository.knowledge_state`, que responde a otra
+    pregunta. Aquella dice **cuán reciente es lo que sabemos**, leyendo la fecha
+    más nueva de los propios datos; ésta dice **cuándo lo preguntamos y si
+    funcionó**. Hacen falta las dos, y la diferencia entre ambas es
+    precisamente el síntoma que hay que poder ver: un contenido que no avanza
+    mientras las sincronizaciones fallan.
+
+    Attributes:
+        source: La fuente (``"nvd"``, ``"kev"``, ``"epss"``). Única: una fila
+            por fuente, sobrescrita en cada intento. No es un historial —para
+            eso están los logs— sino el estado actual, que es lo que se
+            consulta.
+        last_attempt_at: Cuándo se intentó por última vez, salga como salga.
+        last_success_at: Cuándo terminó bien por última vez. Se conserva aunque
+            el último intento fallara: la distancia entre ambas fechas es
+            exactamente "cuánto lleva roto".
+        rows_upserted: Filas escritas en el último intento con éxito.
+        error: El mensaje del último intento fallido, o ``None`` si el último
+            fue bien. Que se limpie al tener éxito es deliberado: la pregunta
+            que responde esta tabla es "¿está bien ahora?".
+    """
+    __tablename__ = "KbSyncStatus"
+
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    source          = Column(String(32), unique=True, nullable=False, index=True)
+    last_attempt_at = Column(DateTime)
+    last_success_at = Column(DateTime)
+    rows_upserted   = Column(Integer)
+    error           = Column(Text)
+
+    def __repr__(self):
+        return f"<KbSyncStatus(source='{self.source}', last_success_at={self.last_success_at})>"
+
+
 # =========================================================================
 # DOCUMENT MODEL
 # =========================================================================

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -46,6 +46,7 @@ from .model import (
     FindingEvidence,
     Host,
     HostService,
+    KbSyncStatus,
     KevEntry,
     NiktoIncident,
     NiktoScan,
@@ -1231,6 +1232,46 @@ class KbRepository(BaseRepository[CveEntry]):
             "kev":  self._session.query(func.max(KevEntry.date_added)).scalar(),
             "epss": self._session.query(func.max(EpssScore.scored_at)).scalar(),
         }
+
+    def record_sync(self, source: str, rows_upserted: Optional[int] = None,
+                    error: Optional[str] = None) -> None:
+        """Anotar el desenlace de un intento de sincronización de una fuente.
+
+        Se llama **siempre**, salga bien o mal: el caso que importa es el malo,
+        porque una sincronización rota no deja ningún otro rastro consultable y
+        los escaneos siguen saliendo en verde contra un catálogo congelado.
+
+        ``last_success_at`` se conserva cuando el intento falla — la distancia
+        entre él y ``last_attempt_at`` es exactamente "cuánto lleva roto", y
+        pisarlo destruiría el único dato que responde a esa pregunta. Al revés,
+        ``error`` sí se limpia al tener éxito: la tabla dice si está bien
+        *ahora*, no lo que pasó alguna vez.
+
+        Args:
+            source: ``"nvd"``, ``"kev"`` o ``"epss"``.
+            rows_upserted: Filas escritas, en un intento con éxito.
+            error: El mensaje del fallo. Su presencia es lo que distingue un
+                intento fallido de uno correcto.
+        """
+        now = utcnow_naive()
+        row = self._session.query(KbSyncStatus).filter_by(source=source).one_or_none()
+        if row is None:
+            row = KbSyncStatus(source=source)
+            self._session.add(row)
+        row.last_attempt_at = now
+        if error is None:
+            row.last_success_at = now
+            row.rows_upserted = rows_upserted
+            row.error = None
+        else:
+            # El mensaje se acota: un traceback entero o el cuerpo de una
+            # respuesta HTTP no aportan más que su primera línea en una tabla
+            # de estado, y el detalle completo ya está en el log.
+            row.error = error[:500]
+
+    def sync_status(self) -> List[KbSyncStatus]:
+        """El estado de sincronización de todas las fuentes registradas."""
+        return self._session.query(KbSyncStatus).order_by(KbSyncStatus.source).all()
 
     def counts(self) -> dict:
         """Row counts per KB table (for the sync summary / health checks)."""

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -5,6 +5,7 @@ viven enteramente en ``Finding`` (Lybra y Nuclei).
 D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
+import logging
 from typing import Dict, Optional
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_LEFT
@@ -16,6 +17,8 @@ import src.modules.system.config_reading as CR
 from src.modules.shared.report_theme import ColorType, safe_markup
 from ..cve_context import enrich_with_cve_context
 from .base import PrintingStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class FindingsPrintingStrategy(PrintingStrategy):
@@ -188,10 +191,39 @@ class FindingsPrintingStrategy(PrintingStrategy):
             ["Fecha de inicio:", started_str],
             ["Total de hallazgos:", str(len(findings))],
             ["Confirmados activamente:", str(confirmed_count)],
+            ["Base de conocimiento:", self._knowledge_base_line()],
         ]
         info_table = theme.kv_table(scan_info, col_widths=[2 * inch, 4 * inch])
         elements.append(info_table)
         elements.append(Spacer(1, 0.3 * inch))
+
+    @staticmethod
+    def _knowledge_base_line() -> str:
+        """Contra qué catálogo se resolvieron estos hallazgos, y de cuándo es.
+
+        Un informe que dice "sincronizada el 29/08/2026" es honesto; uno que
+        calla hace una afirmación sin fecha, y la detección por versión —que es
+        la que produce la mayoría de los hallazgos con CVE— vale exactamente lo
+        que valga la frescura de ese espejo.
+
+        Si alguna fuente está vieja, el informe lo dice: es preferible a que el
+        lector suponga que el catálogo estaba al día. Best-effort — un fallo
+        consultando el estado no puede impedir que se emita el informe.
+        """
+        from src.modules.features.themis.managers.kb_sync import KbSyncManager
+
+        try:
+            status = KbSyncManager().status()
+        except Exception:  # noqa: BLE001
+            logger.exception("No se pudo leer el estado de la base de conocimiento")
+            return "No disponible"
+
+        parts = []
+        for entry in status["sources"]:
+            when = (entry["lastSuccessAt"] or "")[:10] or "nunca"
+            parts.append(f"{entry['source'].upper()} {when}"
+                         + (" (desactualizada)" if entry["isStale"] else ""))
+        return " · ".join(parts) if parts else "Sin fuentes configuradas"
 
     def _append_finding_summary(self, theme: "ReportTheme", elements: list, findings: list) -> None:
         """Tabla resumen: cantidad de hallazgos por prioridad."""

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -778,6 +778,18 @@ class KnowledgeBaseConfig:
     sync_cron: str = "0 3 * * *"
     nvd_window_days: int = 8
 
+    max_age_days: dict = field(
+        default_factory=lambda: {"nvd": 3, "kev": 7, "epss": 7}
+    )
+    """A partir de cuántos días sin sincronizar con éxito se considera vieja
+    cada fuente.
+
+    Los tres números no son el mismo por una razón: NVD publica CVEs a diario y
+    tres días de retraso ya son detección que falta; KEV y EPSS cambian más
+    despacio y una semana es tolerable. Son de operador porque dependen de la
+    red y de la cuota de API de cada despliegue, no de la lógica del motor.
+    """
+
     configured_nvd_api_key: str = field(
         default="", metadata={"key": "nvdApiKey", "optional": True}
     )

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -393,3 +393,114 @@ def test_query_manager_enriches_with_kev_and_epss(app):
     assert exploited.vendor == "microsoft" and exploited.product == "windows"
     assert exploited.url == "https://nvd.nist.gov/vuln/detail/CVE-2026-0401"
     assert quiet.kev is False and quiet.epss is None
+
+
+# ───────────────────────────── estado de sincronización (L36)
+#
+# Una sincronización que funciona ya se nota: aparecen datos. Una que falla no
+# dejaba más rastro que una línea de log, así que el job podía llevar semanas
+# roto mientras los escaneos seguían saliendo en verde contra un catálogo
+# congelado. Esta es la tabla que hace esa avería consultable.
+
+from datetime import timedelta                                    # noqa: E402
+
+from src.modules.shared import utcnow_naive                       # noqa: E402
+from src.modules.features.themis.managers import KbSyncManager    # noqa: E402
+
+
+def test_a_failed_sync_keeps_the_last_success(app):
+    """La distancia entre «último intento» y «último éxito» es exactamente
+    cuánto lleva roto. Pisar la fecha de éxito al fallar destruiría el único
+    dato que responde a esa pregunta."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_sync("nvd", rows_upserted=120)
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_sync("nvd", error="503 desde el feed")
+
+        with UnitOfWork() as uow:
+            row = {r.source: r for r in KbRepository(uow).sync_status()}["nvd"]
+            assert row.last_success_at is not None
+            assert row.last_attempt_at >= row.last_success_at
+            assert row.error == "503 desde el feed"
+            assert row.rows_upserted == 120    # el del último éxito, no None
+
+
+def test_a_successful_sync_clears_the_previous_error(app):
+    """La tabla dice si está bien *ahora*; el historial vive en los logs."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_sync("kev", error="se cayó")
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_sync("kev", rows_upserted=9)
+
+        with UnitOfWork() as uow:
+            row = {r.source: r for r in KbRepository(uow).sync_status()}["kev"]
+            assert row.error is None
+            assert row.rows_upserted == 9
+
+
+def test_a_source_never_synced_counts_as_stale(app):
+    """No saber nada de una fuente es peor que saber que lleva días parada, no
+    mejor: se recorren las fuentes configuradas, no las filas de la tabla."""
+    with app.app_context():
+        status = KbSyncManager().status()
+        by_source = {entry["source"]: entry for entry in status["sources"]}
+
+        assert set(by_source) == {"nvd", "kev", "epss"}
+        assert all(entry["neverSynced"] for entry in by_source.values())
+        assert all(entry["isStale"] for entry in by_source.values())
+        assert status["isStale"] is True
+
+
+def test_a_recent_sync_is_not_stale(app):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            for source in ("nvd", "kev", "epss"):
+                repo.record_sync(source, rows_upserted=1)
+
+        status = KbSyncManager().status()
+        assert status["isStale"] is False
+        assert all(not entry["isStale"] for entry in status["sources"])
+        assert all(entry["ageDays"] == 0 for entry in status["sources"])
+
+
+def test_an_aged_source_is_reported_stale(app):
+    """NVD publica a diario, así que su umbral es más corto que el de KEV y
+    EPSS: cuatro días de retraso ya son detección que falta."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            for source in ("nvd", "kev", "epss"):
+                repo.record_sync(source, rows_upserted=1)
+
+        with UnitOfWork() as uow:
+            rows = {r.source: r for r in KbRepository(uow).sync_status()}
+            rows["nvd"].last_success_at = utcnow_naive() - timedelta(days=4)
+
+        by_source = {e["source"]: e for e in KbSyncManager().status()["sources"]}
+        assert by_source["nvd"]["isStale"] is True
+        assert by_source["kev"]["isStale"] is False   # 4 días < umbral de 7
+
+
+def test_the_kb_status_endpoint_reports_every_source(client, app, admin_user, auth_headers):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_sync("kev", rows_upserted=5)
+
+    resp = client.get("/themis/kb/status", headers=auth_headers(admin_user))
+    assert resp.status_code == 200
+    body = resp.get_json()
+
+    by_source = {entry["source"]: entry for entry in body["sources"]}
+    assert set(by_source) == {"nvd", "kev", "epss"}
+    assert by_source["kev"]["rowsUpserted"] == 5
+    assert by_source["kev"]["neverSynced"] is False
+    assert by_source["nvd"]["neverSynced"] is True
+    assert body["isStale"] is True                     # nvd y epss nunca sincronizadas
+    assert body["feedVersion"].startswith("lybra-kb:")
+
+
+def test_the_kb_status_endpoint_requires_authentication(client):
+    assert client.get("/themis/kb/status").status_code == 401

--- a/API/tests/unit/test_kb_sync_status.py
+++ b/API/tests/unit/test_kb_sync_status.py
@@ -1,0 +1,133 @@
+"""El estado de sincronización de la base de conocimiento (L36).
+
+Toda la detección por versión del motor depende de un espejo local de NVD, KEV
+y EPSS, y hasta ahora no había nada que registrara cuándo se refrescó cada uno.
+Los modos de fallo eran todos silenciosos: el job lleva tres semanas fallando y
+los escaneos siguen saliendo en verde contra un catálogo congelado, porque el
+motor no tiene forma de saber que dejó de aprender.
+
+Lo que se fija aquí es sobre todo **el camino de error**, que es el que importa:
+una sincronización que funciona ya se notaba —los datos aparecían—, mientras que
+una que falla no dejaba ningún rastro consultable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.themis.managers.kb_sync import KbSyncManager
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeRepo:
+    """Registra las llamadas a ``record_sync`` sin tocar la base de datos."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def record_sync(self, source, rows_upserted=None, error=None):
+        self.calls.append({"source": source, "rows": rows_upserted, "error": error})
+
+
+@pytest.fixture(name="recorded")
+def _recorded(monkeypatch):
+    """Sustituye la escritura del estado por una lista en memoria."""
+    repo = _FakeRepo()
+
+    def fake_record(self, source, rows_upserted=None, error=None):
+        repo.record_sync(source, rows_upserted, error)
+
+    monkeypatch.setattr(KbSyncManager, "_record", fake_record)
+    return repo
+
+
+def test_a_successful_sync_is_recorded_with_its_row_count(recorded):
+    manager = KbSyncManager()
+    rows = manager._sync_source("kev", lambda: 42)  # pylint: disable=protected-access
+
+    assert rows == 42
+    assert recorded.calls == [{"source": "kev", "rows": 42, "error": None}]
+
+
+def test_a_failed_sync_is_recorded_too(recorded):
+    """El caso que da sentido a la tabla.
+
+    Un intento con éxito ya se nota: aparecen datos nuevos. Uno que falla no
+    dejaba nada más que una línea de log, así que una fuente rota podía estar
+    semanas sin que nadie se enterase.
+    """
+    def boom():
+        raise RuntimeError("404 desde el feed")
+
+    manager = KbSyncManager()
+    rows = manager._sync_source("nvd", boom)  # pylint: disable=protected-access
+
+    assert rows is None, "un fallo no puede devolver un recuento"
+    assert len(recorded.calls) == 1
+    call = recorded.calls[0]
+    assert call["source"] == "nvd"
+    assert call["rows"] is None
+    assert "404 desde el feed" in call["error"]
+    assert "RuntimeError" in call["error"]
+
+
+def test_a_failing_source_does_not_take_the_others_down(recorded, monkeypatch):
+    """Una fuente rota debe costar una fuente, no tres.
+
+    `sync_all` encadenaba las tres en línea recta, así que un fallo de KEV —una
+    URL caída, un formato cambiado— se llevaba por delante a EPSS y a NVD, que
+    no tienen nada que ver con ella. El resultado era que un feed de terceros
+    caído congelaba la base de conocimiento entera.
+    """
+    import src.modules.system.config_reading as CR
+
+    monkeypatch.setattr(
+        CR, "knowledge_base_config",
+        lambda: type("C", (), {
+            "sources": {"kev": "u1", "epss": "u2", "nvd": "u3"},
+            "nvd_window_days": 8,
+            "nvd_api_key": None,
+        })(),
+    )
+
+    def kev_boom(_url):
+        raise RuntimeError("KEV caído")
+
+    manager = KbSyncManager()
+    monkeypatch.setattr(KbSyncManager, "sync_kev", lambda self, url: kev_boom(url))
+    monkeypatch.setattr(KbSyncManager, "sync_epss", lambda self, url: 7)
+    monkeypatch.setattr(KbSyncManager, "sync_nvd", lambda self, url, **kw: 9)
+    monkeypatch.setattr(KbSyncManager, "rebuild_cpe_product_index", lambda self: 3)
+
+    summary = manager.sync_all()
+
+    assert summary["kev"] is None          # falló, y se sabe
+    assert summary["epss"] == 7            # siguió adelante
+    assert summary["nvd"] == 9
+    assert summary["cpeProductAliases"] == 3
+    assert [call["source"] for call in recorded.calls] == ["kev", "epss", "nvd"]
+
+
+def test_the_alias_index_is_not_rebuilt_when_nvd_failed(recorded, monkeypatch):
+    """El índice se deriva entero de las filas de NVD. Reconstruirlo tras un
+    fallo gastaría una pasada sobre datos que no han cambiado."""
+    import src.modules.system.config_reading as CR
+
+    monkeypatch.setattr(
+        CR, "knowledge_base_config",
+        lambda: type("C", (), {
+            "sources": {"nvd": "u3"}, "nvd_window_days": 8, "nvd_api_key": None,
+        })(),
+    )
+    rebuilt = []
+    monkeypatch.setattr(KbSyncManager, "sync_nvd",
+                        lambda self, url, **kw: (_ for _ in ()).throw(RuntimeError("nope")))
+    monkeypatch.setattr(KbSyncManager, "rebuild_cpe_product_index",
+                        lambda self: rebuilt.append(True))
+
+    summary = KbSyncManager().sync_all()
+
+    assert summary["nvd"] is None
+    assert "cpeProductAliases" not in summary
+    assert rebuilt == []

--- a/web/app/src/stores/themisStore.js
+++ b/web/app/src/stores/themisStore.js
@@ -325,6 +325,31 @@ export const useThemisStore = defineStore('themis', () => {
     finally { authorizedTargets.loading = false }
   }
 
+  /* ── FRESCURA DE LA BASE DE CONOCIMIENTO (L36) ── */
+
+  /**
+   * Estado de sincronización de NVD, KEV y EPSS.
+   *
+   * Toda la detección por versión depende de ese espejo local. Si deja de
+   * refrescarse, los escaneos siguen saliendo en verde contra un catálogo
+   * congelado — un CVE publicado ayer no existe para el motor, y el informe
+   * afirma que el host está limpio. El aviso existe para que eso deje de ser
+   * invisible.
+   */
+  const kbStatus = reactive({ sources: [], isStale: false, feedVersion: null, loaded: false })
+
+  async function loadKbStatus() {
+    try {
+      const res = await apiFetch('/themis/kb/status')
+      if (!res?.ok) return
+      const data = await res.json()
+      kbStatus.sources = data.sources ?? []
+      kbStatus.isStale = !!data.isStale
+      kbStatus.feedVersion = data.feedVersion ?? null
+      kbStatus.loaded = true
+    } catch { /* el aviso es informativo: si no se puede leer, no se muestra */ }
+  }
+
   /** Añade un objetivo (IP o CIDR) al registro de objetivos autorizados. */
   async function addAuthorizedTarget(target, label = '') {
     try {
@@ -848,6 +873,7 @@ export const useThemisStore = defineStore('themis', () => {
   return {
     world, setWorld,
     authorizedTargets, loadAuthorizedTargets, addAuthorizedTarget, removeAuthorizedTarget,
+    kbStatus, loadKbStatus,
     activeTab, stats, loadingStats, statsError, scans, launching,
     preview, details,
     viewMode,

--- a/web/app/src/views/ThemisView.vue
+++ b/web/app/src/views/ThemisView.vue
@@ -36,6 +36,16 @@
         </button>
         <HistoryPanel v-if="store.viewMode === 'history'" />
         <template v-else>
+          <!-- La detección por versión vale lo que valga la frescura del espejo
+               local de NVD/KEV/EPSS. Si deja de refrescarse, los escaneos siguen
+               saliendo en verde contra un catálogo congelado: el aviso existe
+               para que eso deje de ser invisible. -->
+          <div v-if="store.kbStatus.loaded && store.kbStatus.isStale" class="kb-stale">
+            <strong>Base de conocimiento desactualizada.</strong>
+            {{ staleSourcesLabel }} Los hallazgos por versión se resuelven contra ese catálogo,
+            así que un CVE publicado después no aparecerá y la ausencia de hallazgos no es
+            concluyente.
+          </div>
           <LybraLaunchPanel
             :launching="store.launching"
             :launched="hasActiveLybraScan"
@@ -248,6 +258,15 @@ const currentData = computed(() => store.scans[store.activeTab])
 const hasActiveScan = computed(() =>
   currentData.value.results.some(s => s.status === 'pending' || s.status === 'running')
 )
+/** Las fuentes viejas, en una frase legible para el aviso. */
+const staleSourcesLabel = computed(() => {
+  const stale = store.kbStatus.sources.filter(s => s.isStale)
+  const parts = stale.map(s => s.neverSynced
+    ? `${s.source.toUpperCase()} nunca se ha sincronizado`
+    : `${s.source.toUpperCase()} lleva ${s.ageDays} días sin actualizarse`)
+  return parts.length ? `${parts.join('; ')}.` : ''
+})
+
 const hasActiveLybraScan = computed(() =>
   store.scans.lybra.results.some(s => s.status === 'pending' || s.status === 'running')
 )
@@ -287,6 +306,7 @@ let lybraLoaded = false
 watch(() => store.world, (w) => {
   if (w === 'lybra' && !lybraLoaded) {
     lybraLoaded = true
+    store.loadKbStatus()
     store.loadLybraScans()
     store.loadAuthorizedTargets()
   }
@@ -384,6 +404,13 @@ async function handleDeleteScheduled(id) { await scheduledStore.deleteScheduledS
 .world-opt:hover { color: var(--text-dim); }
 .world-opt.active { background: var(--accent-dim); color: var(--accent-bright); font-weight: 600; box-shadow: inset 0 0 0 1px var(--accent); }
 .world-block { display: block; }
+
+.kb-stale {
+  margin-bottom: 0.8rem; padding: 0.6rem 0.8rem; border-radius: 8px;
+  border: 1px solid var(--warn); background: var(--warn-dim);
+  color: var(--text-dim); font-size: var(--fs-md); line-height: 1.45;
+}
+.kb-stale strong { color: var(--text); }
 
 .lybra-history-toggle {
   display: block; margin: 0 0 0.85rem auto; padding: 0.45rem 0.8rem;


### PR DESCRIPTION
Primera necesidad de la **Fase 4 — La verdad del proveedor**.

### Related Issue

Closes #302

---

## El problema

Toda la detección por versión del motor —la que produce la mayoría de los hallazgos con CVE— depende de un espejo local de NVD, KEV y EPSS. Y no había **nada** que registrara cuándo se refrescó cada uno: sólo un `logger.info` con el recuento de filas al final de cada sincronización. Un log no es un estado consultable.

Los modos de fallo son todos silenciosos y todos igual de malos:

- El job lleva tres semanas fallando y los escaneos siguen saliendo en verde, contra un catálogo congelado. Nadie se entera.
- Un CVE crítico publicado ayer no está en la KB, así que para el motor no existe. El informe dice que el host está limpio.
- KEV se actualiza a diario; si lleva un mes parado, la señal de «se explota activamente» —la que más pesa al priorizar— está desactualizada justo en lo que más importa.

Un escáner que no sabe decir cuándo aprendió lo que sabe no es auditable.

---

## Y una avería que apareció al mirar

`sync_all` encadenaba las tres fuentes en línea recta:

```python
summary["kev"]  = self.sync_kev(...)
summary["epss"] = self.sync_epss(...)
summary["nvd"]  = self.sync_nvd(...)
```

Un fallo de KEV —una URL caída, un formato cambiado— propagaba la excepción, y ni EPSS ni NVD llegaban a ejecutarse. `execute_kb_sync` la capturaba arriba del todo, escribía una línea de log y se iba.

O sea: **un feed de terceros caído congelaba la base de conocimiento entera**, en silencio, hasta la noche siguiente. Y otra vez. Es el mismo fallo que el issue describe, pero con el multiplicador puesto.

No estaba en el enunciado del issue, pero es exactamente lo que el issue quiere hacer visible, y arreglarlo mientras se instrumenta cuesta menos que instrumentar una avería y dejarla puesta.

---

## Implementación

### `KbSyncStatus`: una fila por fuente

Último intento, último éxito, filas escritas, y el error si lo hubo. Es un **estado**, no un historial —el historial son los logs—, porque la pregunta que hay que poder responder es «¿está bien ahora?».

Dos decisiones que se toman al revés la una de la otra, a propósito:

- **`last_success_at` se conserva** cuando el intento falla. La distancia entre él y `last_attempt_at` es exactamente cuánto lleva roto, y pisarlo destruiría el único dato que responde a esa pregunta.
- **`error` sí se limpia** al tener éxito, por lo mismo: la tabla dice si está bien *ahora*.

No sustituye a `KbRepository.knowledge_state`, que responde a otra pregunta y sigue existiendo. Aquélla dice **cuán reciente es lo que sabemos** (la fecha más nueva de los propios datos); ésta dice **cuándo lo preguntamos y si funcionó**. Hacen falta las dos, y **la diferencia entre ambas es precisamente el síntoma**: contenido que no avanza mientras las sincronizaciones fallan.

### Cada fuente, aislada

Una fuente rota cuesta una fuente, no tres. El resumen trae `None` en la que falló, que es distinto de un `0` (sincronizó bien y no había nada nuevo).

El registro del estado va **en su propia transacción**, aparte de la de la sincronización: si la escritura de datos falló y su transacción se deshizo, el registro del fallo tiene que sobrevivir — es lo único que va a quedar de ese intento. Y si el propio registro falla, se loguea y no se propaga: observabilidad que no puede tumbar aquello que observa.

El índice de alias de producto sólo se reconstruye si NVD fue bien, porque se deriva entero de sus filas.

### `GET /themis/kb/status`

Responde a las dos preguntas por separado, más el `feedVersion` con el que se estampan los hallazgos.

Se recorren las fuentes **configuradas**, no las filas de la tabla. Una fuente que no se ha sincronizado nunca no tiene fila, y es justo la que más importa reportar: sale con `neverSynced` y cuenta como vieja, porque no saber nada de una fuente es peor que saber que lleva días parada, no mejor.

### El umbral, configurable

`features.themis.kb.maxAgeDays` → `{"nvd": 3, "kev": 7, "epss": 7}`. Los tres números no son el mismo por una razón: NVD publica a diario y tres días de retraso ya son detección que falta; KEV y EPSS cambian más despacio. Son de operador porque dependen de la red y de la cuota de API de cada despliegue, no de la lógica del motor.

El aviso se emite tras cada sincronización programada, que es cuando significa algo: si tras un intento la fuente sigue vieja, es que no se ha arreglado sola.

### La fecha en el informe, y el aviso en la interfaz

El PDF lleva ahora una línea «Base de conocimiento: NVD 2026-08-29 · KEV 2026-08-27 · EPSS 2026-08-30», y marca las fuentes viejas. Es *best-effort*: un fallo consultando el estado no puede impedir que se emita el informe.

El panel de Lybra avisa cuando alguna fuente se ha quedado atrás, diciendo cuál y cuántos días. Lo que explica el aviso no es el retraso en sí sino lo que implica: **la ausencia de hallazgos, que es la conclusión que más se lee en un informe, deja de ser concluyente** con un catálogo congelado.

---

## Validación

- `tests/unit/test_kb_sync_status.py` (nuevo, 4 tests) — se registra el éxito con su recuento; **se registra también el fallo**, que es el caso que da sentido a la tabla; una fuente rota no se lleva a las otras; y el índice de alias no se reconstruye si NVD falló.
- `tests/integration/test_kb_repository.py` (+7 tests) — el último éxito sobrevive a un fallo posterior; el error se limpia al volver a funcionar; una fuente nunca sincronizada cuenta como vieja; una reciente no; el umbral corto de NVD dispara donde el de KEV todavía no; y el endpoint reporta las tres fuentes y exige autenticación.
- Suite completa: **2.624 passed, 50 skipped**, cobertura 82 %.
- **`pylint src`: 10.00/10.**
- `npm run build` en verde.

---

## Notas

- **Migración aditiva** (`d421740891b4`): crea `KbSyncStatus`. Nace vacía y se rellena en la primera sincronización de cada fuente; hasta entonces «nunca sincronizada» es la respuesta correcta, no un hueco. La bajada suelta la tabla — se pierde observabilidad, ningún dato de la KB se toca.
- **Precondición cumplida para #270**, que ya está cerrado pero cuyo `kb_feed_version` documenta en su propio docstring que le faltaba esta tabla para poder hashear la marca en vez de deletrearla. No lo cambio aquí: es otra decisión.
- **Fuera de alcance**: #305 (verificación de backports con OVAL/CSAF) añadirá fuentes nuevas a la KB. Heredarán este registro sin trabajo extra, que es parte de por qué esta necesidad va primero en la fase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
