### PR TITLE
Un ranking de los nombres de producto que el motor no sabe identificar

### DIFF
--- a/API/alembic/versions/71a79c14f9e3_lybra_ranking_de_nombres_de_producto_.py
+++ b/API/alembic/versions/71a79c14f9e3_lybra_ranking_de_nombres_de_producto_.py
@@ -1,0 +1,61 @@
+"""lybra: ranking de nombres de producto sin resolver
+
+Revision ID: 71a79c14f9e3
+Revises: 8b44c3d0a5b1
+Create Date: 2026-09-03 20:11:09.142082
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '71a79c14f9e3'
+down_revision: Union[str, Sequence[str], None] = '8b44c3d0a5b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Un nombre por fila y por origen, con su contador. Es el documento de
+    trabajo del feed curado de alias: cada línea es un alias que merece la pena
+    escribir, ordenado por cuánto duele no tenerlo.
+
+    La tabla nace vacía y se llena sola con el primer escaneo. No hay backfill
+    posible ni deseable: los hallazgos antiguos guardan que la resolución falló
+    (`Finding.cpe_resolved`) pero no **con qué** nombre, que es justo lo que
+    faltaba.
+
+    El único constraint que importa es el de unicidad por `(normalized_name,
+    origin)`: sin él, cada escaneo insertaría filas nuevas en vez de sumar al
+    contador, y el ranking mediría cuántas veces se ha escaneado en lugar de
+    cuánto falla cada nombre.
+    """
+    op.create_table(
+        "UnresolvedProduct",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("normalized_name", sa.String(length=255), nullable=False),
+        sa.Column("origin", sa.String(length=32), nullable=False),
+        sa.Column("occurrences", sa.Integer(), nullable=False),
+        sa.Column("first_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("normalized_name", "origin", name="unique_unresolved_product"),
+    )
+    op.create_index(op.f("ix_UnresolvedProduct_normalized_name"), "UnresolvedProduct",
+                    ["normalized_name"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde el ranking, que es observabilidad: ningún hallazgo ni ningún dato
+    de la KB depende de esta tabla. Se vuelve a llenar sola en cuanto se
+    reinstale, escaneo a escaneo.
+    """
+    op.drop_index(op.f("ix_UnresolvedProduct_normalized_name"), table_name="UnresolvedProduct")
+    op.drop_table("UnresolvedProduct")

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -65,6 +65,7 @@ from .schemas import (
     AuthorizedTargetListResponseSchema,
     AuthorizedTargetActionResponseSchema,
     ResultsQuerySchema,
+    UnresolvedProductsQuerySchema,
     GeneratePdfRequestSchema,
     DocumentStatusQuerySchema,
     DocumentsQuerySchema,
@@ -493,6 +494,36 @@ def get_false_positives():
         "message": "Falsos positivos obtenidos correctamente",
         "count": len(items),
         "falsePositives": items,
+        "user": user.username,
+    }
+
+
+@themis_blp.get("/lybra/unresolved-products")
+@themis_blp.arguments(UnresolvedProductsQuerySchema, location="query")
+@themis_blp.response(200, description="Product names the matcher could not resolve")
+@themis_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@themis_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.THEMIS_READ])
+@limiter.limit("120 per hour; 400 per day")
+@handle_exceptions(default_exception=ScanError, logger=logger)
+def get_unresolved_products(args):
+    """Los nombres de producto que el motor no consigue convertir en un CPE.
+
+    Cuando ninguna de las tres estrategias de resolución acierta, el motor no
+    inventa un CPE —uno fabricado no casaría con nada, en silencio— pero sí
+    apunta el nombre. Cada línea de esta lista es un alias que merece la pena
+    escribir, ordenado por cuántas veces ha hecho falta.
+
+    En cuanto el alias existe, el nombre resuelve y desaparece de aquí en el
+    siguiente escaneo: la lista mide el trabajo que queda, no el que hubo.
+    """
+    user = get_current_user()
+    items = LybraEngineManager.unresolved_products(args["limit"], args["origin"])
+    return {
+        "message": "Nombres sin resolver obtenidos correctamente",
+        "count": len(items),
+        "unresolvedProducts": items,
         "user": user.username,
     }
 

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -159,12 +159,14 @@ class LybraEngine:
         epss_lookup: Optional[Callable[[str], Optional[float]]] = None,
         product_alias_lookup: Optional[Callable[[str], Optional[Tuple[str, str]]]] = None,
         feed_version: Optional[str] = None,
+        record_resolution: Optional[Callable[[str, str, bool], None]] = None,
     ) -> None:
         self._cve_lookup = cve_lookup
         self._kev_lookup = kev_lookup
         self._epss_lookup = epss_lookup
         self._product_alias_lookup = product_alias_lookup
         self._feed_version = feed_version or self.FEED_VERSION
+        self._record_resolution = record_resolution
 
     def analyze(self, services: Iterable[Service]) -> List[dict]:
         """Produce the findings for a set of services.
@@ -182,7 +184,8 @@ class LybraEngine:
             # whether resolution succeeded (Fase I-b observability), and the
             # version-match path reuses the same result instead of resolving
             # the CPE twice.
-            resolved = _resolve_cpe(service, self._product_alias_lookup)
+            resolved = _resolve_cpe(service, self._product_alias_lookup,
+                                    self._record_resolution)
             findings.append(self._informational_finding(service, resolved))
             if self._cve_lookup is not None:
                 findings.extend(self._version_findings(service, resolved))
@@ -355,6 +358,7 @@ def _concrete_version(version: str) -> Optional[str]:
 def _resolve_cpe(
     service: Service,
     product_alias_lookup: Optional[Callable[[str], Optional[Tuple[str, str]]]] = None,
+    record_resolution: Optional[Callable[[str, str, bool], None]] = None,
 ) -> Optional[tuple[str, str, str, str]]:
     """Resolve a service to a ``(vendor, product, version, cpe_2_3)`` for matching.
 
@@ -391,6 +395,17 @@ def _resolve_cpe(
             (``None``) by any caller that has not wired the KB-backed index —
             strategy 3 is simply skipped, same as ``cve_lookup=None`` skips
             detection entirely.
+        record_resolution: Callback ``(nombre_normalizado, origen, resuelto)``
+            para llevar la cuenta de qué nombres de producto no se consiguen
+            resolver (L37). Se invoca **sólo** cuando el nombre y la versión
+            existen y aun así ninguna estrategia dio con el CPE: eso es
+            exactamente "falta un alias", que es lo que el ranking tiene que
+            saber. Un servicio sin versión concreta o sin nombre no falla por
+            falta de alias, así que contarlo ensuciaría la lista con trabajo
+            que no existe.
+
+            Inyectado en vez de escrito aquí porque este paquete es libre de
+            ORM y debe seguir siéndolo (``test_lybra_package_invariants``).
 
     Returns:
         A ``(vendor, product, version, cpe_2_3)`` tuple, or ``None`` if the
@@ -413,9 +428,14 @@ def _resolve_cpe(
     if not normalized:
         return None
 
+    def _note(was_resolved: bool) -> None:
+        if record_resolution is not None:
+            record_resolution(normalized, service.origin, was_resolved)
+
     # 2) The curated alias feed.
     if normalized in CPE_PRODUCT_OVERRIDES:
         vendor, product = CPE_PRODUCT_OVERRIDES[normalized]
+        _note(True)
         return vendor, product, version, f"cpe:2.3:a:{vendor}:{product}:{version}:*:*:*:*:*:*:*"
 
     # 3) The automated index.
@@ -423,6 +443,10 @@ def _resolve_cpe(
         resolved = product_alias_lookup(normalized)
         if resolved:
             vendor, product = resolved
+            _note(True)
             return vendor, product, version, f"cpe:2.3:a:{vendor}:{product}:{version}:*:*:*:*:*:*:*"
 
+    # Nombre y versión había; alias no. Es la muestra que dirige el trabajo del
+    # feed curado: qué producto concreto estamos fallando en identificar.
+    _note(False)
     return None

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -355,6 +355,11 @@ class LybraEngineManager(ScanManager):
                     epss_lookup=lambda cve_id: getattr(kb_repo.get_epss(cve_id), "score", None),
                     product_alias_lookup=kb_repo.resolve_product_alias,
                     feed_version=kb_feed_version(kb_repo.knowledge_state()),
+                    # L37: qué nombres de producto no logramos identificar. El
+                    # motor los cuenta, no los escribe — el paquete `lybra/` es
+                    # libre de ORM y lo sigue siendo porque esto entra
+                    # inyectado, como los demás lookups.
+                    record_resolution=kb_repo.record_resolution,
                 )
                 findings_data = engine.analyze(services)
                 findings_data.extend(fingerprint_findings)
@@ -1065,6 +1070,30 @@ class LybraEngineManager(ScanManager):
                 )
             repo.update(finding)
             return finding
+
+    @staticmethod
+    def unresolved_products(limit: int = 50, origin: Optional[str] = None) -> list:
+        """Los nombres de producto que el matcher no consigue identificar.
+
+        Es el documento de trabajo del feed curado de alias: cada línea es un
+        alias que merece la pena escribir, ordenado por cuánto duele no
+        tenerlo. El roadmap aparcaba este ranking por falta de datos —hacía
+        falta el agente de Hygeia en más de un equipo—, pero eso vale para el
+        volumen y no para la herramienta: hay que construirlo **antes** de que
+        lleguen los datos, o cuando lleguen no habrá dónde mirarlos. Y la vía
+        de red aporta muestras desde el primer escaneo, sin agente ninguno.
+
+        No se acota por usuario: el feed de alias es del producto, no de quien
+        escanea, y un nombre que falla lo hace para todos.
+        """
+        repo = build_repository(KbRepository)
+        return [{
+            "name": row.normalized_name,
+            "origin": row.origin,
+            "occurrences": row.occurrences,
+            "firstSeenAt": isoformat_utc(row.first_seen_at),
+            "lastSeenAt": isoformat_utc(row.last_seen_at),
+        } for row in repo.top_unresolved_products(limit, origin)]
 
     def false_positives(self, user_id: int) -> list:
         """Los hallazgos que este usuario ha desmentido.

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -1074,6 +1074,56 @@ class EpssScore(Base):
         return f"<EpssScore(cve_id='{self.cve_id}', score={self.score})>"
 
 
+class UnresolvedProduct(Base):
+    """Un nombre de producto que el matcher no consiguió convertir en un CPE.
+
+    ``_resolve_cpe`` prueba tres estrategias —el CPE que dio Nmap, el feed
+    curado de alias y el índice automático derivado de la KB— y, si ninguna
+    funciona, devuelve ``None`` sin inventar nada. Esa decisión es correcta: un
+    CPE fabricado que NVD no conoce no casaría con nada, en silencio.
+
+    Pero el fallo tampoco se contaba. Existía ``Finding.cpe_resolved``, que
+    distingue "no hay CVEs" de "ni siquiera supe qué es esto", y ahí se
+    quedaba: un booleano por hallazgo, no un agregado consultable. Sin
+    agregado, la pregunta que dirige todo el trabajo del feed de alias —**qué
+    nombres estamos fallando en resolver, y cuáles con más frecuencia**— no
+    tiene respuesta.
+
+    Cada fila es un alias que merece la pena escribir, y ``occurrences`` dice
+    cuánto duele no tenerlo. Al añadir el alias, el nombre resuelve en el
+    siguiente escaneo y su fila se borra: el ranking mide el trabajo que queda,
+    no el que hubo.
+
+    Attributes:
+        normalized_name: El nombre ya normalizado
+            (:func:`~lybra.kb.normalize_product_name`), que es la clave con la
+            que se busca el alias. El crudo no serviría: un inventario de
+            escritorio mete la versión en el propio nombre ("7-Zip 25.01").
+        origin: ``"network"`` (un banner) o ``"inventory"`` (un paquete que
+            leyó un agente). Se separan porque son dos frentes distintos de
+            trabajo, y porque el de red aporta muestras desde el primer
+            escaneo, sin necesidad de tener agentes desplegados.
+        occurrences: Cuántas veces se ha visto sin resolver.
+        first_seen_at / last_seen_at: Desde cuándo, y la última vez.
+    """
+    __tablename__ = "UnresolvedProduct"
+
+    id              = Column(Integer, primary_key=True, autoincrement=True)
+    normalized_name = Column(String(255), nullable=False, index=True)
+    origin          = Column(String(32), nullable=False, default="network")
+    occurrences     = Column(Integer, nullable=False, default=1)
+    first_seen_at   = Column(DateTime, default=utcnow_naive)
+    last_seen_at    = Column(DateTime, default=utcnow_naive)
+
+    __table_args__ = (
+        UniqueConstraint("normalized_name", "origin", name="unique_unresolved_product"),
+    )
+
+    def __repr__(self):
+        return (f"<UnresolvedProduct(name='{self.normalized_name}', "
+                f"origin='{self.origin}', occurrences={self.occurrences})>")
+
+
 class KbSyncStatus(Base):
     """Cuándo se intentó sincronizar cada fuente de la KB, y cómo salió.
 

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -48,6 +48,7 @@ from .model import (
     HostService,
     KbSyncStatus,
     KevEntry,
+    UnresolvedProduct,
     NiktoIncident,
     NiktoScan,
     NmapScan,
@@ -1286,6 +1287,43 @@ class KbRepository(BaseRepository[CveEntry]):
     def sync_status(self) -> List[KbSyncStatus]:
         """El estado de sincronización de todas las fuentes registradas."""
         return self._session.query(KbSyncStatus).order_by(KbSyncStatus.source).all()
+
+    def record_resolution(self, normalized_name: str, origin: str, was_resolved: bool) -> None:
+        """Llevar la cuenta de un nombre de producto que no resuelve a un CPE.
+
+        Cuando falla, suma uno a su contador; **cuando resuelve, borra la fila**.
+        Esa segunda mitad es la que cierra el bucle que pedía L37: al escribir
+        el alias que faltaba, el nombre desaparece del ranking en el siguiente
+        escaneo. Sin ella el ranking mediría el trabajo que hubo, no el que
+        queda, y no habría forma de saber si el feed está mejorando.
+        """
+        row = (self._session.query(UnresolvedProduct)
+               .filter_by(normalized_name=normalized_name, origin=origin)
+               .one_or_none())
+        if was_resolved:
+            if row is not None:
+                self._session.delete(row)
+            return
+
+        now = utcnow_naive()
+        if row is None:
+            self._session.add(UnresolvedProduct(
+                normalized_name=normalized_name, origin=origin,
+                occurrences=1, first_seen_at=now, last_seen_at=now,
+            ))
+        else:
+            row.occurrences = (row.occurrences or 0) + 1
+            row.last_seen_at = now
+
+    def top_unresolved_products(self, limit: int = 50,
+                                origin: Optional[str] = None) -> List[UnresolvedProduct]:
+        """Los nombres que más veces han quedado sin resolver, el peor primero."""
+        query = self._session.query(UnresolvedProduct)
+        if origin:
+            query = query.filter(UnresolvedProduct.origin == origin)
+        return (query.order_by(UnresolvedProduct.occurrences.desc(),
+                               UnresolvedProduct.normalized_name.asc())
+                .limit(limit).all())
 
     def counts(self) -> dict:
         """Row counts per KB table (for the sync summary / health checks)."""

--- a/API/src/modules/features/themis/schemas.py
+++ b/API/src/modules/features/themis/schemas.py
@@ -55,6 +55,15 @@ class LybraScanRequestSchema(Schema):
     aggressive = fields.Boolean(load_default=False)
 
 
+class UnresolvedProductsQuerySchema(Schema):
+    limit = fields.Integer(load_default=50, validate=validate.Range(min=1, max=500))
+    # El origen separa dos frentes de trabajo distintos: los banners de red
+    # aportan muestras desde el primer escaneo, mientras que el inventario
+    # necesita agentes desplegados.
+    origin = fields.String(load_default=None, allow_none=True,
+                           validate=validate.OneOf(["network", "inventory"]))
+
+
 class FindingStateRequestSchema(Schema):
     # ``accepted`` y ``false_positive`` dicen cosas opuestas y hasta L35
     # compartían casilla: aceptar un riesgo es "esto es real, lo asumo";

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -504,3 +504,75 @@ def test_the_kb_status_endpoint_reports_every_source(client, app, admin_user, au
 
 def test_the_kb_status_endpoint_requires_authentication(client):
     assert client.get("/themis/kb/status").status_code == 401
+
+
+# ───────────────────────── ranking de nombres sin resolver (L37)
+
+
+def test_the_ranking_counts_by_name_and_origin(app):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            for _ in range(3):
+                repo.record_resolution("chachiservidor", "network", False)
+            repo.record_resolution("otracosa", "network", False)
+            repo.record_resolution("chachiservidor", "inventory", False)
+
+        with UnitOfWork() as uow:
+            rows = KbRepository(uow).top_unresolved_products()
+            top = [(r.normalized_name, r.origin, r.occurrences) for r in rows]
+
+    # El peor primero: es el alias que más duele no tener.
+    assert top[0] == ("chachiservidor", "network", 3)
+    # Mismo nombre por dos vías = dos frentes de trabajo, dos filas.
+    assert ("chachiservidor", "inventory", 1) in top
+    assert ("otracosa", "network", 1) in top
+
+
+def test_resolving_a_name_removes_it_from_the_ranking(app):
+    """El bucle cerrado: al escribir el alias que faltaba, el nombre resuelve
+    en el siguiente escaneo y sale de la lista. Sin esto el ranking mediría el
+    trabajo que hubo, no el que queda."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            repo.record_resolution("chachiservidor", "network", False)
+            repo.record_resolution("chachiservidor", "network", False)
+
+        with UnitOfWork() as uow:
+            assert KbRepository(uow).top_unresolved_products()
+
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_resolution("chachiservidor", "network", True)
+
+        with UnitOfWork() as uow:
+            assert KbRepository(uow).top_unresolved_products() == []
+
+
+def test_resolving_a_name_never_seen_before_is_a_no_op(app):
+    """El caso normal: casi todo resuelve, y no debe crear filas."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).record_resolution("apache http server", "network", True)
+        with UnitOfWork() as uow:
+            assert KbRepository(uow).top_unresolved_products() == []
+
+
+def test_the_ranking_endpoint_filters_by_origin(client, app, admin_user, auth_headers):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = KbRepository(uow)
+            repo.record_resolution("de-red", "network", False)
+            repo.record_resolution("de-agente", "inventory", False)
+
+    headers = auth_headers(admin_user)
+    everything = client.get("/themis/lybra/unresolved-products", headers=headers).get_json()
+    assert everything["count"] == 2
+
+    only_network = client.get("/themis/lybra/unresolved-products?origin=network",
+                              headers=headers).get_json()
+    assert [item["name"] for item in only_network["unresolvedProducts"]] == ["de-red"]
+
+
+def test_the_ranking_endpoint_requires_authentication(client):
+    assert client.get("/themis/lybra/unresolved-products").status_code == 401

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -509,3 +509,72 @@ def test_services_from_payload_respects_explicit_origin_and_missing_port():
 
 def test_services_from_payload_empty_returns_empty():
     assert services_from_payload([]) == []
+
+
+# ─────────────── qué nombres no se consiguen resolver (L37)
+#
+# `_resolve_cpe` devuelve None sin inventar un CPE cuando ninguna estrategia
+# acierta, y esa decisión es correcta: uno fabricado que NVD no conozca no
+# casaría con nada, en silencio. Pero el fallo tampoco se contaba, así que la
+# pregunta que dirige todo el trabajo del feed de alias —qué nombres fallamos
+# en resolver, y cuáles más— no tenía respuesta.
+
+from src.modules.features.themis.lybra.engine import _resolve_cpe   # noqa: E402
+
+
+def _recorder():
+    calls = []
+    return calls, lambda name, origin, resolved: calls.append((name, origin, resolved))
+
+
+def test_an_unresolvable_name_is_recorded():
+    calls, record = _recorder()
+    service = Service(port=443, protocol="tcp", name="https",
+                      product="Chachiservidor Ultra", version="3.1")
+
+    assert _resolve_cpe(service, None, record) is None
+    assert calls == [("chachiservidor ultra", "network", False)]
+
+
+def test_a_name_the_curated_feed_knows_is_recorded_as_resolved():
+    """El registro del acierto es lo que cierra el bucle: al escribir el alias
+    que faltaba, la fila del ranking se borra y el nombre desaparece."""
+    calls, record = _recorder()
+    service = Service(port=80, protocol="tcp", name="http",
+                      product="Apache httpd", version="2.4.49")
+
+    assert _resolve_cpe(service, None, record) is not None
+    assert calls and calls[0][2] is True
+
+
+def test_a_service_without_a_version_is_not_recorded():
+    """No falla por falta de alias, sino por falta de versión. Contarlo
+    ensuciaría el ranking con trabajo que no existe."""
+    calls, record = _recorder()
+    service = Service(port=443, protocol="tcp", name="https",
+                      product="Chachiservidor Ultra", version=None)
+
+    assert _resolve_cpe(service, None, record) is None
+    assert calls == []
+
+
+def test_a_service_resolved_from_its_own_cpe_is_not_recorded():
+    """La primera estrategia no pasa por el nombre normalizado: si Nmap ya dio
+    un CPE, no hay ningún alias que escribir."""
+    calls, record = _recorder()
+    service = Service(port=80, protocol="tcp", name="http", product="Apache httpd",
+                      version="2.4.49", cpe="cpe:/a:apache:http_server:2.4.49")
+
+    assert _resolve_cpe(service, None, record) is not None
+    assert calls == []
+
+
+def test_the_inventory_origin_travels_with_the_name():
+    """Red e inventario son dos frentes de trabajo distintos, y el ranking los
+    separa: el de red aporta muestras sin necesidad de agentes desplegados."""
+    calls, record = _recorder()
+    service = Service(port=None, protocol="", name="", product="Chachiapp",
+                      version="1.0", origin="inventory")
+
+    _resolve_cpe(service, None, record)
+    assert calls == [("chachiapp", "inventory", False)]


### PR DESCRIPTION
Tercera necesidad de la **Fase 4 — La verdad del proveedor**.

### Related Issue

Closes #304

---

## El problema

`_resolve_cpe` prueba tres estrategias —el CPE que emitió Nmap, el feed curado de alias, el índice automático derivado de la KB— y si ninguna acierta devuelve `None` **sin inventar nada**. Esa decisión es correcta y su docstring la argumenta bien: un CPE fabricado que NVD no conoce no casaría con nada, en silencio.

Pero el fallo tampoco se contaba. Existía `Finding.cpe_resolved` (Fase I-b), que distingue «no hay CVEs» de «ni siquiera supe qué es esto» — y ahí se quedaba: un booleano por hallazgo, no un agregado consultable.

Sin agregado, la pregunta que dirige **todo** el trabajo del feed de alias no tenía respuesta: *¿qué nombres de producto estamos fallando en resolver, y cuáles con más frecuencia?*

## Por qué ahora y no cuando haya datos

El roadmap identifica este ranking como el siguiente paso de la Fase I-b y lo aparca por falta de datos: *«no es trabajo de ingeniería sino de datos: necesita el agente de Hygeia instalado en más de un equipo»*.

Eso es cierto para el volumen y falso para la herramienta. **El ranking hay que construirlo antes de que lleguen los datos**, o cuando lleguen no habrá dónde mirarlos. Y hay una segunda fuente que el roadmap no consideró: los nombres que fallan por la vía de **red** —banners— que no necesitan ningún agente y aportan muestras desde el primer escaneo.

---

## Implementación

### Cuándo se apunta un nombre, y cuándo no

El motor recibe un callback opcional `(nombre_normalizado, origen, resuelto)`. Va inyectado y no escrito dentro, porque el paquete `lybra/` es libre de ORM y lo sigue siendo (`test_lybra_package_invariants`).

Se invoca con el nombre **normalizado**, que es la clave con la que se busca el alias. El crudo no serviría: un inventario de escritorio mete la versión en el propio nombre («7-Zip 25.01»).

Y se invoca **sólo cuando había nombre y versión y aun así ninguna estrategia acertó**, que es exactamente «falta un alias». Dos casos quedan deliberadamente fuera:

- Un servicio **sin versión concreta** no falla por falta de alias, sino por falta de versión.
- Un servicio que **Nmap ya resolvió con su propio CPE** ni siquiera pasa por el nombre normalizado: no hay alias que escribir.

Contar esos dos llenaría el ranking de trabajo que no existe, que es la forma más rápida de que una lista de tareas deje de usarse.

### El bucle cerrado

También se apunta el **acierto**, y esa mitad es la que hace que esto sea medición y no una sensación: cuando un nombre resuelve, su fila se borra. Se escribe el alias que faltaba, y en el siguiente escaneo el nombre ya no está en la lista.

Sin eso, el ranking mediría el trabajo que hubo en vez del que queda, y no habría forma de saber si el feed está mejorando.

### La tabla

`UnresolvedProduct`, una fila por `(nombre, origen)` con su contador. De la migración lo único que hay que mirar es la unicidad de esa pareja: **sin ella cada escaneo insertaría filas nuevas en vez de sumar al contador**, y el ranking mediría cuántas veces se ha escaneado en lugar de cuánto falla cada nombre.

`origin` separa `network` de `inventory` porque son dos frentes de trabajo distintos, y porque el primero está disponible ya y el segundo depende de tener agentes desplegados.

### El endpoint

`GET /themis/lybra/unresolved-products?origin=&limit=`, ordenado por frecuencia. **No se acota por usuario**: el feed de alias es del producto, no de quien escanea, y un nombre que falla lo hace para todos.

---

## Validación

- `tests/unit/test_lybra_engine.py` (+5) — un nombre irresoluble se apunta con su origen; uno que el feed curado conoce se apunta como resuelto; uno sin versión **no** se apunta; uno que venía con CPE de Nmap tampoco; y el origen `inventory` viaja con el nombre.
- `tests/integration/test_kb_repository.py` (+5) — el ranking agrega por nombre y origen y ordena por frecuencia; el mismo nombre por dos vías son dos filas; resolver un nombre lo borra de la lista; resolver uno nunca visto no crea filas; y el endpoint filtra por origen y exige autenticación.
- Suite completa en verde, **`pylint src` 10.00/10**.

---

## Notas

- **Migración aditiva** (`71a79c14f9e3`). La tabla nace vacía y se llena con el primer escaneo. No hay backfill posible ni deseable: los hallazgos antiguos guardan que la resolución falló, pero no **con qué** nombre — que es justo lo que faltaba.
- **Fuera de alcance**: escribir alias concretos. Esto produce la lista; llenarla de entradas es trabajo de datos, y ahora por fin se puede priorizar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
