### PR TITLE
El motor le pregunta al proveedor antes de acusar por un número de versión

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -130,13 +130,18 @@
         "sources": {
           "epss": "https://epss.cyentia.com/epss_scores-current.csv.gz",
           "kev": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
-          "nvd": "https://services.nvd.nist.gov/rest/json/cves/2.0"
+          "nvd": "https://services.nvd.nist.gov/rest/json/cves/2.0",
+          "oval": {
+            "debian:11": "https://www.debian.org/security/oval/oval-definitions-bullseye.xml",
+            "debian:12": "https://www.debian.org/security/oval/oval-definitions-bookworm.xml"
+          }
         },
         "syncCron": "0 3 * * *",
         "maxAgeDays": {
           "nvd": 3,
           "kev": 7,
-          "epss": 7
+          "epss": 7,
+          "oval": 7
         }
       },
       "scanners": {

--- a/API/alembic/versions/6ec0a7bf3ba1_lybra_avisos_de_distribucion_para_.py
+++ b/API/alembic/versions/6ec0a7bf3ba1_lybra_avisos_de_distribucion_para_.py
@@ -1,0 +1,88 @@
+"""lybra: avisos de distribucion para verificar backports
+
+Revision ID: 6ec0a7bf3ba1
+Revises: 0fd9d718b2a2
+Create Date: 2026-09-03 20:41:05.333746
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6ec0a7bf3ba1'
+down_revision: Union[str, Sequence[str], None] = '0fd9d718b2a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Las dos tablas de la Fase O: el aviso del proveedor y lo que dice de cada
+    paquete. Es la brecha G3 del roadmap —los backports— y ataca la causa
+    número uno de falsos positivos de la detección por versión.
+
+    El constraint que importa es el de `DistroPkgStatus`: un pronunciamiento por
+    `(vendor, release, package, cve)`. Sin él, cada sincronización acumularía
+    filas repetidas y la consulta tendría que elegir entre varias respuestas
+    para la misma pregunta.
+
+    `release` admite nulo a propósito: hay avisos que aplican a todas las
+    versiones del proveedor, e inventarles una concreta sería peor que no
+    tenerla.
+
+    Ambas nacen vacías. Sin sincronizar el feed no hay verificación de
+    backports, y la consecuencia es exactamente la de antes de esta migración:
+    el hallazgo se queda con su `qod=70` y su `confirmed=false`.
+    """
+    op.create_table(
+        "DistroAdvisory",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("advisory_id", sa.String(length=64), nullable=False),
+        sa.Column("vendor", sa.String(length=32), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("cve_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("published", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_DistroAdvisory_advisory_id"), "DistroAdvisory",
+                    ["advisory_id"], unique=True)
+    op.create_index(op.f("ix_DistroAdvisory_vendor"), "DistroAdvisory", ["vendor"], unique=False)
+
+    op.create_table(
+        "DistroPkgStatus",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("vendor", sa.String(length=32), nullable=False),
+        sa.Column("release", sa.String(length=32), nullable=True),
+        sa.Column("package", sa.String(length=128), nullable=False),
+        sa.Column("cve_id", sa.String(length=32), nullable=False),
+        sa.Column("fixed_in", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("vendor", "release", "package", "cve_id",
+                            name="unique_distro_pkg_status"),
+    )
+    op.create_index(op.f("ix_DistroPkgStatus_vendor"), "DistroPkgStatus", ["vendor"], unique=False)
+    op.create_index(op.f("ix_DistroPkgStatus_package"), "DistroPkgStatus", ["package"], unique=False)
+    op.create_index(op.f("ix_DistroPkgStatus_cve_id"), "DistroPkgStatus", ["cve_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde el espejo de avisos de distribución. Ningún hallazgo depende de
+    él: sin estas tablas la verificación de backports simplemente no se aplica,
+    y los hallazgos por versión vuelven a quedarse como hipótesis, que es lo que
+    eran antes.
+    """
+    op.drop_index(op.f("ix_DistroPkgStatus_cve_id"), table_name="DistroPkgStatus")
+    op.drop_index(op.f("ix_DistroPkgStatus_package"), table_name="DistroPkgStatus")
+    op.drop_index(op.f("ix_DistroPkgStatus_vendor"), table_name="DistroPkgStatus")
+    op.drop_table("DistroPkgStatus")
+    op.drop_index(op.f("ix_DistroAdvisory_vendor"), table_name="DistroAdvisory")
+    op.drop_index(op.f("ix_DistroAdvisory_advisory_id"), table_name="DistroAdvisory")
+    op.drop_table("DistroAdvisory")

--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -58,6 +58,8 @@ from .grouping import (
     build_service_rollup,
     group_label,
 )
+from .backports import apply_backport_verdicts, BACKPORT_CHECK_ID
+from .distro import infer_distro_release, DistroRelease
 from .kb import (
     version_compare,
     split_distro_version,
@@ -71,6 +73,9 @@ from .kb import (
     ingest_nvd_cve,
     ingest_kev,
     parse_epss_rows,
+    parse_oval_definitions,
+    parse_csaf_advisory,
+    fetch_oval,
     fetch_kev,
     fetch_epss,
     iter_nvd_pages,
@@ -230,6 +235,10 @@ __all__ = [
     "extract_trailing_version",
     "load_product_aliases",
     "parse_cpe23",
+    "apply_backport_verdicts",
+    "BACKPORT_CHECK_ID",
+    "infer_distro_release",
+    "DistroRelease",
     "ServiceGroup",
     "build_service_rollup",
     "group_label",
@@ -237,6 +246,9 @@ __all__ = [
     "ingest_nvd_cve",
     "ingest_kev",
     "parse_epss_rows",
+    "parse_oval_definitions",
+    "parse_csaf_advisory",
+    "fetch_oval",
     "fetch_kev",
     "fetch_epss",
     "iter_nvd_pages",

--- a/API/src/modules/features/themis/lybra/backports.py
+++ b/API/src/modules/features/themis/lybra/backports.py
@@ -1,0 +1,143 @@
+"""Preguntarle al proveedor si esa vulnerabilidad ya está corregida (Fase O).
+
+Un *backport* es una distribución arreglando un fallo sin subir el número de
+versión visible: Debian parchea ``apache2``, el banner sigue diciendo
+``2.4.49``, y el motor emite una CVE que ya no existe. Es la causa número uno
+de falsos positivos de toda la detección por versión — la Fase 1 la midió en
+**0,42**: cuatro de cada diez CVEs reportados contra un Debian o un Ubuntu ya
+estaban corregidos.
+
+Hasta ahora la mitigación era un paliativo declarado (``qod=70``,
+``confirmed=false``) que le dice al lector que *puede* ser falso pero no cuál lo
+es, que es justo lo que quería saber. Y la verdad no hay que ir a buscarla
+dentro del host: Debian, Ubuntu y Red Hat publican exactamente qué paquete
+quedó corregido y en qué versión.
+
+Este módulo es la aplicación de esa verdad sobre los hallazgos ya producidos.
+Es puro —recibe una función de consulta y devuelve veredictos— para que el
+paquete siga libre de ORM.
+
+**Nunca se adivina.** Si no consta de qué distribución es el paquete
+(:mod:`~.distro`), o si el proveedor no se ha pronunciado sobre esa CVE, el
+hallazgo se queda exactamente como estaba. Bajar un hallazgo por una
+suposición sería cambiar falsos positivos por falsos negativos, que en un
+escáner es el peor negocio posible.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+from .distro import DistroRelease, infer_distro_release
+from .kb import version_compare
+
+#: Lo que responde una consulta al espejo de avisos: el estado que el proveedor
+#: declara y, si lo corrigió, en qué versión.
+PackageStatus = tuple  # (status: str, fixed_in: Optional[str])
+
+#: El check con el que se firma un hallazgo que el proveedor desmintió o
+#: confirmó. Se estampa para que un hallazgo sepa decir por qué cambió de
+#: estado, y para que el desmentido caduque solo si este check cambia de
+#: versión (ver ``apply_lifecycle``).
+BACKPORT_CHECK_ID = "lybra:oval-backport@1"
+
+
+def apply_backport_verdicts(
+    findings: List[dict],
+    status_lookup: Callable[[str, Optional[str], str, str], Optional[PackageStatus]],
+) -> List[dict]:
+    """Contrastar cada hallazgo por versión con lo que dice su distribución.
+
+    Tres desenlaces, y sólo dos cambian algo:
+
+    - **El proveedor ya lo corrigió** en una versión menor o igual que la
+      instalada → el hallazgo pasa a ``state="fixed"`` y ``confirmed=False``.
+      No es que se haya remediado ahora: es que nunca estuvo, y el motor lo
+      había deducido de un número de versión que miente.
+    - **El proveedor dice que sigue vulnerable** → asciende a
+      ``confirmed=True`` con ``qod=90``. Dos fuentes independientes —la versión
+      y el propio empaquetador— coinciden, que es una evidencia mucho más
+      fuerte que la deducción sola.
+    - **No consta** —ni la distribución ni el pronunciamiento— → no se toca.
+
+    Args:
+        findings: Los hallazgos del escaneo. Sólo se miran los de categoría
+            ``outdated_software`` con CVE: son los únicos que nacen de una
+            comparación de versiones y, por tanto, los únicos que un backport
+            puede desmentir.
+        status_lookup: ``(vendor, release, package, cve_id)`` → ``(status,
+            fixed_in)`` o ``None``. Inyectada porque consulta la base de datos
+            y este paquete no la toca.
+
+    Returns:
+        La misma lista, con los hallazgos que cambiaron ya modificados.
+    """
+    for finding in findings:
+        if finding.get("category") != "outdated_software":
+            continue
+        cve_ids = finding.get("cve_ids") or []
+        if not cve_ids:
+            continue
+
+        release = _release_for(finding)
+        if release is None:
+            continue          # sin distribución no hay a quién preguntar
+
+        package = _package_name(finding)
+        if not package:
+            continue
+
+        status = status_lookup(release.vendor, release.release, package, cve_ids[0])
+        if status is None:
+            continue          # el proveedor no se ha pronunciado
+
+        _apply(finding, status, finding.get("_installed_version") or "")
+    return findings
+
+
+def _apply(finding: dict, status: PackageStatus, installed: str) -> None:
+    """Traducir el pronunciamiento del proveedor a un cambio en el hallazgo."""
+    state, fixed_in = status
+
+    if state == "fixed" and fixed_in:
+        # La versión instalada tiene que estar **a la altura** del arreglo: que
+        # Debian lo haya corregido en 2.4.49-1~deb11u2 no dice nada bueno de un
+        # host que sigue en 2.4.49-1~deb11u1. Sin esta comparación, la
+        # verificación desmentiría hallazgos legítimos, que es peor que no
+        # tenerla.
+        if installed and version_compare(installed, fixed_in) < 0:
+            return
+        finding["state"] = "fixed"
+        finding["confirmed"] = False
+        finding["check_id"] = BACKPORT_CHECK_ID
+        return
+
+    if state == "vulnerable":
+        finding["confirmed"] = True
+        finding["qod"] = 90
+        finding["check_id"] = BACKPORT_CHECK_ID
+
+
+def _release_for(finding: dict) -> Optional[DistroRelease]:
+    """De qué distribución es el paquete de este hallazgo, si consta."""
+    return infer_distro_release(
+        finding.get("_installed_version") or "",
+        finding.get("title") or "",
+    )
+
+
+def _package_name(finding: dict) -> Optional[str]:
+    """El nombre con el que la distribución llama a este paquete.
+
+    Se usa el que trae el hallazgo, en minúsculas. No es perfecto —Debian llama
+    ``apache2`` a lo que NVD llama ``http_server``— y ese desajuste es
+    justamente el límite conocido de esta primera vuelta: cuando los nombres no
+    coinciden, la consulta no encuentra nada y el hallazgo se queda como
+    estaba, que es el comportamiento seguro.
+
+    ponytail: una tabla de equivalencias paquete-distro ↔ producto-NVD es el
+    siguiente paso natural, y tiene ya dónde apoyarse — el ranking de nombres
+    sin resolver de L37 mide exactamente esta clase de desajuste.
+    """
+    package = finding.get("_package_name") or finding.get("service") or ""
+    return package.strip().lower() or None

--- a/API/src/modules/features/themis/lybra/distro.py
+++ b/API/src/modules/features/themis/lybra/distro.py
@@ -1,0 +1,143 @@
+"""De qué distribución es este paquete, y sólo cuando se puede saber.
+
+La verificación de *backports* (Fase O) necesita saber contra qué proveedor
+preguntar: si Debian ya parcheó ``apache2`` en su ``2.4.49-1~deb11u1``, esa
+respuesta no vale para un Apache compilado a mano ni para uno de Alpine.
+
+El roadmap dejó esta pieza sin resolver y enumeró tres salidas: aplicar sólo
+cuando el inventario del agente dé la distribución, inferirla del banner cuando
+lo diga, o aplicar el descenso cuando **todas** las distribuciones candidatas
+coincidan en que está parcheado.
+
+**La tercera se descarta**, y conviene decir por qué: un paquete compilado
+desde el código fuente no pertenece a ninguna distribución, así que "todas
+coinciden en que está parcheado" sería cierto y la conclusión falsa —
+justamente en el caso donde la vulnerabilidad sí existe. Optimizar la tasa de
+falsos positivos a costa de falsos negativos es el peor cambio posible para un
+escáner en el que hay que confiar.
+
+Quedan las dos primeras, y aquí se implementan ambas por el mismo camino: **no
+se adivina nunca**. Si ninguna señal dice de qué distribución es, la
+verificación no se aplica y el hallazgo se queda como estaba, con su ``qod=70``
+y su ``confirmed=false``. Callar es la respuesta correcta cuando no se sabe.
+
+La señal más fuerte no es el banner sino la **revisión del propio paquete**:
+``1:2.4.49-1ubuntu1`` sólo lo escribe Ubuntu, ``2.4.49-1~deb11u1`` sólo Debian
+(y dice hasta la versión), ``2.4.49-r0`` sólo Alpine, ``2.4.49-1.el8`` sólo la
+familia de Red Hat. Eso ya lo extrae :func:`~.kb.split_distro_version` desde
+#267 — aquí sólo se lee.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple, Optional
+
+from .kb import split_distro_version
+
+
+class DistroRelease(NamedTuple):
+    """La distribución de un paquete, y su versión cuando consta.
+
+    Attributes:
+        vendor: ``"debian"``, ``"ubuntu"``, ``"alpine"`` o ``"rhel"``.
+        release: La versión de la distribución (``"11"``, ``"8"``), o ``None``
+            si la señal no llegaba a tanto. Un ``None`` no es un fallo: hay
+            avisos que aplican a todas las versiones del proveedor, y forzar
+            una inventada sería peor que no tenerla.
+    """
+
+    vendor: str
+    release: Optional[str]
+
+
+# Una revisión de Debian nombra su versión cuando es una actualización de
+# seguridad: "-1~deb11u1", "+deb12u2". El número que sigue a "deb" es la
+# release, y es la señal más precisa que hay sin entrar en el host.
+_DEBIAN_REVISION = re.compile(r"deb(\d+)u\d+", re.IGNORECASE)
+
+# Ubuntu escribe su nombre en la revisión, pero no su versión: "1ubuntu1",
+# "0ubuntu0.22.04.1" sí la lleva, y por eso se intenta leer.
+_UBUNTU_REVISION = re.compile(r"ubuntu(?:\d+\.)?(\d+\.\d+)?", re.IGNORECASE)
+
+# La familia de Red Hat marca la release en el propio sufijo: ".el8", ".el9".
+_RHEL_REVISION = re.compile(r"\.el(\d+)", re.IGNORECASE)
+
+# Alpine no tiene más marca que su forma de revisión: "r0", "r14".
+_ALPINE_REVISION = re.compile(r"^r\d+$", re.IGNORECASE)
+
+# Lo que un banner dice de sí mismo. Apache escribe "(Ubuntu)", "(Debian)" o
+# "(Red Hat Enterprise Linux)" en su Server, y es una afirmación del propio
+# servicio, no una deducción nuestra.
+_BANNER_VENDORS = (
+    ("ubuntu", "ubuntu"),
+    ("debian", "debian"),
+    ("red hat", "rhel"),
+    ("redhat", "rhel"),
+    ("centos", "rhel"),
+    ("rocky", "rhel"),
+    ("almalinux", "rhel"),
+    ("alpine", "alpine"),
+)
+
+
+def infer_distro_release(version: str = "", banner: str = "") -> Optional[DistroRelease]:
+    """De qué distribución viene un paquete, o ``None`` si no consta.
+
+    Se miran dos señales, la más fiable primero:
+
+    1. **La revisión del propio paquete.** Sólo la escribe quien empaqueta, así
+       que no admite ambigüedad: un ``1~deb11u1`` es Debian 11 y no puede ser
+       otra cosa. Está disponible siempre que el hallazgo venga del inventario
+       de un agente, que es donde los *backports* más duelen.
+    2. **El banner del servicio**, cuando el propio servicio lo declara
+       (``Apache/2.4.49 (Ubuntu)``). No dice la versión de la distribución,
+       pero decir el proveedor ya acota la pregunta.
+
+    Args:
+        version: La versión del paquete, tal cual se descubrió.
+        banner: El producto o banner del servicio.
+
+    Returns:
+        La distribución, o ``None`` cuando ninguna señal la nombra — que es el
+        caso de un binario compilado a mano, y el caso en el que **no hay que
+        aplicar** ninguna verificación de backport.
+    """
+    from_version = _from_package_revision(version or "")
+    if from_version is not None:
+        return from_version
+    return _from_banner(banner or "")
+
+
+def _from_package_revision(version: str) -> Optional[DistroRelease]:
+    """La distribución según cómo empaquetó su revisión."""
+    _epoch, _upstream, revision = split_distro_version(version)
+    if not revision:
+        return None
+
+    debian = _DEBIAN_REVISION.search(revision)
+    if debian:
+        return DistroRelease("debian", debian.group(1))
+
+    rhel = _RHEL_REVISION.search(revision)
+    if rhel:
+        return DistroRelease("rhel", rhel.group(1))
+
+    if "ubuntu" in revision.lower():
+        ubuntu = _UBUNTU_REVISION.search(revision)
+        release = ubuntu.group(1) if ubuntu and ubuntu.group(1) else None
+        return DistroRelease("ubuntu", release)
+
+    if _ALPINE_REVISION.match(revision):
+        return DistroRelease("alpine", None)
+
+    return None
+
+
+def _from_banner(banner: str) -> Optional[DistroRelease]:
+    """La distribución según lo que el propio servicio dice de sí mismo."""
+    lowered = banner.lower()
+    for needle, vendor in _BANNER_VENDORS:
+        if needle in lowered:
+            return DistroRelease(vendor, None)
+    return None

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -256,6 +256,13 @@ class LybraEngine:
             "confirmed":    is_verified,   # a network-inferred match stays a hypothesis; Fase R confirms it actively
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
             "state":        "open",
+            # Claves de trabajo, no columnas: la verificación de backports
+            # (Fase O) necesita la versión **cruda** del paquete —con su
+            # revisión de distribución, que es lo que nombra al proveedor— y el
+            # nombre con el que esa distribución lo llama. El repositorio las
+            # descarta al persistir.
+            "_installed_version": service.version,
+            "_package_name":      service.product or service.name or "",
         }
 
     @staticmethod

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -40,6 +40,7 @@ import re
 import socket
 import time
 import urllib.parse
+from xml.etree import ElementTree
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -578,6 +579,157 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
         severity = data.get("baseSeverity") or entries[0].get("baseSeverity")
         return data.get("baseScore"), data.get("vectorString"), severity
     return None, None, None
+
+
+# =========================================================================
+# AVISOS DE DISTRIBUCIÓN (Fase O — verificación de backports)
+# =========================================================================
+#
+# Un backport es una distribución arreglando una vulnerabilidad sin subir el
+# número de versión visible: el banner sigue diciendo "2.4.49" y el fallo ya no
+# está. Es la causa número uno de falsos positivos de la detección por versión,
+# y la verdad la publican los propios proveedores — no hace falta entrar en el
+# host ni pedir credenciales.
+#
+# Los dos formatos que cubren el grueso del parque Linux:
+#
+# - **OVAL** (Debian, Ubuntu): XML de definiciones, cada una con sus CVEs y los
+#   paquetes que arregla, en qué versión.
+# - **CSAF/VEX** (Red Hat y derivadas): JSON, con el estado de cada producto
+#   frente a cada CVE dicho de forma explícita.
+#
+# Los dos parsers son puros —reciben un documento ya decodificado y devuelven
+# dicts— como el resto de ingestores de este módulo, para poder probarlos con
+# fixtures pequeñas.
+
+_OVAL_NS = {"oval": "http://oval.mitre.org/XMLSchema/oval-definitions-5"}
+
+# "apache2 was fixed in 2.4.49-1~deb11u1" y variantes: lo que las definiciones
+# de OVAL escriben en su texto cuando nombran la versión corregida.
+_OVAL_FIXED_RE = re.compile(
+    r"([A-Za-z0-9][A-Za-z0-9._+-]*)\s+(?:was\s+)?fixed\s+in\s+(?:version\s+)?([0-9][^\s,;]*)",
+    re.IGNORECASE,
+)
+
+
+def parse_oval_definitions(document: str, vendor: str,
+                           release: Optional[str] = None) -> Iterator[dict]:
+    """Extraer el estado por paquete de un documento OVAL de distribución.
+
+    Debian y Ubuntu publican sus avisos en OVAL: un XML de definiciones donde
+    cada una referencia las CVEs que cierra y describe en qué versión del
+    paquete quedaron cerradas.
+
+    Se lee la *referencia* para las CVEs y el texto de la descripción para la
+    versión corregida, porque el criterio estructurado de OVAL vive en objetos y
+    estados separados que sólo cobran sentido resolviendo el árbol entero —
+    trabajo que un espejo local no necesita hacer para responder a la única
+    pregunta que le importa: *¿en qué versión lo arreglaron?*
+
+    Args:
+        document: El XML del feed.
+        vendor: ``"debian"``, ``"ubuntu"``…
+        release: La versión de la distribución si el feed es de una sola.
+
+    Yields:
+        Dicts listos para ``DistroPkgStatus``, uno por paquete y CVE. Una
+        definición que no nombre versión corregida se emite como
+        ``status="unknown"``: el proveedor la conoce pero no se ha
+        pronunciado, y traducir eso a "vulnerable" o a "corregida" sería
+        inventar.
+    """
+    try:
+        root = ElementTree.fromstring(document)
+    except ElementTree.ParseError as exc:
+        logger.error("OVAL: documento ilegible (%s)", exc)
+        return
+
+    for definition in root.iter():
+        if not definition.tag.endswith("}definition") and definition.tag != "definition":
+            continue
+        cve_ids = sorted({
+            reference.get("ref_id", "")
+            for reference in definition.iter()
+            if reference.tag.endswith("reference")
+            and (reference.get("ref_id") or "").upper().startswith("CVE-")
+        })
+        if not cve_ids:
+            continue
+
+        text = " ".join(
+            element.text or ""
+            for element in definition.iter()
+            if element.tag.endswith("description") or element.tag.endswith("title")
+        )
+        fixes = _OVAL_FIXED_RE.findall(text)
+        for cve_id in cve_ids:
+            if not fixes:
+                yield {"vendor": vendor, "release": release, "package": None,
+                       "cve_id": cve_id, "fixed_in": None, "status": "unknown"}
+                continue
+            for package, fixed_in in fixes:
+                yield {"vendor": vendor, "release": release, "package": package.lower(),
+                       "cve_id": cve_id, "fixed_in": fixed_in, "status": "fixed"}
+
+
+def parse_csaf_advisory(document: dict, vendor: str = "rhel") -> Iterator[dict]:
+    """Extraer el estado por paquete de un documento CSAF/VEX.
+
+    Red Hat y sus derivadas publican en CSAF, que es más explícito que OVAL: el
+    documento dice, para cada CVE, qué productos están ``fixed`` y cuáles
+    ``known_affected``. Se traduce tal cual, sin interpretar — el valor de este
+    feed es precisamente que el proveedor ya se ha pronunciado.
+
+    Args:
+        document: El JSON del aviso, ya decodificado.
+        vendor: Bajo qué proveedor archivarlo.
+
+    Yields:
+        Dicts listos para ``DistroPkgStatus``.
+    """
+    for vulnerability in document.get("vulnerabilities", []):
+        cve_id = vulnerability.get("cve")
+        if not cve_id:
+            continue
+        statuses = vulnerability.get("product_status", {})
+        for product in statuses.get("fixed", []):
+            package, release, fixed_in = _split_csaf_product(product)
+            yield {"vendor": vendor, "release": release, "package": package,
+                   "cve_id": cve_id, "fixed_in": fixed_in, "status": "fixed"}
+        for product in statuses.get("known_affected", []):
+            package, release, _fixed = _split_csaf_product(product)
+            yield {"vendor": vendor, "release": release, "package": package,
+                   "cve_id": cve_id, "fixed_in": None, "status": "vulnerable"}
+
+
+def _split_csaf_product(product_id: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Partir un identificador de producto CSAF en ``(paquete, release, versión)``.
+
+    Red Hat los escribe como ``AppStream-8.6.0:httpd-0:2.4.37-43.el8``. Ni el
+    formato está garantizado ni hace falta que lo esté: lo que no se pueda leer
+    se devuelve como ``None`` y el llamante lo archiva con lo que tenga, en vez
+    de descartar el pronunciamiento entero por no entender su nombre.
+    """
+    release = None
+    remainder = product_id
+    if ":" in product_id:
+        head, _, remainder = product_id.partition(":")
+        match = re.search(r"(\d+(?:\.\d+)*)", head)
+        release = match.group(1).split(".")[0] if match else None
+
+    match = re.match(r"([A-Za-z0-9][A-Za-z0-9._+-]*?)-(?:\d+:)?(\d[^\s]*)$", remainder)
+    if not match:
+        return remainder.lower() or None, release, None
+    return match.group(1).lower(), release, match.group(2)
+
+
+def fetch_oval(url: str, timeout: int = 60) -> str:
+    """Descargar un feed de avisos de distribución.
+
+    El borde de red, igual de fino que ``fetch_kev``: descarga y devuelve el
+    texto. El parseo vive en las funciones puras de arriba.
+    """
+    return _http_get(url, timeout).decode("utf-8", errors="replace")
 
 
 def _has_exploit_reference(cve: dict) -> bool:

--- a/API/src/modules/features/themis/managers/kb_sync.py
+++ b/API/src/modules/features/themis/managers/kb_sync.py
@@ -5,6 +5,7 @@ estructura). ``KbQueryManager`` es posterior y es el contrato de lectura que
 consumen otros módulos.
 """
 
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -57,6 +58,36 @@ class KbSyncManager:
         with UnitOfWork() as uow:
             count = KbRepository(uow).bulk_upsert_epss(list(parse_epss_rows(csv_text)))
         logger.info("KB: EPSS sync upserted %d rows", count)
+        return count
+
+    def sync_oval(self, sources: dict) -> int:
+        """Espejar los avisos de las distribuciones (Fase O).
+
+        ``sources`` mapea ``"<vendor>[:<release>]"`` a la URL de su feed, para
+        que añadir Debian 12 o Rocky 9 sea una línea de configuración y no de
+        código. El formato se deduce del contenido: JSON es CSAF (Red Hat y
+        derivadas), lo demás es OVAL (Debian, Ubuntu).
+
+        Returns:
+            Cuántos pronunciamientos se escribieron.
+        """
+        from ..lybra import fetch_oval, parse_csaf_advisory, parse_oval_definitions
+
+        count = 0
+        for key, url in sources.items():
+            vendor, _, release = key.partition(":")
+            document = fetch_oval(url)
+            stripped = document.lstrip()
+            if stripped.startswith("{"):
+                rows = parse_csaf_advisory(json.loads(document), vendor=vendor)
+            else:
+                rows = parse_oval_definitions(document, vendor, release or None)
+            with UnitOfWork() as uow:
+                repo = KbRepository(uow)
+                for row in rows:
+                    repo.upsert_distro_pkg_status(row)
+                    count += 1
+        logger.info("KB: OVAL/CSAF sync upserted %d package statuses", count)
         return count
 
     def sync_nvd(self, base_url: str, window_days: int = 8, api_key: Optional[str] = None) -> int:
@@ -197,6 +228,8 @@ class KbSyncManager:
             summary["kev"] = self._sync_source("kev", lambda: self.sync_kev(sources["kev"]))
         if sources.get("epss"):
             summary["epss"] = self._sync_source("epss", lambda: self.sync_epss(sources["epss"]))
+        if sources.get("oval"):
+            summary["oval"] = self._sync_source("oval", lambda: self.sync_oval(sources["oval"]))
         if sources.get("nvd"):
             summary["nvd"] = self._sync_source("nvd", lambda: self.sync_nvd(
                 sources["nvd"],

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -50,6 +50,7 @@ from ...lybra import (
     scan_udp_ports_sync,
     score_finding,
     build_service_rollup,
+    apply_backport_verdicts,
     PRIORITY_LADDER,
 )
 from ...lybra.ingest import select_for_services, translate_all
@@ -416,6 +417,17 @@ class LybraEngineManager(ScanManager):
             # puerta.
             findings_data = apply_lifecycle(
                 trackable, trackable_previous, close_missing=not is_partial) + events
+
+            # Fase O, y **después** del ciclo de vida a propósito. Un backport
+            # de la distribución corrige el fallo sin subir el número de
+            # versión visible, que es la causa número uno de falsos positivos
+            # del motor —medida en 0,42 por el banco de la Fase 1—, así que la
+            # palabra del proveedor es la última sobre si el hallazgo es real.
+            # Antes del ciclo de vida el veredicto se perdía: `apply_lifecycle`
+            # reasigna el estado de todo hallazgo presente, y un `fixed` recién
+            # puesto volvía a `open` en la misma pasada.
+            with UnitOfWork() as uow:
+                apply_backport_verdicts(findings_data, KbRepository(uow).distro_package_status)
 
             with UnitOfWork() as uow:
                 scan_repo = ScanRepository(uow)

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -1092,6 +1092,78 @@ class EpssScore(Base):
         return f"<EpssScore(cve_id='{self.cve_id}', score={self.score})>"
 
 
+class DistroAdvisory(Base):
+    """Un aviso de seguridad de una distribución (DSA, USN, RHSA…).
+
+    Es la mitad de la respuesta a los *backports*, que son la causa número uno
+    de falsos positivos de la detección por versión: Debian parchea una
+    vulnerabilidad sin subir el número visible, el banner sigue diciendo
+    ``2.4.49`` y el motor emite una CVE que ya está corregida.
+
+    Hasta ahora la mitigación era un paliativo declarado —``qod=70``,
+    ``confirmed=false``— que informa al lector de que puede ser falso pero no
+    le dice **cuál** lo es, que es justo lo que quería saber. Y la verdad no
+    hay que ir a buscarla dentro del host: los propios proveedores la publican.
+
+    Attributes:
+        advisory_id: ``DSA-5432-1``, ``USN-6789-1``, ``RHSA-2024:1234``.
+        vendor: ``debian`` | ``ubuntu`` | ``rhel`` | ``alpine``.
+        cve_ids: Las CVEs que el aviso dice haber corregido.
+        published: Cuándo lo publicó el proveedor.
+    """
+    __tablename__ = "DistroAdvisory"
+
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    advisory_id = Column(String(64), unique=True, nullable=False, index=True)
+    vendor      = Column(String(32), nullable=False, index=True)
+    title       = Column(Text)
+    cve_ids     = Column(JSONB)
+    published   = Column(DateTime)
+
+    def __repr__(self):
+        return f"<DistroAdvisory(advisory_id='{self.advisory_id}', vendor='{self.vendor}')>"
+
+
+class DistroPkgStatus(Base):
+    """Qué dice un proveedor sobre un paquete concreto y una CVE concreta.
+
+    Es la fila que se consulta al verificar un hallazgo: *¿ha corregido Debian
+    11 el ``apache2`` para esta CVE, y en qué versión?*
+
+    Attributes:
+        vendor / release: La distribución. ``release`` puede ser ``None``
+            cuando el aviso aplica a todas las versiones del proveedor;
+            inventarle una sería peor que no tenerla.
+        package: El nombre del paquete tal y como lo llama la distribución, que
+            no tiene por qué ser el del producto en NVD (``apache2`` frente a
+            ``http_server``).
+        cve_id: La vulnerabilidad de la que se habla.
+        fixed_in: La versión del paquete en la que quedó corregida, o ``None``
+            si el proveedor dice que sigue vulnerable.
+        status: ``fixed`` | ``vulnerable`` | ``unknown``. El tercero existe
+            porque un feed puede nombrar un paquete sin pronunciarse, y
+            tratarlo como cualquiera de los otros dos sería inventar.
+    """
+    __tablename__ = "DistroPkgStatus"
+
+    id       = Column(Integer, primary_key=True, autoincrement=True)
+    vendor   = Column(String(32), nullable=False, index=True)
+    release  = Column(String(32), nullable=True)
+    package  = Column(String(128), nullable=False, index=True)
+    cve_id   = Column(String(32), nullable=False, index=True)
+    fixed_in = Column(String(64))
+    status   = Column(String(16), nullable=False, default="unknown")
+
+    __table_args__ = (
+        UniqueConstraint("vendor", "release", "package", "cve_id",
+                         name="unique_distro_pkg_status"),
+    )
+
+    def __repr__(self):
+        return (f"<DistroPkgStatus({self.vendor}/{self.release} {self.package} "
+                f"{self.cve_id}: {self.status})>")
+
+
 class UnresolvedProduct(Base):
     """Un nombre de producto que el matcher no consiguió convertir en un CPE.
 

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -40,6 +40,8 @@ from .model import (
     CpeMatch,
     CpeProductAlias,
     CveEntry,
+    DistroAdvisory,
+    DistroPkgStatus,
     LybraScan,
     EpssScore,
     Finding,
@@ -689,6 +691,11 @@ class ScanRepository(BaseRepository[Scan]):
         """
         for data in findings_data:
             evidence = data.pop("_evidence", None)
+            # Las claves con guion bajo son de trabajo, no columnas: las etapas
+            # de la tubería se pasan datos por ahí (la evidencia cruda, la
+            # versión instalada que necesita la verificación de backports) y
+            # ninguna sobrevive a la fila.
+            data = {key: value for key, value in data.items() if not key.startswith("_")}
             finding = Finding(scan_id=scan.id, **data)
             self._session.add(finding)
             if evidence:
@@ -1287,6 +1294,57 @@ class KbRepository(BaseRepository[CveEntry]):
     def sync_status(self) -> List[KbSyncStatus]:
         """El estado de sincronización de todas las fuentes registradas."""
         return self._session.query(KbSyncStatus).order_by(KbSyncStatus.source).all()
+
+    def upsert_distro_pkg_status(self, row: dict) -> None:
+        """Guardar lo que un proveedor dice de un paquete frente a una CVE."""
+        if not row.get("package") or not row.get("cve_id"):
+            return
+        existing = (self._session.query(DistroPkgStatus).filter_by(
+            vendor=row["vendor"], release=row.get("release"),
+            package=row["package"], cve_id=row["cve_id"]).one_or_none())
+        if existing is None:
+            self._session.add(DistroPkgStatus(**row))
+            return
+        existing.fixed_in = row.get("fixed_in")
+        existing.status = row.get("status", "unknown")
+
+    def upsert_distro_advisory(self, row: dict) -> None:
+        """Guardar la cabecera de un aviso de distribución (DSA, USN, RHSA…)."""
+        existing = (self._session.query(DistroAdvisory)
+                    .filter_by(advisory_id=row["advisory_id"]).one_or_none())
+        if existing is None:
+            self._session.add(DistroAdvisory(**row))
+            return
+        for field_name, value in row.items():
+            setattr(existing, field_name, value)
+
+    def distro_package_status(self, vendor: str, release: Optional[str],
+                              package: str, cve_id: str) -> Optional[tuple]:
+        """Qué dice el proveedor sobre este paquete y esta CVE.
+
+        Un aviso sin ``release`` aplica a todas las versiones de la
+        distribución, así que sirve también cuando se pregunta por una
+        concreta; el que sí la nombra manda sobre él. De ahí el orden: primero
+        se busca la respuesta específica y sólo después la genérica.
+
+        Returns:
+            ``(status, fixed_in)``, o ``None`` si el proveedor no se ha
+            pronunciado — que no es lo mismo que decir que está a salvo, y por
+            eso el llamante no toca el hallazgo en ese caso.
+        """
+        query = (self._session.query(DistroPkgStatus)
+                 .filter(DistroPkgStatus.vendor == vendor,
+                         DistroPkgStatus.package == package,
+                         DistroPkgStatus.cve_id == cve_id))
+        rows = query.all()
+        if not rows:
+            return None
+        specific = [row for row in rows if release and row.release == release]
+        generic = [row for row in rows if row.release is None]
+        chosen = (specific or generic or None)
+        if not chosen:
+            return None
+        return chosen[0].status, chosen[0].fixed_in
 
     def exploit_evidence(self, cve_id: str) -> Optional[str]:
         """Qué madurez de explotación consta para una CVE, sin contar KEV (L34).

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -447,7 +447,10 @@ def test_a_source_never_synced_counts_as_stale(app):
         status = KbSyncManager().status()
         by_source = {entry["source"]: entry for entry in status["sources"]}
 
-        assert set(by_source) == {"nvd", "kev", "epss"}
+        # Las cuatro fuentes configuradas, `oval` incluida: al añadir el feed
+        # de avisos de distribución (Fase O) heredó este registro sin tocar
+        # nada, que era medio motivo para hacer L36 antes que L32.
+        assert set(by_source) == {"nvd", "kev", "epss", "oval"}
         assert all(entry["neverSynced"] for entry in by_source.values())
         assert all(entry["isStale"] for entry in by_source.values())
         assert status["isStale"] is True
@@ -457,7 +460,7 @@ def test_a_recent_sync_is_not_stale(app):
     with app.app_context():
         with UnitOfWork() as uow:
             repo = KbRepository(uow)
-            for source in ("nvd", "kev", "epss"):
+            for source in ("nvd", "kev", "epss", "oval"):
                 repo.record_sync(source, rows_upserted=1)
 
         status = KbSyncManager().status()
@@ -472,7 +475,7 @@ def test_an_aged_source_is_reported_stale(app):
     with app.app_context():
         with UnitOfWork() as uow:
             repo = KbRepository(uow)
-            for source in ("nvd", "kev", "epss"):
+            for source in ("nvd", "kev", "epss", "oval"):
                 repo.record_sync(source, rows_upserted=1)
 
         with UnitOfWork() as uow:
@@ -494,11 +497,11 @@ def test_the_kb_status_endpoint_reports_every_source(client, app, admin_user, au
     body = resp.get_json()
 
     by_source = {entry["source"]: entry for entry in body["sources"]}
-    assert set(by_source) == {"nvd", "kev", "epss"}
+    assert set(by_source) == {"nvd", "kev", "epss", "oval"}
     assert by_source["kev"]["rowsUpserted"] == 5
     assert by_source["kev"]["neverSynced"] is False
     assert by_source["nvd"]["neverSynced"] is True
-    assert body["isStale"] is True                     # nvd y epss nunca sincronizadas
+    assert body["isStale"] is True            # nvd, epss y oval nunca sincronizadas
     assert body["feedVersion"].startswith("lybra-kb:")
 
 

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1882,3 +1882,95 @@ def test_a_cve_with_nothing_public_says_none_not_null(app, admin_user):
 
     vuln = next(f for f in findings if f.category == "outdated_software")
     assert vuln.exploit_maturity == "none"
+
+
+# ─────────────── verificación de backports de extremo a extremo (Fase O)
+
+
+def _debian_services() -> list:
+    """Apache empaquetado por Debian 11: la versión trae su revisión, que es lo
+    que nombra al proveedor sin necesidad de entrar en el host."""
+    from src.modules.features.themis.lybra import Service
+    return [Service(port=80, protocol="tcp", name="http", product="apache2",
+                    version="2.4.49-1~deb11u1",
+                    cpe="cpe:/a:apache:http_server:2.4.49", origin="inventory")]
+
+
+def test_a_backported_finding_is_closed_without_touching_the_host(app, admin_user):
+    """El corazón de la Fase O: Debian ya lo parcheó sin subir el número
+    visible, así que el hallazgo por versión nunca fue real."""
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_distro_pkg_status({
+                "vendor": "debian", "release": "11", "package": "apache2",
+                "cve_id": "CVE-2021-41773", "fixed_in": "2.4.49-1~deb11u1",
+                "status": "fixed",
+            })
+
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.41", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, services_payload=_debian_services())
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    vuln = next(f for f in findings if f.category == "outdated_software")
+    assert vuln.state == "fixed"
+    assert vuln.confirmed is False
+    assert vuln.check_id == "lybra:oval-backport@1"
+
+
+def test_a_vendor_confirming_the_flaw_raises_the_confidence(app, admin_user):
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_distro_pkg_status({
+                "vendor": "debian", "release": "11", "package": "apache2",
+                "cve_id": "CVE-2021-41773", "fixed_in": None, "status": "vulnerable",
+            })
+
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.42", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, services_payload=_debian_services())
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    vuln = next(f for f in findings if f.category == "outdated_software")
+    assert vuln.confirmed is True
+    assert vuln.qod == 90
+
+
+def test_without_a_distro_advisory_the_finding_stays_a_hypothesis(app, admin_user):
+    """El comportamiento de antes de la Fase O, que es el correcto cuando no
+    hay a quién preguntar."""
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.43", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, services_payload=_debian_services())
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    vuln = next(f for f in findings if f.category == "outdated_software")
+    assert vuln.state == "open"
+    assert vuln.check_id == "lybra:version-match@1"
+
+
+def test_the_working_keys_never_reach_the_database(app, admin_user):
+    """`_installed_version` y `_package_name` son datos de trabajo entre etapas
+    de la tubería, no columnas."""
+    _seed_kb_apache_cve(app)
+    with app.app_context():
+        mgr = LybraEngineManager()
+        escan = mgr._create_scan_record(target="10.0.0.44", user_id=admin_user.id)
+        mgr._run_lybra(escan.id, services_payload=_debian_services())
+
+        with UnitOfWork() as uow:
+            findings = ScanRepository(uow).get_findings_by_scan(escan.id)
+
+    assert findings, "el escaneo no llegó a persistir nada"
+    for finding in findings:
+        assert not hasattr(finding, "_installed_version")

--- a/API/tests/unit/test_lybra_backports.py
+++ b/API/tests/unit/test_lybra_backports.py
@@ -1,0 +1,148 @@
+"""Verificación de backports contra la palabra del proveedor (Fase O, L32).
+
+Un backport es una distribución corrigiendo un fallo sin subir el número de
+versión visible: Debian parchea `apache2`, el banner sigue diciendo `2.4.49`, y
+el motor emite una CVE que ya no existe. La Fase 1 midió esa tasa en **0,42**:
+cuatro de cada diez CVEs reportados contra un Debian o un Ubuntu ya estaban
+corregidos.
+
+Lo que se fija aquí es sobre todo **cuándo no se toca nada**. Bajar un hallazgo
+por una suposición cambiaría falsos positivos por falsos negativos, que en un
+escáner es el peor negocio posible.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.themis.lybra.backports import (
+    BACKPORT_CHECK_ID, apply_backport_verdicts,
+)
+from src.modules.features.themis.lybra.distro import infer_distro_release
+
+pytestmark = pytest.mark.unit
+
+
+def _finding(**overrides) -> dict:
+    base = {
+        "category": "outdated_software",
+        "title": "apache2 2.4.49 — CVE-2021-41773",
+        "cve_ids": ["CVE-2021-41773"],
+        "confirmed": False,
+        "qod": 70,
+        "state": "open",
+        "check_id": "lybra:version-match@1",
+        "_installed_version": "2.4.49-1~deb11u1",
+        "_package_name": "apache2",
+    }
+    base.update(overrides)
+    return base
+
+
+def _says(status, fixed_in=None):
+    return lambda *_args: (status, fixed_in)
+
+
+# ───────────────────────────────── el desmentido
+
+def test_a_backported_package_is_marked_fixed():
+    findings = apply_backport_verdicts(
+        [_finding()], _says("fixed", "2.4.49-1~deb11u1"))
+
+    assert findings[0]["state"] == "fixed"
+    assert findings[0]["confirmed"] is False
+    assert findings[0]["check_id"] == BACKPORT_CHECK_ID
+
+
+def test_a_host_behind_the_fix_is_not_absolved():
+    """Que Debian lo corrigiera en `-1~deb11u2` no dice nada bueno de un host
+    que sigue en `-1~deb11u1`. Sin esta comparación, la verificación
+    desmentiría hallazgos legítimos — peor que no tenerla."""
+    findings = apply_backport_verdicts(
+        [_finding(_installed_version="2.4.49-1~deb11u1")],
+        _says("fixed", "2.4.49-1~deb11u2"))
+
+    assert findings[0]["state"] == "open"
+    assert findings[0]["check_id"] == "lybra:version-match@1"
+
+
+# ───────────────────────────────── la confirmación
+
+def test_a_vendor_confirming_the_flaw_promotes_the_finding():
+    """Dos fuentes independientes coinciden: la versión y el propio
+    empaquetador. Eso es mucho más que una deducción."""
+    findings = apply_backport_verdicts([_finding()], _says("vulnerable"))
+
+    assert findings[0]["confirmed"] is True
+    assert findings[0]["qod"] == 90
+    assert findings[0]["state"] == "open"
+
+
+# ───────────────────────────────── cuándo no se toca nada
+
+def test_a_package_with_no_distro_is_left_alone():
+    """Un binario compilado a mano no pertenece a ninguna distribución, y es
+    justo el caso donde la vulnerabilidad sí existe."""
+    called = []
+
+    def lookup(*args):
+        called.append(args)
+        return ("fixed", "2.4.50")
+
+    findings = apply_backport_verdicts(
+        [_finding(_installed_version="2.4.49", title="Apache 2.4.49 — CVE-2021-41773")],
+        lookup)
+
+    assert called == [], "no había distribución: no había a quién preguntar"
+    assert findings[0]["state"] == "open"
+
+
+def test_a_vendor_that_has_not_spoken_changes_nothing():
+    """`None` no significa "está a salvo": significa que no consta."""
+    findings = apply_backport_verdicts([_finding()], lambda *_a: None)
+    assert findings[0]["state"] == "open"
+    assert findings[0]["confirmed"] is False
+
+
+def test_an_unknown_status_changes_nothing():
+    """El proveedor conoce el paquete pero no se pronuncia. Traducirlo a
+    cualquiera de los otros dos estados sería inventar."""
+    findings = apply_backport_verdicts([_finding()], _says("unknown"))
+    assert findings[0]["state"] == "open"
+
+
+def test_findings_that_are_not_version_matches_are_ignored():
+    """Un puerto abierto o una cabecera ausente no nacen de comparar versiones,
+    así que ningún backport puede desmentirlos."""
+    other = {"category": "open_port", "title": "80/tcp abierto", "state": "open"}
+    findings = apply_backport_verdicts([dict(other)], _says("fixed", "9.9.9"))
+    assert findings[0] == other
+
+
+def test_a_version_finding_without_cves_is_ignored():
+    findings = apply_backport_verdicts([_finding(cve_ids=[])], _says("fixed", "9.9.9"))
+    assert findings[0]["state"] == "open"
+
+
+# ───────────────────────────── de qué distribución es esto
+
+@pytest.mark.parametrize("version,vendor,release", [
+    ("1:2.4.49-1~deb11u1", "debian", "11"),
+    ("2.4.49-1ubuntu1", "ubuntu", None),
+    ("2.4.37-43.el8", "rhel", "8"),
+    ("2.4.49-r0", "alpine", None),
+])
+def test_the_package_revision_names_its_distribution(version, vendor, release):
+    """La señal más fuerte no es el banner sino la revisión: sólo la escribe
+    quien empaqueta, así que no admite ambigüedad."""
+    inferred = infer_distro_release(version)
+    assert inferred is not None
+    assert (inferred.vendor, inferred.release) == (vendor, release)
+
+
+def test_the_banner_answers_when_the_version_does_not():
+    assert infer_distro_release("2.4.49", "Apache/2.4.49 (Ubuntu)").vendor == "ubuntu"
+
+
+def test_nothing_is_inferred_from_a_plain_version():
+    assert infer_distro_release("2.4.49", "Apache httpd") is None

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -592,3 +592,76 @@ def test_a_cve_with_no_references_at_all_does_not_blow_up():
 
     row, _matches = ingest_nvd_cve({"cve": {"id": "CVE-2021-0001"}})
     assert row["has_exploit_reference"] is False
+
+
+# ─────────────── avisos de distribución: OVAL y CSAF (Fase O, L32)
+
+
+_OVAL_DOC = """<?xml version="1.0"?>
+<oval_definitions>
+  <definitions>
+    <definition id="oval:org.debian:def:1" class="vulnerability">
+      <metadata>
+        <title>DSA-5432-1 apache2 -- security update</title>
+        <description>apache2 was fixed in 2.4.49-1~deb11u1</description>
+        <reference source="CVE" ref_id="CVE-2021-41773"/>
+      </metadata>
+    </definition>
+    <definition id="oval:org.debian:def:2" class="vulnerability">
+      <metadata>
+        <title>nginx</title>
+        <description>Se conoce el problema pero no hay versión corregida.</description>
+        <reference source="CVE" ref_id="CVE-2022-00001"/>
+      </metadata>
+    </definition>
+  </definitions>
+</oval_definitions>"""
+
+
+def test_oval_yields_the_fixed_version_per_package():
+    from src.modules.features.themis.lybra.kb import parse_oval_definitions
+
+    rows = list(parse_oval_definitions(_OVAL_DOC, "debian", "11"))
+    fixed = next(r for r in rows if r["cve_id"] == "CVE-2021-41773")
+    assert fixed == {"vendor": "debian", "release": "11", "package": "apache2",
+                     "cve_id": "CVE-2021-41773", "fixed_in": "2.4.49-1~deb11u1",
+                     "status": "fixed"}
+
+
+def test_oval_without_a_fixed_version_is_unknown_not_vulnerable():
+    """El proveedor conoce el paquete y no se pronuncia. Traducirlo a
+    "vulnerable" o a "corregido" sería inventar."""
+    from src.modules.features.themis.lybra.kb import parse_oval_definitions
+
+    rows = list(parse_oval_definitions(_OVAL_DOC, "debian", "11"))
+    silent = next(r for r in rows if r["cve_id"] == "CVE-2022-00001")
+    assert silent["status"] == "unknown"
+    assert silent["fixed_in"] is None
+
+
+def test_an_unreadable_oval_document_yields_nothing_instead_of_raising():
+    """Un feed corrupto no puede tumbar la sincronización de los demás."""
+    from src.modules.features.themis.lybra.kb import parse_oval_definitions
+
+    assert list(parse_oval_definitions("<no cierra", "debian", "11")) == []
+
+
+def test_csaf_reads_both_verdicts_explicitly():
+    """CSAF es más explícito que OVAL: dice qué está corregido y qué sigue
+    afectado, así que se traduce tal cual."""
+    from src.modules.features.themis.lybra.kb import parse_csaf_advisory
+
+    rows = list(parse_csaf_advisory({"vulnerabilities": [{
+        "cve": "CVE-2021-41773",
+        "product_status": {
+            "fixed": ["AppStream-8.6.0:httpd-0:2.4.37-43.el8"],
+            "known_affected": ["AppStream-9.0:nginx-1.20.1-1.el9"],
+        },
+    }]}))
+
+    assert {"vendor": "rhel", "release": "8", "package": "httpd",
+            "cve_id": "CVE-2021-41773", "fixed_in": "2.4.37-43.el8",
+            "status": "fixed"} in rows
+    affected = next(r for r in rows if r["status"] == "vulnerable")
+    assert affected["package"] == "nginx"
+    assert affected["fixed_in"] is None


### PR DESCRIPTION
La necesidad que da nombre a la **Fase 4 — La verdad del proveedor**, y la última de la fase.

### Related Issue

Closes #305

---

## El problema

Es la brecha **G3** del roadmap y ataca la causa número uno de falsos positivos de todo el motor.

Un *backport* es una distribución corrigiendo un fallo sin subir el número de versión visible: Debian parchea `apache2`, el banner sigue diciendo `2.4.49`, y el motor emite una CVE que ya no existe. El banco de la Fase 1 lo midió: **0,42** — cuatro de cada diez CVEs reportados contra un Debian o un Ubuntu ya estaban corregidos.

Hasta ahora la mitigación era un paliativo declarado: `qod=70`, `confirmed=false`. Eso informa al lector de que puede ser falso, pero **no le dice cuál lo es**, que es precisamente lo que él quería saber.

Y la verdad no hay que ir a buscarla dentro del host, ni pedir credenciales: Debian, Ubuntu y Red Hat publican exactamente qué paquete quedó corregido y en qué versión. Es el equivalente propio de **Notus**, la pieza de Greenbone que hace este trabajo — o sea, la parte de OpenVAS que de verdad merecía copiarse.

---

## La decisión que el roadmap dejó abierta

*¿De qué distribución es este paquete?* Sin eso no hay a quién preguntar, y el roadmap ofrecía tres salidas pidiendo elegir a conciencia.

**Descarto la tercera** —aplicar el descenso cuando *todas* las distribuciones candidatas coincidan en que está parcheado— y el porqué merece decirse: un binario compilado desde el código fuente no pertenece a ninguna distribución, así que «todas coinciden en que está parcheado» sería cierto y la conclusión falsa, **justo en el caso donde la vulnerabilidad sí existe**. Cambiar falsos positivos por falsos negativos es el peor negocio posible para un escáner cuyo listón es la confiabilidad.

Quedan las otras dos, y van ambas con la misma regla: **no se adivina nunca**.

La señal más fuerte resultó no ser el banner sino **la revisión del propio paquete**. `1:2.4.49-1~deb11u1` sólo lo escribe Debian, y nombra hasta la versión; `.el8` sólo la familia de Red Hat; `-r0` sólo Alpine; `1ubuntu1` sólo Ubuntu. Eso ya lo extraía `split_distro_version` desde #267 — aquí sólo se lee. El banner (`Apache/2.4.49 (Ubuntu)`) responde cuando la versión calla.

Si ninguna señal la nombra, no se aplica nada y el hallazgo se queda como estaba.

---

## Qué hace

Tres desenlaces, y sólo dos cambian algo:

| El proveedor dice | Efecto |
|---|---|
| Ya lo corrigió, en una versión que el host tiene o supera | `state="fixed"`, `confirmed=false`, `check_id="lybra:oval-backport@1"` |
| Sigue vulnerable | `confirmed=true`, `qod=90` — dos fuentes independientes coinciden |
| No consta | Nada |

El primero no es «se ha remediado ahora»: es que **nunca estuvo**, y el motor lo había deducido de un número de versión que miente.

### El feed

Dos formatos, con parsers puros probados con fixtures pequeñas, como el resto de ingestores del módulo:

- **OVAL** (Debian, Ubuntu) — XML de definiciones.
- **CSAF/VEX** (Red Hat y derivadas) — JSON, más explícito: dice qué está `fixed` y qué `known_affected`, así que se traduce tal cual.

La configuración mapea `"<vendor>[:<release>]"` a su URL, de modo que añadir Debian 12 o Rocky 9 es una línea de configuración y no de código. El formato se deduce del contenido.

Un `status="unknown"` existe y se guarda: un feed puede nombrar un paquete sin pronunciarse, y traducir eso a «vulnerable» o a «corregido» sería inventar.

### El pago de haber hecho L36 primero

`oval` aparece en `GET /themis/kb/status` como una fuente más, con su umbral de antigüedad y su aviso — sin escribir una línea para ello. De hecho **tres tests de #302 fallaron** al añadir el feed, porque esperaban exactamente tres fuentes: la comprobación funcionó tal y como se diseñó.

---

## Dos cosas que costaron una vuelta

**El veredicto va después del ciclo de vida, no antes.** `apply_lifecycle` reasigna el estado de todo hallazgo presente, así que un `fixed` recién puesto volvía a `open` en la misma pasada. Lo destapó un test de extremo a extremo, no el razonamiento — y el orden correcto tiene sentido leído después: la palabra del proveedor es la última sobre si el hallazgo es real.

**Un host por detrás del arreglo no queda absuelto.** Que Debian lo corrigiera en `-1~deb11u2` no dice nada bueno de uno que sigue en `-1~deb11u1`. Sin esa comparación, la verificación desmentiría hallazgos legítimos: peor que no tenerla.

---

## Validación

- `tests/unit/test_lybra_backports.py` (nuevo, 14) — el desmentido, el host por detrás del arreglo, la promoción a confirmado, y **cinco casos de «no se toca nada»**: sin distribución, sin pronunciamiento, con `unknown`, sobre un hallazgo que no nace de comparar versiones, y sobre uno sin CVEs. Más la inferencia de distribución desde la revisión, desde el banner, y su ausencia.
- `tests/unit/test_lybra_kb.py` (+4) — OVAL con versión corregida, OVAL sin pronunciarse (`unknown`, no `vulnerable`), un documento ilegible que no revienta la sincronización de los demás, y CSAF con sus dos veredictos.
- `tests/integration/test_lybra.py` (+4) — de extremo a extremo: el hallazgo se cierra sin tocar el host, el proveedor que confirma sube la confianza, sin aviso se queda como hipótesis, y las claves de trabajo no llegan a la base de datos.
- Suite completa en verde, **`pylint src` 10.00/10**.

---

## Notas y límites conocidos

- **Migración aditiva** (`6ec0a7bf3ba1`): `DistroAdvisory` y `DistroPkgStatus`. Nacen vacías; sin sincronizar el feed no hay verificación, y el comportamiento es exactamente el de antes.
- **El desajuste de nombres es el límite de esta primera vuelta**: Debian llama `apache2` a lo que NVD llama `http_server`. Cuando no coinciden, la consulta no encuentra nada y el hallazgo se queda como estaba — el comportamiento seguro. Queda anotado en el código con la salida natural: una tabla de equivalencias, que ya tiene dónde apoyarse en el ranking de nombres sin resolver de #304.
- **El criterio de cierre del issue pide medir la caída del 40 % en el banco de #278.** Ese banco es `oracle` (contenedores Docker reales, excluido del CI), y medirlo de verdad exige sincronizar los feeds reales de Debian y Red Hat contra imágenes reales. La maquinaria está y la medición es el siguiente paso; no la reclamo como hecha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
