### PR TITLE
El autodescubrimiento fallaba en todos los casos, y el aviso de KB salía mal el primer día

### DIFF
--- a/API/src/modules/features/themis/managers/kb_sync.py
+++ b/API/src/modules/features/themis/managers/kb_sync.py
@@ -259,11 +259,21 @@ class KbSyncManager:
 
         Se recorren las fuentes **configuradas**, no las filas de la tabla: una
         fuente que no se ha sincronizado nunca no tiene fila, y es justo la que
-        más importa reportar. Aparece con ``neverSynced`` y cuenta como vieja.
+        más importa reportar.
+
+        **Nunca sincronizada no es lo mismo que desactualizada**, y confundirlas
+        costaba un falso positivo el día del despliegue: ``KbSyncStatus`` nace
+        vacía en cada instalación, así que sin esta distinción el aviso saltaba
+        para todo el mundo hasta la primera sincronización nocturna, sobre un
+        espejo que podía tener 350.000 CVEs dentro. Sólo se afirma que una
+        fuente está vieja cuando se puede establecer: hay registro y está
+        pasado de plazo, o no hay registro **y** la fuente está vacía. Lo de en
+        medio —contenido sin registro— es ``isUnverified``, que es información
+        y no una alarma.
 
         Returns:
-            ``{"sources": [...], "isStale": bool, "feedVersion": str}``, con
-            una entrada por fuente configurada.
+            ``{"sources": [...], "isStale": bool, "isUnverified": bool,
+            "feedVersion": str}``, con una entrada por fuente configurada.
         """
         from ..lybra import kb_feed_version
 
@@ -275,18 +285,37 @@ class KbSyncManager:
             repo = KbRepository(uow)
             rows = {row.source: row for row in repo.sync_status()}
             content_state = repo.knowledge_state()
+            filled = repo.has_content()
             feed_version = kb_feed_version(content_state)
 
         sources = []
         for name in sorted(config.sources):
             row = rows.get(name)
             limit_days = max_age.get(name)
+            has_content = filled.get(name, False)
+
             age_days = None
             if row is not None and row.last_success_at is not None:
                 age_days = round((now - row.last_success_at).total_seconds() / 86400, 2)
-            # Nunca sincronizada cuenta como vieja: no saber nada de una fuente
-            # es peor que saber que lleva días parada, no mejor.
-            is_stale = age_days is None or (limit_days is not None and age_days > limit_days)
+
+            if age_days is not None:
+                is_stale = limit_days is not None and age_days > limit_days
+                is_unverified = False
+            else:
+                # Sin registro de sincronización sólo se puede afirmar que la
+                # fuente está vieja **si además está vacía**. Si tiene
+                # contenido, lo único cierto es que no sabemos cuándo entró: es
+                # una fuente sin verificar, no una fuente caducada, y decir lo
+                # segundo sería gritar sobre un catálogo que puede estar
+                # perfectamente al día.
+                #
+                # No se usa la fecha del contenido para inventarle una edad,
+                # que era la salida tentadora: sirve para NVD y EPSS, que se
+                # publican a diario, y miente para KEV, cuyo `date_added` más
+                # nuevo puede llevar semanas quieto con un espejo impecable.
+                is_stale = not has_content
+                is_unverified = has_content
+
             newest = content_state.get(name)
             sources.append({
                 "source": name,
@@ -295,15 +324,18 @@ class KbSyncManager:
                 "rowsUpserted": row.rows_upserted if row else None,
                 "error": row.error if row else None,
                 "neverSynced": row is None or row.last_success_at is None,
+                "hasContent": has_content,
                 "ageDays": age_days,
                 "maxAgeDays": limit_days,
                 "isStale": is_stale,
+                "isUnverified": is_unverified,
                 "newestContentAt": isoformat_utc(newest) if newest else None,
             })
 
         return {
             "sources": sources,
             "isStale": any(entry["isStale"] for entry in sources),
+            "isUnverified": any(entry["isUnverified"] for entry in sources),
             "feedVersion": feed_version,
         }
 
@@ -322,10 +354,16 @@ class KbSyncManager:
                     logger.warning(
                         "KB: la fuente '%s' está desactualizada (%s, límite %s días)%s",
                         entry["source"],
-                        "nunca sincronizada" if entry["neverSynced"]
+                        "vacía y nunca sincronizada" if entry["neverSynced"]
                         else f"{entry['ageDays']} días",
                         entry["maxAgeDays"],
                         f" — último error: {entry['error']}" if entry["error"] else "",
+                    )
+                elif entry["isUnverified"]:
+                    logger.info(
+                        "KB: la fuente '%s' tiene contenido pero ninguna sincronización "
+                        "registrada todavía; no se puede afirmar su frescura",
+                        entry["source"],
                     )
         except Exception:
             logger.exception("KB sync failed")

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -277,6 +277,12 @@ class LybraEngineManager(ScanManager):
             # alcanzabilidad y las consultas de apertura del escaneo. El
             # cancel_check baja hasta el barrido de puertos —la fase más larga—
             # para que un escaneo grande se pueda parar a mitad.
+            # Los nombres de los argumentos son parte del contrato con
+            # ``_discover_ports``, y esta llamada es la única que lo ejercita en
+            # producción: un desajuste aquí no lo ve ningún test que sustituya
+            # el método por un doble, que es lo que hacen todos los de
+            # integración. `test_the_probe_wiring_reaches_the_real_method` lo
+            # recorre de verdad.
             discover_ports=lambda target, ports: self._discover_ports(
                 target=target,
                 ports=ports,
@@ -454,7 +460,7 @@ class LybraEngineManager(ScanManager):
     def _discover_ports(
         self,
         target: str,
-        discover_ports,
+        ports=None,
         budget_seconds: Optional[float] = None,
         cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Optional[PortSweep]:
@@ -476,7 +482,7 @@ class LybraEngineManager(ScanManager):
         engine = CR.lybra_engine_config()
         try:
             sweep = sweep_with_retries(
-                target, discover_ports,
+                target, ports,
                 concurrency=engine.tcp_concurrency,
                 timeout=engine.tcp_timeout,
                 retries=engine.udp_retries,

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -1407,6 +1407,33 @@ class KbRepository(BaseRepository[CveEntry]):
             "cpeMatches": self._session.query(CpeMatch).count(),
             "kev": self._session.query(KevEntry).count(),
             "epss": self._session.query(EpssScore).count(),
+            "distroPkgStatus": self._session.query(DistroPkgStatus).count(),
+        }
+
+    def has_content(self) -> dict:
+        """Si cada fuente de la KB tiene algo dentro, por nombre de fuente.
+
+        Responde a una pregunta distinta de :meth:`knowledge_state` y de
+        :meth:`sync_status`, y las tres hacen falta para no confundir tres
+        situaciones que se parecen: *cuán reciente es lo que sabemos*, *cuándo
+        lo preguntamos y funcionó*, y *si sabemos algo en absoluto*.
+
+        La tercera es la que evita el falso positivo del día del despliegue:
+        ``KbSyncStatus`` nace vacía en cada instalación, así que "nunca
+        sincronizada" es cierto para todas las fuentes aunque el espejo tenga
+        350.000 CVEs dentro. Sin este recuento, el aviso de frescura le grita a
+        todo el mundo la primera semana — y un aviso que sale mal el primer día
+        enseña a ignorar los avisos.
+
+        Las claves son las de ``features.themis.kb.sources``, no las de las
+        tablas, porque quien pregunta razona en fuentes.
+        """
+        totals = self.counts()
+        return {
+            "nvd": totals["cves"] > 0,
+            "kev": totals["kev"] > 0,
+            "epss": totals["epss"] > 0,
+            "oval": totals["distroPkgStatus"] > 0,
         }
 
     # =========================================================================

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -579,3 +579,49 @@ def test_the_ranking_endpoint_filters_by_origin(client, app, admin_user, auth_he
 
 def test_the_ranking_endpoint_requires_authentication(client):
     assert client.get("/themis/lybra/unresolved-products").status_code == 401
+
+
+def test_a_source_with_content_but_no_sync_record_is_not_stale(app):
+    """El falso positivo del día del despliegue.
+
+    `KbSyncStatus` nace vacía en cada instalación, así que "nunca sincronizada"
+    es cierto para todas las fuentes aunque el espejo tenga cientos de miles de
+    CVEs dentro. Decir "desactualizada" sobre eso es gritar sobre un catálogo
+    que puede estar perfectamente al día — y un aviso que sale mal el primer
+    día enseña a ignorar los avisos.
+    """
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [])
+
+        by_source = {e["source"]: e for e in KbSyncManager().status()["sources"]}
+
+        assert by_source["nvd"]["neverSynced"] is True
+        assert by_source["nvd"]["hasContent"] is True
+        assert by_source["nvd"]["isStale"] is False, "hay contenido: no se puede afirmar que esté vieja"
+        assert by_source["nvd"]["isUnverified"] is True
+
+
+def test_a_source_that_is_empty_and_unsynced_is_stale(app):
+    """Lo que sí se puede afirmar: una fuente sin registro **y** sin contenido
+    no tiene nada que ofrecer, y eso el operador tiene que saberlo."""
+    with app.app_context():
+        by_source = {e["source"]: e for e in KbSyncManager().status()["sources"]}
+
+        assert by_source["oval"]["hasContent"] is False
+        assert by_source["oval"]["isStale"] is True
+        assert by_source["oval"]["isUnverified"] is False
+
+
+def test_the_alarm_separates_what_it_can_prove_from_what_it_cannot(app):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            KbRepository(uow).upsert_cve(_cve_row(), [])
+
+        status = KbSyncManager().status()
+
+    # `oval` sigue vacía, así que hay alarma; pero `nvd` no la provoca.
+    assert status["isStale"] is True
+    assert status["isUnverified"] is True
+    stale = [e["source"] for e in status["sources"] if e["isStale"]]
+    assert "nvd" not in stale

--- a/API/tests/unit/test_lybra_scan_budget.py
+++ b/API/tests/unit/test_lybra_scan_budget.py
@@ -112,3 +112,61 @@ def test_the_worker_entry_point_carries_the_timeout(monkeypatch):
     # El timeout sigue viajando como cuarto posicional; cancel_check y progress
     # van como kwargs (el JobHandle del worker), fuera de esta comprobación.
     assert seen == [(7, [80], None, 90), (8, [80], None, None)]
+
+
+# ─────────────── el cableado entre el motor y sus sondas
+#
+# Todo escaneo de autodescubrimiento falló en producción por un nombre de
+# parámetro: la lambda que construye `DiscoveryProbes` llamaba a
+# `_discover_ports(ports=...)` y el método lo declaraba como `discover_ports`.
+# `TypeError`, capturado por el `except Exception` de `_run_lybra`, escaneo en
+# `failed`.
+#
+# La suite entera pasó en verde. El motivo es que **todos** los tests de
+# integración que ejercitan el autodescubrimiento sustituyen `_discover_ports`
+# por un doble, así que la lambda nunca llega a llamar al método de verdad: la
+# costura que falló era justo la que ningún test recorría. Estos dos la
+# recorren.
+
+
+def _probes_of(manager, **kwargs):
+    """Los `DiscoveryProbes` que `_run_lybra` construye, sin correr el escaneo.
+
+    Se llama al constructor real y se le pasa lo mismo que le pasaría el
+    escaneo, para que el contrato entre la lambda y el método quede ejercitado.
+    """
+    from src.modules.features.themis.managers.lybra.sources import DiscoveryProbes
+
+    return DiscoveryProbes(
+        is_host_reachable=manager.is_host_reachable,
+        discover_ports=lambda target, ports: manager._discover_ports(  # noqa: SLF001
+            target=target, ports=ports, budget_seconds=None, cancel_check=None),
+        discover_udp_ports=manager._discover_udp_ports,  # noqa: SLF001
+    )
+
+
+def test_the_probe_wiring_reaches_the_real_method(monkeypatch):
+    """La llamada que hace `sources.resolve_services`, contra el método real."""
+    captured = {}
+
+    def fake_sweep(target, ports, **kwargs):
+        captured["target"] = target
+        captured["ports"] = ports
+        return _clean_sweep()
+
+    monkeypatch.setattr(engine_module, "sweep_with_retries", fake_sweep)
+
+    probes = _probes_of(LybraEngineManager())
+    sweep = probes.discover_ports("10.0.0.5", [80, 443])
+
+    assert sweep.open_ports == (80,)
+    assert captured == {"target": "10.0.0.5", "ports": [80, 443]}
+
+
+def test_the_udp_probe_wiring_reaches_the_real_method(monkeypatch):
+    """La misma comprobación para la otra sonda: `sources` la llama con un solo
+    argumento posicional, y el método tiene que aceptarlo tal cual."""
+    monkeypatch.setattr(engine_module, "scan_udp_ports_sync", lambda target, **kw: [161])
+
+    probes = _probes_of(LybraEngineManager())
+    assert probes.discover_udp_ports("10.0.0.5") == [161]

--- a/web/app/src/stores/themisStore.js
+++ b/web/app/src/stores/themisStore.js
@@ -335,8 +335,14 @@ export const useThemisStore = defineStore('themis', () => {
    * congelado — un CVE publicado ayer no existe para el motor, y el informe
    * afirma que el host está limpio. El aviso existe para que eso deje de ser
    * invisible.
+   *
+   * `isStale` y `isUnverified` no son lo mismo, y sólo el primero es una
+   * alarma: una fuente con contenido pero sin sincronización registrada no
+   * está caducada, simplemente no se puede afirmar su frescura. Confundirlas
+   * hacía saltar el aviso en toda instalación recién desplegada, porque la
+   * tabla de estado nace vacía.
    */
-  const kbStatus = reactive({ sources: [], isStale: false, feedVersion: null, loaded: false })
+  const kbStatus = reactive({ sources: [], isStale: false, isUnverified: false, feedVersion: null, loaded: false })
 
   async function loadKbStatus() {
     try {
@@ -345,6 +351,7 @@ export const useThemisStore = defineStore('themis', () => {
       const data = await res.json()
       kbStatus.sources = data.sources ?? []
       kbStatus.isStale = !!data.isStale
+      kbStatus.isUnverified = !!data.isUnverified
       kbStatus.feedVersion = data.feedVersion ?? null
       kbStatus.loaded = true
     } catch { /* el aviso es informativo: si no se puede leer, no se muestra */ }

--- a/web/app/src/views/ThemisView.vue
+++ b/web/app/src/views/ThemisView.vue
@@ -37,9 +37,14 @@
         <HistoryPanel v-if="store.viewMode === 'history'" />
         <template v-else>
           <!-- La detección por versión vale lo que valga la frescura del espejo
-               local de NVD/KEV/EPSS. Si deja de refrescarse, los escaneos siguen
-               saliendo en verde contra un catálogo congelado: el aviso existe
-               para que eso deje de ser invisible. -->
+               local de NVD/KEV/EPSS/OVAL. Si deja de refrescarse, los escaneos
+               siguen saliendo en verde contra un catálogo congelado: el aviso
+               existe para que eso deje de ser invisible.
+
+               Sólo se avisa de lo que se puede afirmar. Una fuente con
+               contenido pero sin sincronización registrada no está caducada —y
+               eso le pasa a toda instalación recién desplegada, porque la tabla
+               de estado nace vacía—, así que ésa no dispara la alarma. -->
           <div v-if="store.kbStatus.loaded && store.kbStatus.isStale" class="kb-stale">
             <strong>Base de conocimiento desactualizada.</strong>
             {{ staleSourcesLabel }} Los hallazgos por versión se resuelven contra ese catálogo,
@@ -260,11 +265,18 @@ const currentData = computed(() => store.scans[store.activeTab])
 const hasActiveScan = computed(() =>
   currentData.value.results.some(s => s.status === 'pending' || s.status === 'running')
 )
-/** Las fuentes viejas, en una frase legible para el aviso. */
+/**
+ * Las fuentes de las que sí se puede afirmar que están viejas, en una frase.
+ *
+ * Una fuente sin registro de sincronización sólo entra aquí si además está
+ * vacía — y entonces lo que se dice es que no hay datos, no que hayan
+ * caducado. Decir «nunca se ha sincronizado» sobre un espejo con 350.000 CVEs
+ * dentro era el falso positivo que este aviso traía de fábrica.
+ */
 const staleSourcesLabel = computed(() => {
   const stale = store.kbStatus.sources.filter(s => s.isStale)
   const parts = stale.map(s => s.neverSynced
-    ? `${s.source.toUpperCase()} nunca se ha sincronizado`
+    ? `${s.source.toUpperCase()} está vacía y nunca se ha sincronizado`
     : `${s.source.toUpperCase()} lleva ${s.ageDays} días sin actualizarse`)
   return parts.length ? `${parts.join('; ')}.` : ''
 })


### PR DESCRIPTION
Dos correcciones sobre lo que la Fase 4 dejó, ambas detectadas usando el producto y no leyendo el código. **La primera es urgente**: rompe la funcionalidad principal del panel de Lybra.

---

## 1. El autodescubrimiento fallaba en todos los casos

Todo escaneo lanzado desde el panel terminaba en `failed`:

```
TypeError: LybraEngineManager._discover_ports() got an unexpected keyword argument 'ports'
```

La lambda que construye `DiscoveryProbes` llama a `_discover_ports(ports=...)` y el método declaraba ese parámetro como `discover_ports`. El `TypeError` caía en el `except Exception` de `_run_lybra`, el escaneo se marcaba fallido, y la única pista era una línea de log.

Sólo se salvaba el modo de payload externo —el análisis de inventario de Hygeia—, que nunca pasa por el descubrimiento. Por eso todo *parecía* funcionar por el lado de los agentes.

El parámetro pasa a llamarse `ports`, que además es el nombre correcto: un argumento llamado `discover_ports` dentro de un método llamado `_discover_ports` no dice qué es.

### Por qué 2.700 tests estaban en verde

Esta es la parte que merece la pena.

**Todos** los tests de integración que ejercitan el autodescubrimiento sustituyen `_discover_ports` por un doble:

```python
monkeypatch.setattr(LybraEngineManager, "_discover_ports",
                    lambda self, target, ports, **_kwargs: _sweep([80, 22]))
```

Así que la lambda nunca llega a llamar al método de verdad. El contrato entre ambos —los nombres de sus argumentos— era exactamente lo que ningún test recorría, y un desajuste ahí es invisible para la suite entera.

Dos tests nuevos lo recorren: construyen los `DiscoveryProbes` reales y los llaman como lo hace `sources.resolve_services`, contra el método real. Uno por sonda, porque la de UDP tiene el mismo tipo de contrato y el mismo punto ciego.

---

## 2. El aviso de frescura salía mal el primer día

El panel avisaba de que NVD, KEV, EPSS y OVAL «nunca se han sincronizado» sobre un espejo con cientos de miles de CVEs dentro.

La causa está en una línea de `status()`, que introduje en #432:

```python
is_stale = age_days is None or (limit_days is not None and age_days > limit_days)
```

Ese `age_days is None` traduce *«no hay registro de sincronización»* a *«está desactualizada»*, y no es lo mismo. `KbSyncStatus` la crea la migración vacía y sólo la escribe `sync_all`, así que **toda instalación recién desplegada** dispara el aviso hasta la primera sincronización nocturna. No es un problema de un entorno de desarrollo: le habría pasado a producción el día del despliegue.

Y un aviso que sale mal el primer día enseña a ignorar los avisos, que es lo contrario de para lo que se puso.

### Ahora sólo se afirma lo que se puede establecer

- **Hay registro y está pasado de plazo** → vieja. Alarma.
- **No hay registro y la fuente está vacía** → vieja, y el operador tiene que saberlo: sin avisos de distribución, por ejemplo, la verificación de backports no hace nada en silencio. Alarma.
- **Contenido sin registro** → `isUnverified`. No se puede decir cuándo entró, y decir que ha caducado sería inventarlo. Información, no alarma.

### Una salida que descarté

Usar la fecha del contenido para calcularle una edad cuando no hay registro. Era lo tentador —`newestContentAt` ya viajaba en la misma respuesta— y sirve para NVD y EPSS, que se publican a diario.

**Miente para KEV.** Su `date_added` más nuevo puede llevar semanas quieto con un espejo impecable, porque CISA añade entradas a rachas. Habría cambiado un falso positivo por otro más difícil de ver.

---

## Validación

- `tests/unit/test_lybra_scan_budget.py` (+2) — el cableado real entre la lambda y las dos sondas.
- `tests/integration/test_kb_repository.py` (+3) — una fuente con contenido y sin registro **no** es vieja; una vacía y sin registro sí; y la alarma separa lo que puede probar de lo que no.
- Suite completa en verde, **`pylint src` 10.00/10**, `npm run build` correcto.
- Sin migraciones. El campo `isUnverified` y `hasContent` se suman a la respuesta de `/themis/kb/status`; nada se quita.

## Nota

El bug del autodescubrimiento entró con la Fase 3 y llevaba desde entonces en `v0.5`. Está en el PR de producción #439 sin mergear, así que **conviene meter esto antes de desplegar**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
