### PR TITLE
Visor de logs: atajos de ventana, filtro por severidad minima y lectura que no recorre el fichero entero

### DIFF
--- a/API/src/modules/system/endpoints.py
+++ b/API/src/modules/system/endpoints.py
@@ -119,7 +119,12 @@ def status():
 @system_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
 @system_blp.alt_response(404, schema=ErrorSchema, description="Log file not found")
 @system_blp.alt_response(409, schema=ErrorSchema, description="Log changed during pagination")
-@limiter.limit("30 per hour; 100 per day")
+# Leer el log no es una operación puntual: una sesión de investigación prueba
+# varias ventanas, pagina y refresca, y con el refresco automático del panel
+# son cuatro peticiones por minuto. Las 30/hora anteriores se agotaban en
+# minutos y dejaban el panel inservible justo cuando hacía falta. El tope
+# diario sigue acotando el abuso.
+@limiter.limit("240 per hour; 2000 per day")
 @require_oauth_token
 @require_role(minimum_role=Role.ADMIN)
 def system_logs(query_args):

--- a/API/src/modules/system/schemas.py
+++ b/API/src/modules/system/schemas.py
@@ -101,6 +101,18 @@ class LogQuerySchema(Schema):
         allow_none=True,
         validate=validate.OneOf(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     )
+    min_level = fields.String(
+        data_key="minLevel",
+        load_default=None,
+        allow_none=True,
+        validate=validate.OneOf(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    )
+    """Severidad mínima: ``minLevel=WARNING`` trae WARNING, ERROR y CRITICAL.
+
+    Complementa a ``level``, que sigue siendo de valor exacto. Si se envían
+    los dos, se aplican ambos.
+    """
+
     contains = fields.String(
         load_default=None,
         allow_none=True,
@@ -123,6 +135,11 @@ class SystemLogsResponseSchema(Schema):
     truncated = fields.Boolean(required=True)
     totalLines = fields.Integer(required=True)
     returnedLines = fields.Integer(required=True)
+    levelCounts = fields.Dict(
+        keys=fields.String(),
+        values=fields.Integer(),
+        required=True,
+    )
     page = fields.Integer(required=True)
     perPage = fields.Integer(required=True)
     totalPages = fields.Integer(required=True)

--- a/API/src/modules/system/schemas.py
+++ b/API/src/modules/system/schemas.py
@@ -96,6 +96,18 @@ class LogQuerySchema(Schema):
     )
     from_ = fields.DateTime(data_key="from", load_default=None, allow_none=True)
     to = fields.DateTime(load_default=None, allow_none=True)
+    last_minutes = fields.Integer(
+        data_key="lastMinutes",
+        load_default=None,
+        allow_none=True,
+        validate=validate.Range(min=1, max=525_600),
+    )
+    """Ventana relativa al reloj del servidor: ``lastMinutes=30`` es la media
+    hora anterior. Es incompatible con ``from``, y existe porque las marcas del
+    log son hora local de la API: si la calculara el navegador, un
+    administrador conectado desde otro huso pediría una ventana desplazada.
+    """
+
     level = fields.String(
         load_default=None,
         allow_none=True,
@@ -150,6 +162,7 @@ class SystemLogsResponseSchema(Schema):
     snapshotBytes = fields.Integer(required=True)
     currentBytes = fields.Integer(required=True)
     lastModified = fields.String(required=True)
+    windowStart = fields.String(required=True)
     timeZone = fields.String(required=True)
     firstLine = fields.Integer(allow_none=True)
     lastLine = fields.Integer(allow_none=True)

--- a/API/src/modules/system/services/log_reader.py
+++ b/API/src/modules/system/services/log_reader.py
@@ -161,6 +161,9 @@ def read_logs(query: dict) -> dict:
         "snapshotBytes": snapshot.size,
         "currentBytes": snapshot.current_size,
         "lastModified": snapshot.modified_at,
+        # Hora de servidor desde la que se ha leído, para que el panel pueda
+        # decir qué ventana está enseñando sin recalcularla por su cuenta.
+        "windowStart": filters.start.isoformat(timespec="seconds") if filters.start else "",
         "timeZone": _local_timezone_name(),
         "firstLine": selected[0].number if selected else None,
         "lastLine": selected[-1].number if selected else None,
@@ -170,6 +173,17 @@ def read_logs(query: dict) -> dict:
 def _build_filters(query: dict) -> _LogFilters:
     start = _normalise_datetime(query.get("from_"))
     end = _normalise_datetime(query.get("to"))
+    last_minutes = query.get("last_minutes")
+
+    if last_minutes:
+        if start is not None:
+            raise LogQueryError("lastMinutes y from son excluyentes")
+        # La ventana se resuelve con el reloj del servidor a propósito. Las
+        # marcas del log no llevan zona horaria: son la hora local de la API.
+        # Si el navegador calculara el "hace diez minutos", un administrador
+        # conectado desde otro huso pediría una ventana desplazada.
+        start = datetime.now() - timedelta(minutes=last_minutes)
+
     if start is not None and end is not None and start > end:
         raise LogQueryError("from no puede ser posterior a to")
 

--- a/API/src/modules/system/services/log_reader.py
+++ b/API/src/modules/system/services/log_reader.py
@@ -13,8 +13,9 @@ import gzip
 import hashlib
 import re
 
+from collections import deque
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import src.modules.system.config_reading as CR
@@ -35,6 +36,27 @@ _LEVEL_SEVERITY = {
 }
 _SNAPSHOT_PREFIX_BYTES = 64 * 1024
 _SNAPSHOT_TOKEN_MAX_LENGTH = 512
+
+# El log lo escriben dos procesos (la API y el worker), así que su orden
+# cronológico no es perfecto. Medido sobre un log real de 190 000 líneas: 10
+# inversiones, y la peor de 18 ms. Un segundo de holgura al bisecar cubre ese
+# desorden con varios órdenes de magnitud de margen.
+_MONOTONIC_SLACK = timedelta(seconds=1)
+
+# Por debajo de este tamaño, leer el fichero entero cuesta menos que bisecarlo.
+_BISECTION_MIN_BYTES = 256 * 1024
+
+# Líneas que se aceptan sin marca de tiempo antes de darse por vencido en un
+# sondeo de la bisección. Un traceback de Python es la razón de que haga falta
+# más de una: solo su primera línea lleva prefijo.
+_PROBE_MAX_LINES = 200
+
+# Tope del búfer que permite resolver el modo `tail` en una sola pasada. Por
+# encima —páginas muy profundas— se vuelve a las dos pasadas, que son más
+# lentas pero no retienen nada.
+_TAIL_BUFFER_MAX_LINES = 5000
+
+_LINE_COUNT_CHUNK_BYTES = 1024 * 1024
 
 _LOG_LINE_RE = re.compile(
     r"^\[\+\]\s+\[(?P<level>[A-Z]+)\]\s+"
@@ -248,14 +270,27 @@ def _prefix_digest(path: Path, size: int) -> str:
         return hashlib.sha256(handle.read(min(size, _SNAPSHOT_PREFIX_BYTES))).hexdigest()
 
 
-def _iter_lines(path: Path, snapshot_size: int):
-    consumed = 0
-    line_number = 0
+def _iter_lines(
+    path: Path,
+    snapshot_size: int,
+    start_offset: int = 0,
+    first_line_number: int = 1,
+):
+    """Recorre el log desde ``start_offset``, que debe caer en inicio de línea.
+
+    ``first_line_number`` es el número absoluto de la línea que empieza en ese
+    desplazamiento: quien salta a mitad del fichero tiene que traerlo contado
+    aparte para que ``firstLine``/``lastLine`` sigan siendo números de línea
+    del fichero y no de la ventana.
+    """
+    consumed = start_offset
+    line_number = first_line_number - 1
     previous_timestamp = None
     previous_level = None
 
     try:
         with path.open("rb") as handle:
+            handle.seek(start_offset)
             while consumed < snapshot_size:
                 raw = handle.readline()
                 if not raw:
@@ -283,6 +318,124 @@ def _iter_lines(path: Path, snapshot_size: int):
                 yield _ParsedLine(line_number, text, timestamp, level)
     except OSError as exc:
         raise LogNotFoundError from exc
+
+
+@dataclass(frozen=True)
+class _Probe:
+    """Primera línea con marca de tiempo encontrada a partir de un sondeo."""
+
+    offset: int
+    next_offset: int
+    timestamp: datetime
+
+
+def _iter_window(path: Path, snapshot_size: int, filters: _LogFilters):
+    """Recorre solo el tramo del fichero que la ventana temporal puede tocar.
+
+    Filtrar por fecha después de leer no ahorra ni un byte: pedir los últimos
+    diez minutos de un log de 21 MB seguía leyendo los 21 MB. Como el log se
+    escribe en orden cronológico, el principio de la ventana se encuentra por
+    bisección sobre desplazamientos de byte, y el final corta la lectura en
+    cuanto se pasa de la fecha pedida.
+    """
+    start_offset, first_line_number = _window_start(path, snapshot_size, filters.start)
+    limit = filters.end + _MONOTONIC_SLACK if filters.end else None
+
+    for line in _iter_lines(path, snapshot_size, start_offset, first_line_number):
+        if limit is not None and line.timestamp is not None and line.timestamp > limit:
+            return
+        yield line
+
+
+def _window_start(
+    path: Path, snapshot_size: int, start: datetime | None
+) -> tuple[int, int]:
+    """Devuelve el desplazamiento donde empezar a leer y su número de línea."""
+    if start is None or snapshot_size <= _BISECTION_MIN_BYTES:
+        return 0, 1
+
+    offset = _bisect_offset(path, snapshot_size, start - _MONOTONIC_SLACK)
+    if offset <= 0:
+        return 0, 1
+    return offset, _count_lines_before(path, offset) + 1
+
+
+def _bisect_offset(path: Path, snapshot_size: int, target: datetime) -> int:
+    """Busca el primer inicio de línea cuya marca de tiempo alcanza ``target``."""
+    low = 0
+    high = snapshot_size
+    answer = snapshot_size
+
+    try:
+        with path.open("rb") as handle:
+            while low < high:
+                middle = (low + high) // 2
+                probe = _probe_timestamp(handle, middle, snapshot_size)
+                if probe is None:
+                    # A partir de aquí no queda ninguna línea legible, así que
+                    # lo que se busca solo puede estar por detrás.
+                    high = middle
+                elif probe.timestamp >= target:
+                    answer = min(answer, probe.offset)
+                    high = middle
+                else:
+                    low = probe.next_offset
+    except OSError as exc:
+        raise LogNotFoundError from exc
+
+    # Los dos límites son inicios de línea válidos, y quedarse corto solo
+    # cuesta unas líneas de más que el filtro descartará igualmente. Pasarse
+    # de largo, en cambio, perdería líneas sin que nada lo delatara: la
+    # bisección nunca llega a examinar la línea que empieza justo en `low`.
+    return min(low, answer)
+
+
+def _probe_timestamp(handle, offset: int, snapshot_size: int) -> _Probe | None:
+    """Primera línea con marca de tiempo que empieza en ``offset`` o después."""
+    handle.seek(offset)
+    if offset > 0:
+        # El sondeo cae casi siempre a mitad de línea; ese resto no es una
+        # línea y su prefijo no se puede leer.
+        partial = handle.readline()
+        if not partial:
+            return None
+        offset += len(partial)
+
+    for _ in range(_PROBE_MAX_LINES):
+        if offset >= snapshot_size:
+            return None
+        raw = handle.readline()
+        if not raw or offset + len(raw) > snapshot_size:
+            return None
+        timestamp, _level = _parse_line_prefix(raw.decode("utf-8", errors="replace"))
+        if timestamp is not None:
+            return _Probe(offset, offset + len(raw), timestamp)
+        offset += len(raw)
+
+    return None
+
+
+def _count_lines_before(path: Path, offset: int) -> int:
+    """Cuenta los saltos de línea anteriores a ``offset``.
+
+    Es la parte del prefijo que sí hay que pagar para no perder la numeración
+    absoluta, pero se paga barata: contar saltos de línea en crudo sobre el
+    log de 21 MB cuesta 37 ms, frente a 1,18 s de la lectura completa con
+    decodificación, expresión regular y parseo de fechas.
+    """
+    remaining = offset
+    newlines = 0
+    try:
+        with path.open("rb") as handle:
+            while remaining > 0:
+                chunk = handle.read(min(remaining, _LINE_COUNT_CHUNK_BYTES))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+                newlines += chunk.count(b"\n")
+    except OSError as exc:
+        raise LogNotFoundError from exc
+    return newlines
 
 
 def _parse_line_prefix(text: str) -> tuple[datetime | None, str | None]:
@@ -336,7 +489,7 @@ def _scan_head(
     total = 0
     selected = []
     level_counts = _empty_level_counts()
-    for line in _iter_lines(path, snapshot_size):
+    for line in _iter_window(path, snapshot_size, filters):
         if not _is_in_window(line, filters):
             continue
         if line.level in level_counts:
@@ -361,6 +514,11 @@ def _select_page(
         page_start = (page - 1) * per_page
         return _scan_head(path, snapshot_size, filters, page_start, page_start + per_page)
 
+    if page * per_page <= _TAIL_BUFFER_MAX_LINES:
+        return _scan_tail(path, snapshot_size, filters, page, per_page)
+
+    # Páginas muy profundas: el búfer de la pasada única sería demasiado
+    # grande, así que se vuelve a contar primero y recoger después.
     total_lines, level_counts = _count_matches(path, snapshot_size, filters)
     end_index = total_lines - (page - 1) * per_page
     start_index = max(0, end_index - per_page)
@@ -372,13 +530,52 @@ def _select_page(
     return total_lines, selected, level_counts
 
 
+def _scan_tail(
+    path: Path,
+    snapshot_size: int,
+    filters: _LogFilters,
+    page: int,
+    per_page: int,
+) -> tuple[int, list[_ParsedLine], dict[str, int]]:
+    """Resuelve una página del final del log en una sola pasada.
+
+    Leer desde el final exige saber cuántas coincidencias hay en total, y eso
+    obligaba a recorrer el fichero dos veces: una para contarlas y otra para
+    recoger la página. Guardando por el camino las últimas ``page × per_page``
+    coincidencias —500 líneas para la quinta página de cien— el recuento y la
+    página salen del mismo recorrido.
+    """
+    recent = deque(maxlen=page * per_page)
+    total = 0
+    level_counts = _empty_level_counts()
+
+    for line in _iter_window(path, snapshot_size, filters):
+        if not _is_in_window(line, filters):
+            continue
+        if line.level in level_counts:
+            level_counts[line.level] += 1
+        if not _has_requested_level(line, filters):
+            continue
+        recent.append(line)
+        total += 1
+
+    end_index = total - (page - 1) * per_page
+    if end_index <= 0:
+        return total, [], level_counts
+
+    start_index = max(0, end_index - per_page)
+    buffered_from = total - len(recent)
+    selected = list(recent)[start_index - buffered_from:end_index - buffered_from]
+    return total, selected, level_counts
+
+
 def _count_matches(
     path: Path, snapshot_size: int, filters: _LogFilters
 ) -> tuple[int, dict[str, int]]:
     """Cuenta coincidencias y, de paso, cuántas líneas hay de cada nivel."""
     total = 0
     level_counts = _empty_level_counts()
-    for line in _iter_lines(path, snapshot_size):
+    for line in _iter_window(path, snapshot_size, filters):
         if not _is_in_window(line, filters):
             continue
         if line.level in level_counts:
@@ -397,7 +594,7 @@ def _collect_range(
 ) -> list[_ParsedLine]:
     selected = []
     index = 0
-    for line in _iter_lines(path, snapshot_size):
+    for line in _iter_window(path, snapshot_size, filters):
         if not _matches(line, filters):
             continue
         if start_index <= index < end_index:

--- a/API/src/modules/system/services/log_reader.py
+++ b/API/src/modules/system/services/log_reader.py
@@ -23,6 +23,16 @@ from ..exceptions import LogNotFoundError, LogQueryError, LogSnapshotChangedErro
 
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGE_SIZE = 500
+
+# Orden de severidad de los niveles de logging. Es lo que permite pedir
+# "WARNING y por encima" en una sola consulta en vez de una consulta por nivel.
+_LEVEL_SEVERITY = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARNING": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
 _SNAPSHOT_PREFIX_BYTES = 64 * 1024
 _SNAPSHOT_TOKEN_MAX_LENGTH = 512
 
@@ -45,10 +55,21 @@ class _Snapshot:
 
 @dataclass(frozen=True)
 class _LogFilters:
+    """Filtros de una consulta, separados en dos grupos a propósito.
+
+    ``start``/``end``/``contains`` delimitan la **ventana**: el conjunto de
+    líneas sobre el que se cuenta cuántas hay de cada nivel. ``level`` y
+    ``minimum_severity`` filtran *dentro* de esa ventana. Contar antes de
+    aplicarlos es lo que hace útiles los contadores: quien está mirando solo
+    los errores sigue viendo cuántos avisos hay al lado, y sabe si vale la
+    pena ampliar la consulta.
+    """
+
     start: datetime | None
     end: datetime | None
-    level: str | None
     contains: str | None
+    level: str | None
+    minimum_severity: int | None
 
 
 @dataclass(frozen=True)
@@ -82,7 +103,7 @@ def read_logs(query: dict) -> dict:
     log_path = _log_path()
     snapshot = _resolve_snapshot(log_path, query.get("snapshot"))
 
-    total_lines, selected = _select_page(
+    total_lines, selected, level_counts = _select_page(
         log_path, snapshot.size, filters, page, per_page, position
     )
 
@@ -104,6 +125,10 @@ def read_logs(query: dict) -> dict:
         "truncated": total_lines > len(selected),
         "totalLines": total_lines,
         "returnedLines": len(selected),
+        # Cuenta por nivel de la ventana (fechas + texto), *antes* de aplicar
+        # el filtro de nivel: así el panel puede decir "aquí hay 3 errores"
+        # aunque en ese momento se estén mirando solo los avisos.
+        "levelCounts": level_counts,
         "page": page,
         "perPage": per_page,
         "totalPages": total_pages,
@@ -128,11 +153,20 @@ def _build_filters(query: dict) -> _LogFilters:
 
     level = query.get("level")
     contains = query.get("contains")
+    minimum_level = query.get("min_level")
+
+    minimum_severity = None
+    if minimum_level:
+        minimum_severity = _LEVEL_SEVERITY.get(minimum_level.upper())
+        if minimum_severity is None:
+            raise LogQueryError("min_level no es un nivel de logging conocido")
+
     return _LogFilters(
         start=start,
         end=end,
-        level=level.upper() if level else None,
         contains=contains.casefold() if contains else None,
+        level=level.upper() if level else None,
+        minimum_severity=minimum_severity,
     )
 
 
@@ -262,9 +296,8 @@ def _parse_line_prefix(text: str) -> tuple[datetime | None, str | None]:
     return timestamp, match.group("level")
 
 
-def _matches(line: _ParsedLine, filters: _LogFilters) -> bool:
-    if filters.level and line.level != filters.level:
-        return False
+def _is_in_window(line: _ParsedLine, filters: _LogFilters) -> bool:
+    """Comprueba los filtros que delimitan la ventana, sin mirar el nivel."""
     if filters.contains and filters.contains not in line.text.casefold():
         return False
     if filters.start and (line.timestamp is None or line.timestamp < filters.start):
@@ -274,22 +307,46 @@ def _matches(line: _ParsedLine, filters: _LogFilters) -> bool:
     return True
 
 
+def _has_requested_level(line: _ParsedLine, filters: _LogFilters) -> bool:
+    """Comprueba los filtros de nivel: valor exacto y/o severidad mínima."""
+    if filters.level and line.level != filters.level:
+        return False
+    if filters.minimum_severity is not None:
+        severity = _LEVEL_SEVERITY.get(line.level or "")
+        if severity is None or severity < filters.minimum_severity:
+            return False
+    return True
+
+
+def _matches(line: _ParsedLine, filters: _LogFilters) -> bool:
+    return _is_in_window(line, filters) and _has_requested_level(line, filters)
+
+
+def _empty_level_counts() -> dict[str, int]:
+    return {level: 0 for level in _LEVEL_SEVERITY}
+
+
 def _scan_head(
     path: Path,
     snapshot_size: int,
     filters: _LogFilters,
     start_index: int,
     end_index: int,
-) -> tuple[int, list[_ParsedLine]]:
+) -> tuple[int, list[_ParsedLine], dict[str, int]]:
     total = 0
     selected = []
+    level_counts = _empty_level_counts()
     for line in _iter_lines(path, snapshot_size):
-        if not _matches(line, filters):
+        if not _is_in_window(line, filters):
+            continue
+        if line.level in level_counts:
+            level_counts[line.level] += 1
+        if not _has_requested_level(line, filters):
             continue
         if start_index <= total < end_index:
             selected.append(line)
         total += 1
-    return total, selected
+    return total, selected, level_counts
 
 
 def _select_page(
@@ -299,12 +356,12 @@ def _select_page(
     page: int,
     per_page: int,
     position: str,
-) -> tuple[int, list[_ParsedLine]]:
+) -> tuple[int, list[_ParsedLine], dict[str, int]]:
     if position == "head":
         page_start = (page - 1) * per_page
         return _scan_head(path, snapshot_size, filters, page_start, page_start + per_page)
 
-    total_lines = _count_matches(path, snapshot_size, filters)
+    total_lines, level_counts = _count_matches(path, snapshot_size, filters)
     end_index = total_lines - (page - 1) * per_page
     start_index = max(0, end_index - per_page)
     selected = (
@@ -312,11 +369,23 @@ def _select_page(
         if end_index > 0
         else []
     )
-    return total_lines, selected
+    return total_lines, selected, level_counts
 
 
-def _count_matches(path: Path, snapshot_size: int, filters: _LogFilters) -> int:
-    return sum(1 for line in _iter_lines(path, snapshot_size) if _matches(line, filters))
+def _count_matches(
+    path: Path, snapshot_size: int, filters: _LogFilters
+) -> tuple[int, dict[str, int]]:
+    """Cuenta coincidencias y, de paso, cuántas líneas hay de cada nivel."""
+    total = 0
+    level_counts = _empty_level_counts()
+    for line in _iter_lines(path, snapshot_size):
+        if not _is_in_window(line, filters):
+            continue
+        if line.level in level_counts:
+            level_counts[line.level] += 1
+        if _has_requested_level(line, filters):
+            total += 1
+    return total, level_counts
 
 
 def _collect_range(

--- a/API/tests/integration/test_system.py
+++ b/API/tests/integration/test_system.py
@@ -4,6 +4,7 @@ import copy
 import base64
 import gzip
 import json
+from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
@@ -232,6 +233,65 @@ def test_log_rejects_an_unknown_minimum_level(
     )
 
     assert response.status_code == 422
+
+
+def test_log_last_minutes_uses_the_server_clock(
+    client, admin_user, auth_headers, tmp_path, monkeypatch
+):
+    """La ventana relativa la resuelve el servidor, no el navegador.
+
+    Las marcas del log son hora local de la API y no llevan zona horaria, así
+    que "los últimos diez minutos" solo significa lo mismo para todos si lo
+    calcula quien escribe el log. El test escribe entradas relativas a la hora
+    real de la máquina para que el cálculo sea comprobable.
+    """
+    now = datetime.now()
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    def _entry(minutes_ago, level, message):
+        stamp = now - timedelta(minutes=minutes_ago)
+        printed = stamp.strftime("%Y-%m-%d %H:%M:%S,") + f"{stamp.microsecond // 1000:03d}"
+        return f"[+] [{level}] ({printed}) test: {message}"
+
+    (log_dir / "secops.log").write_text(
+        "\n".join([
+            _entry(120, "ERROR", "hace dos horas"),
+            _entry(45, "WARNING", "hace tres cuartos de hora"),
+            _entry(5, "ERROR", "hace cinco minutos"),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(CR, "get_directory_of", lambda _directory: str(log_dir))
+
+    response = client.get(
+        "/system/logs",
+        query_string={"position": "head", "lastMinutes": 60},
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 200
+    payload, content = _decode_log_content(response)
+    assert [line.split(": ", 1)[1] for line in content.splitlines()] == [
+        "hace tres cuartos de hora",
+        "hace cinco minutos",
+    ]
+    assert payload["windowStart"]
+    assert payload["levelCounts"]["ERROR"] == 1
+
+
+def test_log_rejects_a_relative_and_an_absolute_window_together(
+    client, admin_user, auth_headers, _isolated_log_file
+):
+    """Pedir las dos cosas es ambiguo, y se rechaza en vez de elegir una."""
+    response = client.get(
+        "/system/logs",
+        query_string={"lastMinutes": 30, "from": "2026-08-18T10:00:00"},
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_log_query"
 
 
 def test_log_snapshot_survives_appends(client, admin_user, auth_headers, _isolated_log_file):

--- a/API/tests/integration/test_system.py
+++ b/API/tests/integration/test_system.py
@@ -144,6 +144,96 @@ def test_root_reads_log_and_head_pagination_filters(
     assert payload["lastLine"] == 3
 
 
+def test_log_minimum_level_returns_every_severity_above_it(
+    client, admin_user, auth_headers, _isolated_log_file
+):
+    """`minLevel` evita tener que consultar un nivel cada vez.
+
+    El log de la fixture tiene un WARNING y un ERROR entre dos INFO. Pedir
+    `minLevel=WARNING` debe traer los dos en una sola respuesta.
+    """
+    response = client.get(
+        "/system/logs",
+        query_string={"position": "head", "minLevel": "WARNING"},
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 200
+    payload, content = _decode_log_content(response)
+    assert content.splitlines() == [
+        "[+] [WARNING] (2026-08-18 10:01:00,000) test.two: aviso",
+        "[+] [ERROR] (2026-08-18 10:02:00,000) test.three: fallo",
+    ]
+    assert payload["totalLines"] == 2
+
+
+def test_log_level_counts_ignore_the_level_filter(
+    client, admin_user, auth_headers, _isolated_log_file
+):
+    """Los contadores describen la ventana, no la página filtrada.
+
+    Quien está mirando solo los errores tiene que poder ver que al lado hay
+    avisos; si los contadores se calcularan después del filtro de nivel,
+    marcarían cero en todo lo demás y no servirían para nada.
+    """
+    response = client.get(
+        "/system/logs",
+        query_string={"position": "head", "level": "ERROR"},
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 200
+    payload, content = _decode_log_content(response)
+    assert content.splitlines() == [
+        "[+] [ERROR] (2026-08-18 10:02:00,000) test.three: fallo",
+    ]
+    assert payload["totalLines"] == 1
+    assert payload["levelCounts"] == {
+        "DEBUG": 0,
+        "INFO": 2,
+        "WARNING": 1,
+        "ERROR": 1,
+        "CRITICAL": 0,
+    }
+
+
+def test_log_level_counts_respect_the_time_window(
+    client, admin_user, auth_headers, _isolated_log_file
+):
+    """Acotar por fecha sí cambia los contadores: son de la ventana pedida."""
+    response = client.get(
+        "/system/logs",
+        query_string={
+            "position": "head",
+            "from": "2026-08-18T10:01:00",
+            "to": "2026-08-18T10:02:00",
+        },
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 200
+    payload, _content = _decode_log_content(response)
+    assert payload["levelCounts"] == {
+        "DEBUG": 0,
+        "INFO": 0,
+        "WARNING": 1,
+        "ERROR": 1,
+        "CRITICAL": 0,
+    }
+
+
+def test_log_rejects_an_unknown_minimum_level(
+    client, admin_user, auth_headers, _isolated_log_file
+):
+    response = client.get(
+        "/system/logs",
+        query_string={"minLevel": "TRACE"},
+        headers=auth_headers(admin_user),
+    )
+
+    assert response.status_code == 422
+
+
 def test_log_snapshot_survives_appends(client, admin_user, auth_headers, _isolated_log_file):
     first = client.get(
         "/system/logs?position=tail&per_page=1",

--- a/API/tests/unit/test_log_reader_window.py
+++ b/API/tests/unit/test_log_reader_window.py
@@ -1,0 +1,216 @@
+"""La lectura acelerada del log tiene que devolver lo mismo que la lenta.
+
+``log_reader`` gana velocidad saltándose trabajo: en lugar de recorrer el
+fichero entero y descartar después las líneas fuera de la ventana temporal,
+busca por bisección el byte donde empieza esa ventana y corta la lectura en
+cuanto se pasa del final. Cualquier atajo así tiene la misma trampa: si el
+salto se pasa de largo, se pierden líneas en silencio y nadie se entera,
+porque la respuesta sigue teniendo buena pinta.
+
+Estos tests fijan la invariante que lo impide: **bisecar y no bisecar tienen
+que dar exactamente el mismo resultado**. La comparación se hace contra el
+mismo lector con la bisección desactivada (subiendo el umbral de tamaño por
+encima del fichero de prueba), así que no hay una segunda implementación que
+mantener.
+
+Los casos difíciles que se cubren son los dos que rompen la suposición de que
+el log está ordenado y de que cada línea lleva su fecha:
+
+- **Inversiones de orden.** Al log le escriben dos procesos, la API y el
+  worker, así que una línea puede aparecer unas milésimas antes que otra
+  anterior. La bisección lo absorbe con un margen de holgura; aquí se
+  introducen inversiones a propósito para comprobarlo.
+- **Líneas de continuación.** Un traceback de Python ocupa varias líneas y
+  solo la primera lleva el prefijo ``[+] [ERROR] (fecha)``; las demás heredan
+  la marca de la anterior. La bisección corta siempre en una línea con
+  prefijo, y hay que verificar que eso no deja huérfano el cuerpo de un
+  traceback que sí entra en la ventana.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+import src.modules.system.services.log_reader as log_reader
+
+pytestmark = pytest.mark.unit
+
+
+BASE_TIME = datetime(2026, 9, 1, 12, 0, 0)
+LEVELS = ("INFO", "DEBUG", "WARNING", "ERROR", "INFO", "INFO", "CRITICAL")
+
+
+def _entry(index: int, timestamp: datetime, level: str) -> str:
+    """Una entrada del log con el formato exacto que emite la aplicación."""
+    stamp = timestamp.strftime("%Y-%m-%d %H:%M:%S,") + f"{timestamp.microsecond // 1000:03d}"
+    return f"[+] [{level}] ({stamp}) src.modules.test: entrada numero {index}"
+
+
+def _build_log(path, entries: int = 4000) -> None:
+    """Escribe un log sintético lo bastante grande como para que se bisecte.
+
+    Se pasa del cuarto de mega que exige ``_BISECTION_MIN_BYTES`` y mete a
+    propósito los dos casos difíciles: cada cincuenta líneas, una inversión de
+    quince milisegundos hacia atrás; cada ciento treinta, un traceback de tres
+    líneas sin prefijo.
+    """
+    lines = []
+    for index in range(entries):
+        timestamp = BASE_TIME + timedelta(seconds=index)
+        if index % 50 == 49:
+            timestamp -= timedelta(milliseconds=15)
+        lines.append(_entry(index, timestamp, LEVELS[index % len(LEVELS)]))
+        if index % 130 == 129:
+            lines.append("Traceback (most recent call last):")
+            lines.append('  File "algun/sitio.py", line 12, in funcion')
+            lines.append("ValueError: continuacion sin prefijo")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def log_file(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    path = log_dir / "secops.log"
+    _build_log(path)
+    monkeypatch.setattr(log_reader, "_log_path", lambda: path)
+    return path
+
+
+@pytest.fixture
+def without_bisection(monkeypatch):
+    """Desactiva el atajo subiendo su umbral por encima del fichero de prueba."""
+    monkeypatch.setattr(log_reader, "_BISECTION_MIN_BYTES", 1 << 30)
+
+
+def _read(**query) -> dict:
+    return log_reader.read_logs({"per_page": 100, **query})
+
+
+def _readable(payload: dict) -> str:
+    import base64
+    import gzip
+
+    return gzip.decompress(base64.b64decode(payload["content"])).decode("utf-8")
+
+
+def _comparable(payload: dict) -> dict:
+    """Lo que tiene que coincidir entre las dos lecturas.
+
+    Se deja fuera el snapshot, que depende del inodo del fichero temporal, y
+    el huso horario, que depende de la máquina.
+    """
+    return {
+        "content": _readable(payload),
+        "totalLines": payload["totalLines"],
+        "returnedLines": payload["returnedLines"],
+        "totalPages": payload["totalPages"],
+        "firstLine": payload["firstLine"],
+        "lastLine": payload["lastLine"],
+        "levelCounts": payload["levelCounts"],
+    }
+
+
+QUERIES = [
+    pytest.param({"position": "tail"}, id="cola-sin-filtros"),
+    pytest.param(
+        {"position": "tail", "from_": BASE_TIME + timedelta(minutes=55)},
+        id="cola-ultimos-minutos",
+    ),
+    pytest.param(
+        {"position": "head", "from_": BASE_TIME + timedelta(minutes=30)},
+        id="cabeza-desde-la-mitad",
+    ),
+    pytest.param(
+        {
+            "position": "head",
+            "from_": BASE_TIME + timedelta(minutes=20),
+            "to": BASE_TIME + timedelta(minutes=25),
+        },
+        id="ventana-cerrada",
+    ),
+    pytest.param(
+        {
+            "position": "tail",
+            "from_": BASE_TIME + timedelta(minutes=10),
+            "to": BASE_TIME + timedelta(minutes=40),
+            "min_level": "WARNING",
+        },
+        id="ventana-cerrada-solo-avisos",
+    ),
+    pytest.param(
+        {"position": "tail", "from_": BASE_TIME + timedelta(minutes=15), "page": 3},
+        id="tercera-pagina-de-la-cola",
+    ),
+    pytest.param(
+        {"position": "tail", "from_": BASE_TIME - timedelta(days=1)},
+        id="ventana-anterior-al-log",
+    ),
+    pytest.param(
+        {"position": "tail", "from_": BASE_TIME + timedelta(days=1)},
+        id="ventana-posterior-al-log",
+    ),
+    pytest.param(
+        {"position": "head", "from_": BASE_TIME + timedelta(minutes=5), "contains": "numero 3"},
+        id="ventana-con-busqueda-de-texto",
+    ),
+]
+
+
+@pytest.mark.parametrize("query", QUERIES)
+def test_the_bisected_read_matches_the_full_scan(log_file, monkeypatch, query):
+    fast = _comparable(_read(**query))
+
+    monkeypatch.setattr(log_reader, "_BISECTION_MIN_BYTES", 1 << 30)
+    slow = _comparable(_read(**query))
+
+    assert fast == slow
+
+
+def test_line_numbers_stay_absolute_after_a_jump(log_file):
+    """Saltar a mitad del fichero no puede renumerar las líneas.
+
+    ``firstLine``/``lastLine`` son números de línea del fichero, y el panel los
+    enseña tal cual. Si la bisección los contara desde el punto de salto, la
+    misma línea tendría un número distinto según qué ventana se pidiera.
+    """
+    payload = _read(position="head", from_=BASE_TIME + timedelta(minutes=30))
+    first_visible = _readable(payload).splitlines()[0]
+
+    every_line = log_file.read_text(encoding="utf-8").splitlines()
+    assert every_line[payload["firstLine"] - 1] == first_visible
+
+
+def test_a_traceback_inside_the_window_keeps_its_body(log_file):
+    """El cuerpo de un traceback viaja con su cabecera, también tras un salto.
+
+    Las líneas de continuación no llevan fecha: heredan la de la línea con
+    prefijo anterior. Si la bisección cortara entre la cabecera y el cuerpo,
+    el error aparecería en el panel sin la pila que explica dónde ocurrió.
+    """
+    payload = _read(position="head", per_page=500, from_=BASE_TIME + timedelta(minutes=1))
+    lines = _readable(payload).splitlines()
+
+    header_positions = [
+        index for index, line in enumerate(lines)
+        if line.startswith("Traceback (most recent call last):")
+    ]
+    assert header_positions, "el tramo elegido debería contener algún traceback"
+    for position in header_positions:
+        assert lines[position + 2] == "ValueError: continuacion sin prefijo"
+
+
+def test_the_deep_page_fallback_agrees_with_the_single_pass(log_file, monkeypatch):
+    """Las páginas profundas usan otro camino, y tiene que dar lo mismo.
+
+    Por debajo del tope de búfer, la cola se resuelve en una sola pasada
+    guardando las últimas coincidencias; por encima, se vuelve a las dos
+    pasadas de contar y recoger. Son dos implementaciones del mismo resultado.
+    """
+    query = {"position": "tail", "page": 4, "per_page": 50}
+    single_pass = _comparable(_read(**query))
+
+    monkeypatch.setattr(log_reader, "_TAIL_BUFFER_MAX_LINES", 10)
+    two_passes = _comparable(_read(**query))
+
+    assert single_pass == two_passes

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `DELETE` | `/users/<id>` | (admin/root) Delete another user's account; same purge as self-deletion, hierarchy enforced (an admin cannot delete an admin or the root), own account excluded |
 | `GET` | `/system/say-hello` | **Public** health check, reports the API version |
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |
-| `GET` | `/system/logs` | (admin) Paginated central log viewer |
+| `GET` | `/system/logs` | (admin) Paginated central log viewer — gzip+base64 page, snapshot-anchored. Windowing with `lastMinutes` (relative, resolved against the **server** clock; mutually exclusive with `from`) or `from`/`to`; severity with `level` (exact) or `minLevel` (that level and above). The response carries `levelCounts` for the window, computed *before* the level filter, plus `windowStart` |
 | `GET/PUT` | `/system` | (root) Read / save `SecOpsConfig.json` (`PUT` requires `If-Match` ETag) |
 | `GET` | `/system/tasks` · `/system/tasks/status` · `/system/tasks/<id>` | (admin) List tasks, queue status, task detail |
 | `POST` | `/system/tasks/<id>/cancel` | (admin) Cancel a queued/running task |

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,7 +12,7 @@
     "test:polling": "node test/usePolling.test.mjs",
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
-    "test:logs": "node test/logTransport.test.mjs",
+    "test:logs": "node test/logTransport.test.mjs && node test/logWindows.test.mjs",
     "test:iris": "node test/iris.intake.test.mjs",
     "test:themis": "node test/themis.scanWindow.test.mjs"
   },

--- a/web/app/src/composables/logWindows.js
+++ b/web/app/src/composables/logWindows.js
@@ -1,0 +1,69 @@
+// Sin dependencias a propósito: los tests de este fichero son Node puro, sin
+// Vite, así que no pueden resolver el alias `@` ni cargar Vue ni Pinia.
+
+/**
+ * Ventanas temporales rápidas del visor de logs.
+ *
+ * Cada atajo es solo un número de minutos con nombre. La ventana no se
+ * convierte aquí en un par de fechas: se manda al backend como `lastMinutes`
+ * y es él quien la resuelve contra su propio reloj. Las marcas del log no
+ * llevan zona horaria —son la hora local de la API—, así que si el navegador
+ * calculara «hace diez minutos», un administrador conectado desde otro huso
+ * pediría una ventana desplazada por la diferencia horaria.
+ *
+ * El valor `null` de `TODO` significa «sin límite inferior»: no manda
+ * `lastMinutes`, y el backend lee el fichero entero.
+ */
+export const LOG_WINDOWS = [
+  { id: '10m', label: '10 min', minutes: 10 },
+  { id: '30m', label: '30 min', minutes: 30 },
+  { id: '1h', label: '1 hora', minutes: 60 },
+  { id: '6h', label: '6 horas', minutes: 360 },
+  { id: '24h', label: '24 horas', minutes: 1440 },
+  { id: '7d', label: '7 días', minutes: 10080 },
+  { id: 'all', label: 'Todo', minutes: null },
+]
+
+export const DEFAULT_WINDOW_ID = '1h'
+
+/** Minutos del atajo indicado, o `null` si no acota (o no existe). */
+export function windowMinutes(windowId) {
+  const found = LOG_WINDOWS.find((option) => option.id === windowId)
+  return found ? found.minutes : null
+}
+
+/** Etiqueta legible del atajo, para los textos de la vista. */
+export function windowLabel(windowId) {
+  const found = LOG_WINDOWS.find((option) => option.id === windowId)
+  return found ? found.label : ''
+}
+
+/**
+ * Traduce los filtros de la vista a los parámetros de `GET /system/logs`.
+ *
+ * Se separa de la store para poder probarlo sin navegador: es donde vive la
+ * decisión de qué combinaciones son excluyentes, y el backend rechaza con un
+ * 400 las que no lo respetan (mandar a la vez `lastMinutes` y `from` es
+ * ambiguo, así que un atajo activo desactiva las fechas escritas a mano).
+ */
+export function buildLogQuery(filters) {
+  const params = new URLSearchParams({
+    page: String(filters.page || 1),
+    per_page: String(filters.perPage || 100),
+    position: filters.position || 'tail',
+  })
+
+  const minutes = filters.windowId ? windowMinutes(filters.windowId) : null
+  if (minutes !== null) {
+    params.set('lastMinutes', String(minutes))
+  } else if (!filters.windowId || filters.windowId === 'custom') {
+    if (filters.from) params.set('from', filters.from)
+    if (filters.to) params.set('to', filters.to)
+  }
+
+  if (filters.level) params.set('level', filters.level)
+  if (filters.minLevel) params.set('minLevel', filters.minLevel)
+  if (filters.contains) params.set('contains', filters.contains)
+
+  return params
+}

--- a/web/app/src/stores/logsStore.js
+++ b/web/app/src/stores/logsStore.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useApi } from '@/composables/useApi'
 import { decodeLogPayload } from '@/composables/logTransport'
+import { buildLogQuery } from '@/composables/logWindows'
 
 /**
  * Store de lectura del log del sistema.
@@ -25,15 +26,7 @@ export const useLogsStore = defineStore('logs', () => {
 
   /** Carga una página aplicando los filtros recibidos desde la vista. */
   async function loadLogs(filters) {
-    const params = new URLSearchParams({
-      page: String(filters.page || 1),
-      per_page: String(filters.perPage || 100),
-      position: filters.position || 'tail',
-    })
-    if (filters.from) params.set('from', filters.from)
-    if (filters.to) params.set('to', filters.to)
-    if (filters.level) params.set('level', filters.level)
-    if (filters.contains) params.set('contains', filters.contains)
+    const params = buildLogQuery(filters)
     if (snapshot.value) params.set('snapshot', snapshot.value)
 
     const requestKey = params.toString()
@@ -118,6 +111,8 @@ function emptyMeta() {
     page: 1,
     perPage: 100,
     totalPages: 0,
+    levelCounts: {},
+    windowStart: '',
     position: 'tail',
     hasPrevious: false,
     hasNext: false,

--- a/web/app/src/views/LogsView.vue
+++ b/web/app/src/views/LogsView.vue
@@ -10,9 +10,18 @@
           <h1>Logs del sistema</h1>
           <p class="subtitle">Busca actividad de la API sin abandonar el hilo de la operación.</p>
         </div>
-        <button class="btn btn--secondary" type="button" :disabled="store.loading" @click="refresh">
-          {{ store.loading ? 'Actualizando…' : 'Actualizar' }}
-        </button>
+        <div class="header-actions">
+          <label class="live-toggle" :class="{ 'live-toggle--on': isLiveRefreshOn }">
+            <input v-model="isLiveRefreshOn" type="checkbox" />
+            <span>Refresco automático</span>
+          </label>
+          <button class="btn btn--secondary" type="button" :disabled="store.loading" @click="refresh">
+            {{ store.loading ? 'Actualizando…' : 'Actualizar' }}
+          </button>
+          <button class="btn btn--primary" type="button" :disabled="store.loading" @click="showLatest">
+            Ver últimos logs
+          </button>
+        </div>
       </header>
 
       <form class="filter-panel" @submit.prevent="applyFilters">
@@ -24,6 +33,32 @@
           <span class="snapshot-state" :class="{ 'snapshot-state--live': store.meta.currentBytes > store.meta.snapshotBytes }">
             {{ snapshotLabel }}
           </span>
+        </div>
+
+        <div class="window-row">
+          <span class="window-label">Ver los últimos</span>
+          <div class="chips" role="group" aria-label="Ventana temporal">
+            <button
+              v-for="option in LOG_WINDOWS"
+              :key="option.id"
+              class="chip"
+              :class="{ 'chip--active': draft.windowId === option.id }"
+              type="button"
+              :aria-pressed="draft.windowId === option.id"
+              @click="selectWindow(option.id)"
+            >
+              {{ option.label }}
+            </button>
+            <button
+              class="chip"
+              :class="{ 'chip--active': draft.windowId === 'custom' }"
+              type="button"
+              :aria-pressed="draft.windowId === 'custom'"
+              @click="selectWindow('custom')"
+            >
+              Personalizado
+            </button>
+          </div>
         </div>
 
         <div class="filter-grid">
@@ -41,23 +76,26 @@
             </div>
           </div>
 
+          <template v-if="draft.windowId === 'custom'">
+            <div class="form-group">
+              <label for="logs-from">Desde</label>
+              <input id="logs-from" v-model="draft.from" type="datetime-local" step="1" class="inp" />
+            </div>
+            <div class="form-group">
+              <label for="logs-to">Hasta</label>
+              <input id="logs-to" v-model="draft.to" type="datetime-local" step="1" class="inp" />
+            </div>
+          </template>
+
           <div class="form-group">
-            <label for="logs-from">Desde</label>
-            <input id="logs-from" v-model="draft.from" type="datetime-local" step="1" class="inp" />
-          </div>
-          <div class="form-group">
-            <label for="logs-to">Hasta</label>
-            <input id="logs-to" v-model="draft.to" type="datetime-local" step="1" class="inp" />
-          </div>
-          <div class="form-group">
-            <label for="logs-level">Nivel</label>
-            <select id="logs-level" v-model="draft.level" class="inp">
+            <label for="logs-level">Nivel mínimo</label>
+            <select id="logs-level" v-model="draft.minLevel" class="inp">
               <option value="">Todos</option>
-              <option value="DEBUG">DEBUG</option>
-              <option value="INFO">INFO</option>
-              <option value="WARNING">WARNING</option>
-              <option value="ERROR">ERROR</option>
-              <option value="CRITICAL">CRITICAL</option>
+              <option value="DEBUG">DEBUG y superiores</option>
+              <option value="INFO">INFO y superiores</option>
+              <option value="WARNING">WARNING y superiores</option>
+              <option value="ERROR">ERROR y superiores</option>
+              <option value="CRITICAL">Solo CRITICAL</option>
             </select>
           </div>
           <div class="form-group">
@@ -83,8 +121,18 @@
         </div>
 
         <div class="filter-actions">
-          <span class="filter-hint">Las fechas usan la hora del servidor{{ store.meta.timeZone ? ` (${store.meta.timeZone})` : '' }}.</span>
-          <button class="btn btn--primary" type="submit" :disabled="store.loading">Aplicar filtros</button>
+          <span class="filter-hint">{{ windowHint }}</span>
+          <div class="action-buttons">
+            <button
+              class="btn btn--secondary"
+              :class="{ 'btn--armed': draft.minLevel === 'WARNING' }"
+              type="button"
+              @click="toggleProblemsOnly"
+            >
+              {{ draft.minLevel === 'WARNING' ? 'Viendo solo problemas' : 'Solo avisos y errores' }}
+            </button>
+            <button class="btn btn--primary" type="submit" :disabled="store.loading">Aplicar filtros</button>
+          </div>
         </div>
       </form>
 
@@ -113,11 +161,36 @@
           </div>
         </div>
 
+        <div class="level-summary" role="group" aria-label="Resumen por nivel de la ventana">
+          <button
+            v-for="tally in levelTallies"
+            :key="tally.level"
+            class="tally"
+            :class="[`tally--${tally.level}`, { 'tally--active': applied.minLevel === tally.level }]"
+            type="button"
+            :aria-pressed="applied.minLevel === tally.level"
+            :title="`Ver ${tally.level} y superiores`"
+            @click="filterFromLevel(tally.level)"
+          >
+            <span class="tally-count">{{ tally.count }}</span>
+            <span class="tally-level">{{ tally.level }}</span>
+          </button>
+          <span v-if="!hasAnyTally" class="tally-empty">Sin líneas clasificadas en esta ventana.</span>
+        </div>
+
         <div v-if="store.meta.truncated" class="notice" role="status">
           Esta vista muestra una página de {{ store.meta.totalLines }} líneas coincidentes.
         </div>
         <div v-if="store.content" class="log-window">
-          <pre>{{ store.content }}</pre>
+          <pre><span
+            v-for="line in renderedLines"
+            :key="line.key"
+            class="log-line"
+            :class="`log-line--${line.level}`"
+          ><template v-for="(part, index) in line.parts" :key="index"><mark
+            v-if="part.isMatch"
+            class="hit"
+          >{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></span></pre>
         </div>
         <div v-else class="empty-state">No hay líneas que coincidan con estos filtros.</div>
 
@@ -139,22 +212,30 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
+import { usePolling } from '@/composables/usePolling'
+import { LOG_WINDOWS, DEFAULT_WINDOW_ID, windowLabel } from '@/composables/logWindows'
 import { useLogsStore } from '@/stores/logsStore'
+
+const LIVE_REFRESH_MS = 15000
+const LEVEL_ORDER = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
+const LEVEL_PREFIX_RE = /^\[\+\]\s+\[([A-Z]+)\]/
 
 const store = useLogsStore()
 
 const draft = reactive({
   position: 'tail',
+  windowId: DEFAULT_WINDOW_ID,
   from: '',
   to: '',
-  level: '',
+  minLevel: '',
   contains: '',
   perPage: 100,
 })
 const applied = ref({ ...draft, page: 1 })
+const isLiveRefreshOn = ref(false)
 
 const snapshotLabel = computed(() => {
   if (!store.meta.snapshotBytes) return 'Sin snapshot'
@@ -171,6 +252,92 @@ const lineRange = computed(() => {
   if (store.meta.firstLine === store.meta.lastLine) return `Línea ${store.meta.firstLine}`
   return `Líneas ${store.meta.firstLine}–${store.meta.lastLine}`
 })
+
+const windowHint = computed(() => {
+  const zone = store.meta.timeZone ? ` (${store.meta.timeZone})` : ''
+  if (applied.value.windowId === 'custom') {
+    return `Las fechas usan la hora del servidor${zone}.`
+  }
+  // La ventana la resuelve el servidor con su propio reloj, así que se enseña
+  // el instante que él eligió y no uno recalculado aquí.
+  const since = store.meta.windowStart ? ` — desde ${store.meta.windowStart.replace('T', ' ')}` : ''
+  return `Últimos ${windowLabel(applied.value.windowId)} de la hora del servidor${zone}${since}.`
+})
+
+/**
+ * Recuento por nivel de la ventana consultada.
+ *
+ * Lo calcula el backend *antes* de aplicar el filtro de nivel, así que sigue
+ * diciendo cuántos errores hay aunque ahora mismo se estén mirando solo los
+ * avisos. Se ocultan los niveles con cero para que la fila no sea una tabla
+ * de ceros cuando la ventana es pequeña.
+ */
+const levelTallies = computed(() => {
+  const counts = store.meta.levelCounts || {}
+  return LEVEL_ORDER
+    .filter((level) => counts[level] > 0)
+    .map((level) => ({ level, count: counts[level] }))
+})
+
+const hasAnyTally = computed(() => levelTallies.value.length > 0)
+
+/**
+ * Prepara el contenido para pintarlo coloreado por nivel y con el término
+ * buscado resaltado.
+ *
+ * Las líneas de continuación de un traceback no llevan prefijo, así que
+ * heredan el nivel de la línea anterior: si no, el cuerpo de un error se
+ * pintaría en gris justo debajo de su cabecera en rojo. Todo se pinta por
+ * interpolación de Vue, nunca por HTML crudo: una línea de log puede
+ * contener una ruta o un cuerpo de petición escritos por un tercero.
+ */
+const renderedLines = computed(() => {
+  if (!store.content) return []
+  const term = (applied.value.contains || '').toLowerCase()
+  let previousLevel = 'PLAIN'
+
+  return store.content.split('\n').map((text, key) => {
+    const match = LEVEL_PREFIX_RE.exec(text)
+    if (match) previousLevel = match[1]
+    return { key, level: previousLevel, parts: splitAroundTerm(text, term) }
+  })
+})
+
+/** Parte una línea en tramos, marcando los que coinciden con la búsqueda. */
+function splitAroundTerm(text, term) {
+  if (!term) return [{ text, isMatch: false }]
+
+  const parts = []
+  const haystack = text.toLowerCase()
+  let cursor = 0
+
+  for (;;) {
+    const hit = haystack.indexOf(term, cursor)
+    if (hit === -1) break
+    if (hit > cursor) parts.push({ text: text.slice(cursor, hit), isMatch: false })
+    parts.push({ text: text.slice(hit, hit + term.length), isMatch: true })
+    cursor = hit + term.length
+  }
+
+  if (cursor < text.length) parts.push({ text: text.slice(cursor), isMatch: false })
+  return parts.length ? parts : [{ text, isMatch: false }]
+}
+
+function selectWindow(windowId) {
+  draft.windowId = windowId
+}
+
+/** Conmuta el atajo a «solo problemas», que es `minLevel=WARNING`. */
+function toggleProblemsOnly() {
+  draft.minLevel = draft.minLevel === 'WARNING' ? '' : 'WARNING'
+  applyFilters()
+}
+
+/** Aplica el nivel de un contador pulsado, sin tocar el resto de la consulta. */
+function filterFromLevel(level) {
+  draft.minLevel = applied.value.minLevel === level ? '' : level
+  applyFilters()
+}
 
 async function applyFilters() {
   applied.value = { ...draft, page: 1 }
@@ -191,6 +358,34 @@ async function recover() {
   store.resetSnapshot()
   await store.loadLogs({ ...applied.value, page: 1 })
 }
+
+/** Vuelve al estado de arranque: lo más reciente, sin filtros que estorben. */
+async function showLatest() {
+  draft.position = 'tail'
+  draft.windowId = DEFAULT_WINDOW_ID
+  draft.from = ''
+  draft.to = ''
+  draft.minLevel = ''
+  draft.contains = ''
+  await applyFilters()
+}
+
+// ── Refresco automático ────────────────────────────────────────────────────
+// Se apoya en `usePolling` para no reinventar el sondeo: no solapa peticiones,
+// se para con la pestaña oculta y se limpia solo al salir de la vista. Cada
+// ciclo empieza una lectura nueva —snapshot descartado— porque de eso se trata:
+// de ver lo que se ha escrito desde la última vez.
+const livePolling = usePolling(async () => {
+  if (store.loading) return true
+  store.resetSnapshot()
+  await store.loadLogs({ ...applied.value, page: 1 })
+  return true
+}, { intervalMs: LIVE_REFRESH_MS, immediate: false })
+
+watch(isLiveRefreshOn, (isOn) => {
+  if (isOn) livePolling.start()
+  else livePolling.stop()
+})
 
 function formatBytes(bytes) {
   if (!bytes) return '0 B'
@@ -213,6 +408,9 @@ onMounted(() => applyFilters())
 }
 .main { max-width: 1120px; margin: 0 auto; padding: 2rem 1.1rem 4.5rem; position: relative; z-index: 1; }
 .page-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1rem; margin-bottom: 1.4rem; }
+.header-actions { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.live-toggle { display: flex; align-items: center; gap: 0.4rem; color: var(--text-muted); font-size: var(--fs-md); cursor: pointer; }
+.live-toggle--on { color: var(--accent-bright); }
 .eyebrow, .filter-kicker, .log-card-kicker {
   display: block;
   color: var(--accent);
@@ -227,6 +425,17 @@ onMounted(() => applyFilters())
 .filter-heading h2, .log-card-head h2 { margin: 0.25rem 0 0; color: var(--text); font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-xl); }
 .snapshot-state { color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); }
 .snapshot-state--live { color: var(--warn); }
+.window-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; padding-top: 1rem; }
+.window-label { color: var(--text-muted); font-size: var(--fs-md); font-weight: 600; }
+.chips { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+.chip {
+  padding: 0.35rem 0.7rem; border: 1px solid var(--border-med); border-radius: 999px;
+  background: var(--surface-2); color: var(--text-dim); font-size: var(--fs-md);
+  cursor: pointer; transition: all 0.18s ease;
+}
+.chip:hover { border-color: var(--accent); color: var(--accent-bright); }
+.chip--active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent-bright); font-weight: 600; }
+.chip:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .filter-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.85rem; padding-top: 1rem; }
 .form-group--wide { grid-column: span 2; }
 .form-group label { display: block; color: var(--text-muted); font-size: var(--fs-md); font-weight: 600; margin-bottom: 0.35rem; }
@@ -237,13 +446,35 @@ onMounted(() => applyFilters())
 .segment.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent-bright); }
 .segment:focus-within { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
 .filter-actions { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; }
+.action-buttons { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.btn--armed { border-color: var(--warn); color: var(--warn); }
 .filter-hint { color: var(--text-muted); font-size: var(--fs-sm); }
 .log-card { overflow: hidden; }
 .log-card-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; padding: 1.1rem 1.15rem; border-bottom: 1px solid var(--border); }
 .log-stats { display: flex; gap: 0.85rem; color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); text-align: right; }
+.level-summary { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; padding: 0.75rem 1.15rem; border-bottom: 1px solid var(--border); }
+.tally {
+  display: flex; align-items: baseline; gap: 0.4rem;
+  padding: 0.3rem 0.65rem; border: 1px solid var(--border-med); border-radius: 7px;
+  background: var(--surface-2); cursor: pointer; transition: all 0.18s ease;
+}
+.tally:hover { border-color: currentColor; }
+.tally--active { border-color: currentColor; box-shadow: inset 0 0 0 1px currentColor; }
+.tally-count { font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-md); font-weight: 700; }
+.tally-level { color: var(--text-muted); font-size: var(--fs-sm); letter-spacing: 0.08em; }
+.tally--CRITICAL, .tally--ERROR { color: var(--danger); }
+.tally--WARNING { color: var(--warn); }
+.tally--INFO { color: var(--text-dim); }
+.tally--DEBUG { color: var(--text-muted); }
+.tally-empty { color: var(--text-muted); font-size: var(--fs-sm); }
 .notice { padding: 0.6rem 1.15rem; background: var(--warn-dim); color: var(--warn); border-bottom: 1px solid var(--border); font-size: var(--fs-md); }
 .log-window { max-height: 62vh; overflow: auto; background: var(--bg); }
 .log-window pre { min-width: max-content; margin: 0; padding: 1rem 1.15rem 1.25rem; color: var(--text); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); line-height: 1.65; tab-size: 4; }
+.log-line { display: block; min-height: 1.65em; }
+.log-line--CRITICAL, .log-line--ERROR { color: var(--danger); }
+.log-line--WARNING { color: var(--warn); }
+.log-line--DEBUG { color: var(--text-muted); }
+.hit { background: var(--accent-dim); color: var(--accent-bright); border-radius: 3px; }
 .log-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.85rem 1.15rem; border-top: 1px solid var(--border); }
 .line-range, .page-status { color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-sm); }
 .pagination { display: flex; align-items: center; gap: 0.65rem; }
@@ -273,7 +504,10 @@ onMounted(() => applyFilters())
   .filter-grid .form-group:first-child { margin-top: 0; }
   .filter-actions { align-items: stretch; flex-direction: column; }
   .filter-actions .btn { width: 100%; }
+  .action-buttons { flex-direction: column; }
+  .header-actions { width: 100%; }
   .segmented { min-height: 44px; }
+  .chip { min-height: 34px; }
   .pagination { justify-content: space-between; width: 100%; }
   .page-status { order: 2; }
 }

--- a/web/app/test/logWindows.test.mjs
+++ b/web/app/test/logWindows.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Los atajos de ventana del visor de logs tienen que llegar al backend con la
+ * forma que el backend acepta.
+ *
+ * Lo que se comprueba aquí no es aritmética de fechas —el navegador no calcula
+ * ninguna—, sino la traducción de los filtros de la vista a los parámetros de
+ * `GET /system/logs`. Hay dos reglas que romperlas cuesta un error 400 o, peor,
+ * una ventana silenciosamente equivocada:
+ *
+ *   - Un atajo activo manda `lastMinutes` y **no** manda `from`/`to`. El
+ *     backend rechaza recibir los dos, porque pedir a la vez «los últimos diez
+ *     minutos» y «desde las nueve» no significa nada.
+ *   - «Todo» no es un atajo de cero minutos: es la ausencia de límite, así que
+ *     no manda `lastMinutes` en absoluto.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  LOG_WINDOWS,
+  DEFAULT_WINDOW_ID,
+  buildLogQuery,
+  windowMinutes,
+  windowLabel,
+} from '../src/composables/logWindows.js'
+
+const asObject = (params) => Object.fromEntries(params.entries())
+
+test('cada atajo manda su ventana en minutos y ninguna fecha suelta', () => {
+  for (const option of LOG_WINDOWS) {
+    const query = asObject(buildLogQuery({
+      windowId: option.id,
+      from: '2026-09-01T10:00:00',
+      to: '2026-09-01T11:00:00',
+    }))
+
+    assert.equal(query.from, undefined, `${option.id} no debe mandar from`)
+    assert.equal(query.to, undefined, `${option.id} no debe mandar to`)
+
+    if (option.minutes === null) {
+      assert.equal(query.lastMinutes, undefined, 'la ventana sin límite no acota')
+    } else {
+      assert.equal(query.lastMinutes, String(option.minutes))
+    }
+  }
+})
+
+test('la ventana personalizada manda las fechas escritas a mano', () => {
+  const query = asObject(buildLogQuery({
+    windowId: 'custom',
+    from: '2026-09-01T10:00:00',
+    to: '2026-09-01T11:00:00',
+  }))
+
+  assert.equal(query.from, '2026-09-01T10:00:00')
+  assert.equal(query.to, '2026-09-01T11:00:00')
+  assert.equal(query.lastMinutes, undefined)
+})
+
+test('los minutos de los atajos crecen y no se repiten', () => {
+  const acotados = LOG_WINDOWS.filter((option) => option.minutes !== null)
+  const minutos = acotados.map((option) => option.minutes)
+
+  assert.deepEqual(minutos, [...minutos].sort((a, b) => a - b))
+  assert.equal(new Set(minutos).size, minutos.length)
+  assert.equal(acotados.length + 1, LOG_WINDOWS.length, 'solo «Todo» carece de límite')
+})
+
+test('el atajo por defecto existe y acota', () => {
+  assert.ok(LOG_WINDOWS.some((option) => option.id === DEFAULT_WINDOW_ID))
+  assert.equal(typeof windowMinutes(DEFAULT_WINDOW_ID), 'number')
+  assert.ok(windowLabel(DEFAULT_WINDOW_ID).length > 0)
+})
+
+test('un identificador desconocido no acota ni revienta', () => {
+  assert.equal(windowMinutes('no-existe'), null)
+  assert.equal(windowLabel('no-existe'), '')
+})
+
+test('los filtros de nivel y texto viajan junto a la ventana', () => {
+  const query = asObject(buildLogQuery({
+    windowId: '30m',
+    minLevel: 'WARNING',
+    contains: 'traceback',
+    position: 'head',
+    page: 3,
+    perPage: 250,
+  }))
+
+  assert.deepEqual(query, {
+    page: '3',
+    per_page: '250',
+    position: 'head',
+    lastMinutes: '30',
+    minLevel: 'WARNING',
+    contains: 'traceback',
+  })
+})
+
+test('sin filtros se piden las últimas líneas de la primera página', () => {
+  const query = asObject(buildLogQuery({}))
+
+  assert.deepEqual(query, { page: '1', per_page: '100', position: 'tail' })
+})


### PR DESCRIPTION
## Resumen

El visor de logs del panel de administración servía para *leer* el log, pero no para
*investigar* un incidente. Para ver qué había fallado en la última media hora había que teclear
dos fechas a mano en dos campos `datetime-local`, y como el filtro de nivel era de valor exacto,
los avisos y los errores de esa ventana salían en dos consultas distintas que había que unir a
ojo. Encima, cada consulta recorría el fichero de log entero, así que el panel se volvía más
lento cada día que pasaba.

Este PR cubre las dos mitades: **la funcionalidad que faltaba para encontrar problemas** y **la
velocidad**. Después del cambio, el camino cuando algo va mal es: abrir el panel, pulsar «30
min», pulsar «solo avisos y errores», leer. Tres clics, ninguna fecha escrita, y la respuesta
llegando en decenas de milisegundos en vez de segundos.

## Issue relacionado

Closes #446.

---

## Qué se ha implementado

### 1. Severidad mínima y recuento por nivel (`a79898c9`)

El parámetro nuevo `minLevel` filtra por severidad **mínima**: `minLevel=WARNING` devuelve
WARNING, ERROR y CRITICAL en una sola consulta. El `level` de siempre sigue existiendo y sigue
siendo de valor exacto; si se envían los dos, se aplican ambos.

La respuesta trae además `levelCounts`: cuántas líneas hay de cada nivel en la ventana
consultada. El detalle importante es **cuándo** se cuentan. Se cuentan sobre la ventana —fechas
más texto buscado— *antes* de aplicar el filtro de nivel. Contarlas después las dejaría a cero
en todo lo que no se esté mirando, y el contador no serviría para nada; contándolas antes, quien
está leyendo solo los errores sigue viendo que al lado hay doce avisos y puede decidir si amplía.
Sale de la misma pasada que ya se hacía, así que no cuesta nada.

### 2. Leer solo el tramo que pide la ventana temporal (`1c2e655f`)

Este es el grueso del trabajo de velocidad, y conviene explicarlo desde el problema.

**El problema.** El lector abría el fichero por el byte 0 y lo recorría entero, línea a línea,
decodificando cada una, aplicándole una expresión regular y parseando su fecha. El filtro de
fechas se aplicaba *después* de todo eso, así que pedir «los últimos diez minutos» de un log de
21 MB seguía leyendo los 21 MB. Y el modo `tail` —el que trae la vista por defecto— lo hacía dos
veces: una pasada para contar cuántas líneas coincidían (hace falta para saber cuántas páginas
hay) y otra para recoger el rango de la página pedida.

**El arreglo, primera mitad: bisección.** Como el log se escribe en orden cronológico, el
principio de la ventana se puede encontrar por **búsqueda binaria sobre desplazamientos de
byte**: en vez de leer desde el principio, se salta directamente al byte donde empieza la
ventana. Y por el otro extremo, la lectura corta en cuanto pasa de la fecha final pedida.

La objeción evidente es que al log le escriben **dos procesos distintos** —la API y el worker
RQ—, cada uno con su propio handler abierto sobre el mismo fichero, así que el orden podría no
ser perfecto y la bisección podría saltarse líneas. Lo he medido sobre un log real de 190 414
líneas: de las 119 556 que llevan marca de tiempo hay **10 inversiones**, y la peor es de **18
ms**. Es decir, el orden no es estrictamente monótono pero el desorden está acotado a
centésimas de segundo. La bisección busca el corte con **un segundo de holgura**, que es tres
órdenes de magnitud más de lo que el desorden medido necesita.

**El detalle de la numeración de línea.** `firstLine` y `lastLine` son números de línea *del
fichero*, y el panel los enseña tal cual. Si al saltar a mitad del fichero se renumerara desde el
punto de salto, la misma línea tendría un número distinto según qué ventana se pidiera. Así que
las líneas del tramo saltado sí hay que contarlas — pero se cuentan en crudo, contando saltos de
línea sobre los bytes sin decodificar nada: **37 ms** frente a los **1180 ms** de recorrer lo
mismo decodificando, aplicando la regex y parseando fechas. Treinta veces más barato.

**El arreglo, segunda mitad: una pasada en vez de dos.** El modo `tail` ahora cuenta y recoge en
el mismo recorrido, guardando por el camino las últimas `page × per_page` coincidencias —500
líneas para la quinta página de cien—. Por encima de 5000 líneas de búfer (páginas muy
profundas) se vuelve al camino antiguo de dos pasadas, para no retener demasiado en memoria.

**Lo que se gana**, medido sobre el log de desarrollo real de 21,3 MB:

| Consulta | Antes | Ahora |
|---|---|---|
| `tail` sin filtros, página 1 | 8,6 s | 4,6 s |
| `tail`, últimos 10 minutos | 4,6 s | **64 ms** |
| `tail`, últimos 60 minutos | 4,6 s | **64 ms** |

Las dos últimas filas son la razón por la que los atajos de ventana no son solo comodidad: son
también el camino rápido. Nótese que el coste antiguo era idéntico pidieras la ventana que
pidieras, porque no dependía de cuánto devolvías sino de cuánto log había acumulado.

**Cómo se evita que el atajo pierda líneas en silencio.** Ese es el riesgo real de una
optimización así: si el salto se pasa de largo, faltan líneas y la respuesta sigue teniendo buena
pinta. El test nuevo (`tests/unit/test_log_reader_window.py`) fija la invariante que lo impide:
**bisecar y no bisecar tienen que dar exactamente el mismo resultado**. La comparación se hace
contra el mismo lector con la bisección desactivada, así que no hay una segunda implementación
que mantener. Se comprueba sobre nueve combinaciones de consulta y sobre un log sintético que
mete a propósito los dos casos que rompen la suposición de que el log está ordenado y de que cada
línea lleva su fecha: inversiones de orden cada cincuenta líneas, y tracebacks de tres líneas sin
prefijo cada ciento treinta.

De hecho ese test ya sirvió: cazó un error de uno en la bisección. La búsqueda binaria nunca
llega a examinar la línea que empieza justo en su límite inferior, así que devolver el candidato
encontrado en vez del mínimo entre ese candidato y el límite se saltaba una línea cuando la
fecha pedida caía exactamente en una frontera. Quedarse corto es inofensivo —el filtro normal
descarta las líneas de más—; pasarse de largo pierde datos sin que nada lo delate.

### 3. El panel (`de26ad87`)

- **Atajos de ventana**: 10 min, 30 min, 1 h, 6 h, 24 h, 7 días y «Todo». Las fechas escritas a
  mano siguen estando, ahora bajo «Personalizado».
- **«Ver últimos logs»**, que vuelve al estado de arranque de un clic.
- **Nivel mínimo** en lugar de nivel exacto, con un botón «Solo avisos y errores» que es
  `minLevel=WARNING`.
- **Contadores por nivel** de la ventana, pulsables para filtrar por ese nivel y superiores.
- **Refresco automático** cada 15 s, apoyado en el composable `usePolling` que ya existía y que
  ya sabe no solapar peticiones, pararse con la pestaña oculta y limpiarse al salir de la vista.
- **Coloreado por nivel y resaltado del término buscado**. Las líneas de continuación heredan el
  nivel de su cabecera, para que el cuerpo de un traceback no salga en gris justo debajo de su
  error en rojo. Todo se pinta por interpolación de Vue, nunca por HTML crudo: una línea de log
  puede traer una ruta o un cuerpo de petición escritos por un tercero.

**Una decisión que merece explicación: la ventana relativa la resuelve el servidor, no el
navegador.** Las marcas de tiempo del log no llevan zona horaria — son la hora local de la API.
Si el navegador calculara «hace diez minutos» con su propio reloj, un administrador conectado
desde otro huso pediría una ventana desplazada por la diferencia horaria y no vería nada, o
vería lo que no toca. Por eso el atajo viaja como `lastMinutes=10` y es la API quien lo traduce
contra su propio reloj. La respuesta devuelve `windowStart` para que el panel pueda decir desde
qué instante está enseñando sin recalcularlo por su cuenta.

Como consecuencia, `lastMinutes` y `from` son **excluyentes**: pedir a la vez «los últimos diez
minutos» y «desde las nueve» no significa nada, así que el backend responde 400 en vez de elegir
uno en silencio.

La traducción de los filtros de la vista a parámetros de la petición vive en un composable
aparte (`web/app/src/composables/logWindows.js`) para poder probarla en Node puro, sin navegador,
como ya se hace con `usePolling` y con el transporte de logs.

### 4. El límite de peticiones (`4a5befe2`)

`GET /system/logs` estaba limitado a 30 por hora, calibrado para una lectura puntual. Pero cada
cambio de página, cada «Actualizar» y cada aplicación de filtros consume una, y con el refresco
automático son cuatro por minuto: la cuota se agotaba en minutos y dejaba el panel inservible
justo cuando hacía falta mirarlo. Pasa a 240 por hora; el tope diario sigue acotando el abuso.

### 5. README (`2ceb98be`)

La fila de `/system/logs` documenta ahora los parámetros de ventana y severidad y los campos
nuevos de la respuesta.

---

## Lo que ya estaba resuelto y no se ha tocado

Merece decirse porque era una de las hipótesis de partida del issue: **la compresión y la caché
ya existían**. El endpoint comprime la página con gzip nivel 9 y la codifica en base64, el
cliente la descomprime con `DecompressionStream`, y la store manda `If-None-Match` y trata el 304
sin borrar la página en pantalla. El cuello de botella no estaba en el transporte, estaba en el
escaneo del fichero en el servidor; comprimir más no habría movido la aguja.

## Validación

- `pytest` completo en `API/`: pasa, exit 0 (cobertura total 82 %).
- Tests nuevos: 6 de integración en `tests/integration/test_system.py` (severidad mínima,
  contadores que ignoran el filtro de nivel, contadores que sí respetan la ventana temporal,
  nivel desconocido rechazado, ventana relativa contra el reloj del servidor, ventana relativa y
  absoluta a la vez rechazada) y 12 unitarios en `tests/unit/test_log_reader_window.py`.
- `pylint` sobre los ficheros tocados: sin avisos nuevos (los dos que quedan en `log_reader.py`
  ya estaban antes; la nota subió de 9,63 a 9,78).
- `npm run test:logs` (7 pruebas nuevas más las 3 del transporte), `test:polling`, `test:toast`.
- `npm run build` del SPA.

## Fuera de alcance, y por qué

**La rotación del log.** `system/logging.py` instala un `logging.FileHandler` normal, que no
rota: el fichero crece sin límite hasta que alguien lo borra a mano, y el de desarrollo va ya por
21 MB. Hace falta, pero se ha dejado fuera a propósito por dos razones. La primera es que rotar
sin más *empeora* la herramienta: el log de ayer dejaría de ser consultable desde el panel, salvo
que el visor aprenda a leer también los ficheros rotados, que es una decisión de diseño en sí
misma. La segunda es que `RotatingFileHandler` **no es seguro cuando dos procesos escriben el
mismo fichero** —que es exactamente el caso aquí, API y worker—, porque ambos intentarían
renombrarlo; la alternativa segura es `WatchedFileHandler` con `logrotate` externo, o un fichero
por proceso, y eso tiene consecuencias de despliegue. Merece su propio issue en vez de colarse
dentro de una mejora de interfaz.

También quedan fuera: migrar el log a formato estructurado (una línea JSON por entrada) o a un
índice, el streaming en vivo por SSE o WebSocket —el sondeo cubre el caso sin abrir un canal
nuevo— y la descarga o exportación del log completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
