### PR TITLE
El panel de configuracion llega a todo SecOpsConfig.json, y el modelo de IA se cambia sin redesplegar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ POSTGRES_PORT=5432
 POSTGRES_DIALECT=postgresql+psycopg2
 
 # ── Ollama ────────────────────────────────────────────────────────────────────
+# El host sí vive aquí (es infraestructura del despliegue). El MODELO ya no
+# hace falta tocarlo aquí: se elige desde el panel de configuración
+# (tools.scribe.strategies.ollama.model), que gana a esta variable y se aplica
+# al siguiente trabajo en segundo plano sin reiniciar nada. Esta se sigue
+# usando cuando el campo del panel se deja vacío.
 OLLAMA_HOST=http://127.0.0.1:11434
 OLLAMA_MODEL=qwen2.5:14b
 
@@ -46,12 +51,6 @@ REDIS_PORT=6379
 REDIS_DB=0
 REDIS_PASSWORD=your_redis_password_here
 
-# ── OpenVAS ─────────────────────────────────────────────────────────────────────
-OPENVAS_HOST=localhost
-OPENVAS_USERNAME=your_openvas_username
-OPENVAS_PASSWORD=your_secure_openvas_password_here
-OPENVAS_PORT=9390
-
 # ── SMTP (herald) ─────────────────────────────────────────────────────────────
 SMTP_USERNAME=your_smtp_username
 SMTP_PASSWORD=your_smtp_password
@@ -60,11 +59,18 @@ SMTP_PASSWORD=your_smtp_password
 PUBLIC_WEB_URL=http://localhost:5173
 
 # ── OpenAI ──────────────────────────────────────────────────────────────────────
+# Solo la credencial es obligatoria aquí. El modelo se elige desde el panel
+# (tools.scribe.strategies.openai.model); OPENAI_MODEL es el fallback para
+# cuando ese campo se deja vacío.
 OPENAI_API_KEY=sk-proj-your_openai_api_key_here
+OPENAI_MODEL=gpt-4o-mini        # opcional, fallback si el panel no fija modelo
+# Apunta a un proveedor compatible con la API de OpenAI (vLLM, LM Studio, un
+# gateway propio). Vacío = api.openai.com.
+OPENAI_BASE_URL=
 
 # ── Google Gemini ──────────────────────────────────────────────────────────────
 GOOGLE_API_KEY=your_google_api_key_here
-GOOGLE_MODEL=gemini-2.0-flash   # opcional, por defecto gemini-2.0-flash
+GOOGLE_MODEL=gemini-2.0-flash   # opcional, fallback si el panel no fija modelo
 
 # ── Iris mailbox connector (Gmail / Microsoft Graph) ───────────────────────────
 # Clave Fernet para cifrar en reposo el refresh token OAuth de cada buzón

--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -56,14 +56,27 @@
       "maxInputTokens": 24000,
       "modules": {
         "aegis": "openai",
-        "themis": "openai"
+        "themis": "openai",
+        "iris": "openai"
+      },
+      "resilience": {
+        "maxRetries": 3,
+        "retryBaseSeconds": 1.5,
+        "breakerThreshold": 3,
+        "breakerTimeoutSeconds": 60
       },
       "strategies": {
+        "ollama": {
+          "model": "",
+          "timeout": 300
+        },
         "google": {
-          "model": ""
+          "model": "",
+          "timeout": 120
         },
         "openai": {
-          "model": "gpt-4.1-2025-04-14"
+          "model": "gpt-4.1-2025-04-14",
+          "timeout": 120
         }
       }
     },

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -627,6 +627,46 @@ class ScribeConfig(_StrategySelection):
     total estimado (no solo al último mensaje) e independientemente del
     backend, ya que un contexto local también tiene un tope real."""
 
+    def timeout_for(self, strategy_name: str, default: int) -> int:
+        """Timeout de cliente declarado para ``strategy_name``, o ``default``.
+
+        Vive aquí y no en cada estrategia porque el valor está en la misma
+        rama que el modelo (``strategies.<proveedor>.timeout``) y se resuelve
+        igual: lo que diga el fichero gana, y si no dice nada se usa el que la
+        estrategia considere razonable para su backend — un modelo local tarda
+        mucho más que una API en la nube, así que no hay un único default
+        sensato para los tres."""
+        configured = self.options_for(strategy_name).get("timeout")
+        return int(configured) if configured else default
+
+
+@config_block("tools.scribe.resilience")
+@dataclass(frozen=True)
+class ScribeResilienceConfig:
+    """Lo que ``AIGenerator`` hace cuando el proveedor de IA falla.
+
+    Eran cuatro constantes en la firma de ``AIGenerator.__init__`` que la
+    factory nunca sobreescribía, así que los valores del código eran los
+    únicos que existían: ajustar la tolerancia a un proveedor lento o
+    inestable obligaba a tocar el código y redesplegar.
+    """
+
+    max_retries: int = 3
+    """Intentos totales de una misma generación antes de rendirse."""
+
+    retry_base_seconds: float = 1.5
+    """Base de la espera exponencial entre intentos: el intento ``n`` espera
+    ``base ** n`` segundos. Con 1.5 son 1 s y 1,5 s antes del tercero."""
+
+    breaker_threshold: int = 3
+    """Fallos seguidos que abren el *circuit breaker*. Abierto, las llamadas
+    se rechazan al instante en vez de encadenar timeouts contra un backend
+    que ya se sabe caído."""
+
+    breaker_timeout_seconds: int = 60
+    """Segundos que el breaker permanece abierto antes de dejar pasar una
+    llamada de prueba."""
+
 
 @config_block("tools.herald")
 @dataclass(frozen=True)
@@ -647,6 +687,10 @@ class HeraldConfig(_StrategySelection):
 
 def scribe_config() -> ScribeConfig: # type: ignore
     return load_block(ScribeConfig) # type: ignore
+
+
+def scribe_resilience_config() -> ScribeResilienceConfig: # type: ignore
+    return load_block(ScribeResilienceConfig) # type: ignore
 
 
 def herald_config() -> HeraldConfig: # type: ignore

--- a/API/src/modules/system/endpoints.py
+++ b/API/src/modules/system/endpoints.py
@@ -27,6 +27,7 @@ from .schemas import (
     TaskPaginationQuerySchema,
     LogQuerySchema,
     SystemLogsResponseSchema,
+    AIModelsResponseSchema,
 )
 from .exceptions import (
     LogNotFoundError,
@@ -36,6 +37,7 @@ from .exceptions import (
 from .services import (
     read_logs,
 )
+from src.modules.tools.scribe import strategy_catalog
 
 import src.modules.system.config_reading as CR
 
@@ -198,6 +200,26 @@ def update_config():
     config = CR.save_full_config(new_config, expected_version=if_match)
     logger.info("Configuracion actualizada correctamente | user=%s", current_actor())
     return config, 200, {"ETag": CR.get_config_version()}
+
+
+@system_blp.get("/ai/models")
+@system_blp.response(200, AIModelsResponseSchema, description="Models each AI provider serves")
+@system_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@system_blp.alt_response(403, schema=ErrorSchema, description="Insufficient role")
+@limiter.limit("30 per hour")
+@require_oauth_token
+# Root, como el resto de /system: la respuesta dice qué proveedores de IA hay
+# configurados y cuáles responden, que es información del despliegue.
+@require_role(minimum_role=Role.ROOT)
+@handle_exceptions(default_exception=IllegalStateError, logger=logger)
+def get_ai_models():
+    """Modelos disponibles en cada proveedor de IA configurado.
+
+    Alimenta el desplegable de modelo del panel de configuración: sin esto,
+    elegir modelo es escribir un identificador de memoria, y equivocarse no
+    se nota hasta que falla un job de fondo.
+    """
+    return {"strategies": strategy_catalog()}
 
 
 # =============================================================================

--- a/API/src/modules/system/schemas.py
+++ b/API/src/modules/system/schemas.py
@@ -166,3 +166,24 @@ class SystemLogsResponseSchema(Schema):
     timeZone = fields.String(required=True)
     firstLine = fields.Integer(allow_none=True)
     lastLine = fields.Integer(allow_none=True)
+
+
+class AIStrategyModelsSchema(Schema):
+    """Una estrategia de scribe y los modelos que su proveedor sirve ahora.
+
+    ``isReachable`` en false no es un error de la petición: significa que a
+    ese proveedor concreto no se le pudo preguntar (sin credenciales, servidor
+    apagado, red cortada) y que ``error`` dice por qué. El resto de filas
+    siguen siendo válidas — tener OpenAI caído no impide elegir modelo de
+    Ollama.
+    """
+
+    strategy = fields.String(required=True)
+    configuredModel = fields.String(required=True)
+    models = fields.List(fields.String(), required=True)
+    isReachable = fields.Boolean(required=True)
+    error = fields.String(required=True)
+
+
+class AIModelsResponseSchema(Schema):
+    strategies = fields.List(fields.Nested(AIStrategyModelsSchema), required=True)

--- a/API/src/modules/tools/scribe/__init__.py
+++ b/API/src/modules/tools/scribe/__init__.py
@@ -18,6 +18,7 @@ from .inputs import AIInput, AIResult, Example, estimate_tokens
 from .strategies import ModelStrategy, OllamaStrategy, OpenAIStrategy, GoogleStrategy, ToolExecutor
 from .generator import AIGenerator
 from .factory import build_generator
+from .catalog import strategy_catalog
 from .tools import web_search, WEB_SEARCH_TOOL
 from .exceptions import (
     AIConnectionError,
@@ -40,6 +41,7 @@ __all__ = [
     "ToolExecutor",
     "AIGenerator",
     "build_generator",
+    "strategy_catalog",
     "web_search",
     "WEB_SEARCH_TOOL",
     "AIConnectionError",

--- a/API/src/modules/tools/scribe/catalog.py
+++ b/API/src/modules/tools/scribe/catalog.py
@@ -1,0 +1,62 @@
+"""
+scribe.catalog
+──────────────
+Qué modelos puede usar este despliegue, preguntándoselo a los proveedores.
+
+Existe para que el panel de configuración ofrezca un desplegable con los
+modelos que de verdad hay disponibles, en vez de un campo de texto en el que
+hay que escribir ``gpt-4.1-2025-04-14`` sin equivocarse. Un identificador mal
+escrito no falla al guardar: falla más tarde, dentro de un job de fondo, y lo
+único que ve el usuario es que el informe no se generó.
+
+La consulta se hace por estrategia y **cada una falla por su cuenta**: que
+OpenAI esté caído o sin credenciales no es motivo para no poder elegir modelo
+de Ollama, así que un proveedor inalcanzable devuelve su error en su fila en
+lugar de romper la respuesta entera.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import src.modules.system.config_reading as CR
+
+from .strategies import ModelStrategy
+
+logger = logging.getLogger(__name__)
+
+
+def strategy_catalog() -> list[dict]:
+    """Una fila por estrategia registrada, con su modelo elegido y su catálogo.
+
+    Returns:
+        Lista de diccionarios con las claves ``strategy`` (el nombre del
+        proveedor), ``configuredModel`` (lo que hoy dice
+        ``tools.scribe.strategies.<proveedor>.model``, vacío si se delega en
+        el ``.env``), ``models`` (lo que el proveedor sirve ahora mismo),
+        ``isReachable`` y ``error``.
+    """
+    scribe = CR.scribe_config()
+    catalog = []
+
+    for strategy_name in ModelStrategy.registered_names():
+        row = {
+            "strategy": strategy_name,
+            "configuredModel": scribe.options_for(strategy_name).get("model") or "",
+            "models": [],
+            "isReachable": False,
+            "error": "",
+        }
+        try:
+            row["models"] = ModelStrategy.resolve_class(strategy_name).available_models()
+            row["isReachable"] = True
+        except Exception as exc:  # noqa: BLE001 — se reporta, no se propaga
+            # Falta de credenciales, servidor apagado, versión de librería que
+            # no trae el listado: todo se ve igual desde aquí y todo tiene la
+            # misma respuesta útil, que es decírselo al usuario en su fila.
+            logger.info("[scribe/catalog] %s no responde: %s", strategy_name, exc)
+            row["error"] = str(exc)
+
+        catalog.append(row)
+
+    return catalog

--- a/API/src/modules/tools/scribe/factory.py
+++ b/API/src/modules/tools/scribe/factory.py
@@ -47,4 +47,17 @@ def build_generator(module: Optional[str] = None) -> AIGenerator:
     """
     strategy_name = CR.scribe_config().strategy_for(module)
     logger.info("[scribe] módulo=%s → estrategia=%s", module, strategy_name)
-    return AIGenerator(_build_strategy(strategy_name))
+
+    # La resiliencia se pasa desde aquí y no se deja en los defaults de
+    # ``AIGenerator``: la factory es el único sitio que construye generadores
+    # de producción, así que es donde la configuración tiene que entrar. Los
+    # defaults de la firma siguen valiendo para quien instancia el generador
+    # a mano en un test.
+    resilience = CR.scribe_resilience_config()
+    return AIGenerator(
+        _build_strategy(strategy_name),
+        max_retries=resilience.max_retries,
+        retry_base=resilience.retry_base_seconds,
+        breaker_threshold=resilience.breaker_threshold,
+        breaker_timeout=resilience.breaker_timeout_seconds,
+    )

--- a/API/src/modules/tools/scribe/strategies.py
+++ b/API/src/modules/tools/scribe/strategies.py
@@ -95,7 +95,11 @@ class OllamaStrategy(ModelStrategy):
     def from_config(cls, overrides: dict) -> "OllamaStrategy":
         import src.modules.system.config_reading as CR
         host, model = CR.get_ollama_environment()
-        return cls(host=host, model=overrides.get("model") or model)
+        return cls(
+            host=host,
+            model=overrides.get("model") or model,
+            timeout=CR.scribe_config().timeout_for("ollama", 300),
+        )
 
     def __init__(self, host: str, model: str, timeout: int = 300) -> None:
         import ollama
@@ -168,6 +172,7 @@ class OpenAIStrategy(ModelStrategy):
             api_key=env["api_key"],
             model=overrides.get("model") or env["model"],
             base_url=env.get("base_url"),
+            timeout=CR.scribe_config().timeout_for("openai", 120),
         )
 
     def __init__(
@@ -257,6 +262,7 @@ class GoogleStrategy(ModelStrategy):
         return cls(
             api_key=env["api_key"],
             model=overrides.get("model") or env["model"],
+            timeout=CR.scribe_config().timeout_for("google", 120),
         )
 
     def __init__(self, api_key: str, model: str, timeout: int = 120) -> None:
@@ -266,6 +272,10 @@ class GoogleStrategy(ModelStrategy):
         logger.info("[scribe/google] cliente model=%s", model)
         genai.configure(api_key=api_key)
         self._genai = genai
+        # Gemini no ata el timeout al cliente como Ollama y OpenAI: va por
+        # llamada, en ``request_options``. De ahí que se guarde en vez de
+        # consumirse en el constructor.
+        self._request_options = {"timeout": timeout}
 
     @staticmethod
     def _build_tool_declarations(tools: list[dict]) -> list[dict]:
@@ -355,6 +365,7 @@ class GoogleStrategy(ModelStrategy):
                 contents=contents,
                 generation_config=generation_config,
                 tools=tools,
+                request_options=self._request_options,
             )
 
             if tool_executor and tools:
@@ -380,6 +391,7 @@ class GoogleStrategy(ModelStrategy):
                         contents=contents,
                         generation_config=generation_config,
                         tools=tools,
+                        request_options=self._request_options,
                     )
 
             try:

--- a/API/src/modules/tools/scribe/strategies.py
+++ b/API/src/modules/tools/scribe/strategies.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 # Ejecutor de herramientas: recibe (nombre, argumentos) y devuelve texto.
 ToolExecutor = Callable[[str, dict], str]
 
+# Prefijos de los modelos de chat de OpenAI. ``models.list()`` devuelve el
+# catálogo entero de la cuenta —embeddings, whisper, dall-e, moderación—, y
+# ninguno de esos sirve para generar texto con scribe.
+_OPENAI_CHAT_PREFIXES = ("gpt-", "o1", "o3", "o4", "chatgpt-")
+
 
 class ModelStrategy(ABC):
     """Contrato de una estrategia de llamada al modelo.
@@ -53,12 +58,34 @@ class ModelStrategy(ABC):
         return decorator
 
     @classmethod
-    def resolve(cls, name: str, overrides: dict) -> "ModelStrategy":
-        """Instancia la estrategia ``name`` con credenciales de entorno/config."""
+    def registered_names(cls) -> list[str]:
+        """Nombres de las estrategias dadas de alta, ordenados.
+
+        El registro es privado a propósito —nadie de fuera debe poder
+        manipularlo—, pero saber *qué proveedores existen* sí es información
+        pública: es lo que el catálogo de modelos recorre para preguntarle a
+        cada uno qué sirve.
+        """
+        return sorted(cls._registry)
+
+    @classmethod
+    def resolve_class(cls, name: str) -> type["ModelStrategy"]:
+        """La clase dada de alta con ``name``, sin construirla.
+
+        Separada de ``resolve`` porque el catálogo de modelos pregunta al
+        proveedor sin necesitar una instancia: construir una exigiría las
+        credenciales completas, y el catálogo tiene que poder responder
+        aunque a un proveedor le falte alguna.
+        """
         strategy_cls = cls._registry.get(name)
         if strategy_cls is None:
             raise AIStrategyConfigurationError(f"estrategia desconocida: '{name}'")
-        return strategy_cls.from_config(overrides)
+        return strategy_cls
+
+    @classmethod
+    def resolve(cls, name: str, overrides: dict) -> "ModelStrategy":
+        """Instancia la estrategia ``name`` con credenciales de entorno/config."""
+        return cls.resolve_class(name).from_config(overrides)
 
     @classmethod
     def from_config(cls, overrides: dict) -> "ModelStrategy":
@@ -70,6 +97,28 @@ class ModelStrategy(ABC):
         estrategia directamente (sin pasar por ``resolve``/config real) no
         tiene por qué implementarlo — solo lo necesitan las estrategias
         registradas de verdad."""
+        raise NotImplementedError
+
+    @classmethod
+    def available_models(cls) -> list[str]:
+        """Modelos que este proveedor sirve ahora mismo, ordenados.
+
+        Es lo que permite que el panel ofrezca un desplegable en vez de un
+        campo de texto en el que hay que escribir de memoria
+        ``gpt-4.1-2025-04-14``. Un identificador mal escrito no falla al
+        guardar: falla mucho después, dentro de un job de fondo, y el usuario
+        solo ve que el informe no se generó.
+
+        No es ``@abstractmethod`` por el mismo motivo que ``from_config``: un
+        doble de test no tiene por qué implementarlo.
+
+        Raises:
+            Exception: Lo que lance el cliente del proveedor. Quien pregunta
+                decide qué hacer con un proveedor inalcanzable — el endpoint
+                lo reporta por estrategia en vez de romper la respuesta
+                entera, porque tener OpenAI caído no es motivo para no poder
+                elegir modelo de Ollama.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -100,6 +149,25 @@ class OllamaStrategy(ModelStrategy):
             model=overrides.get("model") or model,
             timeout=CR.scribe_config().timeout_for("ollama", 300),
         )
+
+    @classmethod
+    def available_models(cls) -> list[str]:
+        """Lo que el servidor de Ollama tiene descargado (``/api/tags``)."""
+        import ollama
+        import src.modules.system.config_reading as CR
+
+        host, _ = CR.get_ollama_environment()
+        listing = ollama.Client(host=host, timeout=10).list()
+        # La librería devolvió durante un tiempo diccionarios planos y ahora
+        # devuelve objetos; se acepta cualquiera de las dos formas para no
+        # atar el catálogo a la versión instalada.
+        entries = listing.get("models", []) if isinstance(listing, dict) else listing.models
+        names = [
+            entry.get("model") or entry.get("name") if isinstance(entry, dict)
+            else getattr(entry, "model", None) or getattr(entry, "name", None)
+            for entry in entries
+        ]
+        return sorted(name for name in names if name)
 
     def __init__(self, host: str, model: str, timeout: int = 300) -> None:
         import ollama
@@ -173,6 +241,24 @@ class OpenAIStrategy(ModelStrategy):
             model=overrides.get("model") or env["model"],
             base_url=env.get("base_url"),
             timeout=CR.scribe_config().timeout_for("openai", 120),
+        )
+
+    @classmethod
+    def available_models(cls) -> list[str]:
+        """El catálogo que la cuenta de OpenAI tiene habilitado.
+
+        Se filtra a los modelos de chat: la lista cruda trae también
+        *embeddings*, transcripción de audio e imagen, que no sirven para
+        nada en scribe y solo estorban en el desplegable.
+        """
+        from openai import OpenAI
+        import src.modules.system.config_reading as CR
+
+        env = CR.get_openai_environment()
+        client = OpenAI(api_key=env["api_key"], base_url=env.get("base_url") or None, timeout=10)
+        return sorted(
+            model.id for model in client.models.list()
+            if any(model.id.startswith(prefix) for prefix in _OPENAI_CHAT_PREFIXES)
         )
 
     def __init__(
@@ -263,6 +349,24 @@ class GoogleStrategy(ModelStrategy):
             api_key=env["api_key"],
             model=overrides.get("model") or env["model"],
             timeout=CR.scribe_config().timeout_for("google", 120),
+        )
+
+    @classmethod
+    def available_models(cls) -> list[str]:
+        """Los modelos de Gemini que aceptan ``generateContent``.
+
+        Los identificadores llegan con el prefijo ``models/``, que la API
+        acepta pero que en el desplegable solo es ruido: se recorta para que
+        lo que se guarde sea el mismo nombre que uno escribiría a mano.
+        """
+        import google.generativeai as genai
+        import src.modules.system.config_reading as CR
+
+        genai.configure(api_key=CR.get_google_environment()["api_key"])
+        return sorted(
+            entry.name.removeprefix("models/")
+            for entry in genai.list_models()
+            if "generateContent" in getattr(entry, "supported_generation_methods", [])
         )
 
     def __init__(self, api_key: str, model: str, timeout: int = 120) -> None:

--- a/API/tests/integration/test_system.py
+++ b/API/tests/integration/test_system.py
@@ -481,3 +481,58 @@ def test_status_filter_by_concrete_state_still_works(client, admin_user, auth_he
         resp = client.get("/system/tasks?status=failed", headers=auth_headers(admin_user))
     data = resp.get_json()
     assert [t["id"] for t in data["tasks"]] == ["b"]
+
+
+# =============================================================================
+# CATÁLOGO DE MODELOS DE IA
+# =============================================================================
+
+
+def test_ai_models_requires_root(client, admin_user, auth_headers):
+    """Como el resto de /system: la respuesta describe el despliegue (qué
+    proveedores hay y cuáles responden), no un recurso del usuario."""
+    assert client.get("/system/ai/models", headers=auth_headers(admin_user)).status_code == 403
+
+
+def test_ai_models_lists_every_registered_strategy(client, root_user, auth_headers):
+    """Aunque ninguno responda: el panel necesita saber que la estrategia
+    existe para poder ofrecerla, y el error explica por qué está vacía."""
+    response = client.get("/system/ai/models", headers=auth_headers(root_user))
+
+    assert response.status_code == 200
+    strategies = response.get_json()["strategies"]
+    assert {row["strategy"] for row in strategies} == {"ollama", "openai", "google"}
+
+
+def test_ai_models_reports_the_configured_model_per_strategy(client, root_user, auth_headers):
+    response = client.get("/system/ai/models", headers=auth_headers(root_user))
+
+    openai_row = next(r for r in response.get_json()["strategies"] if r["strategy"] == "openai")
+    assert openai_row["configuredModel"] == CR.scribe_config().options_for("openai")["model"]
+
+
+def test_ai_models_survives_a_provider_that_cannot_be_reached(client, root_user, auth_headers):
+    """La suite está sellada contra la red, así que preguntarle de verdad a
+    Ollama falla — que es justo el caso que hay que cubrir: la fila trae el
+    error y la respuesta sigue siendo un 200 con el resto de proveedores."""
+    response = client.get("/system/ai/models", headers=auth_headers(root_user))
+
+    assert response.status_code == 200
+    ollama_row = next(r for r in response.get_json()["strategies"] if r["strategy"] == "ollama")
+    assert ollama_row["isReachable"] is False
+    assert ollama_row["error"]
+    assert ollama_row["models"] == []
+
+
+def test_ai_models_returns_what_a_reachable_provider_serves(client, root_user, auth_headers):
+    from src.modules.tools.scribe.strategies import OllamaStrategy
+
+    with mock.patch.object(
+        OllamaStrategy, "available_models", classmethod(lambda cls: ["qwen2.5:14b", "llama3.2"])
+    ):
+        response = client.get("/system/ai/models", headers=auth_headers(root_user))
+
+    ollama_row = next(r for r in response.get_json()["strategies"] if r["strategy"] == "ollama")
+    assert ollama_row["isReachable"] is True
+    assert ollama_row["models"] == ["qwen2.5:14b", "llama3.2"]
+    assert ollama_row["error"] == ""

--- a/API/tests/unit/test_config_shape.py
+++ b/API/tests/unit/test_config_shape.py
@@ -205,6 +205,7 @@ CONFIG_BLOCKS = [
     (CR.AegisConfig, CR.aegis_config),
     (CR.IrisConfig, CR.iris_config),
     (CR.ScribeConfig, CR.scribe_config),
+    (CR.ScribeResilienceConfig, CR.scribe_resilience_config),
     (CR.HeraldConfig, CR.herald_config),
     (CR.GeneralConfig, CR.general_config),
     (CR.RegistrationConfig, CR.registration_config),

--- a/API/tests/unit/test_config_view_paths.py
+++ b/API/tests/unit/test_config_view_paths.py
@@ -4,7 +4,12 @@
 ``web/app/src/views/ConfigView.vue`` enlaza cada control del formulario con
 ``store.configFlat['ruta.con.puntos']``. Ese ``configFlat`` es el aplanado de
 lo que devuelve ``GET /system``, es decir de ``SecOpsConfig.json`` entero, así
-que cada una de esas ~45 rutas literales es una ruta real dentro del JSON.
+que cada una de esas rutas literales es una ruta real dentro del JSON.
+
+Los controles pintados con ``v-for`` no escriben la ruta entera, la componen
+—``configFlat[`features.hygeia.limits.${limit.key}`]``—, así que el recorrido
+de rutas literales no los ve. De esos se verifica el tramo fijo: que apunte a
+una rama que existe de verdad, que es lo que se rompe al mover una clave.
 
 El modo de fallo que esto cierra es silencioso en las dos direcciones:
 
@@ -37,10 +42,26 @@ _SECOPS_CONFIG = _REPO_ROOT / "API" / "SecOpsConfig.json"
 # store.configFlat['features.themis.enabled'] -> features.themis.enabled
 _CONFIG_FLAT_PATH_RE = re.compile(r"configFlat\[\s*'([^']+)'\s*\]")
 
+# Los controles que se pintan con v-for no escriben la ruta entera, la
+# componen: configFlat[`features.hygeia.limits.${limit.key}`]. La parte
+# variable no se puede resolver sin ejecutar el .vue, pero el tramo literal
+# de delante sí, y es el que se rompe cuando alguien mueve una rama del JSON.
+_CONFIG_FLAT_TEMPLATE_RE = re.compile(r"configFlat\[\s*`([^`]*?)\$\{")
+
 
 def _config_view_paths() -> list[str]:
     source = _CONFIG_VIEW.read_text(encoding="utf-8")
     return sorted(set(_CONFIG_FLAT_PATH_RE.findall(source)))
+
+
+def _config_view_branch_prefixes() -> list[str]:
+    """Los tramos literales de las rutas compuestas, sin el punto final."""
+    source = _CONFIG_VIEW.read_text(encoding="utf-8")
+    return sorted({
+        prefix.rstrip(".")
+        for prefix in _CONFIG_FLAT_TEMPLATE_RE.findall(source)
+        if prefix.strip(".")
+    })
 
 
 def _resolve(config: dict, dotted_path: str):
@@ -109,4 +130,43 @@ def test_every_config_view_path_points_at_a_leaf(secops_config):
         "ConfigView.vue enlaza rutas que apuntan a una rama del JSON.\n"
         "`flatten` solo produce claves para hojas, así que ese control no se "
         "enlaza con nada:\n" + "\n".join(branches)
+    )
+
+
+def test_config_view_binds_some_composed_paths():
+    """Red de seguridad del test de abajo, igual que la del de rutas literales:
+    si el .vue dejara de componer rutas con plantillas, esto caería en vez de
+    dar por buenos cero prefijos."""
+    prefixes = _config_view_branch_prefixes()
+    assert len(prefixes) > 5, f"solo se extrajeron {len(prefixes)} prefijos de ConfigView.vue"
+
+
+def test_every_composed_path_prefix_is_a_real_branch(secops_config):
+    """El tramo fijo de una ruta compuesta apunta a una rama que existe.
+
+    Los controles que se pintan con ``v-for`` —los umbrales y los límites de
+    Hygeia, los diales del motor de Lybra, el modelo de cada proveedor de IA—
+    no llevan la ruta escrita entera, así que el test de rutas literales no
+    los ve: son decenas de campos sin ninguna red debajo.
+
+    Resolver la parte variable exigiría ejecutar el ``.vue``, pero no hace
+    falta para cubrir el fallo que de verdad ocurre: mover o renombrar una
+    rama del JSON. Si ``features.hygeia.limits`` pasara a llamarse de otra
+    forma, el prefijo dejaría de resolver aquí — y en el panel, esos diez
+    controles se pintarían igual sin estar enlazados a nada.
+    """
+    broken = []
+    for prefix in _config_view_branch_prefixes():
+        try:
+            node = _resolve(secops_config, prefix)
+        except KeyError as exc:
+            broken.append(f"  {prefix}: {exc.args[0]}")
+            continue
+        if not isinstance(node, dict):
+            broken.append(f"  {prefix}: existe pero es un valor, no una rama")
+
+    assert not broken, (
+        "ConfigView.vue compone rutas sobre prefijos que no son ramas del JSON.\n"
+        "Los controles pintados con v-for se dibujan igual pero no guardan nada:\n"
+        + "\n".join(broken)
     )

--- a/API/tests/unit/test_scribe_config_wiring.py
+++ b/API/tests/unit/test_scribe_config_wiring.py
@@ -1,0 +1,119 @@
+"""Lo que ``scribe`` lee de ``SecOpsConfig.json`` en vez de tenerlo a fuego.
+
+Antes, el modelo de cada proveedor solo se podía cambiar por el ``.env`` (que
+es parte del despliegue: cambiarlo obliga a redesplegar) y los cuatro
+parámetros de resiliencia del generador estaban escritos en la firma de
+``AIGenerator.__init__``, sin ninguna ruta de configuración. Estos tests atan
+las tres costuras que hacen que ahora se puedan cambiar desde el panel:
+
+- ``ScribeConfig.timeout_for`` resuelve el timeout de cliente por proveedor.
+- ``build_generator`` le pasa al generador la resiliencia configurada, en vez
+  de dejarle usar los defaults de su propia firma.
+- La estrategia de un módulo sale de ``tools.scribe.modules``, incluido Iris,
+  que usa IA desde ``iris/services/ai_writer.py`` y no estaba declarado.
+"""
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.tools.scribe import factory
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeStrategy:
+    """Estrategia de mentira: evita construir un cliente real de proveedor."""
+
+    name = "fake"
+
+    def complete(self, ai_input, tool_executor=None):  # pragma: no cover - no se llama
+        return "ok"
+
+
+# ------------------------------------------------------- ScribeConfig.timeout_for
+
+def test_timeout_for_prefers_the_configured_value():
+    config = CR.ScribeConfig(strategies={"openai": {"timeout": 45}})
+    assert config.timeout_for("openai", 120) == 45
+
+
+def test_timeout_for_falls_back_when_the_strategy_declares_nothing():
+    """Cada backend tiene un default razonable distinto —un modelo local tarda
+    mucho más que una API en la nube—, así que el fallback lo pone quien
+    pregunta, no el bloque de configuración."""
+    config = CR.ScribeConfig(strategies={"openai": {"model": "gpt-4o-mini"}})
+    assert config.timeout_for("openai", 120) == 120
+    assert config.timeout_for("ollama", 300) == 300
+
+
+def test_timeout_for_ignores_a_zero_because_it_would_mean_no_wait_at_all():
+    config = CR.ScribeConfig(strategies={"ollama": {"timeout": 0}})
+    assert config.timeout_for("ollama", 300) == 300
+
+
+# ------------------------------------------------------------- build_generator
+
+def test_build_generator_uses_the_configured_resilience(monkeypatch):
+    """Sin esto, la factory construía el generador con los defaults de la
+    firma y los valores del fichero no llegaban a ninguna parte."""
+    monkeypatch.setattr(factory, "_build_strategy", lambda name: _FakeStrategy())
+    monkeypatch.setattr(CR, "scribe_config", lambda: CR.ScribeConfig(default_strategy="fake"))
+    monkeypatch.setattr(
+        CR, "scribe_resilience_config",
+        lambda: CR.ScribeResilienceConfig(
+            max_retries=7,
+            retry_base_seconds=2.5,
+            breaker_threshold=9,
+            breaker_timeout_seconds=11,
+        ),
+    )
+
+    generator = factory.build_generator("aegis")
+
+    assert generator._max_retries == 7
+    assert generator._retry_base == 2.5
+    assert generator._breaker_threshold == 9
+    assert generator._breaker_timeout == 11
+
+
+def test_build_generator_picks_the_strategy_declared_for_the_module(monkeypatch):
+    requested: list[str] = []
+    monkeypatch.setattr(
+        factory, "_build_strategy",
+        lambda name: requested.append(name) or _FakeStrategy(),
+    )
+    monkeypatch.setattr(
+        CR, "scribe_config",
+        lambda: CR.ScribeConfig(default_strategy="openai", modules={"iris": "ollama"}),
+    )
+    monkeypatch.setattr(CR, "scribe_resilience_config", CR.ScribeResilienceConfig)
+
+    factory.build_generator("iris")
+    factory.build_generator("aegis")
+
+    assert requested == ["ollama", "openai"]
+
+
+# ------------------------------------------------------ el fichero que se despliega
+
+def test_the_shipped_config_declares_a_strategy_for_every_ai_module():
+    """Los tres módulos que llaman a ``build_generator`` tienen que estar en
+    ``tools.scribe.modules``, o su estrategia queda implícita en el default y
+    el panel no tiene qué pintar para ellos."""
+    modules = CR.scribe_config().modules
+    assert set(modules) >= {"themis", "aegis", "iris"}, (
+        f"faltan módulos en tools.scribe.modules: {sorted({'themis', 'aegis', 'iris'} - set(modules))}"
+    )
+
+
+def test_the_shipped_config_declares_a_block_for_every_registered_strategy():
+    """Un proveedor sin bloque propio en ``strategies`` no tiene dónde guardar
+    su modelo, así que el panel no puede ofrecerlo — que es exactamente lo que
+    le pasaba a Ollama."""
+    from src.modules.tools.scribe.strategies import ModelStrategy
+
+    declared = set(CR.scribe_config().strategies)
+    registered = set(ModelStrategy._registry)
+    assert registered <= declared, (
+        f"estrategias registradas sin bloque en SecOpsConfig.json: {sorted(registered - declared)}"
+    )

--- a/API/tests/unit/test_scribe_config_wiring.py
+++ b/API/tests/unit/test_scribe_config_wiring.py
@@ -113,7 +113,7 @@ def test_the_shipped_config_declares_a_block_for_every_registered_strategy():
     from src.modules.tools.scribe.strategies import ModelStrategy
 
     declared = set(CR.scribe_config().strategies)
-    registered = set(ModelStrategy._registry)
+    registered = set(ModelStrategy.registered_names())
     assert registered <= declared, (
         f"estrategias registradas sin bloque en SecOpsConfig.json: {sorted(registered - declared)}"
     )

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ A subscription with no explicit plan falls back to the default plan (seeded by m
 | `GET` | `/system/info` · `/system/status` | (admin) App metadata / CPU-mem-disk status |
 | `GET` | `/system/logs` | (admin) Paginated central log viewer — gzip+base64 page, snapshot-anchored. Windowing with `lastMinutes` (relative, resolved against the **server** clock; mutually exclusive with `from`) or `from`/`to`; severity with `level` (exact) or `minLevel` (that level and above). The response carries `levelCounts` for the window, computed *before* the level filter, plus `windowStart` |
 | `GET/PUT` | `/system` | (root) Read / save `SecOpsConfig.json` (`PUT` requires `If-Match` ETag) |
+| `GET` | `/system/ai/models` | (root) Models each configured AI provider currently serves — feeds the model dropdown in the config panel. Providers are queried independently: one that cannot be reached reports its error in its own row instead of failing the response |
 | `GET` | `/system/tasks` · `/system/tasks/status` · `/system/tasks/<id>` | (admin) List tasks, queue status, task detail |
 | `POST` | `/system/tasks/<id>/cancel` | (admin) Cancel a queued/running task |
 | `PUT` | `/system/tasks/config` | (admin) Change `max_workers` (applies on worker restart) |
@@ -612,29 +613,48 @@ AI generation uses an injectable strategy chosen in `API/SecOpsConfig.json` unde
 ```json
 "scribe": {
   "defaultStrategy": "openai",
-  "modules": { "themis": "openai", "aegis": "openai" },
+  "maxInputTokens": 24000,
+  "modules": { "themis": "openai", "aegis": "openai", "iris": "openai" },
+  "resilience": { "maxRetries": 3, "retryBaseSeconds": 1.5, "breakerThreshold": 3, "breakerTimeoutSeconds": 60 },
   "strategies": {
-    "google": { "model": "" },
-    "openai": { "model": "gpt-4.1-2025-04-14" }
+    "ollama": { "model": "", "timeout": 300 },
+    "google": { "model": "", "timeout": 120 },
+    "openai": { "model": "gpt-4.1-2025-04-14", "timeout": 120 }
   }
 }
 ```
 
 | Strategy | Model | Use case |
 |---|---|---|
-| `ollama` | `llama3.2` (env default) | Local, GPU-friendly, no API cost |
-| `openai` | `gpt-4.1-2025-04-14` (JSON default; env `OPENAI_MODEL` overrides, default `gpt-4o-mini`) | Cloud, for VPS without GPU |
-| `google` | `gemini-2.0-flash` (env default) | Cloud alternative to OpenAI |
+| `ollama` | JSON, else env `OLLAMA_MODEL` | Local, GPU-friendly, no API cost |
+| `openai` | `gpt-4.1-2025-04-14` (JSON), else env `OPENAI_MODEL` (default `gpt-4o-mini`) | Cloud, for VPS without GPU |
+| `google` | JSON, else env `GOOGLE_MODEL` (default `gemini-2.0-flash`) | Cloud alternative to OpenAI |
 
-Environment variables (in `API/.env`):
+**Changing the model does not need a redeploy.** `strategies.<provider>.model` wins over the
+environment variable, and the JSON is hot-reloadable: `PUT /system` (what the config panel does)
+refreshes the API process in place, the RQ worker re-reads the file per job when its mtime changed,
+and the generator is built inside the job — so the next background job uses the new model. An
+empty `model` means "use this provider's environment variable", which is how it behaved before the
+model became configurable from the panel.
+
+`GET /system/ai/models` asks each registered provider what it serves so the panel can offer a
+dropdown instead of a free-text field; a provider that cannot be reached (missing credentials,
+server down) reports its error in its own row and the field falls back to free text.
+
+`resilience` holds what the generator does when a provider fails: retries with exponential backoff,
+and the circuit breaker that stops calling a backend already known to be down. `timeout` is
+per-provider because a local model is far slower than a cloud API.
+
+Environment variables (in `API/.env` — credentials, plus the model fallbacks):
 
 ```
 OLLAMA_HOST=http://localhost:11434
-OLLAMA_MODEL=llama3.2
+OLLAMA_MODEL=llama3.2        # fallback when the panel leaves the model empty
 OPENAI_API_KEY=sk-...        # only needed if a module uses "openai"
-OPENAI_MODEL=gpt-4o-mini
+OPENAI_MODEL=gpt-4o-mini     # fallback
+OPENAI_BASE_URL=             # optional: an OpenAI-compatible endpoint (vLLM, LM Studio, a gateway)
 GOOGLE_API_KEY=...           # only needed if a module/strategy uses "google"
-GOOGLE_MODEL=gemini-2.0-flash
+GOOGLE_MODEL=gemini-2.0-flash  # fallback
 ```
 
 ### Email sending (herald module)
@@ -714,6 +734,8 @@ Ellysia uses a layered configuration system (`API/src/modules/system/config_read
 
 Config is read through frozen dataclasses bound to a branch of the tree (`@config_block`, e.g. `CR.nuclei_config().rate_limit`), not one getter per value, and cached — changes to `SecOpsConfig.json` require an app restart unless applied via `PUT /system`. Background jobs pick them up too: the worker re-reads the file per job when its mtime changed (`CR.reload_if_changed()`).
 
+The config panel (`web/app/src/views/ConfigView.vue`) exposes every settable key of the tree — the AI and email layers, the Themis knowledge base and Lybra engine dials, JWT and MFA policy, Hygeia thresholds, limits and report palette. The one branch deliberately left out is `features.iris.data.*`: those are the anti-phishing heuristic corpora (word lists, homoglyph maps, suspicious TLDs), detection content rather than deployment settings. `API/tests/unit/test_config_view_paths.py` pins the panel's paths against the JSON — the literal ones by full path, the ones composed in a `v-for` by their fixed prefix.
+
 > [!WARNING]
 > `features.themis.areLocalIpsAllowed` ships as `false`, and a test pins that value (`test_the_anti_ssrf_defence_ships_enabled`): with `true`, a user can point a scan at the server's internal network or the cloud metadata endpoint. Flip it to `true` in your working copy for local development against private IPs, but do not commit it.
 
@@ -726,4 +748,4 @@ Config is read through frozen dataclasses bound to a branch of the tree (`@confi
 - `API/src/data/` and `docs/` are gitignored (scan outputs, generated PDFs).
 - PostgreSQL uses port **15432** locally (not standard 5432).
 - There is a single `TaskStatus` enum, in `system/taskqueue/task.py`; `themis/services/tasks.py` imports it rather than defining its own.
-- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.10`, read by `CR.get_app_version()`).
+- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.13`, read by `CR.get_app_version()`).

--- a/web/app/src/components/config/ModelPicker.vue
+++ b/web/app/src/components/config/ModelPicker.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="form-group model-picker">
+    <label>{{ label }}</label>
+
+    <select v-if="usesDropdown" :value="modelValue" class="inp sel" @change="pick($event.target.value)">
+      <option value="">Usar el del entorno ({{ envHint }})</option>
+      <option v-for="name in options" :key="name" :value="name">{{ name }}</option>
+    </select>
+
+    <input
+      v-else
+      :value="modelValue"
+      type="text"
+      class="inp mono"
+      :placeholder="envHint"
+      @input="pick($event.target.value)"
+    />
+
+    <div class="mp-foot">
+      <span v-if="loading" class="field-hint">Consultando al proveedor…</span>
+      <span v-else-if="catalog?.isReachable" class="field-hint">
+        {{ options.length }} {{ options.length === 1 ? 'modelo disponible' : 'modelos disponibles' }}
+      </span>
+      <span v-else class="field-hint field-hint--warn" :title="catalog?.error">
+        No se pudo consultar el proveedor: escribe el identificador a mano.
+      </span>
+
+      <button v-if="catalog?.isReachable" type="button" class="mp-toggle" @click="isManual = !isManual">
+        {{ isManual ? 'Elegir de la lista' : 'Escribirlo a mano' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Selector del modelo de un proveedor de IA.
+ *
+ * Escribir el identificador a mano (`gpt-4.1-2025-04-14`) es fácil de
+ * equivocar, y equivocarse no se nota al guardar: falla mucho después, dentro
+ * de un job de fondo, y lo único que ve el usuario es que el informe no se
+ * generó. Por eso lo normal aquí es un desplegable con lo que el proveedor
+ * dice servir ahora mismo (`GET /system/ai/models`).
+ *
+ * El campo de texto sigue existiendo por dos motivos, y por eso no es un
+ * `<select>` a secas: cuando al proveedor no se le puede preguntar (sin
+ * credenciales, servidor apagado) hay que poder configurarlo igual, y cuando
+ * el modelo es más nuevo que lo que el catálogo devuelve hay que poder
+ * adelantarse.
+ *
+ * El valor vacío no es "sin modelo": significa delegar en la variable de
+ * entorno del proveedor, que es como se comportaba todo antes de que el
+ * modelo se pudiera configurar desde aquí.
+ */
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  label: { type: String, required: true },
+  /** Fila de GET /system/ai/models: { models, isReachable, error } */
+  catalog: { type: Object, default: null },
+  /** Variable de entorno que se usa cuando el campo queda vacío */
+  envHint: { type: String, required: true },
+  loading: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const isManual = ref(false)
+
+/** Lo que sirve el proveedor, más el valor guardado si el catálogo no lo trae
+ *  todavía: un modelo configurado no puede desaparecer del desplegable por no
+ *  estar en la respuesta, o al abrir el panel se perdería sin tocar nada. */
+const options = computed(() => {
+  const served = props.catalog?.models || []
+  if (props.modelValue && !served.includes(props.modelValue)) return [props.modelValue, ...served]
+  return served
+})
+
+const usesDropdown = computed(() => !isManual.value && props.catalog?.isReachable)
+
+function pick(value) { emit('update:modelValue', value) }
+</script>
+
+<style scoped>
+/* Los estilos de formulario de ConfigView son `scoped`, así que no cruzan al
+   interior de un componente hijo: se repiten aquí los cuatro que este usa. */
+.form-group { display: flex; flex-direction: column; gap: 0.25rem; }
+.form-group label { font-size: var(--fs-md); font-weight: 600; color: var(--text-dim); }
+.inp { background: var(--bg); border: 1px solid var(--border-solid); border-radius: 6px; padding: 0.45rem 0.6rem; color: var(--text); font-size: var(--fs-input); outline: none; transition: border-color 0.2s; width: 100%; }
+.inp:focus { border-color: var(--accent); }
+.sel { cursor: pointer; appearance: none; -webkit-appearance: none; padding-right: 1.8rem; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2382829a' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 0.55rem center; background-size: 0.85rem; }
+.sel option { background: var(--surface-2); color: var(--text); }
+.mono { font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); }
+.field-hint { font-size: var(--fs-md); color: var(--text-muted); line-height: 1.5; }
+
+.mp-foot { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
+.field-hint--warn { color: var(--warning, #d0a215); }
+.mp-toggle { background: none; border: none; padding: 0; color: var(--accent-bright); font-size: var(--fs-md); font-weight: 600; cursor: pointer; white-space: nowrap; }
+.mp-toggle:hover { text-decoration: underline; }
+</style>

--- a/web/app/src/stores/configStore.js
+++ b/web/app/src/stores/configStore.js
@@ -31,6 +31,12 @@ export const useConfigStore = defineStore('config', () => {
   const loading = ref(false)
   /** Guardado en curso */
   const saving = ref(false)
+  /** Catálogo de modelos por proveedor de IA, indexado por nombre de estrategia.
+   *  Cada entrada es { models, isReachable, error } tal cual la devuelve
+   *  GET /system/ai/models. */
+  const aiModels = reactive({})
+  /** Consulta del catálogo en curso */
+  const aiModelsLoading = ref(false)
 
   /**
    * Carga la configuración desde GET /system y la aplana.
@@ -46,6 +52,24 @@ export const useConfigStore = defineStore('config', () => {
       Object.assign(configFlat, flat)
       originalFlat = { ...flat }
     } finally { loading.value = false }
+  }
+
+  /**
+   * Pregunta a cada proveedor de IA qué modelos sirve ahora mismo.
+   *
+   * Va aparte de `loadConfig` y no bloquea el formulario: son llamadas de red
+   * a terceros (OpenAI, Google) que pueden tardar o no responder, y el panel
+   * tiene que poder pintarse igual. Mientras no llegue —o si nunca llega— el
+   * selector de modelo cae a campo de texto libre.
+   */
+  async function loadAiModels() {
+    aiModelsLoading.value = true
+    try {
+      const res = await apiFetch('/system/ai/models')
+      if (!res?.ok) return
+      const data = await res.json()
+      for (const row of data.strategies || []) aiModels[row.strategy] = row
+    } finally { aiModelsLoading.value = false }
   }
 
   /** Restaura los valores del formulario a la última configuración guardada */
@@ -88,11 +112,15 @@ export const useConfigStore = defineStore('config', () => {
    * toda la config global (root-only), no debe sobrevivir a la sesión. */
   function $reset() {
     for (const key of Object.keys(configFlat)) delete configFlat[key]
+    for (const key of Object.keys(aiModels)) delete aiModels[key]
     originalFlat = {}
     etag = null
     loading.value = false
     saving.value = false
   }
 
-  return { configFlat, loading, saving, loadConfig, resetForm, saveConfig, $reset }
+  return {
+    configFlat, loading, saving, aiModels, aiModelsLoading,
+    loadConfig, loadAiModels, resetForm, saveConfig, $reset,
+  }
 })

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -162,6 +162,45 @@
             </div>
           </section>
 
+          <section id="section-herald" class="section">
+            <div class="section-head"><h2>Correo</h2><p class="section-desc">Relay de salida y marca de los mensajes</p></div>
+            <div class="section-body">
+              <p class="field-hint">Por aquí salen las campañas de Aegis, los avisos de Hygeia e Iris y los correos de cuenta (verificación, invitaciones, recuperación). El usuario y la contraseña del relay viven en <code>SMTP_USERNAME</code> y <code>SMTP_PASSWORD</code> del <code>.env</code>; lo de aquí no es secreto.</p>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Estrategia por defecto</label>
+                  <select v-model="store.configFlat['tools.herald.defaultStrategy']" class="inp sel">
+                    <option v-for="s in mailStrategies" :key="s.value" :value="s.value">{{ s.label }}</option>
+                  </select>
+                </div>
+                <div v-for="m in mailModules" :key="m.key" class="form-group"><label>{{ m.label }}</label>
+                  <select v-model="store.configFlat[`tools.herald.modules.${m.key}`]" class="inp sel">
+                    <option v-for="s in mailStrategies" :key="s.value" :value="s.value">{{ s.label }}</option>
+                  </select>
+                </div>
+              </div>
+
+              <h3 class="subsection-title">Relay SMTP</h3>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Host</label><input v-model="store.configFlat['tools.herald.strategies.smtp.host']" type="text" class="inp mono" /></div>
+                <div class="form-group"><label>Puerto</label><input v-model.number="store.configFlat['tools.herald.strategies.smtp.port']" type="number" min="1" max="65535" class="inp" /></div>
+                <div class="form-group"><label>Dirección del remitente</label><input v-model="store.configFlat['tools.herald.strategies.smtp.fromAddress']" type="text" class="inp mono" /></div>
+                <div class="form-group"><label>Nombre del remitente</label><input v-model="store.configFlat['tools.herald.strategies.smtp.fromName']" type="text" class="inp" /></div>
+              </div>
+              <div class="cfg-row"><label class="toggle-row"><input v-model="store.configFlat['tools.herald.strategies.smtp.useTls']" type="checkbox" class="toggle" /><span>Cifrar con STARTTLS</span></label></div>
+
+              <h3 class="subsection-title">Marca de los correos</h3>
+              <p class="field-hint">Lo que pintan las plantillas. Es la marca base del producto: el white-label por organización se configura en cada organización y se aplica encima de esta.</p>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Nombre del producto</label><input v-model="store.configFlat['tools.herald.branding.productName']" type="text" class="inp" /></div>
+                <div class="form-group"><label>Color de acento</label><input v-model="store.configFlat['tools.herald.branding.accentColor']" type="color" class="inp color-inp" /></div>
+                <div class="form-group"><label>URL del logotipo</label><input v-model="store.configFlat['tools.herald.branding.logoUrl']" type="text" class="inp mono" /><span class="field-hint">Vacío = sin logotipo</span></div>
+                <div class="form-group"><label>Correo de soporte</label><input v-model="store.configFlat['tools.herald.branding.supportEmail']" type="text" class="inp mono" /></div>
+              </div>
+              <div class="form-group"><label>Nota del pie</label><input v-model="store.configFlat['tools.herald.branding.footerNote']" type="text" class="inp" /></div>
+              <div class="form-group"><label>Directorio de plantillas</label><input v-model="store.configFlat['tools.herald.templatesDir']" type="text" class="inp mono" /><span class="field-hint">Vacío = las plantillas que trae la aplicación</span></div>
+            </div>
+          </section>
+
           <section id="section-iris" class="section">
             <div class="section-head"><h2>Iris</h2><p class="section-desc">Umbrales de análisis de cabeceras de correo</p></div>
             <div class="section-body">
@@ -320,6 +359,7 @@ const ICON = {
   redis:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>',
   taskqueue: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><line x1="8" y1="9" x2="16" y2="9"/><line x1="8" y1="13" x2="14" y2="13"/></svg>',
   ai:        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="6" height="6" rx="1"/><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 15h3M1 9h3M1 15h3"/></svg>',
+  herald:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v16H4z"/><path d="m4 7 8 6 8-6"/><path d="M2 20h6"/></svg>',
   iris:      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 5L2 7"/></svg>',
   themis:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>',
   aegis:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>',
@@ -336,6 +376,7 @@ const navGroups = [
   ]},
   { label: 'Módulos', items: [
     { id: 'ai',       label: 'IA',       icon: ICON.ai },
+    { id: 'herald',   label: 'Correo',   icon: ICON.herald },
     { id: 'iris',     label: 'Iris',     icon: ICON.iris },
     { id: 'themis', label: 'Themis', icon: ICON.themis },
     { id: 'aegis',    label: 'Aegis',    icon: ICON.aegis },
@@ -360,6 +401,19 @@ const aiModules = [
   { key: 'themis', label: 'Themis' },
   { key: 'aegis',  label: 'Aegis' },
   { key: 'iris',   label: 'Iris' },
+]
+
+// Herald solo tiene una estrategia registrada hoy (relay SMTP). El selector se
+// mantiene porque la capa es enchufable por diseño y la alternativa —esconder
+// el control— haría invisible qué está eligiendo el sistema.
+const mailStrategies = [
+  { value: 'smtp', label: 'Relay SMTP' },
+]
+const mailModules = [
+  { key: 'aegis',    label: 'Aegis (campañas)' },
+  { key: 'iris',     label: 'Iris (avisos)' },
+  { key: 'hygeia',   label: 'Hygeia (avisos)' },
+  { key: 'accounts', label: 'Cuentas (verificación, invitaciones)' },
 ]
 const severities = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
 
@@ -455,6 +509,9 @@ function handleSave() { store.saveConfig() }
 .sel { cursor: pointer; appearance: none; -webkit-appearance: none; padding-right: 1.8rem; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2382829a' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 0.55rem center; background-size: 0.85rem; }
 .sel option { background: var(--surface-2); color: var(--text); }
 .mono { font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); }
+/* Un `input[type=color]` con el relleno de `.inp` deja la muestra reducida a
+   una línea: aquí el control ES la muestra, así que se le quita el relleno. */
+.color-inp { padding: 0.15rem; height: 2.1rem; cursor: pointer; }
 .toggle-row { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; font-size: var(--fs-lg); font-weight: 500; color: var(--text); }
 .toggle { width: 16px; height: 16px; accent-color: var(--accent); cursor: pointer; }
 .field-hint { font-size: var(--fs-md); color: var(--text-muted); line-height: 1.5; }

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -62,13 +62,36 @@
           </section>
 
           <section id="section-security" class="section">
-            <div class="section-head"><h2>Seguridad</h2><p class="section-desc">Hashing de contraseñas (Argon2id)</p></div>
+            <div class="section-head"><h2>Seguridad</h2><p class="section-desc">Contraseñas, sesión y segundo factor</p></div>
             <div class="section-body">
               <p class="field-hint">Parámetros de coste de Argon2id. Subirlos endurece los hashes pero ralentiza el inicio de sesión. Solo afectan a contraseñas creadas o cambiadas tras guardar.</p>
               <div class="cfg-grid">
                 <div class="form-group"><label>Iteraciones (time cost)</label><input v-model.number="store.configFlat['general.security.argon2.time_cost']" type="number" min="1" max="20" class="inp" /></div>
                 <div class="form-group"><label>Memoria (KiB)</label><input v-model.number="store.configFlat['general.security.argon2.memory_cost']" type="number" min="8192" step="1024" class="inp" /><span class="field-hint">65536 KiB = 64 MiB por hash</span></div>
                 <div class="form-group"><label>Paralelismo (hilos)</label><input v-model.number="store.configFlat['general.security.argon2.parallelism']" type="number" min="1" max="16" class="inp" /></div>
+              </div>
+
+              <h3 class="subsection-title">Sesión (JWT)</h3>
+              <p class="field-hint">Cuánto vive una sesión. El token de acceso es el que acompaña a cada petición; el de refresco es el que permite renovarlo sin volver a pedir la contraseña, así que su vigencia es la duración real de la sesión. El secreto de firma vive en <code>JWT_SECRET_KEY</code> y no está aquí. En contenedores, <code>JWT_ALGORITHM</code>, <code>ACCESS_TOKEN_EXPIRY_MINUTES</code> y <code>REFRESH_TOKEN_EXPIRY_DAYS</code> tienen prioridad sobre estos valores.</p>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Algoritmo de firma</label>
+                  <select v-model="store.configFlat['general.security.jwt.algorithm']" class="inp sel">
+                    <option v-for="alg in jwtAlgorithms" :key="alg" :value="alg">{{ alg }}</option>
+                  </select>
+                  <span class="field-hint">Solo la familia HS*: la firma usa un secreto simétrico</span>
+                </div>
+                <div class="form-group"><label>Vigencia del token de acceso (min)</label><input v-model.number="store.configFlat['general.security.jwt.access_token_expiry_minutes']" type="number" min="1" max="1440" class="inp" /></div>
+                <div class="form-group"><label>Vigencia del token de refresco (días)</label><input v-model.number="store.configFlat['general.security.jwt.refresh_token_expiry_days']" type="number" min="1" max="365" class="inp" /></div>
+              </div>
+
+              <h3 class="subsection-title">Segundo factor (TOTP)</h3>
+              <p class="field-hint">El emisor es el nombre que la aplicación autenticadora enseña junto al código. Los códigos de recuperación se generan una sola vez al activar el segundo factor: cambiar aquí su número no afecta a quien ya lo tenga activado.</p>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Emisor</label><input v-model="store.configFlat['general.security.mfa.issuer']" type="text" class="inp" /></div>
+                <div class="form-group"><label>Vigencia del reto (min)</label><input v-model.number="store.configFlat['general.security.mfa.challenge_expiry_minutes']" type="number" min="1" max="60" class="inp" /></div>
+                <div class="form-group"><label>Intentos por reto</label><input v-model.number="store.configFlat['general.security.mfa.max_challenge_attempts']" type="number" min="1" max="20" class="inp" /></div>
+                <div class="form-group"><label>Códigos de recuperación</label><input v-model.number="store.configFlat['general.security.mfa.recovery_codes_count']" type="number" min="1" max="50" class="inp" /></div>
+                <div class="form-group"><label>Recordatorio de activación (días)</label><input v-model.number="store.configFlat['general.security.mfa.notice_interval_days']" type="number" min="1" max="365" class="inp" /><span class="field-hint">Cada cuánto se le recuerda a quien no lo tiene activado</span></div>
               </div>
             </div>
           </section>
@@ -374,6 +397,16 @@
                   <div v-if="metric.sustained" class="form-group"><label>{{ metric.label }} — latidos sostenidos</label><input v-model.number="store.configFlat[`features.hygeia.thresholds.${metric.key}.sustainedHeartbeats`]" type="number" min="1" max="60" class="inp" /></div>
                 </template>
               </div>
+              <h3 class="subsection-title">Colores del informe</h3>
+              <p class="field-hint">La paleta con la que se genera el PDF de Hygeia, igual que la de cada escáner de Themis.</p>
+              <div class="color-grid">
+                <div v-for="color in reportColors" :key="color.key" class="color-pick">
+                  <input v-model="store.configFlat[`features.hygeia.colorPalette.${color.key}`]" type="color" class="color-input" />
+                  <span class="color-label">{{ color.label }}</span>
+                  <span class="color-hex">{{ store.configFlat[`features.hygeia.colorPalette.${color.key}`] }}</span>
+                </div>
+              </div>
+
               <h3 class="subsection-title">Límites</h3>
               <p class="field-hint">Topes de lo que el agente puede enviar y de lo que la API acepta. Recortarlos protege a la API de un agente comprometido o mal configurado.</p>
               <div class="cfg-grid">
@@ -441,6 +474,9 @@ const navGroups = [
 const navSections = navGroups.flatMap((g) => g.items)
 
 const isolationLevels = ['READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE']
+// Solo la familia HS*: la firma usa un secreto simétrico, y el backend
+// rechaza cualquier otra cosa (S8).
+const jwtAlgorithms = ['HS256', 'HS384', 'HS512']
 // `envVar` es la variable que se usa cuando el campo de modelo queda vacío, y
 // se enseña como pista dentro del propio control: sin ella, un campo vacío se
 // lee como «sin modelo» en vez de como «el que diga el entorno».
@@ -509,6 +545,18 @@ const hygeiaMetrics = [
   { key: 'diskPct', label: 'Disco (%)',  sustained: false },
   { key: 'swapPct', label: 'Swap (%)',   sustained: false },
 ]
+// Las seis tintas de una paleta de informe. Mismo juego que usa ScannerCard
+// para los escáneres de Themis; aquí se repite la lista porque Hygeia no pasa
+// por ese componente (no es un escáner, no tiene prompts ni tarjeta propia).
+const reportColors = [
+  { key: 'black',     label: 'Negro' },
+  { key: 'dark',      label: 'Oscuro' },
+  { key: 'main',      label: 'Principal' },
+  { key: 'secondary', label: 'Secundario' },
+  { key: 'light',     label: 'Claro' },
+  { key: 'white',     label: 'Blanco' },
+]
+
 const hygeiaLimits = [
   { key: 'maxBodyBytes',         label: 'Tamaño máx. del cuerpo (bytes)', hint: '1048576 = 1 MiB' },
   { key: 'maxDecompressedBytes', label: 'Tamaño máx. descomprimido (bytes)', hint: '4194304 = 4 MiB' },
@@ -517,7 +565,8 @@ const hygeiaLimits = [
   { key: 'maxNetInterfaces',     label: 'Interfaces de red' },
   { key: 'maxSeriesPoints',      label: 'Puntos por serie temporal' },
   { key: 'minIntervalSec',       label: 'Intervalo mínimo entre latidos (s)' },
-  { key: 'clockSkewSec',         label: 'Desfase de reloj tolerado (s)' },
+  { key: 'clockSkewSec',         label: 'Desfase de reloj tolerado (s)', hint: 'Cuánto se acepta que el reloj del agente vaya adelantado' },
+  { key: 'maxBackfillSec',       label: 'Antigüedad máx. de un latido (s)', hint: '86400 = un día; más viejo que eso se rechaza' },
   { key: 'maxAssetsPerUser',     label: 'Activos por usuario' },
   { key: 'maxInventoryItems',    label: 'Elementos de inventario' },
 ]
@@ -593,6 +642,11 @@ function handleSave() { store.saveConfig() }
 .cfg-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; }
 .cfg-grid--tight { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.5rem; }
 .cfg-row { display: flex; align-items: center; }
+.color-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)); gap: 0.35rem; max-width: 560px; }
+.color-pick { display: flex; flex-direction: column; align-items: center; gap: 0.1rem; padding: 0.4rem 0.2rem; background: var(--bg); border-radius: 5px; border: 1px solid var(--border); }
+.color-input { width: 30px; height: 22px; border: none; border-radius: 3px; cursor: pointer; background: transparent; padding: 0; }
+.color-label { font-size: var(--fs-body); font-weight: 600; color: var(--text-dim); }
+.color-hex { font-size: var(--fs-body); color: var(--text-muted); font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); }
 .chip-row { display: flex; flex-wrap: wrap; gap: 0.35rem; }
 .chip { display: flex; align-items: center; gap: 0.3rem; padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border-solid); border-radius: 999px; font-size: var(--fs-md); color: var(--text-dim); cursor: pointer; }
 .chip input { accent-color: var(--accent); cursor: pointer; }

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -117,22 +117,46 @@
           <section id="section-ai" class="section">
             <div class="section-head"><h2>IA</h2><p class="section-desc">Estrategia de los modelos de lenguaje por módulo</p></div>
             <div class="section-body">
-              <p class="field-hint">Elige qué proveedor genera el contenido de cada módulo. Las credenciales y los modelos se configuran en <code>.env</code> (<code>OLLAMA_*</code>, <code>OPENAI_*</code>).</p>
+              <p class="field-hint">Elige qué proveedor genera el contenido de cada módulo. Las credenciales siguen en <code>.env</code>; el modelo se elige aquí y se aplica al siguiente trabajo en segundo plano, sin reiniciar nada.</p>
               <div class="cfg-grid">
                 <div class="form-group"><label>Estrategia por defecto</label>
                   <select v-model="store.configFlat['tools.scribe.defaultStrategy']" class="inp sel">
                     <option v-for="s in aiStrategies" :key="s.value" :value="s.value">{{ s.label }}</option>
                   </select>
                 </div>
-                <div class="form-group"><label>Themis</label>
-                  <select v-model="store.configFlat['tools.scribe.modules.themis']" class="inp sel">
+                <div v-for="m in aiModules" :key="m.key" class="form-group"><label>{{ m.label }}</label>
+                  <select v-model="store.configFlat[`tools.scribe.modules.${m.key}`]" class="inp sel">
                     <option v-for="s in aiStrategies" :key="s.value" :value="s.value">{{ s.label }}</option>
                   </select>
                 </div>
-                <div class="form-group"><label>Aegis</label>
-                  <select v-model="store.configFlat['tools.scribe.modules.aegis']" class="inp sel">
-                    <option v-for="s in aiStrategies" :key="s.value" :value="s.value">{{ s.label }}</option>
-                  </select>
+              </div>
+
+              <h3 class="subsection-title">Modelo de cada proveedor</h3>
+              <p class="field-hint">La lista sale de preguntarle al proveedor qué sirve ahora mismo. Dejar el campo vacío significa usar la variable de entorno, que es como funcionaba antes de que el modelo se pudiera elegir desde aquí.</p>
+              <div class="cfg-grid">
+                <ModelPicker
+                  v-for="s in aiStrategies" :key="s.value"
+                  v-model="store.configFlat[`tools.scribe.strategies.${s.value}.model`]"
+                  :label="s.label" :env-hint="s.envVar"
+                  :catalog="store.aiModels[s.value]" :loading="store.aiModelsLoading" />
+              </div>
+
+              <h3 class="subsection-title">Límites y reintentos</h3>
+              <p class="field-hint">El tope de tokens rechaza un prompt desproporcionado antes de gastar la llamada. El corte automático deja de llamar al proveedor tras los fallos seguidos indicados, para no encadenar esperas contra un backend que ya se sabe caído.</p>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Tokens máximos del prompt</label><input v-model.number="store.configFlat['tools.scribe.maxInputTokens']" type="number" min="1000" max="200000" step="1000" class="inp" /></div>
+                <div class="form-group"><label>Intentos por generación</label><input v-model.number="store.configFlat['tools.scribe.resilience.maxRetries']" type="number" min="1" max="10" class="inp" /></div>
+                <div class="form-group"><label>Base de la espera entre intentos (s)</label><input v-model.number="store.configFlat['tools.scribe.resilience.retryBaseSeconds']" type="number" min="1" max="10" step="0.1" class="inp" /></div>
+                <div class="form-group"><label>Fallos que abren el corte</label><input v-model.number="store.configFlat['tools.scribe.resilience.breakerThreshold']" type="number" min="1" max="20" class="inp" /></div>
+                <div class="form-group"><label>Duración del corte (s)</label><input v-model.number="store.configFlat['tools.scribe.resilience.breakerTimeoutSeconds']" type="number" min="5" max="3600" class="inp" /></div>
+              </div>
+
+              <h3 class="subsection-title">Timeout de cada proveedor (s)</h3>
+              <p class="field-hint">Un modelo local tarda mucho más que una API en la nube, así que cada proveedor lleva el suyo.</p>
+              <div class="cfg-grid">
+                <div v-for="s in aiStrategies" :key="s.value" class="form-group">
+                  <label>{{ s.label }}</label>
+                  <input v-model.number="store.configFlat[`tools.scribe.strategies.${s.value}.timeout`]" type="number" min="10" max="1800" class="inp" />
                 </div>
               </div>
             </div>
@@ -284,6 +308,7 @@ import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
 import { useConfigStore } from '@/stores/configStore'
 import ScannerCard from '@/components/config/ScannerCard.vue'
+import ModelPicker from '@/components/config/ModelPicker.vue'
 import PromptField from '@/components/shared/PromptField.vue'
 
 const store = useConfigStore()
@@ -320,9 +345,21 @@ const navGroups = [
 const navSections = navGroups.flatMap((g) => g.items)
 
 const isolationLevels = ['READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE']
+// `envVar` es la variable que se usa cuando el campo de modelo queda vacío, y
+// se enseña como pista dentro del propio control: sin ella, un campo vacío se
+// lee como «sin modelo» en vez de como «el que diga el entorno».
 const aiStrategies = [
-  { value: 'ollama', label: 'Ollama (local)' },
-  { value: 'openai', label: 'OpenAI' },
+  { value: 'ollama', label: 'Ollama (local)', envVar: 'OLLAMA_MODEL' },
+  { value: 'openai', label: 'OpenAI',        envVar: 'OPENAI_MODEL' },
+  { value: 'google', label: 'Google Gemini', envVar: 'GOOGLE_MODEL' },
+]
+// Los módulos que generan contenido con IA. Iris faltaba: llama a
+// `build_generator("iris")` desde su redactor de resúmenes, pero su estrategia
+// no estaba declarada, así que caía en la de por defecto sin que se viera.
+const aiModules = [
+  { key: 'themis', label: 'Themis' },
+  { key: 'aegis',  label: 'Aegis' },
+  { key: 'iris',   label: 'Iris' },
 ]
 const severities = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
 
@@ -356,6 +393,9 @@ onMounted(async () => {
   // no está en el DOM (v-else), así que registrar el observer antes dejaba el
   // resaltado del nav sin observar nada — no fallaba, simplemente no hacía nada.
   await store.loadConfig()
+  // Sin `await`: son llamadas a proveedores externos que pueden tardar, y el
+  // formulario no debe esperarlas para pintarse.
+  store.loadAiModels()
   await nextTick()
   observer = new IntersectionObserver((entries) => {
     // Con este rootMargin varias secciones intersecan a la vez; la activa es la

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -237,6 +237,8 @@
               <div class="cfg-grid">
                 <div class="form-group"><label>Carpeta por defecto</label><input v-model="store.configFlat['features.themis.folders.defaultFolderName']" type="text" class="inp" /><span class="field-hint">Nombre de la carpeta virtual para escaneos sin agrupar</span></div>
                 <div class="form-group"><label>Escaneos en estadísticas</label><input v-model.number="store.configFlat['features.themis.history.maxScans']" type="number" min="1" max="100" class="inp" /><span class="field-hint">Escaneos recientes que se promedian en el histórico</span></div>
+                <div class="form-group"><label>Vigencia del riesgo aceptado (días)</label><input v-model.number="store.configFlat['features.themis.acceptedRiskDays']" type="number" min="1" max="3650" class="inp" /><span class="field-hint">Pasado ese plazo, un hallazgo aceptado vuelve a contar</span></div>
+                <div class="form-group"><label>Plazo por defecto de un trabajo (s)</label><input v-model.number="store.configFlat['features.themis.taskDefaults.timeout']" type="number" min="60" max="604800" class="inp" /><span class="field-hint">Lo que espera la cola antes de dar por muerto un escaneo</span></div>
               </div>
               <h3 class="subsection-title">Verificación de accesibilidad del host</h3>
               <div class="cfg-grid">
@@ -251,6 +253,23 @@
                 <div class="form-group"><label>Timeout (s)</label><input v-model.number="store.configFlat['features.themis.traceroute.timeout']" type="number" min="1" max="600" class="inp" /></div>
                 <div class="form-group"><label>Reintento si falla (min)</label><input v-model.number="store.configFlat['features.themis.traceroute.retryFailedMinutes']" type="number" min="1" max="1440" class="inp" /></div>
               </div>
+              <h3 class="subsection-title">Base de conocimiento</h3>
+              <p class="field-hint">El espejo local de NVD, KEV, EPSS y OVAL con el que Lybra decide si un servicio detectado es vulnerable. «Antigüedad máxima» es lo que se tolera desde la última sincronización de cada fuente antes de avisar de que está rancia; no borra nada.</p>
+              <div class="cfg-row"><label class="toggle-row"><input v-model="store.configFlat['features.themis.kb.enabled']" type="checkbox" class="toggle" /><span>Sincronización activa</span></label></div>
+              <div class="cfg-grid">
+                <div class="form-group"><label>Cron de sincronización</label><input v-model="store.configFlat['features.themis.kb.syncCron']" type="text" class="inp mono" /><span class="field-hint">Formato cron de cinco campos</span></div>
+                <div class="form-group"><label>Ventana pedida a NVD (días)</label><input v-model.number="store.configFlat['features.themis.kb.nvdWindowDays']" type="number" min="1" max="120" class="inp" /><span class="field-hint">Cuánto histórico se pide en cada pasada</span></div>
+                <div v-for="feed in kbFeeds" :key="feed.key" class="form-group">
+                  <label>Antigüedad máxima — {{ feed.label }} (días)</label>
+                  <input v-model.number="store.configFlat[`features.themis.kb.maxAgeDays.${feed.key}`]" type="number" min="1" max="365" class="inp" />
+                </div>
+              </div>
+              <div class="cfg-grid">
+                <div v-for="source in kbSourcePaths" :key="source.path" class="form-group">
+                  <label>Origen — {{ source.label }}</label>
+                  <input v-model="store.configFlat[source.path]" type="text" class="inp mono" />
+                </div>
+              </div>
             </div>
             <div class="scanner-grid">
               <ScannerCard name="Nmap" icon="scan" :flat="store.configFlat" prefix="features.themis.scanners.nmap" />
@@ -264,6 +283,16 @@
                   <div class="form-group"><label>Timeout por petición (s)</label><input v-model.number="store.configFlat['features.themis.scanners.nuclei.requestTimeout']" type="number" min="1" max="120" class="inp" /></div>
                   <div class="form-group"><label>Timeout del escaneo (s)</label><input v-model.number="store.configFlat['features.themis.scanners.nuclei.timeout']" type="number" min="60" max="14400" class="inp" /></div>
                 </div>
+                <div class="form-group">
+                  <label>Severidades por defecto</label>
+                  <div class="chip-row">
+                    <label v-for="sev in nucleiSeverities" :key="sev" class="chip">
+                      <input v-model="store.configFlat['features.themis.scanners.nuclei.defaultSeverities']" type="checkbox" :value="sev" />
+                      <span>{{ sev }}</span>
+                    </label>
+                  </div>
+                  <span class="field-hint">Lo que se escanea si el usuario no elige otra cosa</span>
+                </div>
               </ScannerCard>
               <ScannerCard name="Lybra" icon="scan" :flat="store.configFlat" prefix="features.themis.scanners.lybra">
                 <div class="cfg-row"><label class="toggle-row"><input v-model="store.configFlat['features.themis.scanners.lybra.activeChecks']" type="checkbox" class="toggle" /><span>Comprobaciones activas</span></label></div>
@@ -276,6 +305,32 @@
                     </select>
                   </div>
                   <div class="form-group"><label>Máx. comprobaciones</label><input v-model.number="store.configFlat['features.themis.scanners.lybra.ingest.maxChecks']" type="number" min="1" max="5000" class="inp" /></div>
+                </div>
+
+                <h4 class="card-subtitle">Motor</h4>
+                <p class="field-hint">Cuánto empuja el motor contra el objetivo. Subir la concurrencia o bajar el intervalo acelera el escaneo y aumenta el riesgo de que el objetivo lo trate como un ataque.</p>
+                <div class="cfg-grid cfg-grid--tight">
+                  <div v-for="dial in lybraEngineDials" :key="dial.key" class="form-group">
+                    <label>{{ dial.label }}</label>
+                    <input
+                      v-model.number="store.configFlat[`features.themis.scanners.lybra.engine.${dial.key}`]"
+                      type="number" :min="dial.min" :max="dial.max" :step="dial.step || 1" class="inp" />
+                  </div>
+                  <div class="form-group"><label>User-Agent</label><input v-model="store.configFlat['features.themis.scanners.lybra.engine.httpUserAgent']" type="text" class="inp mono" /></div>
+                </div>
+
+                <h4 class="card-subtitle">Evidencia</h4>
+                <p class="field-hint">El trozo de respuesta cruda que se guarda junto a cada hallazgo para poder revisarlo después.</p>
+                <div class="cfg-row"><label class="toggle-row"><input v-model="store.configFlat['features.themis.scanners.lybra.evidence.enabled']" type="checkbox" class="toggle" /><span>Guardar evidencia</span></label></div>
+                <div class="cfg-grid cfg-grid--tight">
+                  <div class="form-group"><label>Tamaño máx. (bytes)</label><input v-model.number="store.configFlat['features.themis.scanners.lybra.evidence.maxBodyBytes']" type="number" min="256" step="256" class="inp" /></div>
+                  <div class="form-group"><label>Retención (días)</label><input v-model.number="store.configFlat['features.themis.scanners.lybra.evidence.retentionDays']" type="number" min="1" max="3650" class="inp" /></div>
+                </div>
+
+                <h4 class="card-subtitle">Credenciales por defecto</h4>
+                <p class="field-hint">Es la única fase que escribe en el objetivo: cada intento es un inicio de sesión real. El tope es por cuenta, no por servicio, y evita que la comprobación se convierta en fuerza bruta.</p>
+                <div class="cfg-grid cfg-grid--tight">
+                  <div class="form-group"><label>Intentos por cuenta</label><input v-model.number="store.configFlat['features.themis.scanners.lybra.credentials.maxAttempts']" type="number" min="1" max="20" class="inp" /></div>
                 </div>
               </ScannerCard>
             </div>
@@ -342,7 +397,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
 import { useConfigStore } from '@/stores/configStore'
@@ -416,6 +471,35 @@ const mailModules = [
   { key: 'accounts', label: 'Cuentas (verificación, invitaciones)' },
 ]
 const severities = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
+// Nuclei etiqueta sus plantillas en minúsculas; el valor que se guarda tiene
+// que coincidir exactamente con lo que espera el binario.
+const nucleiSeverities = ['critical', 'high', 'medium', 'low', 'info']
+
+const kbFeeds = [
+  { key: 'nvd',  label: 'NVD' },
+  { key: 'kev',  label: 'KEV' },
+  { key: 'epss', label: 'EPSS' },
+  { key: 'oval', label: 'OVAL' },
+]
+
+// Los diales del motor de Lybra son quince campos numéricos con la misma
+// forma: se describen aquí y se pintan con v-for, como ya se hace con los
+// umbrales y los límites de Hygeia.
+const lybraEngineDials = [
+  { key: 'tcpConcurrency',       label: 'Concurrencia TCP',        min: 1,   max: 2000 },
+  { key: 'tcpTimeout',           label: 'Timeout TCP (s)',         min: 0.1, max: 60, step: 0.1 },
+  { key: 'udpTimeout',           label: 'Timeout UDP (s)',         min: 0.1, max: 60, step: 0.1 },
+  { key: 'udpRetries',           label: 'Reintentos UDP',          min: 0,   max: 10 },
+  { key: 'udpBudgetSeconds',     label: 'Presupuesto UDP (s)',     min: 1,   max: 600, step: 0.5 },
+  { key: 'rateLimitInterval',    label: 'Intervalo entre envíos (s)', min: 0, max: 10, step: 0.05 },
+  { key: 'hostPoolSize',         label: 'Hosts en paralelo',       min: 1,   max: 64 },
+  { key: 'httpTimeout',          label: 'Timeout HTTP (s)',        min: 1,   max: 120 },
+  { key: 'httpMaxBodyBytes',     label: 'Cuerpo HTTP máx. (bytes)', min: 1024, max: 8388608, step: 1024 },
+  { key: 'networkTimeout',       label: 'Timeout de red (s)',      min: 0.5, max: 120, step: 0.5 },
+  { key: 'bannerTimeout',        label: 'Timeout de banner (s)',   min: 0.5, max: 60, step: 0.5 },
+  { key: 'maxBlindProbes',       label: 'Sondeos a ciegas máx.',   min: 0,   max: 20 },
+  { key: 'maxPayloadExpansions', label: 'Expansiones de payload máx.', min: 1, max: 500 },
+]
 
 // Los umbrales y los límites de Hygeia son 22 campos con la misma forma: se
 // describen aquí y se pintan con v-for en vez de a mano uno por uno.
@@ -437,6 +521,14 @@ const hygeiaLimits = [
   { key: 'maxAssetsPerUser',     label: 'Activos por usuario' },
   { key: 'maxInventoryItems',    label: 'Elementos de inventario' },
 ]
+
+const kbSourcePaths = computed(() => {
+  const prefix = 'features.themis.kb.sources.'
+  return Object.keys(store.configFlat)
+    .filter((key) => key.startsWith(prefix))
+    .sort()
+    .map((path) => ({ path, label: path.slice(prefix.length).replace('oval.', 'OVAL ').toUpperCase() }))
+})
 
 const activeSection = ref('general')
 let observer = null
@@ -501,6 +593,10 @@ function handleSave() { store.saveConfig() }
 .cfg-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; }
 .cfg-grid--tight { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.5rem; }
 .cfg-row { display: flex; align-items: center; }
+.chip-row { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.chip { display: flex; align-items: center; gap: 0.3rem; padding: 0.25rem 0.5rem; background: var(--bg); border: 1px solid var(--border-solid); border-radius: 999px; font-size: var(--fs-md); color: var(--text-dim); cursor: pointer; }
+.chip input { accent-color: var(--accent); cursor: pointer; }
+.card-subtitle { font-size: var(--fs-md); font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin: 0.4rem 0 0; }
 .scanner-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.85rem; margin-top: 0.85rem; }
 .form-group { display: flex; flex-direction: column; gap: 0.25rem; }
 .form-group label { font-size: var(--fs-md); font-weight: 600; color: var(--text-dim); }


### PR DESCRIPTION
## Resumen

El panel de configuración de la web no genera sus controles a partir de `SecOpsConfig.json`: cada
campo está escrito a mano en `ConfigView.vue`, enlazado a una ruta con puntos. Eso significa que
una clave nueva en el fichero no aparece sola en el panel, y unas cuantas veces nadie se acordó de
pintarla. Cruzando las hojas del JSON (los valores finales, no las ramas) con lo que el `.vue`
enlaza de verdad —bucles y componente `ScannerCard` incluidos— había **67 valores vivos sin ningún
control**, más 36 que se quedan fuera a propósito.

Esta rama los expone todos y, sobre todo, arregla el caso que más costaba: **cambiar el modelo de
IA ya no exige redesplegar**.

Cierra #448.

### Por qué el modelo de IA era el caso caro

`scribe` es la capa que habla con los modelos de lenguaje, con una clase por proveedor (Ollama,
OpenAI, Google Gemini). Cuando un módulo genera texto llama a `build_generator("aegis")` y la
*factory* mira en la configuración qué proveedor le toca.

El proveedor sí estaba en el panel. El **modelo** no: vivía en el `.env`, que es parte del
despliegue, así que probar un modelo nuevo obligaba a redesplegar. Lo llamativo es que casi todo lo
necesario para evitarlo ya estaba construido:

- `OpenAIStrategy.from_config` hace `overrides.get("model") or env["model"]`, o sea que
  **el JSON ya ganaba al `.env`**. La clave `tools.scribe.strategies.openai.model` existía y era
  invisible desde la web.
- Ollama, en cambio, no tenía bloque en `strategies`, así que su modelo salía siempre del entorno —
  justo el despliegue en el que uno más quiere ir probando modelos.
- Y la propagación en caliente ya funcionaba: `PUT /system` (lo que hace el panel al guardar)
  refresca la configuración del proceso de la API; el worker de RQ, que es otro proceso, relee el
  fichero antes de cada job cuando cambia su fecha de modificación (`CR.reload_if_changed()`); y
  `build_generator()` se llama **dentro** del job, no al arrancar el proceso.

Con el modelo en el JSON y un control en el panel, guardar cambia el modelo del siguiente trabajo
en segundo plano sin reiniciar nada.

### Y la otra mitad: saber qué modelos hay

Un campo de texto libre resuelve el redespliegue pero traslada el problema: hay que escribir
`gpt-4.1-2025-04-14` de memoria, y equivocarse no falla al guardar — falla mucho después, dentro de
un job, y lo único que ve el usuario es que el informe no se generó.

Los tres proveedores saben decir qué sirven (Ollama por `/api/tags`, OpenAI por `models.list()`,
Google por `list_models()`), así que `available_models()` pasa a ser parte del contrato de
`ModelStrategy` y `GET /system/ai/models` recorre el registro que ya existía. Cada proveedor se
consulta por su cuenta: que OpenAI no tenga credenciales no impide elegir modelo de Ollama, así que
uno inalcanzable devuelve su error en su fila y la respuesta sigue siendo un 200. En el panel, ese
caso cae a campo de texto con un aviso, en vez de dejar al usuario sin control.

## Implementación

**1 · `feat(scribe)`** — `tools.scribe` recoge lo que estaba a fuego: bloque `strategies.ollama`,
`timeout` por proveedor y `resilience` con los cuatro parámetros que vivían en la firma de
`AIGenerator.__init__` y que la factory nunca sobreescribía (reintentos, base de la espera
exponencial, umbral y duración del corte automático). Se declara además
`tools.scribe.modules.iris`, que faltaba pese a que Iris llama a `build_generator("iris")` desde su
redactor de resúmenes. El timeout de Gemini se pasa por `request_options` en cada llamada, que es
donde su librería lo acepta.

**2 · `feat(system)`** — `GET /system/ai/models` (root, como el resto de `/system`), con
`available_models()` en el contrato y `scribe.catalog` agregando por estrategia. `resolve_class`
separa buscar la clase de construirla, porque el catálogo pregunta sin instanciar: instanciar
exigiría las credenciales completas, que es precisamente lo que puede faltar.

**3 · `feat(web)`** — sección «IA» rehecha: los tres módulos (Themis, Aegis **e Iris**), el modelo
de cada proveedor con desplegable en vivo y escape a texto libre, el tope de tokens del prompt, los
reintentos, el corte automático y el timeout por proveedor. El catálogo se pide sin bloquear el
formulario, porque son llamadas a terceros.

**4 · `feat(web)`** — sección «Correo» nueva con Herald entero: estrategia por defecto y por módulo,
relay SMTP y la marca que pintan las plantillas. Por ahí salen las campañas de Aegis, los avisos de
Hygeia e Iris y los correos de cuenta, y cambiar el remitente obligaba a entrar al servidor. Nada de
esto es secreto: el usuario y la contraseña del relay siguen en el `.env`.

**5 · `feat(web)`** — Themis: la base de conocimiento (NVD/KEV/EPSS/OVAL) y los diales del motor de
Lybra que #307 hizo configurables en el backend y nunca llegaron al panel, más la evidencia, las
credenciales por defecto, las severidades de Nuclei (una lista, así que van como casillas), la
vigencia del riesgo aceptado y el plazo por defecto de un trabajo. Los orígenes de la KB se derivan
de lo cargado en vez de escribirse a mano, porque `sources.oval` lleva una clave por distribución.

**6 · `feat(web)`** — «Seguridad» gana la política de sesión (JWT) y la de segundo factor, que
estaban justo al lado de Argon2id en el fichero y no se veían; Hygeia gana su paleta de informe (el
mismo widget que ya tienen los escáneres) y `maxBackfillSec`, la única de sus once claves de límites
que faltaba en el array del `.vue`.

**7 · `docs(readme)`** — README y `.env.example`.

## Validación

- `pytest` completo (suite entera, incluidos los tests nuevos).
- `pylint src` → 10.00/10, sin regresión respecto a la base.
- `npm run build` en `web/app`.
- **Verificación del objetivo**: el mismo cruce de hojas del JSON contra el `.vue` que abrió el
  issue da ahora **0 sin cubrir**, frente a 67.

Tests nuevos y ampliados:

- `tests/unit/test_scribe_config_wiring.py` (nuevo) — `timeout_for` resuelve el timeout por
  proveedor y respeta el fallback; la factory pasa la resiliencia configurada en vez de dejar los
  defaults de la firma; y dos tests sobre el fichero que se despliega: que declara estrategia para
  los tres módulos que usan IA, y que ninguna estrategia registrada se queda sin bloque donde
  guardar su modelo (que es lo que le pasaba a Ollama).
- `tests/integration/test_system.py` — cinco tests del endpoint: exige root, lista las tres
  estrategias aunque ninguna responda, reporta el modelo configurado, sobrevive a un proveedor
  inalcanzable (la suite está sellada contra la red, así que ese caso sale gratis y es justo el que
  hay que cubrir) y devuelve lo que sirve uno que sí responde.
- `tests/unit/test_config_view_paths.py` — **gana la mitad que le faltaba**. Solo miraba rutas
  escritas enteras entre comillas simples, así que todo lo pintado con `v-for` quedaba sin red:
  decenas de campos. Resolver la parte variable exigiría ejecutar el `.vue`, pero el tramo fijo sí
  se puede comprobar, y es el que se rompe cuando alguien mueve una rama del JSON.

## Notas

- **Fuera de alcance, señalado en #448**: los 170 `@limiter.limit("N per hour")` repartidos por los
  `endpoints.py`. Son política de despliegue escrita a fuego, pero los decoradores se evalúan al
  importar el módulo, así que llevarlos al JSON no es reubicar una constante sino cambiar cómo se
  registran los límites. Merece issue propio.
- **`features.iris.data.*` se queda fuera a propósito**: 36 corpus de heurísticas anti-phishing
  (verbos de acción, frases de fraude del CEO, mapa de homóglifos, TLD sospechosos). Es contenido de
  detección, no ajustes de despliegue; un editor de listas sería otra pantalla.
- `.env.example` está en la **raíz** del repositorio, no en `API/` como decía el issue. Ahí se
  aplicó el cambio: se le quitó el bloque de OpenVAS (retirado del producto) y se le añadieron
  `OPENAI_MODEL` y `OPENAI_BASE_URL`, que el código lee y no estaban documentadas.
- El `appVersion` citado en las notas del README iba por detrás del fichero (0.5.10 contra 0.5.12);
  se ha puesto al día en el commit de documentación.
- La librería `google.generativeai` avisa en cada import de que está descontinuada en favor de
  `google.genai`. Es previo a esta rama y no se toca aquí: migrar de librería es un cambio propio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
