### PR TITLE
fix(web): la gráfica de Hygeia deja de lanzar un TypeError de ResizeObserver sobre activos sin lecturas

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.13",
+  "appVersion": "0.5.14",
   "general": {
     "directories": {
       "logdir": "..",

--- a/README.md
+++ b/README.md
@@ -748,4 +748,4 @@ The config panel (`web/app/src/views/ConfigView.vue`) exposes every settable key
 - `API/src/data/` and `docs/` are gitignored (scan outputs, generated PDFs).
 - PostgreSQL uses port **15432** locally (not standard 5432).
 - There is a single `TaskStatus` enum, in `system/taskqueue/task.py`; `themis/services/tasks.py` imports it rather than defining its own.
-- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.13`, read by `CR.get_app_version()`).
+- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.14`, read by `CR.get_app_version()`).

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "test:acheron": "node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
     "test:hygeia": "node test/hygeia.format.test.mjs && node test/hygeia.chartMath.test.mjs",
     "test:polling": "node test/usePolling.test.mjs",
+    "test:element-width": "node test/useElementWidth.test.mjs",
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs && node test/logWindows.test.mjs",

--- a/web/app/src/components/hygeia/MetricsChart.vue
+++ b/web/app/src/components/hygeia/MetricsChart.vue
@@ -166,7 +166,8 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useElementWidth } from '@/composables/useElementWidth'
 import { timeAgo } from './format'
 import {
   DEFAULT_WINDOW_MS, detectGaps, fmtDuration, formatTimeTick, formatValue,
@@ -216,17 +217,11 @@ const t0 = computed(() => Date.now() - (props.windowMs || DEFAULT_WINDOW_MS))
 const t1 = computed(() => Date.now())
 
 const plotEl = ref(null)
-const plotW = ref(600)
+// El gráfico vive bajo el `v-if` de la tarjeta, así que `plotEl` está vacío
+// siempre que se pinte el estado vacío: la medida tiene que engancharse al
+// ref, no al elemento, o el montaje sin datos acaba observando un `null`.
+const plotW = useElementWidth(plotEl, 600)
 const plotDataW = computed(() => plotWidthForAxis(plotW.value))
-let resizeObserver = null
-
-onMounted(() => {
-  resizeObserver = new ResizeObserver(() => {
-    plotW.value = plotEl.value?.clientWidth || 0
-  })
-  resizeObserver.observe(plotEl.value)
-})
-onUnmounted(() => resizeObserver?.disconnect())
 
 const clampTime = (t) => Math.min(Math.max(t, t0.value), t1.value)
 const xFor = (t) => ((clampTime(t) - t0.value) / Math.max(1, t1.value - t0.value)) * plotDataW.value

--- a/web/app/src/composables/useElementWidth.js
+++ b/web/app/src/composables/useElementWidth.js
@@ -1,0 +1,59 @@
+/**
+ * Ancho reactivo de un elemento, atado al `ref` de plantilla y no al elemento.
+ *
+ * La diferencia importa porque un `ref` de plantilla que vive bajo un `v-if`
+ * no apunta a nada mientras esa condición sea falsa. Leerlo una sola vez en
+ * `onMounted` —que es como estaba escrito en MetricsChart— tiene dos fallos:
+ *
+ *   - si el componente monta con la condición en falso, se le pasa `null` a
+ *     `ResizeObserver.observe()`, que exige un `Element` y lanza `TypeError`;
+ *   - si el elemento se destruye y se vuelve a crear, el observador se queda
+ *     mirando el nodo viejo, ya fuera del documento, y el ancho se congela.
+ *
+ * Vigilando el `ref` los dos casos se caen solos: mientras no haya elemento no
+ * se observa nada, y cuando aparece uno nuevo se suelta el anterior.
+ */
+import { getCurrentInstance, onUnmounted, ref, watch } from 'vue'
+
+/**
+ * @param {import('vue').Ref<Element|null>} elementRef  ref de plantilla a vigilar
+ * @param {number} fallbackWidth  ancho mientras no haya elemento que medir
+ * @returns {import('vue').Ref<number>}  ancho en píxeles, reactivo
+ */
+export function useElementWidth(elementRef, fallbackWidth = 0) {
+  const width = ref(fallbackWidth)
+  let resizeObserver = null
+
+  const disconnect = () => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+  }
+
+  // `flush: 'post'` para que el watcher corra con el DOM ya parcheado: al
+  // montar, el ref todavía no está asignado en la fase previa.
+  watch(
+    elementRef,
+    (element) => {
+      disconnect()
+      if (!element) {
+        width.value = fallbackWidth
+        return
+      }
+      width.value = element.clientWidth || fallbackWidth
+      // Sin ResizeObserver (entornos sin DOM, navegadores antiguos) el ancho
+      // medido sigue siendo correcto; sencillamente deja de actualizarse.
+      if (typeof ResizeObserver === 'undefined') return
+      resizeObserver = new ResizeObserver(() => {
+        width.value = elementRef.value?.clientWidth || 0
+      })
+      resizeObserver.observe(element)
+    },
+    { immediate: true, flush: 'post' },
+  )
+
+  // Igual que `usePolling`: la guarda permite usar el composable fuera de un
+  // componente, que es lo que hace testeable el módulo en Node puro.
+  if (getCurrentInstance()) onUnmounted(disconnect)
+
+  return width
+}

--- a/web/app/test/useElementWidth.test.mjs
+++ b/web/app/test/useElementWidth.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * Tests de `useElementWidth` — la medida se ata al ref, no al elemento.
+ *
+ * Node puro, sin framework ni DOM, misma convencion que el resto de `test/`.
+ * Lo que se comprueba es justo lo que rompio la grafica de Hygeia: el ref de
+ * plantilla vive bajo un `v-if`, asi que puede valer `null` al montar y puede
+ * cambiar de elemento a mitad de vida.
+ *
+ *   - un ref vacio no llega a `observe()` (era el TypeError del navegador:
+ *     `ResizeObserver.observe` exige un Element y `null` no lo es);
+ *   - cuando aparece elemento, se observa;
+ *   - si el elemento se sustituye, se suelta el viejo y se observa el nuevo;
+ *   - sin `ResizeObserver` en el entorno, no se lanza nada.
+ */
+
+import assert from 'node:assert/strict'
+import { nextTick, ref } from 'vue'
+
+const { useElementWidth } = await import('../src/composables/useElementWidth.js')
+
+/** Elemento falso: al composable solo le interesa `clientWidth`. */
+const fakeElement = (clientWidth) => ({ clientWidth })
+
+/**
+ * ResizeObserver falso instalado como global. Registra a quien observa y
+ * expone el callback para poder simular un redimensionado.
+ */
+function installResizeObserver() {
+  // `attempts` guarda TODO lo que se le pasa a observe(), valido o no. Es lo
+  // que hace que el test detecte la regresion: si el composable volviera a
+  // observar un `null`, el TypeError lo tragaria el watcher de Vue y
+  // `observed` seguiria vacio, o sea, el test pasaria en verde.
+  const attempts = []
+  const observed = []
+  const disconnected = []
+  const instances = []
+  globalThis.ResizeObserver = class {
+    constructor(callback) {
+      this.callback = callback
+      instances.push(this)
+    }
+    observe(element) {
+      attempts.push(element)
+      // La comprobacion que hace el navegador de verdad, y que es la que
+      // reventaba en produccion.
+      if (!element || typeof element !== 'object') {
+        throw new TypeError("parameter 1 is not of type 'Element'")
+      }
+      observed.push(element)
+    }
+    disconnect() { disconnected.push(this) }
+  }
+  return {
+    attempts,
+    observed,
+    disconnected,
+    lastInstance: () => instances[instances.length - 1],
+  }
+}
+
+function uninstallResizeObserver() {
+  delete globalThis.ResizeObserver
+}
+
+let failures = 0
+async function test(name, fn) {
+  try { await fn(); console.log(`  ok   ${name}`) }
+  catch (err) { failures++; console.error(`  FAIL ${name}\n       ${err.message}`) }
+  finally { uninstallResizeObserver() }
+}
+
+console.log('useElementWidth')
+
+await test('un ref vacio no se observa y conserva el ancho de respaldo', async () => {
+  const spy = installResizeObserver()
+  const elementRef = ref(null)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+  assert.equal(spy.attempts.length, 0, 'llamo a observe() con un ref vacio')
+  assert.equal(width.value, 600)
+})
+
+await test('cuando el ref recibe elemento, se observa y se mide', async () => {
+  const spy = installResizeObserver()
+  const elementRef = ref(null)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  const element = fakeElement(480)
+  elementRef.value = element
+  await nextTick()
+
+  assert.deepEqual(spy.observed, [element], 'no observo el elemento nuevo')
+  assert.equal(width.value, 480, 'no midio el elemento al engancharse')
+})
+
+await test('un redimensionado actualiza el ancho', async () => {
+  const spy = installResizeObserver()
+  const element = fakeElement(480)
+  const elementRef = ref(element)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  element.clientWidth = 320
+  spy.lastInstance().callback()
+  assert.equal(width.value, 320)
+})
+
+await test('sustituir el elemento suelta el viejo y observa el nuevo', async () => {
+  const spy = installResizeObserver()
+  const first = fakeElement(480)
+  const elementRef = ref(first)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  // Lo que pasa cuando la tarjeta se destruye (ventana sin lecturas) y se
+  // vuelve a crear: el ref pasa por null y luego apunta a otro nodo.
+  elementRef.value = null
+  await nextTick()
+  assert.equal(spy.disconnected.length, 1, 'no solto el observador del nodo destruido')
+  assert.equal(width.value, 600, 'no volvio al ancho de respaldo sin elemento')
+
+  const second = fakeElement(300)
+  elementRef.value = second
+  await nextTick()
+  assert.deepEqual(spy.observed, [first, second], 'no reengancho al nodo nuevo')
+  assert.equal(width.value, 300)
+
+  // Y el observador nuevo es el que manda: el viejo ya no debe mover nada.
+  second.clientWidth = 260
+  spy.lastInstance().callback()
+  assert.equal(width.value, 260)
+})
+
+await test('sin ResizeObserver en el entorno no lanza y mide una vez', async () => {
+  uninstallResizeObserver()
+  const elementRef = ref(fakeElement(512))
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+  assert.equal(width.value, 512)
+})
+
+console.log(failures ? `\n${failures} test(s) fallaron` : '\nTodos los tests de useElementWidth pasaron')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
## Resumen

Abrir la vista de Hygeia sobre un activo que no tenía lecturas de la métrica
seleccionada lanzaba un `TypeError` durante el montaje del componente, y el
error acababa en el manejador global del SPA: el usuario veía un toast de
«Error no controlado» en lugar del panel de «sin datos» que el componente ya
tenía escrito para ese caso.

```
[Ellysia] Error no controlado: TypeError: Failed to execute 'observe' on
'ResizeObserver': parameter 1 is not of type 'Element'.
```

### Por qué pasaba

`MetricsChart.vue` pinta dos árboles excluyentes: la tarjeta con el gráfico
(`v-if="hasPlottableData"`) y el estado vacío (`v-else`). El `ref="plotEl"` que
mide el ancho del gráfico vive **sólo** dentro del primero.

Un `ref` de plantilla apunta a un elemento real únicamente si ese elemento
llegó a renderizarse; en cualquier otro caso vale `null`. El componente leía
ese ref una sola vez, en `onMounted`, y se lo pasaba directamente al
observador de tamaño:

```js
resizeObserver.observe(plotEl.value)   // null cuando monta sin datos
```

`ResizeObserver.observe()` no es tolerante: el navegador exige un `Element` y
lanza `TypeError` si recibe otra cosa. Como la excepción salía de un hook de
ciclo de vida, Vue la escalaba a `app.config.errorHandler`, que es el que
imprime «Error no controlado».

La condición `v-if` de la raíz entró en `a5e00f36` (issue #443, el arreglo de
los «-Infinity» del pie de la tarjeta). Ese cambio es correcto en lo suyo;
simplemente dejó bajo condición un ref que el `onMounted` seguía dando por
seguro.

### Un segundo defecto, en el mismo punto

`observe()` se llamaba una única vez. Si el componente montaba **con** datos y
la ventana temporal se quedaba después sin lecturas, el `v-if` destruía el
`<div>`; al volver a haber datos se creaba uno **nuevo**, pero el observador
seguía apuntando al nodo antiguo, ya fuera del documento. A partir de ahí el
ancho se quedaba congelado y el SVG dejaba de responder al redimensionado de
la ventana hasta que el componente se desmontase entero. No lanzaba nada, así
que se veía como «la gráfica se ha quedado con un tamaño raro».

## Issue relacionado

Closes #452

## Implementación

Cuatro commits, uno por fase:

1. **`feat(web)`** — nuevo composable `useElementWidth(elementRef, fallback)`
   en `web/app/src/composables/`. En vez de leer el ref al montar, **vigila el
   ref**: mientras valga `null` no observa nada y mantiene el ancho de
   respaldo; cuando aparece un elemento lo mide y lo observa; si el elemento se
   sustituye, suelta el anterior y engancha el nuevo. Degrada sin lanzar si el
   entorno no tiene `ResizeObserver` (deja de actualizarse, pero la medida
   inicial sigue siendo correcta) y se desconecta al desmontar tras la guarda
   `getCurrentInstance()` que ya usaba `usePolling`.
2. **`fix(web)`** — `MetricsChart.vue` pasa a medir con el composable; se van
   el `onMounted`, el `onUnmounted` y la variable `resizeObserver`. El ancho de
   respaldo se mantiene en los 600 px que ya tenía, así que no cambia nada del
   comportamiento visible cuando sí hay datos.
3. **`test(web)`** — `web/app/test/useElementWidth.test.mjs`, Node puro con un
   `ResizeObserver` falso, siguiendo la convención del resto de `test/` (el SPA
   no tiene framework de test de componentes; por eso el arreglo se extrae a un
   módulo, que es lo único que se puede probar así). Cubre el ref vacío al
   arrancar, el enganche cuando aparece elemento, el redimensionado, la
   sustitución de elemento y el entorno sin `ResizeObserver`.
4. **`chore(system)` + `docs(readme)`** — `appVersion` 0.5.13 → **0.5.14**, y
   el `README.md` en su commit de docs aparte, como manda `CLAUDE.md`.

Un detalle del test que conviene explicar porque no se ve solo: el
`ResizeObserver` falso registra **todo** lo que se le pasa a `observe()`,
también lo inválido, antes de lanzar. Si no lo hiciera, una regresión que
volviera a observar un `null` pasaría desapercibida: el `TypeError` se lo
tragaría el watcher de Vue y una aserción que sólo mirase los elementos
observados con éxito seguiría viendo la lista vacía, o sea, verde.

## Validación

- `npm run test:element-width` — 5/5.
- Resto de la suite del SPA: `test:hygeia`, `test:polling`, `test:toast`,
  `test:quiz`, `test:logs`, `test:iris`, `test:themis` en verde.
- `npm run build` del SPA, correcto.
- `python -m pytest tests/unit/test_config_shape.py` — 181/181, que es lo que
  ata el `SecOpsConfig.json` tocado por el bump.

## Notas

- El script npm quedó como **`test:element-width`** y no `test:layout`, para
  seguir la convención existente de nombrar el script por el módulo que prueba
  (`usePolling` → `test:polling`).
- `npm run test:acheron` falla en el checkout local por un fixture ausente
  (`tests/acheron-vectors.json`, que no está versionado). Es previo a esta rama
  y no tiene relación con el cambio.
- `grep -rn ResizeObserver web/app/src` devuelve una única línea, así que no
  hay otros componentes con el mismo patrón que arreglar.
- Detrás de esta PR va un hotfix equivalente a `main`, con estos mismos
  commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
