### PR TITLE
release: v0.5 → main (0.5.14) — arreglo de la gráfica de Hygeia y el banco nocturno de Lybra

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1,5 +1,5 @@
 {
-  "appVersion": "0.5.13",
+  "appVersion": "0.5.14",
   "general": {
     "directories": {
       "logdir": "..",

--- a/API/tests/oracle/_docker_helpers.py
+++ b/API/tests/oracle/_docker_helpers.py
@@ -17,7 +17,7 @@ import shutil
 import socket
 import subprocess
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 
 def _working_docker(path: str) -> bool:
@@ -78,16 +78,117 @@ def docker_rm(docker_path: str, name: str) -> None:
     subprocess.run([docker_path, "rm", "-f", name], capture_output=True, timeout=30)
 
 
-def wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
-    """Block until ``host:port`` accepts a TCP connection, or raise on timeout."""
+# Qué contenedor del banco publica cada puerto. Lo rellena remember_container()
+# al arrancar cada objetivo y sólo se lee para diagnosticar: es lo que permite
+# que un "no respondió en 240s" diga además *por qué* no había nadie al otro
+# lado. Ver diagnose_port().
+_CONTAINERS_BY_PORT: Dict[int, str] = {}
+
+
+def remember_container(port: int, name: str) -> None:
+    """Apuntar que ``name`` es el contenedor que publica ``port``.
+
+    Sin este apunte, los esperadores de este módulo sólo pueden informar de que
+    un puerto no contestó, que es el síntoma y nunca la causa. Con él pueden
+    mirar si el contenedor sigue vivo y adjuntar su log. Ver #455: el objetivo
+    de ProFTPD moría al arrancar y el banco lo comunicaba como un timeout de
+    cuatro minutos contra un puerto, sin una sola línea sobre el contenedor.
+    """
+    _CONTAINERS_BY_PORT[port] = name
+
+
+def container_is_running(docker_path: str, name: str) -> bool:
+    """¿Sigue en marcha el contenedor ``name``?
+
+    Un contenedor que no existe cuenta como no arrancado, no como error: las
+    fixtures borran los suyos al terminar, y preguntar por uno ya retirado es
+    normal.
+    """
+    completed = subprocess.run(
+        [docker_path, "inspect", "-f", "{{.State.Running}}", name],
+        capture_output=True, text=True, timeout=30,
+    )
+    return completed.returncode == 0 and completed.stdout.strip() == "true"
+
+
+def container_diagnosis(docker_path: str, name: str) -> str:
+    """Por qué murió el contenedor ``name``, en una cadena para un mensaje de error.
+
+    Devuelve el estado con el que terminó y el final de su salida, que es donde
+    están las cosas que de verdad explican un arranque fallido: un paquete que
+    no existe en el índice de la distribución, un usuario que la configuración
+    nombra y el sistema no tiene, un fichero de configuración que no parsea.
+    """
+    state = subprocess.run(
+        [docker_path, "inspect", "-f", "{{.State.Status}} (código {{.State.ExitCode}})", name],
+        capture_output=True, text=True, timeout=30,
+    )
+    if state.returncode != 0:
+        return f"el contenedor {name} ya no existe"
+
+    logs = subprocess.run(
+        [docker_path, "logs", "--tail", "40", name],
+        capture_output=True, text=True, timeout=30,
+    )
+    output = (logs.stdout + logs.stderr).strip() or "(sin salida)"
+    return f"contenedor {name}: {state.stdout.strip()}\n--- docker logs --tail 40 ---\n{output}"
+
+
+def diagnose_port(docker_path: Optional[str], port: int) -> str:
+    """El diagnóstico del contenedor que publica ``port``, si se sabe cuál es.
+
+    Cadena vacía cuando no hay nada que añadir, para poder concatenarla sin
+    condicionales en el sitio donde se construye el mensaje de error.
+    """
+    name = _CONTAINERS_BY_PORT.get(port)
+    if not name or not docker_path:
+        return ""
+    return "\n" + container_diagnosis(docker_path, name)
+
+
+def container_died(docker_path: Optional[str], port: int) -> bool:
+    """¿Ha muerto ya el contenedor que publica ``port``?
+
+    Sirve para rendirse pronto. Los esperadores del banco dan plazos largos a
+    propósito —un objetivo se instala sus paquetes dentro del contenedor y eso
+    tarda—, pero esperar el plazo entero a un contenedor que ya no existe sólo
+    retrasa el diagnóstico: cuatro minutos por objetivo caído, multiplicados por
+    la veintena que levanta el banco nocturno.
+
+    Un puerto del que no se sabe nada nunca se da por muerto: la respuesta por
+    defecto tiene que ser «sigue esperando», que es el comportamiento de antes.
+    """
+    name = _CONTAINERS_BY_PORT.get(port)
+    if not name or not docker_path:
+        return False
+    return not container_is_running(docker_path, name)
+
+
+def wait_for_port(host: str, port: int, timeout: float = 30.0,
+                  docker_path: Optional[str] = None) -> None:
+    """Block until ``host:port`` accepts a TCP connection, or raise on timeout.
+
+    Args:
+        host: El anfitrión donde el contenedor publica el puerto.
+        port: El puerto publicado.
+        timeout: Cuánto esperar antes de rendirse.
+        docker_path: Cliente Docker con el que diagnosticar el contenedor si
+            no llega a contestar. Opcional: sin él el fallo sigue siendo un
+            timeout a secas, como antes.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
             with socket.create_connection((host, port), timeout=1.0):
                 return
         except OSError:
+            if container_died(docker_path, port):
+                raise TimeoutError(
+                    f"{host}:{port} no respondió: su contenedor no sigue en "
+                    f"marcha.{diagnose_port(docker_path, port)}"
+                ) from None
             time.sleep(0.3)
-    raise TimeoutError(f"{host}:{port} no respondió en {timeout}s")
+    raise TimeoutError(f"{host}:{port} no respondió en {timeout}s{diagnose_port(docker_path, port)}")
 
 
 def port_is_free(host: str, port: int) -> bool:

--- a/API/tests/oracle/_nmap_oracle.py
+++ b/API/tests/oracle/_nmap_oracle.py
@@ -26,7 +26,7 @@ import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, List, Optional
 
 # La imagen del oráculo. Se fija por nombre y no por digest a propósito: lo que
 # se mide es la concordancia con *Nmap*, no con una versión congelada suya, y
@@ -35,8 +35,9 @@ from typing import Dict, Iterable, Optional
 NMAP_IMAGE = "instrumentisto/nmap"
 
 # Cómo alcanza el contenedor de Nmap los puertos que los contenedores del
-# catálogo publican en el host. Docker Desktop resuelve este nombre; en un
-# runner Linux hace falta ``--add-host``, que es lo que añade _docker_args().
+# catálogo publican en el host. Docker Desktop resuelve este nombre por su
+# cuenta; Docker sobre Linux no, y hay que pedirlo con ``--add-host``. Lo añade
+# _docker_args(), que existe justamente para eso.
 _HOST_FROM_CONTAINER = "host.docker.internal"
 
 
@@ -59,6 +60,35 @@ def _target_from_container(host: str) -> str:
         if host in ("localhost", ""):
             return _HOST_FROM_CONTAINER
     return host
+
+
+def _docker_args(docker_path: str) -> List[str]:
+    """El ``docker run`` con el que se lanza el oráculo, hasta la imagen.
+
+    Todo lo interesante está en ``--add-host``. Un contenedor no alcanza por
+    ``127.0.0.1`` los puertos que otro publica en la máquina anfitriona —ese
+    loopback es el suyo propio—, así que hay que rebotar por el nombre
+    ``host.docker.internal``. Docker Desktop lo inyecta él solo en todos los
+    contenedores; **Docker sobre Linux no**, y ahí el nombre simplemente no
+    resuelve salvo que se mapee a mano contra la puerta de enlace del host,
+    que es lo que significa el valor mágico ``host-gateway``.
+
+    Sin esta bandera, en un runner Linux el oráculo se quedaba sin objetivo, y
+    el modo de fallo era el peor posible: Nmap, ante un nombre que no resuelve,
+    avisa por la salida de error, escribe un XML perfectamente válido sin ni un
+    host dentro y **termina con código 0**. Nada lanzaba, el banco leía «Nmap
+    no identificó nada» y lo apuntaba como desacuerdo de fingerprint. Tres
+    tests de concordancia fallaban cada noche por una discrepancia que no
+    existía (#455).
+
+    En Docker Desktop la bandera es redundante pero inocua: mapea a la misma
+    puerta de enlace que ya estaba puesta.
+    """
+    return [
+        docker_path, "run", "--rm",
+        "--add-host", f"{_HOST_FROM_CONTAINER}:host-gateway",
+        NMAP_IMAGE,
+    ]
 
 
 @dataclass(frozen=True)
@@ -92,19 +122,62 @@ def run_nmap_sv(
         Un puerto cerrado o filtrado simplemente no aparece.
     """
     port_list = ",".join(str(port) for port in sorted(set(ports)))
-    scan_flag = "-sU" if protocol == "udp" else "-sV"
     flags = ["-sV", "-Pn", "-p", port_list] if protocol == "tcp" else ["-sU", "-sV", "-Pn", "-p", port_list]
 
     local_nmap = shutil.which("nmap")
     if local_nmap:
         command = [local_nmap, *flags, "-oX", "-", host]
+        target = host
     else:
         if not docker_path:
             raise RuntimeError("Ni nmap instalado ni Docker disponible para el oráculo")
-        command = [docker_path, "run", "--rm", NMAP_IMAGE, *flags, "-oX", "-", _target_from_container(host)]
+        target = _target_from_container(host)
+        command = [*_docker_args(docker_path), *flags, "-oX", "-", target]
 
     completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=True)
+    assert_target_was_scanned(completed.stdout, completed.stderr, target)
     return parse_nmap_xml(completed.stdout)
+
+
+def assert_target_was_scanned(document: str, error_output: str, target: str) -> None:
+    """Comprobar que el oráculo llegó a mirar el objetivo, y no a otra cosa.
+
+    Hay dos formas muy distintas de que ``run_nmap_sv`` devuelva un mapa vacío,
+    y confundirlas es lo que tuvo el banco nocturno en rojo tres noches (#455):
+
+    - **El puerto no está abierto.** Es un resultado legítimo, y el que la
+      documentación de :func:`parse_nmap_xml` describe: Nmap habló con el
+      objetivo y no encontró nada escuchando.
+    - **Nmap no llegó al objetivo.** El nombre no resolvió, o la red del
+      contenedor no alcanza al host. Aquí no hay medición ninguna, pero el
+      resultado es indistinguible del anterior si sólo se miran los puertos: un
+      diccionario vacío que el banco interpreta como «Nmap no supo identificar
+      el servicio» y anota como desacuerdo con el motor.
+
+    Lo que separa un caso del otro es el elemento ``<host>``. Como el oráculo
+    escanea siempre con ``-Pn``, Nmap da el objetivo por vivo sin comprobarlo y
+    emite su ``<host>`` incluso cuando todos los puertos salen cerrados o
+    filtrados; que **no haya ni uno** sólo puede significar que no hubo objetivo
+    que escanear. Esto se convierte en una excepción a propósito: un oráculo que
+    no midió tiene que interrumpir el banco, nunca aportar un cero a la cifra.
+
+    Args:
+        document: El XML que escribió Nmap.
+        error_output: Su salida de error, que es donde explica por qué no
+            resolvió el nombre. Se adjunta al mensaje porque sin ella el fallo
+            obliga a reproducirlo a mano.
+        target: El objetivo tal y como se le pasó a Nmap.
+
+    Raises:
+        RuntimeError: Si Nmap no escaneó ningún host.
+    """
+    if next(ET.fromstring(document).iter("host"), None) is not None:
+        return
+    raise RuntimeError(
+        f"El oráculo de Nmap no escaneó ningún host para {target!r}: no llegó a "
+        f"medir nada, así que su silencio no es un desacuerdo de fingerprint. "
+        f"Salida de error de Nmap: {error_output.strip() or '(vacía)'}"
+    )
 
 
 def parse_nmap_xml(document: str) -> Dict[int, NmapService]:

--- a/API/tests/oracle/_security_headers.py
+++ b/API/tests/oracle/_security_headers.py
@@ -1,0 +1,69 @@
+"""Qué checks de ``security_header`` debe disparar un servidor sin endurecer.
+
+Los bancos necesitan saber qué es un acierto y qué es un falso positivo, y para
+la familia de cabeceras esa lista estaba escrita a mano **dos veces**: una en
+``test_lybra_precision_bench.py`` y otra en ``test_lybra_oracle_bench.py``, las
+dos con los mismos tres identificadores. Cuando el feed creció de 28 a 55 checks
+(#296) y aparecieron CSP, ``Referrer-Policy`` y ``Permissions-Policy``, ninguna
+de las dos se enteró. Los tres checks nuevos son detecciones **correctas** —un
+nginx recién sacado de la caja no manda ninguna de esas cabeceras— pero como el
+catálogo no los listaba como esperados, se contaron como falsos positivos en los
+diecisiete objetivos HTTP del banco y hundieron la precisión de la Fase R a
+0,557 frente a un umbral de 0,90. El banco nocturno llevaba tres noches en rojo
+por eso (#455).
+
+La lección es la del repositorio de siempre: una lista que hay que acordarse de
+actualizar a mano se desincroniza, y lo hace en silencio. Así que aquí no se
+escribe la lista, **se deriva del feed** — la misma fuente de la que el motor
+saca los checks que ejecuta, de modo que las dos no pueden divergir.
+
+Lo único que se declara a mano es la excepción, y con su razón al lado: los
+checks de la familia que **no** dispara todo servidor sin endurecer, porque
+dependen de que la respuesta traiga algo que un ``return 200 "ok"`` no trae.
+
+Not a test module itself (no ``test_`` prefix) — pytest does not collect it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Set
+
+from src.modules.features.themis.lybra.checks import load_checks
+
+HEADER_CATEGORY = "security_header"
+
+# Los checks de la familia que dependen de algo que la respuesta puede traer o
+# no, con el motivo por el que no valen como cabecera "que falta siempre".
+#
+# Clasificar mal uno de éstos falla en la dirección segura: pasaría a esperarse
+# en todos los objetivos, no dispararía en ninguno, y saldría como falso
+# negativo ruidoso en vez de inflar la precisión en silencio.
+CONDITIONAL_HEADER_CHECKS: Dict[str, str] = {
+    "lybra:session-cookie-without-secure@1":
+        "necesita un Set-Cookie en la respuesta; los objetivos del catálogo "
+        "sirven un 200 sin cookies, así que no hay cookie que juzgar",
+}
+
+
+def _check_id(check) -> str:
+    """El identificador con el que un hallazgo nombra a su check."""
+    return f"{check.namespace}:{check.id}@{check.version}"
+
+
+def header_family_from_feed() -> Set[str]:
+    """Todos los checks de ``security_header`` que declara el feed."""
+    return {
+        _check_id(check)
+        for check in load_checks()
+        if check.category == HEADER_CATEGORY
+    }
+
+
+def always_missing_header_checks() -> Set[str]:
+    """Los que debe disparar cualquier servidor que no mande ninguna cabecera.
+
+    Es la familia entera menos las excepciones declaradas arriba. Se deriva en
+    cada llamada en vez de congelarse en una constante de módulo para que un
+    test que parchee el feed vea lo que ha parcheado.
+    """
+    return header_family_from_feed() - set(CONDITIONAL_HEADER_CHECKS)

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -59,7 +59,8 @@ from src.modules.features.themis.lybra import (
 )
 
 from ._concordance import agrees_with_nmap, concordance_rate
-from ._docker_helpers import resolve_docker, docker_rm, port_is_free, wait_for_port
+from ._docker_helpers import (resolve_docker, docker_rm, port_is_free, wait_for_port,
+                              container_died, diagnose_port, remember_container)
 from ._nmap_oracle import run_nmap_sv
 
 pytestmark = [pytest.mark.oracle, pytest.mark.integration]
@@ -120,8 +121,16 @@ def _wait_for_http(port: int, timeout: float = 240.0) -> None:
             last = "respuesta que no es HTTP"
         except OSError as exc:
             last = str(exc)
+        if container_died(_DOCKER, port):
+            raise TimeoutError(
+                f"{_HOST}:{port} no contestó HTTP: su contenedor no sigue en "
+                f"marcha ({last}).{diagnose_port(_DOCKER, port)}"
+            )
         time.sleep(1.0)
-    raise TimeoutError(f"{_HOST}:{port} no contestó HTTP en {timeout}s ({last})")
+    raise TimeoutError(
+        f"{_HOST}:{port} no contestó HTTP en {timeout}s ({last})"
+        f"{diagnose_port(_DOCKER, port)}"
+    )
 
 
 def _wait_for_greeting(port: int, expect: bytes, timeout: float = 240.0) -> None:
@@ -146,8 +155,16 @@ def _wait_for_greeting(port: int, expect: bytes, timeout: float = 240.0) -> None
             last = f"saludo inesperado: {banner!r}"
         except OSError as exc:
             last = str(exc)
+        if container_died(_DOCKER, port):
+            raise TimeoutError(
+                f"{_HOST}:{port} no emitió {expect!r}: su contenedor no sigue "
+                f"en marcha ({last}).{diagnose_port(_DOCKER, port)}"
+            )
         time.sleep(1.0)
-    raise TimeoutError(f"{_HOST}:{port} no emitió {expect!r} en {timeout}s ({last})")
+    raise TimeoutError(
+        f"{_HOST}:{port} no emitió {expect!r} en {timeout}s ({last})"
+        f"{diagnose_port(_DOCKER, port)}"
+    )
 
 
 def _start(name: str, port: int, inner: int, image: str, *command: str,
@@ -165,6 +182,9 @@ def _start(name: str, port: int, inner: int, image: str, *command: str,
     for variable in env:
         arguments += ["-e", variable]
     _docker(*arguments, image, *command)
+    # A partir de aquí, cualquier espera contra este puerto puede mirar el
+    # contenedor en vez de limitarse a informar de que nadie contestó.
+    remember_container(port, name)
 
 
 # ================================================================== catálogo
@@ -174,7 +194,7 @@ def ftp_target():
     """vsftpd, que anuncia producto y versión en su saludo — el caso fácil."""
     port, name = _PORTS["ftp"], "lybra-concordance-ftp"
     _start(name, port, 21, "alpine:latest", "sh", "-c",
-           "apk add --no-cache vsftpd >/dev/null 2>&1 && "
+           "apk add --no-cache vsftpd && "
            "mkdir -p /var/lib/ftp && chmod 555 /var/lib/ftp && "
            "printf '%s\\n' 'listen=YES' 'listen_ipv6=NO' 'anonymous_enable=YES' "
            "'local_enable=NO' 'no_anon_password=NO' 'seccomp_sandbox=NO' "
@@ -203,8 +223,23 @@ def proftpd_target():
     en el catálogo, la familia deja de medirse contra sí misma.
     """
     port, name = _PORTS["proftpd"], "lybra-concordance-proftpd"
+    # La cuenta de servicio se crea aquí y no se da por hecha. La receta
+    # original venía de Debian, cuyo paquete la crea en su postinstalación, y
+    # se ejecutaba sobre Alpine, donde no tiene por qué existir: ProFTPD aborta
+    # con un fatal si el usuario que nombra su configuración no está, y el
+    # contenedor moría en el segundo uno (#455). Los dos ``||`` la hacen
+    # idempotente, para que la receta siga valiendo el día que el paquete sí
+    # traiga la cuenta.
+    #
+    # La salida de ``apk add`` **no** se tira a /dev/null. Tirarla es lo que
+    # hizo que tres noches de CI no dijeran ni una palabra sobre la causa: lo
+    # único que llegaba al log era un timeout de cuatro minutos contra un
+    # puerto en el que nunca hubo nadie.
     _start(name, port, 21, "alpine:latest", "sh", "-c",
-           "apk add --no-cache proftpd >/dev/null 2>&1 && "
+           "apk add --no-cache proftpd && "
+           "(getent group proftpd || addgroup -S proftpd) && "
+           "(id -u proftpd >/dev/null 2>&1 || adduser -S -D -H -G proftpd proftpd) && "
+           "mkdir -p /var/run/proftpd && "
            "printf '%s\\n' 'ServerName \"lybra\"' 'ServerType standalone' "
            "'Port 21' 'User proftpd' 'Group proftpd' "
            "> /etc/proftpd/proftpd.conf && "
@@ -235,7 +270,7 @@ def reverse_proxy_target():
     """
     port, name = _PORTS["reverse-proxy"], "lybra-concordance-reverse-proxy"
     _start(name, port, 80, "alpine:latest", "sh", "-c",
-           "apk add --no-cache apache2 nginx >/dev/null 2>&1 && "
+           "apk add --no-cache apache2 nginx && "
            "sed -i 's/^Listen 80$/Listen 8081/' /etc/apache2/httpd.conf && "
            "httpd && "
            "printf '%s\\n' 'events {}' 'http { server { listen 80; "
@@ -255,7 +290,7 @@ def smtp_target():
     llama "no inventar CPE". Nmap sí extrae el producto de ese mismo saludo."""
     port, name = _PORTS["smtp"], "lybra-concordance-smtp"
     _start(name, port, 25, "alpine:latest", "sh", "-c",
-           "apk add --no-cache postfix >/dev/null 2>&1 && "
+           "apk add --no-cache postfix && "
            "postconf -e 'inet_interfaces=all' 'mynetworks=0.0.0.0/0' "
            "'smtpd_client_restrictions=' && newaliases; postfix start-fg")
     try:
@@ -272,7 +307,7 @@ def mysql_target():
     port, name = _PORTS["mysql"], "lybra-concordance-mysql"
     _start(name, port, 3306, "mariadb:11", env=("MARIADB_ROOT_PASSWORD=bench",))
     try:
-        wait_for_port(_HOST, port, 240)
+        wait_for_port(_HOST, port, 240, docker_path=_DOCKER)
         # MariaDB no saluda hasta que ha terminado de inicializar el datadir, y
         # su saludo es binario: no hay prefijo estable que esperar, así que aquí
         # sí toca dar tiempo en vez de esperar una cadena.
@@ -291,7 +326,7 @@ def smb_target():
     port, name = _PORTS["smb"], "lybra-concordance-smb"
     _start(name, port, 445, "dperson/samba", "-p", "-s", "public;/tmp;yes;no;yes")
     try:
-        wait_for_port(_HOST, port, 240)
+        wait_for_port(_HOST, port, 240, docker_path=_DOCKER)
         time.sleep(10)
         yield Target("smb", port, "microsoft-ds")
     finally:
@@ -319,7 +354,7 @@ def smb1_target():
            "-g", "client min protocol = NT1",
            "-s", "public;/tmp;yes;no;yes")
     try:
-        wait_for_port(_HOST, port, 240)
+        wait_for_port(_HOST, port, 240, docker_path=_DOCKER)
         time.sleep(10)
         yield Target("smb1", port, "microsoft-ds")
     finally:
@@ -331,7 +366,7 @@ def redis_target():
     port, name = _PORTS["redis"], "lybra-concordance-redis"
     _start(name, port, 6379, "redis:7")
     try:
-        wait_for_port(_HOST, port, 240)
+        wait_for_port(_HOST, port, 240, docker_path=_DOCKER)
         time.sleep(3)
         yield Target("redis", port, "redis")
     finally:
@@ -345,7 +380,7 @@ def vnc_target():
     antes de que exista el display."""
     port, name = _PORTS["vnc"], "lybra-concordance-vnc"
     _start(name, port, 5900, "alpine:latest", "sh", "-c",
-           "apk add --no-cache x11vnc xvfb >/dev/null 2>&1 && "
+           "apk add --no-cache x11vnc xvfb && "
            "(Xvfb :1 -screen 0 800x600x16 &) && sleep 3 && "
            "x11vnc -display :1 -nopw -forever -rfbport 5900")
     try:

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -36,6 +36,7 @@ from src.modules.features.themis.managers import LybraEngineManager, AuthorizedT
 from src.modules.features.themis.repositories import ScanRepository, KbRepository
 
 from ._concordance import port_concordance
+from ._security_headers import always_missing_header_checks
 from ._docker_helpers import (resolve_docker, docker_run, docker_rm, wait_for_port,
                               port_is_free, container_died, diagnose_port,
                               remember_container)
@@ -423,11 +424,10 @@ def test_missing_security_headers_detected_against_real_container(app, admin_use
     findings = _run_self_discovery(app, admin_user, "127.0.0.1", git_exposed_port, monkeypatch)
 
     headers = {f.check_id for f in findings if f.category == "security_header"}
-    assert headers == {
-        "lybra:missing-hsts-header@1",
-        "lybra:missing-x-frame-options-header@1",
-        "lybra:missing-x-content-type-options-header@1",
-    }
+    # La familia esperada sale del feed, no de una lista escrita aquí. La lista
+    # estuvo escrita, con tres identificadores, y se quedó atrás en cuanto el
+    # feed creció (#455).
+    assert headers == always_missing_header_checks()
     assert all(f.confirmed and f.qod == 99 for f in findings if f.category == "security_header")
 
 

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -36,7 +36,9 @@ from src.modules.features.themis.managers import LybraEngineManager, AuthorizedT
 from src.modules.features.themis.repositories import ScanRepository, KbRepository
 
 from ._concordance import port_concordance
-from ._docker_helpers import resolve_docker, docker_run, docker_rm, wait_for_port, port_is_free
+from ._docker_helpers import (resolve_docker, docker_run, docker_rm, wait_for_port,
+                              port_is_free, container_died, diagnose_port,
+                              remember_container)
 
 pytestmark = [pytest.mark.oracle, pytest.mark.integration]
 
@@ -50,7 +52,13 @@ def _docker(*args: str) -> subprocess.CompletedProcess:
     return docker_run(_DOCKER, *args)
 
 
-_wait_for_port = wait_for_port
+def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
+    """``wait_for_port`` con el cliente Docker ya puesto.
+
+    Sin él, un contenedor que muere al arrancar se comunica como un puerto
+    que no contestó, que es el síntoma y nunca la causa (#455).
+    """
+    wait_for_port(host, port, timeout, docker_path=_DOCKER)
 
 
 # is_http_service() (checks.py) only recognises a fixed port set for HTTP
@@ -139,9 +147,16 @@ def _wait_until_answering(port: int, expect: bytes, send: bytes = None, timeout:
                     return
         except OSError:
             pass
+        if container_died(_DOCKER, port):
+            raise TimeoutError(
+                f"127.0.0.1:{port} no contestó {expect!r}: su contenedor no sigue "
+                f"en marcha (última respuesta: {seen!r})."
+                f"{diagnose_port(_DOCKER, port)}"
+            )
         time.sleep(0.3)
     raise TimeoutError(
         f"127.0.0.1:{port} no contestó {expect!r} en {timeout}s (última respuesta: {seen!r})"
+        f"{diagnose_port(_DOCKER, port)}"
     )
 
 
@@ -206,6 +221,7 @@ def httpd_2449_port():
     port = _free_http_port()
     name = f"lybra-oracle-httpd-{port}"
     _docker("run", "-d", "--name", name, "-p", f"{port}:80", "httpd:2.4.49")
+    remember_container(port, name)
     try:
         _wait_for_port("127.0.0.1", port)
         yield port
@@ -229,6 +245,7 @@ def git_exposed_port():
         "> /usr/share/nginx/html/.git/config && nginx -g 'daemon off;'"
     )
     _docker("run", "-d", "--name", name, "-p", f"{port}:80", "nginx:alpine", "sh", "-c", write_config)
+    remember_container(port, name)
     try:
         _wait_for_port("127.0.0.1", port)
         yield port
@@ -253,6 +270,7 @@ def tls_healthy_port():
     name = f"lybra-oracle-tls-healthy-{port}"
     _docker("run", "-d", "--name", name, "-p", f"{port}:443", "nginx:alpine",
             "sh", "-c", _tls_container_cmd(days=365, expired=False))
+    remember_container(port, name)
     try:
         _wait_for_port("127.0.0.1", port)
         yield port
@@ -269,6 +287,7 @@ def tls_expired_port():
     name = f"lybra-oracle-tls-expired-{port}"
     _docker("run", "-d", "--name", name, "-p", f"{port}:443", "nginx:alpine",
             "sh", "-c", _tls_container_cmd(days=30, expired=True))
+    remember_container(port, name)
     try:
         _wait_for_port("127.0.0.1", port)
         yield port
@@ -283,6 +302,7 @@ def ftp_anonymous_port():
     name = f"lybra-oracle-ftp-anon-{_FTP_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=True))
+    remember_container(_FTP_PORT, name)
     try:
         _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
@@ -301,6 +321,7 @@ def ftp_no_anonymous_port():
     name = f"lybra-oracle-ftp-noanon-{_FTP_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_FTP_PORT}:21", "alpine:3.19",
             "sh", "-c", _vsftpd_container_cmd(anonymous=False))
+    remember_container(_FTP_PORT, name)
     try:
         _wait_until_answering(_FTP_PORT, expect=b"220")
         yield _FTP_PORT
@@ -314,6 +335,7 @@ def redis_open_port():
     _require_free_port(_REDIS_PORT, "Redis")
     name = f"lybra-oracle-redis-open-{_REDIS_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7")
+    remember_container(_REDIS_PORT, name)
     try:
         _wait_until_answering(_REDIS_PORT, expect=b"+PONG", send=b"PING\r\n")
         yield _REDIS_PORT
@@ -328,6 +350,7 @@ def redis_password_port():
     name = f"lybra-oracle-redis-auth-{_REDIS_PORT}"
     _docker("run", "-d", "--name", name, "-p", f"{_REDIS_PORT}:6379", "redis:7",
             "redis-server", "--requirepass", "lybra-oracle")
+    remember_container(_REDIS_PORT, name)
     try:
         _wait_until_answering(_REDIS_PORT, expect=b"-NOAUTH", send=b"PING\r\n")
         yield _REDIS_PORT

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -25,7 +25,7 @@ verlo.
 la familia entera de cabeceras —la que declare el feed en cada momento, no una
 lista fija: se quedó en tres cuando el feed pasó a seis y dejó de ser un control
 negativo (#455)— y no debe producir ni un hallazgo de esa familia;
-``nginx-decoys`` sirve un 200 en las seis rutas que los checks de ``exposed_path``
+``nginx-senuelos`` sirve un 200 en las rutas que los checks de ``exposed_path``
 piden, pero con un cuerpo que no es lo que el check busca — un ``.git/config``
 que no es un config de Git, un ``backup.sql`` que no es un volcado. Un check que
 mirase solo el código de estado sacaría aquí seis falsos positivos de golpe.

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -50,7 +50,9 @@ import pytest
 from src.modules.features.themis.lybra.checks import HttpProbe, negotiates_tls
 
 from ._security_headers import always_missing_header_checks
-from ._docker_helpers import resolve_docker, docker_run, docker_rm, wait_for_port, port_is_free
+from ._docker_helpers import (resolve_docker, docker_run, docker_rm, wait_for_port,
+                              port_is_free, container_died, diagnose_port,
+                              remember_container)
 from .test_lybra_oracle_bench import _run_self_discovery, _tls_container_cmd
 
 pytestmark = [pytest.mark.oracle, pytest.mark.integration]
@@ -468,8 +470,17 @@ def _wait_until_serving(port: int, tls: bool, label: str = "", timeout: float = 
                 last = "responde algo que no es HTTP"
         except OSError as exc:
             last = str(exc)
+        if container_died(_DOCKER, port):
+            raise TimeoutError(
+                f"[{label}] 127.0.0.1:{port} no sirvió su protocolo: su "
+                f"contenedor no sigue en marcha ({last})."
+                f"{diagnose_port(_DOCKER, port)}"
+            )
         time.sleep(1.0)
-    raise TimeoutError(f"[{label}] 127.0.0.1:{port} aceptó pero no sirvió su protocolo en {timeout}s ({last})")
+    raise TimeoutError(
+        f"[{label}] 127.0.0.1:{port} aceptó pero no sirvió su protocolo en "
+        f"{timeout}s ({last}){diagnose_port(_DOCKER, port)}"
+    )
 
 
 @contextlib.contextmanager
@@ -485,8 +496,13 @@ def _running(target: Target) -> Iterator[int]:
     if target.command:
         args += ["sh", "-c", target.command]
     docker_run(_DOCKER, *args)
+    # Un contenedor que muere al arrancar —una configuración de nginx que no
+    # parsea, sin ir más lejos— produce cero hallazgos, y cero hallazgos es
+    # indistinguible de "el motor no detectó nada" en el agregado. Registrarlo
+    # es lo que hace que el log diga cuál de las dos cosas pasó (#455).
+    remember_container(port, name)
     try:
-        wait_for_port("127.0.0.1", port)
+        wait_for_port("127.0.0.1", port, docker_path=_DOCKER)
         _wait_until_serving(port, tls=target.tls, label=target.name)
         yield port
     finally:

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -170,15 +170,31 @@ _REAL_EXPOSURES = {
     "server-status": "<h1>Apache Server Status for localhost</h1>",
 }
 
+# Un volcado de base de datos expuesto dispara **dos** checks del feed, no uno.
+# ``sql-backup-exposure`` (CRITICAL) pide /backup.sql con un cuerpo que contenga
+# INSERT INTO o CREATE TABLE; ``sql-dump-exposure`` (HIGH), añadido cuando el
+# feed creció (#296), pide una lista de nombres en la que /backup.sql también
+# está. El mismo fichero satisface a los dos.
+#
+# El catálogo los etiqueta como pareja porque, tal y como está hoy el feed, los
+# dos hallazgos son ciertos: contarlos como uno solo haría del segundo un falso
+# positivo que no lo es. Pero el solapamiento **sí es un defecto del feed**, no
+# del banco —en producción produce dos hallazgos con severidades distintas para
+# el mismo fichero— y se sigue en #456. Cuando ahí se decida deduplicarlos, esta
+# pareja vuelve a ser un solo identificador.
+_SQL_DUMP_CHECKS = {
+    "lybra:sql-backup-exposure@1",
+    "lybra:sql-dump-exposure@1",
+}
+
 _ALL_EXPOSURE_CHECKS = {
     "lybra:git-config-exposure@1",
     "lybra:dotenv-exposure@1",
     "lybra:phpinfo-exposure@1",
     "lybra:wpconfig-source-exposure@1",
     "lybra:ssh-private-key-exposure@1",
-    "lybra:sql-backup-exposure@1",
     "lybra:apache-server-status-exposure@1",
-}
+} | _SQL_DUMP_CHECKS
 
 
 def _catch_all(body: str, status: int = 200) -> str:
@@ -296,7 +312,7 @@ _CATALOGUE = (
             "backup.sql": "-- MySQL dump 10.13\\nCREATE TABLE users (id int);\\n"
                           "INSERT INTO users VALUES (1);\\n",
         }),
-        expected=_HEADERS | {"lybra:sql-backup-exposure@1"},
+        expected=_HEADERS | _SQL_DUMP_CHECKS,
     ),
     # --- señuelos: aquí no debe disparar nada de exposed_path/security_header ---
     Target(

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -21,8 +21,10 @@ umbral; el recall se mide y se imprime porque un banco con precisión perfecta y
 recall ruinoso sería trivial de conseguir (no disparar nunca) y hay que poder
 verlo.
 
-**Los señuelos son la mitad del banco a propósito.** ``nginx-hardened`` manda
-las tres cabeceras y no debe producir ni un hallazgo de esa familia;
+**Los señuelos son la mitad del banco a propósito.** ``nginx-endurecido`` manda
+la familia entera de cabeceras —la que declare el feed en cada momento, no una
+lista fija: se quedó en tres cuando el feed pasó a seis y dejó de ser un control
+negativo (#455)— y no debe producir ni un hallazgo de esa familia;
 ``nginx-decoys`` sirve un 200 en las seis rutas que los checks de ``exposed_path``
 piden, pero con un cuerpo que no es lo que el check busca — un ``.git/config``
 que no es un config de Git, un ``backup.sql`` que no es un volcado. Un check que
@@ -47,6 +49,7 @@ import pytest
 
 from src.modules.features.themis.lybra.checks import HttpProbe, negotiates_tls
 
+from ._security_headers import always_missing_header_checks
 from ._docker_helpers import resolve_docker, docker_run, docker_rm, wait_for_port, port_is_free
 from .test_lybra_oracle_bench import _run_self_discovery, _tls_container_cmd
 
@@ -68,11 +71,13 @@ _PRECISION_THRESHOLD = 0.9
 _HTTP_PORT = 8080
 _TLS_PORT = 8443
 
-_HEADERS = {
-    "lybra:missing-hsts-header@1",
-    "lybra:missing-x-frame-options-header@1",
-    "lybra:missing-x-content-type-options-header@1",
-}
+# La familia de cabeceras se **deriva del feed**, no se escribe aquí. Estuvo
+# escrita a mano, con tres identificadores, y cuando el feed creció (#296) nadie
+# la actualizó: los tres checks nuevos —CSP, Referrer-Policy y
+# Permissions-Policy— pasaron a contarse como falsos positivos en los diecisiete
+# objetivos HTTP del catálogo y tumbaron la precisión de la Fase R a 0,557
+# (#455). Ver ``_security_headers.py`` para la derivación y su única excepción.
+_HEADERS = always_missing_header_checks()
 
 
 def _serve(files: dict) -> str:
@@ -115,11 +120,25 @@ def _tls_serve(files: dict) -> str:
     return " && ".join(parts)
 
 
+# El control negativo del catálogo: un nginx que no debe producir ni un
+# hallazgo. Manda la familia **entera** de cabeceras, no sólo las tres con
+# las que se escribió: en cuanto el feed creció, un «endurecido» al que le
+# faltaban tres cabeceras dejó de ser un control negativo y pasó a aportar
+# tres falsos positivos él solo (#455).
 _HARDENED_CONF = (
     "printf '%s' 'server { listen 80; "
     'add_header Strict-Transport-Security "max-age=31536000" always; '
     "add_header X-Frame-Options DENY always; "
     "add_header X-Content-Type-Options nosniff always; "
+    # Los valores van sin comilla simple a propósito: toda la configuración
+    # viaja dentro de una cadena de shell entrecomillada con comillas simples,
+    # y una sola dentro la cerraría — el contenedor moriría al arrancar y sus
+    # tres cabeceras que faltan parecerían un fallo del motor. La misma cautela
+    # que ya documenta _redirect_conf(). Qué valor lleve la cabecera da igual:
+    # estos checks juzgan que esté, no lo que dice.
+    'add_header Content-Security-Policy "default-src https:" always; '
+    "add_header Referrer-Policy no-referrer always; "
+    'add_header Permissions-Policy "geolocation=(), camera=()" always; '
     'location / { return 200 "ok"; } }\' > /etc/nginx/conf.d/default.conf '
     "&& nginx -g 'daemon off;'"
 )
@@ -361,10 +380,10 @@ _CATALOGUE = (
         name="nginx-cabeceras-parciales",
         image="nginx:alpine",
         command=_PARTIAL_HEADERS_CONF,
-        expected={
-            "lybra:missing-hsts-header@1",
-            "lybra:missing-x-content-type-options-header@1",
-        },
+        # Manda X-Frame-Options y nada más, así que espera todo el resto de
+        # la familia. Se calcula restando en vez de enumerarse, para que crezca
+        # sola con el feed.
+        expected=_HEADERS - {"lybra:missing-x-frame-options-header@1"},
     ),
     Target(
         name="nginx-redirige",

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -68,7 +68,7 @@ def test_a_target_that_does_not_resolve_does_not_sink_the_rest(monkeypatch):
 # Son puras (no lanzan Nmap ni Docker), así que corren en CI como el resto de
 # este fichero, sin marcador ``oracle``.
 
-from ._nmap_oracle import _target_from_container
+from ._nmap_oracle import _docker_args, _target_from_container, assert_target_was_scanned
 
 
 def test_loopback_is_reached_through_the_docker_host():
@@ -85,6 +85,54 @@ def test_an_external_target_is_scanned_directly():
     loopback se pasa tal cual."""
     assert _target_from_container("emesa.com") == "emesa.com"
     assert _target_from_container("203.0.113.9") == "203.0.113.9"
+
+
+def test_the_oracle_container_is_told_how_to_reach_the_host():
+    """Traducir el objetivo a ``host.docker.internal`` no sirve de nada si el
+    contenedor no sabe resolver ese nombre, que es lo que pasa en Docker sobre
+    Linux — y por tanto en el runner del banco nocturno (#455). La bandera que
+    lo mapea contra la puerta de enlace del host tiene que ir en el ``docker
+    run``, y antes de la imagen: lo que va después son argumentos de Nmap."""
+    arguments = _docker_args("/usr/bin/docker")
+
+    assert "--add-host" in arguments
+    assert arguments[arguments.index("--add-host") + 1] == "host.docker.internal:host-gateway"
+    assert arguments.index("--add-host") < arguments.index("instrumentisto/nmap")
+    assert arguments[-1] == "instrumentisto/nmap"
+
+
+_XML_WITH_A_CLOSED_PORT = """<?xml version="1.0"?>
+<nmaprun><host><address addr="192.168.65.2" addrtype="ipv4"/>
+<ports><port protocol="tcp" portid="12121"><state state="closed"/></port></ports>
+</host></nmaprun>"""
+
+_XML_WITHOUT_A_HOST = """<?xml version="1.0"?>
+<nmaprun><runstats><hosts up="0" down="0" total="0"/></runstats></nmaprun>"""
+
+
+def test_a_closed_port_is_a_measurement_and_not_an_error():
+    """Nmap habló con el objetivo y no encontró nada escuchando. Es un
+    resultado legítimo del banco y no debe interrumpir nada."""
+    assert_target_was_scanned(_XML_WITH_A_CLOSED_PORT, "", "host.docker.internal")
+
+
+def test_an_unreachable_target_stops_the_bench_instead_of_scoring_zero():
+    """El fallo que estuvo tres noches disfrazado de desacuerdo de fingerprint.
+
+    Cuando el nombre no resuelve, Nmap emite este XML —válido, sin ni un
+    ``<host>`` dentro— y sale con código 0. Antes eso se colaba como «Nmap no
+    identificó el servicio» y restaba en la cifra de concordancia; ahora lanza,
+    y el mensaje lleva la salida de error de Nmap para que el log de CI diga
+    por sí solo qué pasó."""
+    with pytest.raises(RuntimeError) as failure:
+        assert_target_was_scanned(
+            _XML_WITHOUT_A_HOST,
+            'Failed to resolve "host.docker.internal".',
+            "host.docker.internal",
+        )
+
+    assert "no escaneó ningún host" in str(failure.value)
+    assert "Failed to resolve" in str(failure.value)
 
 
 # --------------------------------------------------------------------------

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -136,6 +136,45 @@ def test_an_unreachable_target_stops_the_bench_instead_of_scoring_zero():
 
 
 # --------------------------------------------------------------------------
+# Un contenedor caído no puede leerse como un fallo del motor (#455)
+# --------------------------------------------------------------------------
+#
+# Puras también: sólo comprueban qué hace el registro cuando no sabe nada del
+# puerto, que es la mitad de la que depende que este cambio no rompa nada.
+
+from ._docker_helpers import container_died, diagnose_port, remember_container
+
+
+def test_an_unknown_port_is_never_declared_dead():
+    """El comportamiento por defecto tiene que seguir siendo «sigue esperando».
+
+    Los esperadores del banco preguntan por todos los puertos, también por los
+    que nadie registró. Si un puerto desconocido se diera por muerto, el
+    diagnóstico nuevo convertiría cualquier arranque lento en un fallo
+    inmediato — justo la carrera que estos plazos largos existen para evitar."""
+    assert container_died("/usr/bin/docker", 65_432) is False
+    assert diagnose_port("/usr/bin/docker", 65_432) == ""
+
+
+def test_without_a_docker_client_nothing_is_diagnosed():
+    """En una máquina sin Docker los bancos se saltan enteros, pero los
+    esperadores siguen siendo importables y no deben intentar inspeccionar
+    nada con un cliente que no existe."""
+    remember_container(65_433, "lybra-inexistente")
+    try:
+        assert container_died(None, 65_433) is False
+        assert diagnose_port(None, 65_433) == ""
+    finally:
+        _forget_container(65_433)
+
+
+def _forget_container(port: int) -> None:
+    """Sacar un puerto del registro para no filtrarlo a otros tests."""
+    from ._docker_helpers import _CONTAINERS_BY_PORT
+    _CONTAINERS_BY_PORT.pop(port, None)
+
+
+# --------------------------------------------------------------------------
 # Un Docker colgado no puede tumbar la suite
 # --------------------------------------------------------------------------
 

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -175,6 +175,64 @@ def _forget_container(port: int) -> None:
 
 
 # --------------------------------------------------------------------------
+# La familia de cabeceras del banco no puede quedarse atrás del feed (#455)
+# --------------------------------------------------------------------------
+#
+# Éste es el test que faltaba. Los bancos que miden la familia necesitan Docker
+# y corren de noche, así que un feed que crece y un catálogo que no se entera
+# tardaban semanas en encontrarse — y se encontraron en forma de precisión 0,557
+# a las tres de la mañana. Esta comprobación es pura, corre en el CI por defecto,
+# y falla en el mismo PR que añade el check.
+
+from ._security_headers import (CONDITIONAL_HEADER_CHECKS, always_missing_header_checks,
+                                header_family_from_feed)
+
+
+def test_every_security_header_check_is_classified():
+    """Cada check de la familia está o entre los que faltan siempre o entre las
+    excepciones declaradas, y nunca en ninguno de los dos sitios a la vez.
+
+    Es una tautología dada la implementación de hoy —una resta de conjuntos— y
+    ésa es justamente la garantía que se quiere fijar: que la clasificación se
+    derive del feed y no se pueda escribir a mano una lista que se quede corta.
+    """
+    family = header_family_from_feed()
+    always_missing = always_missing_header_checks()
+    conditional = set(CONDITIONAL_HEADER_CHECKS)
+
+    assert always_missing | conditional == family
+    assert not (always_missing & conditional)
+
+
+def test_the_declared_exceptions_still_exist_in_the_feed():
+    """Una excepción que ya no corresponde a ningún check del feed es una
+    excepción caducada: dejaría de excluir nada y nadie se enteraría. Si un
+    check desaparece o se le sube la versión, esto lo dice."""
+    missing = set(CONDITIONAL_HEADER_CHECKS) - header_family_from_feed()
+    assert not missing, f"excepciones que ya no están en el feed: {sorted(missing)}"
+
+
+def test_the_header_family_covers_what_the_bench_measured():
+    """Los seis checks que un servidor sin endurecer debe disparar hoy.
+
+    Enumerarlos aquí puede parecer contradictorio con derivarlos del feed, pero
+    hace un trabajo distinto: el resto del fichero comprueba que la derivación
+    es coherente consigo misma, y esto ata **qué se despliega de verdad**. Sin
+    ello, un feed que perdiera los tres checks nuevos volvería a dejar la
+    familia en tres y todo seguiría en verde — la misma distinción entre
+    comprobar el comportamiento y atar el valor desplegado que documenta
+    `test_the_anti_ssrf_defence_ships_enabled`."""
+    assert always_missing_header_checks() == {
+        "lybra:missing-hsts-header@1",
+        "lybra:missing-x-frame-options-header@1",
+        "lybra:missing-x-content-type-options-header@1",
+        "lybra:missing-csp-header@1",
+        "lybra:missing-referrer-policy-header@1",
+        "lybra:missing-permissions-policy-header@1",
+    }
+
+
+# --------------------------------------------------------------------------
 # Un Docker colgado no puede tumbar la suite
 # --------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ Run it in its **own** pytest invocation. The fast suite's SQLite shim rewrites `
 
 CI runs two workflows on push/PR to `main` and the `vX.Y` release branches: `.github/workflows/tests.yml` (`python -m pytest -q -m "not oracle"`, on SQLite) and `.github/workflows/tests-postgres.yml` (`python -m pytest -q -m postgres`, with ephemeral PostgreSQL and Redis services). They are separate jobs on purpose — the service matrix must not slow down the cycle that runs on every push. Some tests use `xfail(strict=True)` to document real known bugs — when a bug is fixed the test XPASSes and the marker must be removed. A green push to `main` (a merged pull request) additionally triggers the automatic production deploy — see [Continuous deployment](#continuous-deployment-cicd).
 
+A third workflow, `.github/workflows/lybra-bench.yml`, runs the `oracle` bench on a schedule (03:15 UTC) and on demand. It is separate because it brings up around twenty Docker containers and takes tens of minutes, which no per-push job can afford. Its deliverable is the numbers, not the green tick: it publishes the Lybra engine's Phase R precision, its agreement with Nmap and its false-positive rate to the run summary, and uploads the full log as an artifact.
+
 ### Web SPA (node, no framework)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -748,4 +748,4 @@ The config panel (`web/app/src/views/ConfigView.vue`) exposes every settable key
 - `API/src/data/` and `docs/` are gitignored (scan outputs, generated PDFs).
 - PostgreSQL uses port **15432** locally (not standard 5432).
 - There is a single `TaskStatus` enum, in `system/taskqueue/task.py`; `themis/services/tasks.py` imports it rather than defining its own.
-- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.13`, read by `CR.get_app_version()`).
+- The API version is declared as `appVersion` in `SecOpsConfig.json` (currently `0.5.14`, read by `CR.get_app_version()`).

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "test:acheron": "node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
     "test:hygeia": "node test/hygeia.format.test.mjs && node test/hygeia.chartMath.test.mjs",
     "test:polling": "node test/usePolling.test.mjs",
+    "test:element-width": "node test/useElementWidth.test.mjs",
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs && node test/logWindows.test.mjs",

--- a/web/app/src/components/hygeia/MetricsChart.vue
+++ b/web/app/src/components/hygeia/MetricsChart.vue
@@ -166,7 +166,8 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useElementWidth } from '@/composables/useElementWidth'
 import { timeAgo } from './format'
 import {
   DEFAULT_WINDOW_MS, detectGaps, fmtDuration, formatTimeTick, formatValue,
@@ -216,17 +217,11 @@ const t0 = computed(() => Date.now() - (props.windowMs || DEFAULT_WINDOW_MS))
 const t1 = computed(() => Date.now())
 
 const plotEl = ref(null)
-const plotW = ref(600)
+// El gráfico vive bajo el `v-if` de la tarjeta, así que `plotEl` está vacío
+// siempre que se pinte el estado vacío: la medida tiene que engancharse al
+// ref, no al elemento, o el montaje sin datos acaba observando un `null`.
+const plotW = useElementWidth(plotEl, 600)
 const plotDataW = computed(() => plotWidthForAxis(plotW.value))
-let resizeObserver = null
-
-onMounted(() => {
-  resizeObserver = new ResizeObserver(() => {
-    plotW.value = plotEl.value?.clientWidth || 0
-  })
-  resizeObserver.observe(plotEl.value)
-})
-onUnmounted(() => resizeObserver?.disconnect())
 
 const clampTime = (t) => Math.min(Math.max(t, t0.value), t1.value)
 const xFor = (t) => ((clampTime(t) - t0.value) / Math.max(1, t1.value - t0.value)) * plotDataW.value

--- a/web/app/src/composables/useElementWidth.js
+++ b/web/app/src/composables/useElementWidth.js
@@ -1,0 +1,59 @@
+/**
+ * Ancho reactivo de un elemento, atado al `ref` de plantilla y no al elemento.
+ *
+ * La diferencia importa porque un `ref` de plantilla que vive bajo un `v-if`
+ * no apunta a nada mientras esa condición sea falsa. Leerlo una sola vez en
+ * `onMounted` —que es como estaba escrito en MetricsChart— tiene dos fallos:
+ *
+ *   - si el componente monta con la condición en falso, se le pasa `null` a
+ *     `ResizeObserver.observe()`, que exige un `Element` y lanza `TypeError`;
+ *   - si el elemento se destruye y se vuelve a crear, el observador se queda
+ *     mirando el nodo viejo, ya fuera del documento, y el ancho se congela.
+ *
+ * Vigilando el `ref` los dos casos se caen solos: mientras no haya elemento no
+ * se observa nada, y cuando aparece uno nuevo se suelta el anterior.
+ */
+import { getCurrentInstance, onUnmounted, ref, watch } from 'vue'
+
+/**
+ * @param {import('vue').Ref<Element|null>} elementRef  ref de plantilla a vigilar
+ * @param {number} fallbackWidth  ancho mientras no haya elemento que medir
+ * @returns {import('vue').Ref<number>}  ancho en píxeles, reactivo
+ */
+export function useElementWidth(elementRef, fallbackWidth = 0) {
+  const width = ref(fallbackWidth)
+  let resizeObserver = null
+
+  const disconnect = () => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+  }
+
+  // `flush: 'post'` para que el watcher corra con el DOM ya parcheado: al
+  // montar, el ref todavía no está asignado en la fase previa.
+  watch(
+    elementRef,
+    (element) => {
+      disconnect()
+      if (!element) {
+        width.value = fallbackWidth
+        return
+      }
+      width.value = element.clientWidth || fallbackWidth
+      // Sin ResizeObserver (entornos sin DOM, navegadores antiguos) el ancho
+      // medido sigue siendo correcto; sencillamente deja de actualizarse.
+      if (typeof ResizeObserver === 'undefined') return
+      resizeObserver = new ResizeObserver(() => {
+        width.value = elementRef.value?.clientWidth || 0
+      })
+      resizeObserver.observe(element)
+    },
+    { immediate: true, flush: 'post' },
+  )
+
+  // Igual que `usePolling`: la guarda permite usar el composable fuera de un
+  // componente, que es lo que hace testeable el módulo en Node puro.
+  if (getCurrentInstance()) onUnmounted(disconnect)
+
+  return width
+}

--- a/web/app/test/useElementWidth.test.mjs
+++ b/web/app/test/useElementWidth.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * Tests de `useElementWidth` — la medida se ata al ref, no al elemento.
+ *
+ * Node puro, sin framework ni DOM, misma convencion que el resto de `test/`.
+ * Lo que se comprueba es justo lo que rompio la grafica de Hygeia: el ref de
+ * plantilla vive bajo un `v-if`, asi que puede valer `null` al montar y puede
+ * cambiar de elemento a mitad de vida.
+ *
+ *   - un ref vacio no llega a `observe()` (era el TypeError del navegador:
+ *     `ResizeObserver.observe` exige un Element y `null` no lo es);
+ *   - cuando aparece elemento, se observa;
+ *   - si el elemento se sustituye, se suelta el viejo y se observa el nuevo;
+ *   - sin `ResizeObserver` en el entorno, no se lanza nada.
+ */
+
+import assert from 'node:assert/strict'
+import { nextTick, ref } from 'vue'
+
+const { useElementWidth } = await import('../src/composables/useElementWidth.js')
+
+/** Elemento falso: al composable solo le interesa `clientWidth`. */
+const fakeElement = (clientWidth) => ({ clientWidth })
+
+/**
+ * ResizeObserver falso instalado como global. Registra a quien observa y
+ * expone el callback para poder simular un redimensionado.
+ */
+function installResizeObserver() {
+  // `attempts` guarda TODO lo que se le pasa a observe(), valido o no. Es lo
+  // que hace que el test detecte la regresion: si el composable volviera a
+  // observar un `null`, el TypeError lo tragaria el watcher de Vue y
+  // `observed` seguiria vacio, o sea, el test pasaria en verde.
+  const attempts = []
+  const observed = []
+  const disconnected = []
+  const instances = []
+  globalThis.ResizeObserver = class {
+    constructor(callback) {
+      this.callback = callback
+      instances.push(this)
+    }
+    observe(element) {
+      attempts.push(element)
+      // La comprobacion que hace el navegador de verdad, y que es la que
+      // reventaba en produccion.
+      if (!element || typeof element !== 'object') {
+        throw new TypeError("parameter 1 is not of type 'Element'")
+      }
+      observed.push(element)
+    }
+    disconnect() { disconnected.push(this) }
+  }
+  return {
+    attempts,
+    observed,
+    disconnected,
+    lastInstance: () => instances[instances.length - 1],
+  }
+}
+
+function uninstallResizeObserver() {
+  delete globalThis.ResizeObserver
+}
+
+let failures = 0
+async function test(name, fn) {
+  try { await fn(); console.log(`  ok   ${name}`) }
+  catch (err) { failures++; console.error(`  FAIL ${name}\n       ${err.message}`) }
+  finally { uninstallResizeObserver() }
+}
+
+console.log('useElementWidth')
+
+await test('un ref vacio no se observa y conserva el ancho de respaldo', async () => {
+  const spy = installResizeObserver()
+  const elementRef = ref(null)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+  assert.equal(spy.attempts.length, 0, 'llamo a observe() con un ref vacio')
+  assert.equal(width.value, 600)
+})
+
+await test('cuando el ref recibe elemento, se observa y se mide', async () => {
+  const spy = installResizeObserver()
+  const elementRef = ref(null)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  const element = fakeElement(480)
+  elementRef.value = element
+  await nextTick()
+
+  assert.deepEqual(spy.observed, [element], 'no observo el elemento nuevo')
+  assert.equal(width.value, 480, 'no midio el elemento al engancharse')
+})
+
+await test('un redimensionado actualiza el ancho', async () => {
+  const spy = installResizeObserver()
+  const element = fakeElement(480)
+  const elementRef = ref(element)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  element.clientWidth = 320
+  spy.lastInstance().callback()
+  assert.equal(width.value, 320)
+})
+
+await test('sustituir el elemento suelta el viejo y observa el nuevo', async () => {
+  const spy = installResizeObserver()
+  const first = fakeElement(480)
+  const elementRef = ref(first)
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+
+  // Lo que pasa cuando la tarjeta se destruye (ventana sin lecturas) y se
+  // vuelve a crear: el ref pasa por null y luego apunta a otro nodo.
+  elementRef.value = null
+  await nextTick()
+  assert.equal(spy.disconnected.length, 1, 'no solto el observador del nodo destruido')
+  assert.equal(width.value, 600, 'no volvio al ancho de respaldo sin elemento')
+
+  const second = fakeElement(300)
+  elementRef.value = second
+  await nextTick()
+  assert.deepEqual(spy.observed, [first, second], 'no reengancho al nodo nuevo')
+  assert.equal(width.value, 300)
+
+  // Y el observador nuevo es el que manda: el viejo ya no debe mover nada.
+  second.clientWidth = 260
+  spy.lastInstance().callback()
+  assert.equal(width.value, 260)
+})
+
+await test('sin ResizeObserver en el entorno no lanza y mide una vez', async () => {
+  uninstallResizeObserver()
+  const elementRef = ref(fakeElement(512))
+  const width = useElementWidth(elementRef, 600)
+  await nextTick()
+  assert.equal(width.value, 512)
+})
+
+console.log(failures ? `\n${failures} test(s) fallaron` : '\nTodos los tests de useElementWidth pasaron')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
Integración de la línea `v0.5` en `main`. `appVersion` queda en **0.5.14**.

Recordatorio de lo que implica: un push verde a `main` dispara el despliegue automático a producción (`.github/workflows/deploy.yml`). Esto no es una integración más, es una salida.

## Qué entra

Dos bloques independientes.

### 1. El arreglo de la gráfica de Hygeia (0.5.14)

Un `TypeError` de `ResizeObserver` en `MetricsChart.vue`. El composable de ancho reactivo pasa a atarse al `ref` y no al elemento, con lo que la gráfica deja de reventar cuando todavía no hay lecturas que pintar. Lleva su propio test del ciclo de vida de `useElementWidth`.

Es lo único de esta integración que **cambia el producto** y, por tanto, lo único con riesgo real de despliegue.

**Ojo al historial: este arreglo aparece dos veces.** Entró en `v0.5` por #453 y otra vez por #454, que era el hotfix pensado originalmente para ir directo a `main` y acabó reapuntado a `v0.5`. Son los mismos cambios hechos por duplicado, con SHAs distintos:

| #453 | #454 |
|---|---|
| `599aee03` | `8134403a` |
| `44fde6e3` | `56723ba9` |
| `09ad5101` | `475ecf57` |
| `45f69a71` | `8f9cb087` |
| `b93bdc29` | `8ee03d6f` |

El segundo merge no cambió ni un byte del árbol —está verificado: el árbol resultante era idéntico al que ya había— así que el **contenido** que se despliega es correcto y no hay nada que reconciliar. Lo que queda duplicado es el relato: quien busque cuándo llegó este arreglo encontrará dos merges y ninguno de los dos es falso. Se deja constancia aquí para que no cueste una tarde dentro de tres meses.

### 2. El banco nocturno de Lybra vuelve a medir (#457)

Cierra #455. **Todo el cambio es de `API/tests/` y `README.md`; no toca `src/`**, así que no llega a producción nada de este bloque.

El workflow `lybra-bench.yml` no había terminado en verde ni una sola vez desde que se añadió el 31 de agosto: las tres ejecuciones programadas fallaron y el correo diario de fallo era real. Ninguno de los fallos era una regresión del motor. Eran cuatro cosas distintas:

- **El oráculo de Nmap no alcanzaba ningún objetivo en un runner Linux.** Se lanza en contenedor contra `host.docker.internal`, nombre que Docker Desktop inyecta solo pero Docker sobre Linux no; faltaba `--add-host=host.docker.internal:host-gateway`. El comentario del módulo decía que eso lo añadía `_docker_args()`, una función que nunca se escribió. Lo insidioso es el modo de fallo: ante un nombre que no resuelve, Nmap emite un XML válido sin ni un host y **sale con código 0**, así que el banco lo leía como «Nmap no identificó el servicio» y lo apuntaba como desacuerdo de fingerprint inexistente. Ahora, además de la bandera, un XML sin `<host>` interrumpe el banco en vez de aportar un cero a la cifra.
- **Un contenedor caído se leía como un fallo del motor.** El objetivo de ProFTPD moría al arrancar y lo único que llegaba al log era un timeout de cuatro minutos contra un puerto. Se añade un registro puerto→contenedor: los esperadores se rinden en cuanto el contenedor deja de estar en marcha y el error adjunta `docker logs`. La causa concreta era una receta de Debian corriendo sobre Alpine.
- **El catálogo etiquetado se quedó atrás cuando el feed creció.** Al pasar el feed de 28 a 55 checks (#296) aparecieron CSP, `Referrer-Policy` y `Permissions-Policy`; el banco seguía declarando la familia como tres identificadores escritos a mano y por duplicado. Tres detecciones **correctas** se contaron como falsos positivos en los diecisiete objetivos HTTP y dejaron la precisión en 0,557 frente a un umbral de 0,90. Ahora la familia se deriva del feed, el control negativo manda las seis cabeceras, y un test que corre en el **CI por defecto** hace que el desfase falle en el mismo PR que añada el check en vez de descubrirse de madrugada tres semanas después.
- **El par SQL.** `sql-dump-exposure` y `sql-backup-exposure` reconocen el mismo `/backup.sql` con severidades distintas. Aquí se etiquetan como pareja esperada porque hoy los dos hallazgos son ciertos; la duplicación real es del feed y se sigue en **#456**.

## Validación

- `API Tests` y `API Tests (PostgreSQL + Redis)` sobre `v0.5`.
- Suite completa en local (`pytest -x`) sobre la rama del banco antes de integrarla.

**Lo que todavía no está comprobado:** la ejecución manual del banco nocturno sobre estos cambios ([run 33874782416](https://github.com/ProjectEllysia/EllysiaServer/actions/runs/33874782416)) seguía en curso al abrir este PR. Es la única verificación real de las dos primeras causas, porque sólo se manifiestan en un runner Linux. No bloquea el despliegue —ese bloque no toca `src/`— pero hasta que termine, «el banco nocturno está arreglado» es una expectativa razonada y no un hecho medido. La expectativa, para poder contrastarla: precisión **1,00** y recall ~**0,98**, con el único falso negativo en `nginx-redirige`, que es un fallo de sonda ya documentado con `xfail(strict=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
