### PR TITLE
fix(web): los tests de Acheron encuentran otra vez sus vectores

### DIFF
--- a/web/app/test/README.md
+++ b/web/app/test/README.md
@@ -1,0 +1,39 @@
+# Suites del cliente de Acheron
+
+Se ejecutan con `node` a secas, sin framework. Salen con código distinto de cero si algo falla,
+para poder usarse en CI:
+
+```bash
+npm run test:acheron    # interop + CRUD + sync
+```
+
+## `acheron-vectors.json` — vectores de interoperabilidad
+
+La criptografía de la bóveda está implementada **dos veces y sin compartir código**: en Java
+dentro de [`AcheronCore`](https://github.com/ProjectEllysia/AcheronCore) (la usa la app Android) y
+en JavaScript dentro de `web/app/src/acheron/` (la usa esta SPA). Cada una implementa por su
+cuenta el mismo formato de cable, así que pueden divergir en silencio.
+
+Lo único que lo impide son estos vectores. `AcheronCore` cifra unas bóvedas de prueba con
+contraseñas y salts fijos y vuelca el resultado junto con los valores en claro esperados;
+`acheron.interop.test.mjs` las abre y comprueba que descifra exactamente eso. Si una de las dos
+implementaciones cambia el formato y la otra no, el test falla.
+
+**No se editan a mano.** Los genera `VectorGenerator` en `AcheronCore`:
+
+```bash
+./gradlew test --tests '*VectorGenerator'     # salida en build/acheron-vectors.json
+```
+
+| | |
+|---|---|
+| **Generados desde** | `AcheronCore` @ [`516bb7a`](https://github.com/ProjectEllysia/AcheronCore/commit/516bb7a0f6a02df22fb8ae8f6041e66cdf143d49) |
+| **Cobertura** | Argon2id y PBKDF2, con `account`, `creditcard` y `securenote` |
+
+Al actualizarlos hay que anotar aquí la versión de `AcheronCore` de la que salieron: sin eso, un
+fallo de interoperabilidad no se puede atribuir a un cambio concreto del motor Java.
+
+> Estos vectores cubren la dirección **Java → JS**: comprueban que este cliente sabe leer lo que
+> escribe el Java. La dirección contraria —que el Java sepa leer lo que escribe este cliente— no
+> la cubre nadie todavía; es el asunto de
+> [#486](https://github.com/ProjectEllysia/EllysiaServer/issues/486).

--- a/web/app/test/acheron-vectors.json
+++ b/web/app/test/acheron-vectors.json
@@ -1,0 +1,151 @@
+{
+  "cases": [
+    {
+      "kdf": "Argon2",
+      "masterPassword": "Master-Argon2-123!",
+      "username": "alice",
+      "vault": {
+        "version": 1,
+        "checker": "yqzkivmeNaR8qNKUOUZuNOXQej38dc3xxWJwOowT17mdMG2jw379TS+8t3126j8RctSnw/7FnW5euI2Gi1rr8hoHPnq02sKdOUcEN4FGaJCcsthwd+3teY98R2w\u003d",
+        "vaultKey": "eRzMc7GzJ2LMc5cdZBu65D72sxPimcTo2k4lz9LCFoLSndS5/CnZDDgnXVPmJ86AjpnXRhQgF/DfLiTSFZa/uofoczLO/RuW",
+        "algorithm": {
+          "transformation": "AES/GCM/NoPadding",
+          "kdf": "Argon2",
+          "kdfIterations": 3,
+          "kdfMemoryKiB": 65536,
+          "kdfParallelism": 1,
+          "salt": "AaIAMSaaAapdO4iYQupBCw\u003d\u003d"
+        },
+        "accounts": [
+          {
+            "id": "ACC0",
+            "title": "zLdZiJIIMsg57W2ZmD9ULNAWkrRE9GkJ1Dv66gmzRb7r",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "username": "wpKi/0i0QSTZU040QN5kdLb9Ma6rQ50moeVYspUJtkv/FhFmQS+/ERxHKQ\u003d\u003d",
+            "domain": "Md2kwpsRn91yZXCWFLs5/jn+VPu6ZzKCc8N/C2xG3NOqPPm9sLWxNC36nw\u003d\u003d",
+            "password": "Vz0XZXGqteaVwaQEybVeYyGBvnbrZDSLylMpfJQQE83kLPf+4hQ4a5Kn"
+          }
+        ],
+        "creditcards": [
+          {
+            "id": "CDC0",
+            "title": "gExGAv0BBsK6xwPttFqJ+0a9nqbgzQJZA//Zt/KJ0hXE5zlZxE2y5UU\u003d",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "cardHolderName": "Y1H3FuQXXiIvwlumBvdpq+rHoow3U5RQNEfIJru+oIXe2YA6QQ\u003d\u003d",
+            "cardNumber": "LcnTcN1j2zD8AP9kcA9wYA9gtyqycFkRcJ45IyRy5TsVsPFMIlhlDuCL9VQ\u003d",
+            "expirationDate": "TyMM6Mjxl6Ow3yYiF19Wns+R04fbV6L924gWrigOL+kR",
+            "postalCode": "mpLGskwPoKUPFS+1KiiDJuIDbhraz+MKyG5i3M5MIz+S",
+            "cvv": "kk5Zo6seRJFwZUkWrW+sAOJYhUiBIVEwxwFL4XyuCw\u003d\u003d"
+          }
+        ],
+        "securenotes": [
+          {
+            "id": "SCN0",
+            "title": "O8A6OXdfYapshLT5ToFSeNz/dmJL0jdK0cfEHJn2zqPPpxbqAqlhC7HZ",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "content": "1brHTTvimvqM3wz9VttjPoEiYzfbPSdpWpFDN1NalyTF85rUzHcy0GN755Kaz9Xi/1r5ICH1nzSk"
+          }
+        ]
+      },
+      "expected": {
+        "ACC0": {
+          "title": "Gmail",
+          "username": "alice@gmail.com",
+          "domain": "mail.google.com",
+          "password": "P@ssw0rd-acc-0"
+        },
+        "CDC0": {
+          "title": "Personal Card",
+          "cardHolderName": "ALICE DOE",
+          "cardNumber": "4111111111111111",
+          "expirationDate": "12/29",
+          "postalCode": "28001",
+          "cvv": "123"
+        },
+        "SCN0": {
+          "title": "Recovery codes",
+          "content": "8F3K-2L9P-77QX\n1A2B-3C4D-5E6F"
+        }
+      }
+    },
+    {
+      "kdf": "PBKDF2",
+      "masterPassword": "Master-PBKDF2-123!",
+      "username": "alice",
+      "vault": {
+        "version": 1,
+        "checker": "mkErVvMzeKcMk3ihP8EV929d82Xla5VA1X9UoonmVAJVcuefwEXLRCZgMZOGPFF+KHIeNz6hrKVg1E0ZYP4b2DDR/K9eXXLV+HxKRZtkdHHTN4/7vnXZSzhqvrw\u003d",
+        "vaultKey": "wfKTL2DLUXdtP2ZsLhiWOo6KPFOuoM8JNL+OXrfIxDW3fapI+Qmz/4jSG/Xqj6sTsC8QD9PX8OkIAz6ccRQhca8HLu5lRyyF",
+        "algorithm": {
+          "transformation": "AES/GCM/NoPadding",
+          "kdf": "PBKDF2",
+          "kdfIterations": 600000,
+          "kdfKeyLength": 256,
+          "salt": "DhLP/HYlewVNctzrXsRASA\u003d\u003d"
+        },
+        "accounts": [
+          {
+            "id": "ACC0",
+            "title": "+ML+wjgesuF3BbW4CYQZjLV4eCMF8z7Wxgcgef76wknL",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "username": "qrblGwQUePo4ikoxK7CqmfvmHnpjawIOK2AS6rZ/ommrrbe2ez2YYzU2+w\u003d\u003d",
+            "domain": "JPUrtjCocpym4bzPuV62HLHYoXOKbQzmb8/lSTpDP/Yx9mIQXR0ZOCAwAg\u003d\u003d",
+            "password": "j+aI7Sd0LsFZ16Yij5CEvkNt12mSNGPf/BBjyWElQa5q3CWAUhwDmW8f"
+          }
+        ],
+        "creditcards": [
+          {
+            "id": "CDC0",
+            "title": "ZBRyMrPfXoj+YcxfnT4cqIpVLUUidSIQveLO76p4ZFeP2P7Ljy2wbIQ\u003d",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "cardHolderName": "5ai+4FUE4nNqaxuLYkjOxsn5MdomNPGLIGvBlKNya6nPQg348w\u003d\u003d",
+            "cardNumber": "inOAdAcTGs3v6Pvr0Kkw6RyHCIKb8dfEFn0cV2OF9J+nXE3liTN6yJzLksU\u003d",
+            "expirationDate": "HxN/UITCZkQ475p8jR3BrARVU0sW+W9VREH4hbTHKiFs",
+            "postalCode": "9TysAU4qkthACbkfBB5k9bKvypVOaCwzYJoD6kux9sTu",
+            "cvv": "87YMpQEDub3evb7sO08NwIHADSzGKR/NieHZ2+t61w\u003d\u003d"
+          }
+        ],
+        "securenotes": [
+          {
+            "id": "SCN0",
+            "title": "YYU24Xd+B36kwSp803WsbqGVzUFh/rEAz9NQDFy89tcLlDqK75jmcW7K",
+            "createdAt": "2026-01-01T01:00:00+01:00",
+            "updatedAt": "2026-01-01T01:00:00+01:00",
+            "allowedUsers": [],
+            "content": "FGyOqHyQ/th4CwVlh2qXE3UJICF8Mfb+Km48s7LFPHU5oVDTiN1A3C3OqZj19mZgtoJYkxzSFuTd"
+          }
+        ]
+      },
+      "expected": {
+        "ACC0": {
+          "title": "Gmail",
+          "username": "alice@gmail.com",
+          "domain": "mail.google.com",
+          "password": "P@ssw0rd-acc-0"
+        },
+        "CDC0": {
+          "title": "Personal Card",
+          "cardHolderName": "ALICE DOE",
+          "cardNumber": "4111111111111111",
+          "expirationDate": "12/29",
+          "postalCode": "28001",
+          "cvv": "123"
+        },
+        "SCN0": {
+          "title": "Recovery codes",
+          "content": "8F3K-2L9P-77QX\n1A2B-3C4D-5E6F"
+        }
+      }
+    }
+  ]
+}

--- a/web/app/test/acheron.crud.test.mjs
+++ b/web/app/test/acheron.crud.test.mjs
@@ -16,7 +16,7 @@ import { dirname, resolve } from 'node:path'
 import { openVault, WrongPasswordError } from '../src/acheron/vault.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
-const vectorsPath = resolve(here, '../../../tests/acheron-vectors.json')
+const vectorsPath = resolve(here, 'acheron-vectors.json')
 
 let passed = 0
 let failed = 0

--- a/web/app/test/acheron.interop.test.mjs
+++ b/web/app/test/acheron.interop.test.mjs
@@ -1,7 +1,8 @@
 /**
  * Test de interoperabilidad Java → JS para el cliente cripto de Acheron.
  *
- * Carga los vectores generados por AcheronCore (tests/acheron-vectors.json),
+ * Carga los vectores generados por AcheronCore (acheron-vectors.json, en este
+ * mismo directorio; ver el README de la suite para saber de qué versión salen),
  * abre cada vault con su master password y comprueba que el módulo JS descifra
  * EXACTAMENTE los valores en texto plano esperados. Verifica además el
  * round-trip (cifrar → descifrar) y que un master password incorrecto falla.
@@ -20,7 +21,7 @@ import { openVault, WrongPasswordError } from '../src/acheron/vault.js'
 import { STORABLE_CATEGORIES } from '../src/acheron/storableFields.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
-const vectorsPath = resolve(here, '../../../tests/acheron-vectors.json')
+const vectorsPath = resolve(here, 'acheron-vectors.json')
 
 let passed = 0
 let failed = 0


### PR DESCRIPTION
## Resumen

Restaura los vectores de interoperabilidad de Acheron, que desaparecieron hace un mes y dejaron dos suites de tests sin poder ejecutarse.

## Contexto, para quien no conozca el módulo

Acheron es la bóveda de credenciales de Ellysia. Su criptografía está implementada **dos veces y sin compartir código**: una en Java, en el repositorio [`AcheronCore`](https://github.com/ProjectEllysia/AcheronCore), que usa la app de Android; y otra en JavaScript, en `web/app/src/acheron/`, que usa esta SPA. Ninguna de las dos es una traducción automática de la otra: cada una implementa por su cuenta el mismo *formato de cable* — cuántas pasadas de Argon2id, en qué orden van los bytes, dónde acaba el vector de inicialización y empieza el texto cifrado.

Eso importa porque **las dos escriben en la misma bóveda**. Si guardas una credencial desde el móvil y luego abres la web, la web tiene que descifrar exactamente lo que escribió el móvil. El servidor no puede ayudar: es *zero-knowledge*, guarda un bloque cifrado que no sabe leer.

Como no se puede comparar código Java contra código JavaScript, lo que se comparan son **resultados sobre entradas conocidas**. A eso se le llama vectores de interoperabilidad: `AcheronCore` cifra unas bóvedas de prueba con contraseñas y salts fijos, vuelca el JSON resultante junto con los valores en claro esperados, y el test JS abre esas bóvedas y comprueba que obtiene exactamente eso. Si una implementación cambia el formato y la otra no, el test falla.

## El problema

El commit `e11fb066` ("refactor: removed acheron files (moved to new repo)"), que separó `AcheronCore` a su propio repositorio, borró de aquí `tests/acheron-vectors.json`. Las suites que lo leían siguieron apuntando a esa ruta:

```
Error: ENOENT: no such file or directory, open '...\EllysiaServer\tests\acheron-vectors.json'
```

Resultado: el único control que existe sobre la interoperabilidad de la criptografía con la app móvil lleva un mes sin ejecutarse. Cualquier divergencia introducida en ese tiempo habría pasado inadvertida.

Nótese que el productor nunca se rompió: `VectorGenerator` en `AcheronCore` sigue funcionando. Lo que se perdió fue el canal entre los dos.

## Qué cambia

- **Los vectores vuelven**, generados desde `AcheronCore` @ [`516bb7a`](https://github.com/ProjectEllysia/AcheronCore/commit/516bb7a0f6a02df22fb8ae8f6041e66cdf143d49).
- **Se colocan junto a la suite que los consume** (`web/app/test/`) en lugar de en un directorio `tests/` en la raíz que ya no existe para nada más. Así viajan con el resto de la suite cuando el motor se mude a `AcheronCoreWeb`.
- **Se corrigen las dos rutas.** La issue solo mencionaba `acheron.interop.test.mjs`, pero `acheron.crud.test.mjs` leía el mismo fichero con la misma ruta rota; se descubrió al ejecutar la suite completa y va arreglado también.
- **Un README de la suite** anota de qué versión de `AcheronCore` salieron los vectores y cómo se regeneran. Sin esa anotación, un fallo futuro de interoperabilidad no se puede atribuir a un cambio concreto del motor Java.

## Validación

```
npm run test:acheron
  acheron.interop.test.mjs   62 OK, 0 fallidos
  acheron.crud.test.mjs      20 OK, 0 fallidos
  acheron.sync.test.mjs      OK
```

Los vectores se regeneraron localmente con `./gradlew test --tests '*VectorGenerator'` sobre un clon limpio de `AcheronCore`, y cubren los dos KDF (Argon2id y PBKDF2) con `account`, `creditcard` y `securenote`.

## Notas y alcance excluido

- **Esto no arregla la causa raíz.** Que el fichero se borrara es el síntoma; que nadie se enterara durante un mes es la causa, y es que `npm run test:acheron` no está en ningún workflow de CI. Va en #470.
- **Cómo viajan los vectores de forma sostenible** —hoy siguen siendo una copia manual— es #469.
- **La verificación sigue siendo de un solo sentido.** Estos vectores prueban que el JavaScript sabe leer lo que escribe el Java, no al revés. Va en #486.

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
