### PR TITLE
test(web): generador de vectores del lado JavaScript

### DIFF
--- a/web/app/test/acheron-vectors-js.json
+++ b/web/app/test/acheron-vectors-js.json
@@ -1,0 +1,225 @@
+{
+  "cases": [
+    {
+      "kdf": "Argon2",
+      "masterPassword": "correct horse battery staple",
+      "username": "alice",
+      "vault": {
+        "version": 1,
+        "checker": "459QRDOASk87AuJOlyP3KJIbsLoDT7XEj+SClAXF9iJMbXnZSfY83W416o94rPi3iulZg4wiEv49YPfSTr28V/BRY4aVVZLWLGxmUOESL4Hb+qa12q4YI/akers=",
+        "vaultKey": "NGZkACk1JN7o05YE6I4GYo+7qydPQeMZRVwfaWn3Lv7b8zSYPMmnzTnO/dUuAX6i5W4gJBw4nsoJEvvapwmHjJznIGpMzBb5",
+        "algorithm": {
+          "transformation": "AES/GCM/NoPadding",
+          "kdf": "Argon2",
+          "kdfIterations": "3",
+          "kdfMemoryKiB": "65536",
+          "kdfParallelism": "1",
+          "salt": "8I/cLmJto1ZV4Jyoc9fKtg=="
+        },
+        "accounts": [
+          {
+            "id": "3ddda920be1ad1e5",
+            "allowedUsers": [],
+            "title": "PM3uQ+NhS1z7bo+s3MSj0HEPAO6za0IgCKmgBkyec9F1",
+            "createdAt": "2026-09-05T16:26:30.178Z",
+            "updatedAt": "2026-09-05T16:26:30.178Z",
+            "username": "wVdCIU7T6SI4GDYtpgMlM3EKfXOOpbs2VL7fdOr7kcGgC59HkDjuggd1Sg==",
+            "domain": "2fD/LgIvMXgHyD+gavYzrne+3Y+iIGaY0vT4ll1mk12C4HwDvXkqq15qeQ==",
+            "password": "y5EgrnJc2HZCuawbGftBIajWpwuBSguZwIIDsJsVOj7J222/64fM+3z2"
+          }
+        ],
+        "creditcards": [
+          {
+            "id": "e0f40c964d8d1215",
+            "allowedUsers": [],
+            "title": "Q5fdbcFH8mGqgItD/7ppR89m2gEl9tk5EOaM7tbmBdJwJec6rwN+xIk=",
+            "createdAt": "2026-09-05T16:26:30.180Z",
+            "updatedAt": "2026-09-05T16:26:30.180Z",
+            "cardHolderName": "C8ttoqaicE8dPu/gtACqVm7c9L6f9gRPpKuDJfUmee80hr3pzA==",
+            "cardNumber": "/cUQhCiAMS87S0dWapyPv92rDYS+lzYRTZWNaGy38SiPMoMvZq2oGtNfkGY=",
+            "expirationDate": "Lp/lPY2o2uefiZcsC1psHJKsrP/NR6MPNhKnOST6t9fW",
+            "cvv": "DL+kTsRFc5TjkPcFtq06SgBffIdS6bRDcnNyctHiRA==",
+            "postalCode": "fjl9IJtnm88lW/tatFzzOKisfLYSVvzolbZta7CgXpzF"
+          }
+        ],
+        "securenotes": [
+          {
+            "id": "ae65090295f5d569",
+            "allowedUsers": [],
+            "title": "XsqeH+UWJ3qby7I0v3zVkOt5g9IF+0K1gtJholOwQD9YwIRmIUNGynWG",
+            "createdAt": "2026-09-05T16:26:30.181Z",
+            "updatedAt": "2026-09-05T16:26:30.181Z",
+            "content": "j8G35zRrs1ooyCPYt6QuOc1V/Wdthz7dqJ5ge7ksXW7ST/o8+PerdVBDaT8d3WN9FJzWaVxL6OZi+Puu2aV3q5W8gqbAdAavhUSavV+nzRs="
+          }
+        ]
+      },
+      "expected": {
+        "3ddda920be1ad1e5": {
+          "title": "Gmail",
+          "username": "alice@gmail.com",
+          "domain": "mail.google.com",
+          "password": "P@ssw0rd-acc-0"
+        },
+        "e0f40c964d8d1215": {
+          "title": "Personal Card",
+          "cardHolderName": "ALICE DOE",
+          "cardNumber": "4111111111111111",
+          "expirationDate": "12/29",
+          "postalCode": "28001",
+          "cvv": "123"
+        },
+        "ae65090295f5d569": {
+          "title": "Recovery codes",
+          "content": "linea uno\nlinea dos con acentos: ñ á ü\nlinea tres"
+        }
+      }
+    },
+    {
+      "kdf": "PBKDF2",
+      "masterPassword": "correct horse battery staple",
+      "username": "alice",
+      "vault": {
+        "version": 1,
+        "algorithm": {
+          "transformation": "AES/GCM/NoPadding",
+          "kdf": "PBKDF2",
+          "kdfIterations": "600000",
+          "kdfKeyLength": "256",
+          "salt": "dTI/fLCXFaaPzoKZgvqrgA=="
+        },
+        "checker": "kFy5dTbY1y5jm5py4XV4XwIehynWrbpu/bl3LiqrtlyTGkORE7Q7ZWYMzPIBLoPUTjnEGoN9i6DzwEaPEKRcSGF3fW3sLKU+qgszeUGZ+8mT9a68lxiWATaSTlQ=",
+        "vaultKey": "+/6K4gcjOV5Bpw26zaswwoVRgWP2NKDejrnzFghI1EuheNUZ+aBqmYQVKn5relO9WrGyGV6rUm+9uKX8jRadAK+hsvC2UILE",
+        "accounts": [
+          {
+            "id": "8205336915d69640",
+            "allowedUsers": [],
+            "title": "pbo42IiQ1H9OUFOy9RLBevsPY60cjFuoRu/xbAUIqHYn",
+            "createdAt": "2026-09-05T16:26:30.307Z",
+            "updatedAt": "2026-09-05T16:26:30.307Z",
+            "username": "DH4lHcHrkGPydkTToWk0ht1Lr2N26dpGXrfGeFJO16MlHNrM4lcj8R/JfA==",
+            "domain": "3hahIjchwIDzPlX4YnuKTLjt/Vtc86lhhriZS5LfaiLb95aXY5YkLOdrSQ==",
+            "password": "25djE3doRLzNsnedr1PRHWQZChV0dANkXFQjsQAuv8gGVNquywa0yRk7"
+          }
+        ],
+        "creditcards": [
+          {
+            "id": "2c27dcf1dd4ba5ab",
+            "allowedUsers": [],
+            "title": "6MGDZCVUfTXbFJYKrs9ZqJTRTY6HzuLdyrxf6LN+d8rzF989V5Qo7uc=",
+            "createdAt": "2026-09-05T16:26:30.307Z",
+            "updatedAt": "2026-09-05T16:26:30.307Z",
+            "cardHolderName": "p0rz83nKaVMG8IlXwQwepVyq9xk5NtFmzK3nfljLMrHf6R7g+w==",
+            "cardNumber": "fDz9VrQ0ZrS8Q7W/xSDaxkSznbY1qqavgmJRMbY53/q0MaB5HxGHvIbCgH0=",
+            "expirationDate": "9rtiRC5dpi7QfzHwKJP8i5mjl4eszkGf7gwiU0MgGrGL",
+            "cvv": "w6t8JcSvLNQHDNAn64vNTDKEc+qL+Ac1hgsZb5aXCg==",
+            "postalCode": "DtRJr2aTpSGe3mLeu4pcu+DIPJBIBroAs8kNrNRJG6PL"
+          }
+        ],
+        "securenotes": [
+          {
+            "id": "2402bd69c4358c20",
+            "allowedUsers": [],
+            "title": "pB7D98TES/5tWTyHCpT/hDsz44UD++2CxXqyD0wPus805ud6GGJIyVmY",
+            "createdAt": "2026-09-05T16:26:30.307Z",
+            "updatedAt": "2026-09-05T16:26:30.307Z",
+            "content": "yi9lSYRC9oaW6C1FQQkKOo+YmIV3a+6iUwSmz//GJ+sLEaAwAWwMZoVbUCuFeYCIyU3qH24sL7vtDCuTzEOis1SeuF5XXk1DMTNlhpQd3mQ="
+          }
+        ]
+      },
+      "expected": {
+        "8205336915d69640": {
+          "title": "Gmail",
+          "username": "alice@gmail.com",
+          "domain": "mail.google.com",
+          "password": "P@ssw0rd-acc-0"
+        },
+        "2c27dcf1dd4ba5ab": {
+          "title": "Personal Card",
+          "cardHolderName": "ALICE DOE",
+          "cardNumber": "4111111111111111",
+          "expirationDate": "12/29",
+          "postalCode": "28001",
+          "cvv": "123"
+        },
+        "2402bd69c4358c20": {
+          "title": "Recovery codes",
+          "content": "linea uno\nlinea dos con acentos: ñ á ü\nlinea tres"
+        }
+      }
+    },
+    {
+      "kdf": "Argon2-rotado",
+      "masterPassword": "correct horse battery staple-rotada",
+      "username": "alice",
+      "vault": {
+        "version": 1,
+        "checker": "b8KdWJvnfcTfdQ/hDCRpwFXkjy2t8S5kc/cPb9Krtsk8NYR1wDotnLN4FXfwwtR6U+rE0U+zPS6msivXgh7P09BqrJrEnK2BcKBMjM1uHjhSfhQE6Skvt4sgmns=",
+        "vaultKey": "xJkJOhq5X2pWyaHdPPbdLkgpSb2d0vbBmUmGYDYPBJ55sC0FYnhV4OTtOcirVG6ai2JGM2HtD60V/hlAu+aM36/orFeHx7he",
+        "algorithm": {
+          "transformation": "AES/GCM/NoPadding",
+          "kdf": "Argon2",
+          "kdfIterations": "3",
+          "kdfMemoryKiB": "65536",
+          "kdfParallelism": "1",
+          "salt": "/9EQjnah2NM1LMzkPswOPQ=="
+        },
+        "accounts": [
+          {
+            "id": "a97336f1a9dfb16c",
+            "allowedUsers": [],
+            "title": "jqxyisTHtolMo+N1WylWs9vQIcLb3QR87grspn2mqY1R",
+            "createdAt": "2026-09-05T16:26:30.561Z",
+            "updatedAt": "2026-09-05T16:26:30.561Z",
+            "username": "3uDdbLkZhQlF8vAF7bkk5lRrVMzIIvYwO4uy0mx7xWWsMxDBDwN4CdUR4A==",
+            "domain": "YNbAB4GXuCdsl5Y6ewEsjpPq1ClAlEjYQXGjJsXIdEoP82kTaHsXX6CvrA==",
+            "password": "bwqufwk/HP76/NKFUGLR2skOQwcawrwRKhhfOlhevACg0OLLUuYCQUb4"
+          }
+        ],
+        "creditcards": [
+          {
+            "id": "5214b3312bc606d3",
+            "allowedUsers": [],
+            "title": "2nCrqWc2KWxsIxFd3bRzhzxjsyMtuExkc55ejMFVDf9zqTMN86WFDbk=",
+            "createdAt": "2026-09-05T16:26:30.562Z",
+            "updatedAt": "2026-09-05T16:26:30.562Z",
+            "cardHolderName": "hHxd+RYoSdazmA4wJppx+rPuWraJgR8bOBjkYYmmTJx8UwzXLw==",
+            "cardNumber": "/ejuSVdoVqymy5SOxW66QSHgiG3c1c/vrcEYyDOwACkR+F8iXIOhzA3uJQ0=",
+            "expirationDate": "16uWZ6jnCq+ctQd1IlrLyoOmCOGMs0KlyrWpXIw/3oS/",
+            "cvv": "5DD3lQHzJ6lZ0yLVncdQNpCCM6P8HZ+nnXDYubOrLQ==",
+            "postalCode": "rT5Sf18G7BOkp7SXDvzKeJhhbaL1GAKozxXyq+a0EsS5"
+          }
+        ],
+        "securenotes": [
+          {
+            "id": "934ebab96b1023d3",
+            "allowedUsers": [],
+            "title": "RJIJsOMKLtBVc1hAkVOOEooQGssdNW+SDKfCjpPDXliQOSz5JlNTOc2k",
+            "createdAt": "2026-09-05T16:26:30.562Z",
+            "updatedAt": "2026-09-05T16:26:30.562Z",
+            "content": "0nMzu1l/X47pY0/8PJRzwIrcvI5UhRRo/hlaeElbN3jtKbN1rR2G9jgtxsDpB9niQQhfdxvvI0iOwSP9GHhBSIF/tKebZS170XGQ1FaboXQ="
+          }
+        ]
+      },
+      "expected": {
+        "a97336f1a9dfb16c": {
+          "title": "Gmail",
+          "username": "alice@gmail.com",
+          "domain": "mail.google.com",
+          "password": "P@ssw0rd-acc-0"
+        },
+        "5214b3312bc606d3": {
+          "title": "Personal Card",
+          "cardHolderName": "ALICE DOE",
+          "cardNumber": "4111111111111111",
+          "expirationDate": "12/29",
+          "postalCode": "28001",
+          "cvv": "123"
+        },
+        "934ebab96b1023d3": {
+          "title": "Recovery codes",
+          "content": "linea uno\nlinea dos con acentos: ñ á ü\nlinea tres"
+        }
+      }
+    }
+  ]
+}

--- a/web/app/test/acheron.vectorgen.mjs
+++ b/web/app/test/acheron.vectorgen.mjs
@@ -1,0 +1,154 @@
+/**
+ * Genera los VECTORES DE PRUEBA que produce el cliente JS, para que
+ * AcheronCore (Java) verifique que sabe leer lo que escribe este motor.
+ *
+ * Es el espejo de `VectorGenerator.java`, con los papeles cambiados: allí Java
+ * es el emisor y este cliente el receptor; aquí es al revés. Entre los dos
+ * cierran el círculo, porque hasta ahora sólo se comprobaba la dirección
+ * Java → JS: que este cliente supiera leer lo que escribe el Java. La dirección
+ * contraria importa igual, porque la SPA escribe en la bóveda cada vez que un
+ * usuario guarda una credencial, y quien lo lee después es la app Android.
+ *
+ * No es un test: es un generador. Se ejecuta a propósito cuando cambia el
+ * formato de cable, y su salida se commitea.
+ *
+ *   node web/app/test/acheron.vectorgen.mjs [ruta-de-salida]
+ *
+ * Salida por defecto: acheron-vectors-js.json, en este mismo directorio.
+ *
+ * SOBRE EL DETERMINISMO: la salida cambia en cada ejecución aunque no cambie
+ * nada del código. AES-GCM usa un IV aleatorio por operación y cada bóveda
+ * nueva estrena salt y vaultKey, así que el ciphertext nunca se repite. Eso es
+ * correcto y deseado: el consumidor Java no compara bytes, DESCIFRA y compara
+ * el texto en claro, que es la única forma de verificar interoperabilidad con
+ * un cifrado autenticado. Por eso el fichero se regenera a mano y no en cada
+ * arranque de la suite.
+ */
+
+import { writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { openVault, createVault } from '../src/acheron/vault.js'
+import { deriveKey, aesGcmEncrypt, sha256Hex, generateSaltB64, randomBytes, b64encode }
+  from '../src/acheron/crypto.js'
+
+const USERNAME = 'alice'
+const MASTER_PASSWORD = 'correct horse battery staple'
+
+/** Los tres storables de cada caso, en claro. Mismos tipos que el generador Java. */
+const STORABLES = [
+  ['accounts', 'Gmail', {
+    username: 'alice@gmail.com', domain: 'mail.google.com', password: 'P@ssw0rd-acc-0',
+  }],
+  ['creditcards', 'Personal Card', {
+    cardHolderName: 'ALICE DOE', cardNumber: '4111111111111111',
+    expirationDate: '12/29', postalCode: '28001', cvv: '123',
+  }],
+  ['securenotes', 'Recovery codes', {
+    content: 'linea uno\nlinea dos con acentos: ñ á ü\nlinea tres',
+  }],
+]
+
+/**
+ * Metadatos de una bóveda PBKDF2. `createVault` sólo sabe hacer Argon2id, que
+ * es lo que la SPA usa en producción, así que el caso PBKDF2 se arma aquí con
+ * los mismos pasos: derivar, cifrar el checker y envolver la vaultKey.
+ */
+async function createPbkdf2Vault(masterPassword, username) {
+  const algorithm = {
+    transformation: 'AES/GCM/NoPadding',
+    kdf: 'PBKDF2',
+    kdfIterations: '600000',
+    kdfKeyLength: '256',
+    salt: generateSaltB64(),
+  }
+  const derivedKey = await deriveKey(masterPassword, algorithm)
+  return {
+    algorithm,
+    checker: await aesGcmEncrypt(derivedKey, await sha256Hex(username)),
+    vaultKey: await aesGcmEncrypt(derivedKey, b64encode(randomBytes(32))),
+  }
+}
+
+/** Arma una bóveda completa con sus tres storables cifrados. */
+async function buildCase(kdf, meta, masterPassword) {
+  const vault = { version: 1, ...meta }
+  for (const [category] of STORABLES) vault[category] = []
+
+  const openable = await openVault(vault, masterPassword, USERNAME)
+  const expected = {}
+
+  for (const [category, title, fields] of STORABLES) {
+    const { payload, item } = await openable.createStorable(category, title, fields)
+    // El vault JSON usa `id`; el payload de la API usa `internalId`. Los
+    // vectores reproducen la forma del vault, que es la que se descifra.
+    const { internalId, kind, ...ciphertext } = payload
+    vault[category].push({
+      id: internalId, allowedUsers: [], ...ciphertext,
+    })
+    expected[internalId] = { title, ...fields }
+    void item
+  }
+
+  return { kdf, masterPassword, username: USERNAME, vault, expected }
+}
+
+async function main() {
+  const cases = []
+
+  // 1) Argon2id: lo que la SPA escribe en producción.
+  cases.push(await buildCase('Argon2', await createVault(MASTER_PASSWORD, USERNAME), MASTER_PASSWORD))
+
+  // 2) PBKDF2: el otro KDF que el formato admite.
+  cases.push(await buildCase('PBKDF2', await createPbkdf2Vault(MASTER_PASSWORD, USERNAME), MASTER_PASSWORD))
+
+  // 3) Argon2id tras rotar la contraseña maestra. Es el caso de mayor riesgo:
+  //    changePassword reescribe los tres campos maestros de la bóveda
+  //    (checker, vaultKey y algorithm), así que un fallo aquí no corrompe un
+  //    campo suelto, deja la bóveda entera ilegible para el otro cliente.
+  const rotatedBase = await buildCase('Argon2', await createVault(MASTER_PASSWORD, USERNAME), MASTER_PASSWORD)
+  const newPassword = MASTER_PASSWORD + '-rotada'
+  const opened = await openVault(rotatedBase.vault, MASTER_PASSWORD, USERNAME)
+  const rotatedMeta = await opened.changePassword(MASTER_PASSWORD, newPassword, USERNAME)
+  cases.push({
+    ...rotatedBase,
+    kdf: 'Argon2-rotado',
+    masterPassword: newPassword,
+    vault: { ...rotatedBase.vault, ...rotatedMeta },
+  })
+
+  // Autoverificación antes de escribir. No sustituye a la comprobación del
+  // lado Java —que es la que de verdad cierra el círculo— pero impide
+  // commitear un fichero que ni este propio motor sabe releer.
+  for (const c of cases) {
+    const reopened = await openVault(c.vault, c.masterPassword, c.username)
+    for (const [category] of STORABLES) {
+      for (const item of c.vault[category]) {
+        const got = await reopened.decryptStorable(category, item)
+        for (const [field, value] of Object.entries(c.expected[item.id])) {
+          if (got[field] !== value) {
+            throw new Error(
+              `caso ${c.kdf}: ${item.id}.${field} debería ser ${JSON.stringify(value)} ` +
+                `y se releyó ${JSON.stringify(got[field])}`,
+            )
+          }
+        }
+      }
+    }
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url))
+  const out = process.argv[2] || resolve(here, 'acheron-vectors-js.json')
+  writeFileSync(out, JSON.stringify({ cases }, null, 2) + '\n', 'utf8')
+
+  console.log(`Vectores escritos en ${out}`)
+  for (const c of cases) {
+    console.log(`  caso kdf=${c.kdf}  storables=${Object.keys(c.expected).length}`)
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Resumen

Añade la mitad JavaScript de la verificación de interoperabilidad en el sentido que faltaba: **JS → Java**. Es la primera de las dos piezas de #486; la segunda vive en `AcheronCore` y no está en este PR.

## El problema, para quien no conozca el módulo

La bóveda de Acheron la cifran **dos implementaciones distintas y sin código compartido**: una en Java (`AcheronCore`, la usa la app Android) y otra en JavaScript (la usa esta SPA). Las dos escriben en la misma bóveda del mismo usuario, así que tienen que coincidir hasta en el último byte del formato.

Como no se puede comparar código Java contra código JavaScript, se comparan resultados sobre entradas conocidas: un lado cifra bóvedas de prueba y vuelca el JSON junto con los valores en claro esperados; el otro las abre y comprueba que obtiene exactamente eso.

**Hasta ahora eso sólo existía en una dirección.** `VectorGenerator.java` produce vectores y `acheron.interop.test.mjs` los consume, así que está probado que el JavaScript sabe leer lo que escribe el Java. Lo contrario no lo comprobaba nadie.

Y es un camino que los usuarios recorren a diario: la SPA **escribe** en la bóveda cada vez que alguien guarda una credencial desde el navegador, y quien la lee después es su móvil.

El caso peor no es un campo suelto. Es `changePassword`, que rota la contraseña maestra reescribiendo de golpe los tres campos maestros de la bóveda —`checker`, `vaultKey` y `algorithm`—. Un fallo ahí significa que un usuario cambia su contraseña maestra desde la web y **su móvil deja de poder abrir la bóveda entera**. Nada de lo que había lo detectaría.

## Por qué no basta con comparar ficheros

AES-GCM usa un vector de inicialización aleatorio en cada operación, así que cifrar el mismo texto dos veces da salidas distintas. Comparar el ciphertext de Java contra el de JavaScript byte a byte no funcionaría ni aunque ambos fueran correctos.

La única vía es que el receptor **descifre** lo que produjo el emisor y compruebe el texto en claro. Por eso este fichero se regenera a mano y su diff es ruidoso por diseño: es la declaración del emisor sobre su propio comportamiento en un momento dado, no un fichero estable.

## Qué cambia

- `web/app/test/acheron.vectorgen.mjs` — el generador, espejo de `VectorGenerator.java` con los papeles cambiados.
- `web/app/test/acheron-vectors-js.json` — su salida, commiteada.

Tres casos, alineados con lo que el generador Java cubre más el escenario de riesgo:

| Caso | Por qué está |
|---|---|
| `Argon2` | lo que la SPA escribe en producción |
| `PBKDF2` | el otro KDF que el formato admite |
| `Argon2-rotado` | bóveda después de `changePassword`, el camino que puede dejarla ilegible |

Usa las rutas de código reales (`createVault`, `openVault`, `createStorable`, `changePassword`) en lugar de armar el JSON a mano: lo que interesa verificar es lo que el motor escribe de verdad, no lo que un fixture dice que escribe. La única excepción es el bloque `algorithm` de PBKDF2, porque `createVault` sólo sabe hacer Argon2id; se arma con los mismos pasos y está comentado.

## Un hallazgo que salió al generarlo

Los dos generadores emiten los parámetros del KDF con **tipos distintos**:

```
vectores Java:  "kdfIterations": 3      ← número
vectores JS:    "kdfIterations": "3"    ← cadena
```

La forma con cadena es la que la SPA escribe en producción, y `crypto.js` lo tiene documentado (`parseInt(algorithm.kdfIterations, 10)`, con el comentario "La API exporta los parámetros KDF como STRING"). El lado JavaScript tolera ambas.

Lo que nadie ha comprobado nunca es **si el Java tolera la forma con cadena**. El test de la otra mitad será lo primero que lo verifique, y si falla, habrá encontrado un fallo real de producción y no un problema del test.

## Validación

```
node test/acheron.vectorgen.mjs   →  3 casos, 3 storables cada uno
npm test                          →  exit 0, las nueve suites en verde
```

El generador **se autoverifica antes de escribir**: reabre cada bóveda que acaba de construir y descifra los tres storables, comparándolos con los valores esperados. No sustituye a la comprobación del lado Java —esa es la que cierra el círculo— pero impide commitear un fichero que ni este propio motor sabe releer.

Comprobado que la autoverificación falla de verdad:

- Rompiendo el formato de cable (`IV_LENGTH` de 12 a 11 en `crypto.js`) → exit 1.
- Corrompiendo un byte de un ciphertext antes de la comprobación → exit 1, con el tag de AES-GCM rechazando el descifrado.

## Alcance excluido

**Este PR no cierra #486.** Falta el consumidor del lado Java: un test en `AcheronCore` que lea `acheron-vectors-js.json` y compruebe que descifra lo esperado. Hasta entonces el círculo sigue abierto y este fichero no protege de nada por sí solo.

Tampoco decide cómo viaja el fichero hasta `AcheronCore`, que es #469.

Refs #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
