### PR TITLE
fix(ci): el despliegue vuelve a encadenarse con el workflow de tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # Despliegue automático a producción.
 #
-# Se dispara cuando el workflow "API Tests" (tests.yml) termina con éxito tras
+# Se dispara cuando el workflow "Tests" (tests.yml) termina con éxito tras
 # un push a `main` — es decir, cuando un pull request se ha aceptado y los
 # tests del commit mergeado han pasado. Decisiones de diseño, con su porqué:
 #
@@ -42,7 +42,10 @@ name: Deploy to production
 
 on:
   workflow_run:
-    workflows: ["API Tests"]
+    # OJO: se referencia por NOMBRE exacto, el del `name:` de tests.yml.
+    # Renombrar aquel workflow sin tocar esta linea deja el despliegue
+    # automatico sin disparador, en silencio y sin ningun rojo en CI.
+    workflows: ["Tests"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Resumen

Corrige una regresión que introduje en #488: el despliegue automático a producción se habría quedado sin disparador.

## Qué pasó

`deploy.yml` no se dispara con un `push` normal. Usa `workflow_run`, que espera a que **otro** workflow termine con éxito, y lo identifica **por su nombre exacto**:

```yaml
on:
  workflow_run:
    workflows: ["API Tests"]
```

En #488 añadí el job de las suites del SPA a `tests.yml` y, como el workflow ya no contenía sólo tests de la API, lo renombré de `API Tests` a `Tests`. Con eso la referencia dejó de casar con nada.

**Consecuencia:** cuando este trabajo llegara a `main`, cada merge habría pasado sus tests en verde y el despliegue simplemente no habría ocurrido. Sin error, sin rojo, sin aviso — que es la peor forma posible de romper un pipeline de despliegue, porque no se descubre hasta que alguien nota que producción lleva semanas sin actualizarse.

## Por qué no se detectó antes

Nada lo comprueba, y no hay forma barata de comprobarlo: el encadenamiento sólo se ejerce en un push a `main`, que es exactamente lo que no ocurre durante el desarrollo.

Lo que sí había era documentación. El `README.md` lo advierte de forma explícita:

> **Renaming the "API Tests" workflow breaks the trigger:** `deploy.yml` references it by name (`workflows: ["API Tests"]`).

Estaba escrito y lo hice igual. La advertencia vive en la sección de despliegue del README, a cientos de líneas del sitio donde uno edita un YAML de CI, así que en la práctica no estaba donde hacía falta.

## Qué cambia

- `workflows: ["API Tests"]` → `workflows: ["Tests"]`, que es como se llama ahora.
- El comentario de cabecera del fichero, que también nombraba el workflow viejo.
- **Un aviso en la propia línea del trigger**, para que quien renombre el workflow lo lea donde importa y no a cientos de líneas de distancia en otro fichero.

No cambia nada más del pipeline: ni el filtro `branches: [main]`, ni la condición del job, ni los pasos de SSH, ni el smoke test.

## Validación

Los dos ficheros se parsean y los nombres casan:

```
.github/workflows/deploy.yml  -> trigger workflows: ['Tests']
.github/workflows/tests.yml   -> name: Tests
```

`tests-postgres.yml` sigue llamándose `API Tests (PostgreSQL + Redis)`, que es un workflow distinto y nunca fue el del encadenamiento. `workflow_run` compara el nombre completo, así que no hay ambigüedad entre ambos.

Verificarlo de extremo a extremo no es posible sin un push a `main`, cosa que este PR no hace ni debe hacer.

## Notas

- Va en su propio PR y no enmendado sobre #488 porque aquél ya está mergeado, y porque un fallo que habría dejado producción sin desplegar merece quedar visible en la historia en lugar de desaparecer en un `--amend`.
- La corrección del `README.md`, que sigue nombrando el workflow viejo en dos sitios más, va aparte: la guía del repositorio pide que todos los cambios del README vayan en un único commit propio.

Refs #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
