### PR TITLE
refactor(acheron): separar el contrato de datos de su presentación

### DIFF
--- a/web/app/src/acheron/storableFields.js
+++ b/web/app/src/acheron/storableFields.js
@@ -1,28 +1,32 @@
 /**
- * Vista que necesita la capa cripto: qué campos sensibles tiene cada categoría
- * y las correspondencias categoría↔kind. Se DERIVA del registro único
- * `storableTypes.js` para que no pueda divergir de la UI ni del móvil.
+ * Vista que necesita la capa cripto: qué campos tiene cada categoría y las
+ * correspondencias categoría↔kind. Se DERIVA de `storableSchema.js`, el
+ * contrato de datos, para que no pueda divergir de la API ni del móvil.
+ *
+ * Deriva del esquema y no de `storableTypes.js` a propósito: aquél lleva
+ * además las etiquetas de la interfaz, y la criptografía no debe depender de
+ * nada que se vea en pantalla.
  *
  * Cada campo aquí listado se cifra individualmente como Base64(IV‖ct). Además,
  * `title` SIEMPRE va cifrado (lo añade `vault.js`). Los metadatos `id`,
  * `createdAt`, `updatedAt`, `allowedUsers` van en claro.
  */
-import { STORABLE_TYPES } from './storableTypes.js'
+import { STORABLE_SCHEMA } from './storableSchema.js'
 
 /** category → array de claves de campos sensibles. */
 export const STORABLE_FIELDS = Object.fromEntries(
-  STORABLE_TYPES.map((t) => [t.category, t.fields.map((f) => f.key)]),
+  STORABLE_SCHEMA.map((t) => [t.category, t.fields.map((f) => f.key)]),
 )
 
 /** Las categorías de storables presentes en un vault JSON, en orden. */
-export const STORABLE_CATEGORIES = STORABLE_TYPES.map((t) => t.category)
+export const STORABLE_CATEGORIES = STORABLE_SCHEMA.map((t) => t.category)
 
 /** category (plural, vault JSON) → kind (singular, API `POST /storables`). */
 export const KIND_BY_CATEGORY = Object.fromEntries(
-  STORABLE_TYPES.map((t) => [t.category, t.kind]),
+  STORABLE_SCHEMA.map((t) => [t.category, t.kind]),
 )
 
 /** kind → category. */
 export const CATEGORY_BY_KIND = Object.fromEntries(
-  STORABLE_TYPES.map((t) => [t.kind, t.category]),
+  STORABLE_SCHEMA.map((t) => [t.kind, t.category]),
 )

--- a/web/app/src/acheron/storableLabels.js
+++ b/web/app/src/acheron/storableLabels.js
@@ -1,0 +1,91 @@
+/**
+ * Presentación de los tipos de storable: lo que se ve en pantalla y cómo se
+ * comporta el formulario. Es la otra mitad de `storableSchema.js`, y la que
+ * NO viaja al paquete compartido — la extensión de navegador no pinta este
+ * formulario y no necesita estas cadenas.
+ *
+ * Indexado por `kind`, y dentro por la clave del campo, para que la
+ * correspondencia con el esquema sea comprobable. `storableTypes.js` compone
+ * ambos ficheros y `acheron.schema.test.mjs` verifica que no se desincronizan:
+ * un campo sin etiqueta pinta un `undefined`, y una etiqueta sin campo es
+ * código muerto que nadie ve.
+ *
+ * Por campo, más de `label`:
+ *   - prefill:   en EDICIÓN se pre-rellena con el valor actual. Los secretos
+ *                más sensibles (contraseña, PAN, CVV) van a false: se dejan en
+ *                blanco y solo se reescriben si el usuario teclea algo.
+ *                Ojo, NO equivale a `!secret` del esquema: `documentId`,
+ *                `iban`, `swiftBic`, `accountNumber` y `licenseKey` son
+ *                secretos y aun así se pre-rellenan. Son dos ejes distintos.
+ *   - numeric:   teclado/inputmode numérico.
+ *   - multiline: se pinta como textarea.
+ *   - minLength: longitud mínima exigida cuando el campo lleva valor.
+ *
+ * `subtitleKey` no lo lee nadie hoy; se conserva tal cual estaba, pendiente de
+ * decidir si la lista debe mostrar ese subtítulo o si sobra.
+ */
+export const STORABLE_LABELS = {
+  account: {
+    label: 'Cuenta', plural: 'Cuentas', newLabel: 'Nueva cuenta', subtitleKey: 'username',
+    fields: {
+      username: { label: 'Usuario / Email' },
+      domain: { label: 'Dominio / Servicio' },
+      password: { label: 'Contraseña', prefill: false },
+    },
+  },
+  creditcard: {
+    label: 'Tarjeta', plural: 'Tarjetas', newLabel: 'Nueva tarjeta', subtitleKey: 'cardNumber',
+    fields: {
+      cardHolderName: { label: 'Titular' },
+      cardNumber: { label: 'Número de tarjeta', prefill: false, numeric: true, minLength: 4 },
+      expirationDate: { label: 'Caducidad (MM/YY)' },
+      cvv: { label: 'CVV', prefill: false, numeric: true },
+      postalCode: { label: 'Código postal' },
+    },
+  },
+  securenote: {
+    label: 'Nota segura', plural: 'Notas', newLabel: 'Nueva nota', subtitleKey: 'content',
+    fields: {
+      content: { label: 'Contenido', multiline: true },
+    },
+  },
+  identity: {
+    label: 'Identidad', plural: 'Identidades', newLabel: 'Nueva identidad', subtitleKey: 'fullName',
+    fields: {
+      fullName: { label: 'Nombre completo' },
+      email: { label: 'Email' },
+      phone: { label: 'Teléfono' },
+      address: { label: 'Dirección' },
+      city: { label: 'Ciudad' },
+      country: { label: 'País' },
+      documentId: { label: 'Documento (DNI/Pasaporte)' },
+    },
+  },
+  bankaccount: {
+    label: 'Cuenta bancaria', plural: 'Bancos', newLabel: 'Nueva cuenta bancaria', subtitleKey: 'bankName',
+    fields: {
+      bankName: { label: 'Banco' },
+      holder: { label: 'Titular' },
+      iban: { label: 'IBAN' },
+      swiftBic: { label: 'SWIFT / BIC' },
+      accountNumber: { label: 'Número de cuenta' },
+    },
+  },
+  wifi: {
+    label: 'Wi-Fi', plural: 'Wi-Fi', newLabel: 'Nueva red Wi-Fi', subtitleKey: 'ssid',
+    fields: {
+      ssid: { label: 'Nombre de red (SSID)' },
+      password: { label: 'Contraseña', prefill: false },
+      securityType: { label: 'Seguridad (WPA2/WPA3)' },
+    },
+  },
+  license: {
+    label: 'Licencia', plural: 'Licencias', newLabel: 'Nueva licencia', subtitleKey: 'product',
+    fields: {
+      product: { label: 'Producto' },
+      licenseKey: { label: 'Clave de licencia' },
+      licensedTo: { label: 'Licenciado a' },
+      version: { label: 'Versión' },
+    },
+  },
+}

--- a/web/app/src/acheron/storableSchema.js
+++ b/web/app/src/acheron/storableSchema.js
@@ -1,0 +1,94 @@
+/**
+ * Esquema de los tipos de storable de Acheron: el CONTRATO DE DATOS, sin nada
+ * que se vea en pantalla.
+ *
+ * Qué categorías existen, qué claves tiene cada una y cuáles son sensibles.
+ * Estas claves son las del JSON del vault y las que espera la API, así que
+ * tienen que coincidir con `storable_specs.py` (API), `StorableTypes.kt`
+ * (móvil) y las clases de `vault/storables/` (AcheronCore). Cambiar un nombre
+ * aquí sin cambiarlo allí hace que un cliente no sepa leer lo que escribió otro.
+ *
+ * Este fichero es el que se moverá a un paquete propio para que lo compartan
+ * la SPA y la extensión de navegador; por eso no contiene ni una cadena de
+ * texto visible para el usuario. Las etiquetas viven en `storableLabels.js`, y
+ * `storableTypes.js` compone ambos para la interfaz.
+ *
+ * `secret` marca los campos sensibles. Es propiedad del dato, no de la
+ * pantalla: la interfaz los enmascara, y la futura extensión necesitará saber
+ * cuál es el campo de contraseña para autocompletarlo sin mostrarlo en claro.
+ */
+export const STORABLE_SCHEMA = [
+  {
+    kind: 'account', category: 'accounts',
+    fields: [
+      { key: 'username' },
+      { key: 'domain' },
+      { key: 'password', secret: true },
+    ],
+  },
+  {
+    kind: 'creditcard', category: 'creditcards',
+    fields: [
+      { key: 'cardHolderName' },
+      { key: 'cardNumber', secret: true },
+      { key: 'expirationDate' },
+      { key: 'cvv', secret: true },
+      { key: 'postalCode' },
+    ],
+  },
+  {
+    kind: 'securenote', category: 'securenotes',
+    fields: [
+      { key: 'content' },
+    ],
+  },
+  {
+    kind: 'identity', category: 'identities',
+    fields: [
+      { key: 'fullName' },
+      { key: 'email' },
+      { key: 'phone' },
+      { key: 'address' },
+      { key: 'city' },
+      { key: 'country' },
+      { key: 'documentId', secret: true },
+    ],
+  },
+  {
+    kind: 'bankaccount', category: 'bankaccounts',
+    fields: [
+      { key: 'bankName' },
+      { key: 'holder' },
+      { key: 'iban', secret: true },
+      { key: 'swiftBic', secret: true },
+      { key: 'accountNumber', secret: true },
+    ],
+  },
+  {
+    kind: 'wifi', category: 'wifinetworks',
+    fields: [
+      { key: 'ssid' },
+      { key: 'password', secret: true },
+      { key: 'securityType' },
+    ],
+  },
+  {
+    kind: 'license', category: 'licenses',
+    fields: [
+      { key: 'product' },
+      { key: 'licenseKey', secret: true },
+      { key: 'licensedTo' },
+      { key: 'version' },
+    ],
+  },
+]
+
+/** Entrada del esquema por categoría (clave plural del vault JSON). */
+export const SCHEMA_BY_CATEGORY = Object.fromEntries(
+  STORABLE_SCHEMA.map((t) => [t.category, t]),
+)
+
+/** Entrada del esquema por kind (singular de la API). */
+export const SCHEMA_BY_KIND = Object.fromEntries(
+  STORABLE_SCHEMA.map((t) => [t.kind, t]),
+)

--- a/web/app/src/acheron/storableTypes.js
+++ b/web/app/src/acheron/storableTypes.js
@@ -1,96 +1,40 @@
 /**
- * Registro data-driven de los tipos de storable de Acheron.
+ * Vista compuesta de los tipos de storable para la interfaz: une el contrato
+ * de datos (`storableSchema.js`) con su presentación (`storableLabels.js`).
  *
- * Espejo en JS de `StorableTypes.kt` de la app móvil: es la ÚNICA fuente de
- * verdad para la UI (formulario, lista, detalle) y, derivado, para la capa
- * cripto (`storableFields.js`). Añadir un tipo nuevo = añadir una entrada aquí.
+ * Antes las dos cosas vivían en el mismo literal. Se separaron porque el
+ * esquema tiene que viajar a un paquete compartido con la extensión de
+ * navegador y con la API, y no se podía publicar sin arrastrar las etiquetas
+ * en castellano: cambiar el texto de un botón habría obligado a publicar una
+ * versión nueva del paquete de criptografía.
  *
- * Por cada campo:
- *   - key:       nombre del campo (coincide con el vault JSON y con la API).
- *   - label:     etiqueta legible (idéntica a la del móvil).
- *   - secret:    se enmascara en el detalle y se escribe como contraseña.
- *   - prefill:   en EDICIÓN se pre-rellena con el valor actual. Los secretos
- *                sensibles (contraseña, PAN, CVV) van a false: se dejan en
- *                blanco y solo se reescriben si el usuario teclea algo.
- *   - numeric:   teclado/inputmode numérico.
- *   - multiline: textarea (notas).
- *   - minLength: longitud mínima exigida cuando el campo lleva valor.
+ * La forma que exporta este fichero es la misma de antes, así que los
+ * componentes no notan la separación. La capa cripto NO pasa por aquí: lee
+ * directamente el esquema a través de `storableFields.js`, y por eso nunca ve
+ * una etiqueta.
  *
- * `category` es la clave plural usada en el vault JSON (`accounts`, ...);
- * `kind` es el singular que espera la API en `POST /storables` (`account`, ...).
+ * `acheron.schema.test.mjs` verifica que las dos mitades siguen hablando de
+ * los mismos campos.
  */
-export const STORABLE_TYPES = [
-  {
-    kind: 'account', category: 'accounts',
-    label: 'Cuenta', plural: 'Cuentas', newLabel: 'Nueva cuenta', subtitleKey: 'username',
-    fields: [
-      { key: 'username', label: 'Usuario / Email' },
-      { key: 'domain', label: 'Dominio / Servicio' },
-      { key: 'password', label: 'Contraseña', secret: true, prefill: false },
-    ],
-  },
-  {
-    kind: 'creditcard', category: 'creditcards',
-    label: 'Tarjeta', plural: 'Tarjetas', newLabel: 'Nueva tarjeta', subtitleKey: 'cardNumber',
-    fields: [
-      { key: 'cardHolderName', label: 'Titular' },
-      { key: 'cardNumber', label: 'Número de tarjeta', secret: true, prefill: false, numeric: true, minLength: 4 },
-      { key: 'expirationDate', label: 'Caducidad (MM/YY)' },
-      { key: 'cvv', label: 'CVV', secret: true, prefill: false, numeric: true },
-      { key: 'postalCode', label: 'Código postal' },
-    ],
-  },
-  {
-    kind: 'securenote', category: 'securenotes',
-    label: 'Nota segura', plural: 'Notas', newLabel: 'Nueva nota', subtitleKey: 'content',
-    fields: [
-      { key: 'content', label: 'Contenido', multiline: true },
-    ],
-  },
-  {
-    kind: 'identity', category: 'identities',
-    label: 'Identidad', plural: 'Identidades', newLabel: 'Nueva identidad', subtitleKey: 'fullName',
-    fields: [
-      { key: 'fullName', label: 'Nombre completo' },
-      { key: 'email', label: 'Email' },
-      { key: 'phone', label: 'Teléfono' },
-      { key: 'address', label: 'Dirección' },
-      { key: 'city', label: 'Ciudad' },
-      { key: 'country', label: 'País' },
-      { key: 'documentId', label: 'Documento (DNI/Pasaporte)', secret: true },
-    ],
-  },
-  {
-    kind: 'bankaccount', category: 'bankaccounts',
-    label: 'Cuenta bancaria', plural: 'Bancos', newLabel: 'Nueva cuenta bancaria', subtitleKey: 'bankName',
-    fields: [
-      { key: 'bankName', label: 'Banco' },
-      { key: 'holder', label: 'Titular' },
-      { key: 'iban', label: 'IBAN', secret: true },
-      { key: 'swiftBic', label: 'SWIFT / BIC', secret: true },
-      { key: 'accountNumber', label: 'Número de cuenta', secret: true },
-    ],
-  },
-  {
-    kind: 'wifi', category: 'wifinetworks',
-    label: 'Wi-Fi', plural: 'Wi-Fi', newLabel: 'Nueva red Wi-Fi', subtitleKey: 'ssid',
-    fields: [
-      { key: 'ssid', label: 'Nombre de red (SSID)' },
-      { key: 'password', label: 'Contraseña', secret: true, prefill: false },
-      { key: 'securityType', label: 'Seguridad (WPA2/WPA3)' },
-    ],
-  },
-  {
-    kind: 'license', category: 'licenses',
-    label: 'Licencia', plural: 'Licencias', newLabel: 'Nueva licencia', subtitleKey: 'product',
-    fields: [
-      { key: 'product', label: 'Producto' },
-      { key: 'licenseKey', label: 'Clave de licencia', secret: true },
-      { key: 'licensedTo', label: 'Licenciado a' },
-      { key: 'version', label: 'Versión' },
-    ],
-  },
-]
+import { STORABLE_SCHEMA } from './storableSchema.js'
+import { STORABLE_LABELS } from './storableLabels.js'
+
+/**
+ * Tipos con esquema y etiquetas fusionados. Cada campo lleva su `key` y
+ * `secret` del esquema, más `label` y las pistas de formulario de las
+ * etiquetas.
+ */
+export const STORABLE_TYPES = STORABLE_SCHEMA.map((type) => {
+  const labels = STORABLE_LABELS[type.kind] ?? { fields: {} }
+  return {
+    ...type,
+    ...labels,
+    fields: type.fields.map((field) => ({
+      ...field,
+      ...(labels.fields[field.key] ?? {}),
+    })),
+  }
+})
 
 /** Spec por categoría (clave plural del vault JSON). */
 export const TYPE_BY_CATEGORY = Object.fromEntries(STORABLE_TYPES.map((t) => [t.category, t]))


### PR DESCRIPTION
## Resumen

Parte `storableTypes.js` en dos: el contrato de datos por un lado y la presentación del formulario por otro. Sin cambios de comportamiento.

## El problema, para quien no conozca el módulo

Acheron es la bóveda de credenciales. `web/app/src/acheron/storableTypes.js` es el registro de los siete tipos de elemento que se pueden guardar (cuenta, tarjeta, nota segura, identidad, cuenta bancaria, red wifi, licencia). Su propia cabecera se describía como *"la ÚNICA fuente de verdad para la UI"*.

Dentro del mismo objeto convivían dos responsabilidades:

- **Contrato de datos** — `kind`, `category`, las claves de cada campo y `secret`. Lo consume la capa criptográfica, porque determina qué se cifra. Estas claves son las del JSON de la bóveda y tienen que coincidir con `storable_specs.py` de la API, `StorableTypes.kt` del móvil y las clases de `AcheronCore`.
- **Presentación del formulario de la SPA** — `label`, `plural`, `newLabel`, `subtitleKey`, `numeric`, `multiline`, `minLength`, `prefill`. Textos en castellano y pistas de teclado.

Mientras las dos mitades vivan en el mismo literal **no se puede publicar la primera sin publicar también la segunda**. Traducido a lo que viene: cuando el esquema se mude a `AcheronSchema` y el motor a `AcheronCoreWeb`, cambiar el texto de un botón de la web obligaría a publicar una versión nueva del paquete de criptografía. Ésa es la clase de fricción que hace que la gente deje de actualizar paquetes.

Conviene precisar el diagnóstico, porque abarata la solución: **no era acoplamiento entre capas.** La dirección de dependencias ya era correcta — `storableFields.js` derivaba del registro quedándose sólo con lo que necesitaba, y ningún módulo criptográfico leía una etiqueta. El problema era **co-ubicación en el mismo fichero**, que se arregla partiendo datos, no rediseñando nada.

## La línea de corte no hubo que inventarla

Estaba ya en el uso, y sale limpia:

| Propiedad | Quién la usa |
|---|---|
| `newLabel`, `numeric`, `multiline`, `minLength`, `prefill` | sólo `StorableFormModal.vue` |
| `plural` | sólo `AcheronView.vue` |
| `label` | esos dos, y nadie más |
| `kind`, `category`, `key`, `secret` | esos dos **y** la capa cripto |

Todo lo discutible tiene exactamente un consumidor, y es un componente de formulario.

## Qué cambia

**`storableSchema.js`** (nuevo) — el contrato. `kind`, `category` y por campo `key` y `secret`. Ni una cadena visible para el usuario. Es el fichero que viajará al paquete compartido.

**`storableLabels.js`** (nuevo) — la presentación, indexada por `kind` y por clave de campo. Se queda en la SPA.

**`storableTypes.js`** — pasa a **componer** ambos y exporta exactamente la misma forma de antes (`STORABLE_TYPES`, `TYPE_BY_CATEGORY`, `TYPE_BY_KIND`). Por eso **los dos componentes no se tocan**: el diff no incluye ningún `.vue`.

**`storableFields.js`** — deriva ahora de `storableSchema.js` en lugar de la vista compuesta, para que la criptografía no dependa de nada que se vea en pantalla.

## Dos decisiones de reparto que merecen justificarse

**`secret` se va al esquema**, aunque hoy sólo lo use la interfaz para enmascarar. Es una propiedad del dato, no de la pantalla, y la extensión de navegador la necesitará de inmediato: para saber cuál es el campo de contraseña que debe rellenar y para no mostrarlo en claro en su desplegable.

**`prefill` se queda en la presentación, y no es redundante con `secret`.** Se comprobó antes de decidir: `documentId`, `iban`, `swiftBic`, `accountNumber` y `licenseKey` son secretos y **sí** se pre-rellenan al editar; sólo contraseñas, número de tarjeta y CVV se dejan en blanco. Son dos ejes independientes —"esto se enmascara" y "esto no se recupera al editar"— y fusionarlos habría cambiado el comportamiento de cinco campos sin querer.

## Validación

**La vista compuesta reproduce el registro original byte a byte.** Comparado contra la versión de `git show HEAD:...` normalizando las siete propiedades de tipo y las siete de campo:

```
IDENTICO: la vista compuesta reproduce el registro original
tipos: 7 | campos: 28
TYPE_BY_CATEGORY igual: true | TYPE_BY_KIND igual: true
```

Es la prueba fuerte de que el refactor es neutro: cualquier componente que lea el registro ve exactamente lo mismo que antes.

Además:

```
npm test        →  exit 0, las nueve suites en verde
npm run build   →  ✓ built in 1.53s
```

Las suites de `test:acheron` pasan **sin tocarlas**, que era el criterio: si el esquema se parte bien, la capa cripto no se entera.

No se verificó en el navegador porque montar la SPA con datos reales exige la API en Linux/WSL, una sesión autenticada y una bóveda; la equivalencia demostrada del registro más los componentes intactos cubren el mismo riesgo sin tocar la base de datos de desarrollo.

## Notas

- **La red de seguridad de esta separación es #472**, que va a continuación: a partir de ahora nada garantiza que las dos mitades sigan hablando de los mismos campos, y sin ese test la separación es un riesgo neto en lugar de una mejora.
- **`subtitleKey` no lo lee nadie.** Está declarado en los siete tipos y no aparece en ningún `.vue` ni en ningún test. Lo he movido tal cual a las etiquetas sin decidir sobre él: borrar datos que alguien puso a propósito enturbiaría un diff que debe ser neutro. Queda como candidato a limpieza.

Refs #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
