### PR TITLE
test(acheron): correspondencia entre el esquema y sus etiquetas

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "npm run test:acheron && npm run test:hygeia && npm run test:polling && npm run test:element-width && npm run test:toast && npm run test:quiz && npm run test:logs && npm run test:iris && npm run test:themis",
-    "test:acheron": "node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
+    "test:acheron": "node test/acheron.schema.test.mjs && node test/acheron.interop.test.mjs && node test/acheron.crud.test.mjs && node test/acheron.sync.test.mjs",
     "test:hygeia": "node test/hygeia.format.test.mjs && node test/hygeia.chartMath.test.mjs",
     "test:polling": "node test/usePolling.test.mjs",
     "test:element-width": "node test/useElementWidth.test.mjs",

--- a/web/app/test/acheron.schema.test.mjs
+++ b/web/app/test/acheron.schema.test.mjs
@@ -1,0 +1,132 @@
+/**
+ * Correspondencia entre el esquema de storables y sus etiquetas.
+ *
+ * `storableSchema.js` (el contrato de datos) y `storableLabels.js` (lo que se
+ * ve en pantalla) vivían en el mismo literal y era imposible desincronizarlos.
+ * Al separarlos, esa imposibilidad desapareció: si el esquema añade un campo y
+ * las etiquetas no, el formulario pinta un `undefined` donde iba un nombre; si
+ * sobra una etiqueta, queda código muerto que nadie ve.
+ *
+ * La comprobación es en AMBOS sentidos a propósito. Verificar sólo que "todo
+ * campo tiene etiqueta" deja pasar el caso de la etiqueta que sobra, que es
+ * justo el que aparece al borrar un campo del esquema.
+ *
+ * Sin este test la separación sería un riesgo neto en lugar de una mejora.
+ *
+ *   node web/app/test/acheron.schema.test.mjs
+ */
+
+import { STORABLE_SCHEMA } from '../src/acheron/storableSchema.js'
+import { STORABLE_LABELS } from '../src/acheron/storableLabels.js'
+import { STORABLE_TYPES } from '../src/acheron/storableTypes.js'
+
+let passed = 0
+let failed = 0
+
+function check(name, condition, detail = '') {
+  if (condition) {
+    passed++
+    console.log(`  ✓ ${name}`)
+  } else {
+    failed++
+    console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`)
+  }
+}
+
+/** Diferencia de conjuntos, como lista ordenada para que el mensaje sea legible. */
+const missingFrom = (wanted, have) => wanted.filter((x) => !have.includes(x)).sort()
+
+console.log('Correspondencia esquema ↔ etiquetas\n')
+
+/* ── 1) Cada tipo del esquema tiene su bloque de etiquetas, y al revés ── */
+
+const schemaKinds = STORABLE_SCHEMA.map((t) => t.kind)
+const labelKinds = Object.keys(STORABLE_LABELS)
+
+check(
+  'todo tipo del esquema tiene etiquetas',
+  missingFrom(schemaKinds, labelKinds).length === 0,
+  `sin etiquetas: ${missingFrom(schemaKinds, labelKinds).join(', ')}`,
+)
+check(
+  'no sobra ningún bloque de etiquetas',
+  missingFrom(labelKinds, schemaKinds).length === 0,
+  `etiquetas huérfanas: ${missingFrom(labelKinds, schemaKinds).join(', ')}`,
+)
+
+/* ── 2) Campo a campo, en ambos sentidos ── */
+
+for (const type of STORABLE_SCHEMA) {
+  const labels = STORABLE_LABELS[type.kind]
+  if (!labels) continue // ya reportado arriba
+
+  const schemaFields = type.fields.map((f) => f.key)
+  const labelFields = Object.keys(labels.fields ?? {})
+
+  check(
+    `${type.kind}: todo campo tiene etiqueta`,
+    missingFrom(schemaFields, labelFields).length === 0,
+    `sin etiqueta: ${missingFrom(schemaFields, labelFields).join(', ')}`,
+  )
+  check(
+    `${type.kind}: no sobra ninguna etiqueta`,
+    missingFrom(labelFields, schemaFields).length === 0,
+    `huérfanas: ${missingFrom(labelFields, schemaFields).join(', ')}`,
+  )
+
+  // Una etiqueta vacía pinta igual de mal que una ausente.
+  for (const [key, field] of Object.entries(labels.fields ?? {})) {
+    check(
+      `${type.kind}.${key}: la etiqueta no está vacía`,
+      typeof field.label === 'string' && field.label.trim() !== '',
+      `label = ${JSON.stringify(field.label)}`,
+    )
+  }
+
+  for (const meta of ['label', 'plural', 'newLabel']) {
+    check(
+      `${type.kind}: tiene ${meta}`,
+      typeof labels[meta] === 'string' && labels[meta].trim() !== '',
+      `${meta} = ${JSON.stringify(labels[meta])}`,
+    )
+  }
+}
+
+/* ── 3) El esquema no debe llevar texto visible ── */
+
+// Es la invariante que hace publicable el esquema: si alguien vuelve a meter
+// una etiqueta ahí, el fichero deja de poder viajar al paquete compartido sin
+// arrastrar castellano, que es justo lo que la separación vino a evitar.
+const TEXTO_VISIBLE = ['label', 'plural', 'newLabel', 'subtitleKey']
+for (const type of STORABLE_SCHEMA) {
+  const enTipo = TEXTO_VISIBLE.filter((k) => k in type)
+  check(
+    `${type.kind}: el esquema no lleva texto visible`,
+    enTipo.length === 0,
+    `encontrado: ${enTipo.join(', ')}`,
+  )
+  for (const field of type.fields) {
+    const enCampo = TEXTO_VISIBLE.filter((k) => k in field)
+    check(
+      `${type.kind}.${field.key}: el campo del esquema no lleva texto visible`,
+      enCampo.length === 0,
+      `encontrado: ${enCampo.join(', ')}`,
+    )
+  }
+}
+
+/* ── 4) La vista compuesta sirve lo que el formulario espera ── */
+
+for (const type of STORABLE_TYPES) {
+  const sinLabel = type.fields.filter((f) => !f.label).map((f) => f.key)
+  check(
+    `${type.kind}: compuesto, todo campo trae label`,
+    sinLabel.length === 0,
+    `sin label tras componer: ${sinLabel.join(', ')}`,
+  )
+  const sinKey = type.fields.filter((f) => !f.key).length
+  check(`${type.kind}: compuesto, todo campo conserva su key`, sinKey === 0)
+}
+
+console.log(`\nResultado: ${passed} OK, ${failed} fallidos`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
## Resumen

Añade la red de seguridad que necesita la separación hecha en #492. Cierra la Fase 1.

## Por qué hace falta

En #492 se partió `storableTypes.js` en dos: el contrato de datos (`storableSchema.js`) y la presentación del formulario (`storableLabels.js`).

Eso resolvió un problema y creó otro. **Mientras las dos mitades vivían en el mismo literal era imposible desincronizarlas**; a partir de ahora nada lo impide:

- Si el esquema añade un campo y las etiquetas no, el formulario pinta un `undefined` donde iba el nombre del campo.
- Si se borra un campo del esquema y queda su etiqueta, es código muerto que nadie ve.

Sin este test, la separación es un **riesgo neto** en lugar de una mejora: se cambia una garantía estructural (imposible que difieran) por ninguna garantía.

## Qué comprueba

**En ambos sentidos, que no es un adorno.** Verificar sólo que "todo campo tiene etiqueta" deja pasar el caso de la etiqueta que sobra, que es justo el que aparece al borrar un campo del esquema. Así que se comprueban los dos:

1. Todo tipo del esquema tiene su bloque de etiquetas, y no sobra ningún bloque.
2. Campo a campo, toda clave del esquema tiene etiqueta y no hay etiquetas huérfanas.
3. Ninguna etiqueta está vacía — una cadena en blanco pinta igual de mal que una ausente.
4. Cada tipo conserva sus metadatos de interfaz (`label`, `plural`, `newLabel`).

**Y una invariante que no estaba en la issue pero es la razón de ser de todo esto:** que el esquema **no lleve texto visible**. Si alguien vuelve a meter un `label` ahí, el fichero deja de poder viajar a `AcheronSchema` sin arrastrar castellano — exactamente lo que la separación vino a evitar. Es barato comprobarlo ahora y caro descubrirlo al extraer el paquete.

Finalmente comprueba que la vista compuesta sirve lo que el formulario espera: todo campo con `label` y con `key`.

## Validación

```
node test/acheron.schema.test.mjs   →  114 OK, 0 fallidos
npm test                            →  exit 0, las nueve suites en verde
```

Verificado que **falla en los cuatro modos** que debe detectar, mutando los ficheros de verdad y restaurándolos después:

| Mutación | Resultado |
|---|---|
| Campo nuevo en el esquema sin su etiqueta | `exit 1` |
| Etiqueta huérfana sin campo que la respalde | `exit 1` |
| Un `label` colándose en el esquema | `exit 1` |
| Etiqueta presente pero vacía | `exit 1` |
| Sin tocar nada | `exit 0` |

Queda enganchado a `test:acheron`, y va **primero** de las cuatro suites de Acheron: un fallo estructural del registro explica los fallos que vendrían después, así que conviene verlo antes.

Sigue el estilo de las suites del SPA que ya existen — `node` a secas, sin framework, saliendo con código distinto de cero al fallar — y por tanto entra automáticamente en el job `SPA suites` del CI que añadió #488.

Refs #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
