### PR TITLE
test(acheron): verificar el esquema de la SPA contra AcheronSchema

### DIFF
--- a/web/app/test/README.md
+++ b/web/app/test/README.md
@@ -33,6 +33,31 @@ implementaciones cambia el formato y la otra no, el test falla.
 Al actualizarlos hay que anotar aquí la versión de `AcheronCore` de la que salieron: sin eso, un
 fallo de interoperabilidad no se puede atribuir a un cambio concreto del motor Java.
 
+## `acheron-schema.json` — el catálogo compartido
+
+El catálogo de tipos de la bóveda (qué es una «cuenta», qué campos tiene una «tarjeta») está
+escrito en cuatro sitios: aquí, en la API (`storable_specs.py`), en la app Android
+(`StorableTypes.kt`) y en `AcheronCore`. Los cuatro tienen que coincidir en los nombres exactos de
+los campos, porque son las claves del JSON de la bóveda.
+
+[`AcheronSchema`](https://github.com/ProjectEllysia/AcheronSchema) es la fuente de verdad común, y
+esto es una copia versionada suya. `acheron.schema.test.mjs` comprueba que
+`src/acheron/storableSchema.js` no se ha ido por su cuenta.
+
+Se compara contra la copia y no contra el repositorio remoto a propósito: la suite no toca la red,
+y una comprobación que necesite internet no es una comprobación, es una fuente de fallos
+intermitentes.
+
+**No se edita a mano.** Se actualiza copiando el fichero de `AcheronSchema` a un tag concreto, y
+anotando aquí cuál:
+
+| | |
+|---|---|
+| **Copiado de** | `AcheronSchema` @ [`v1.0.0`](https://github.com/ProjectEllysia/AcheronSchema/releases/tag/v1.0.0) (`05f5be7`) |
+
+Al añadir un tipo o un campo, el orden es: primero `AcheronSchema`, después esta copia y el
+esquema de la SPA. Al revés, la suite falla — que es justo lo que debe hacer.
+
 > Estos vectores cubren la dirección **Java → JS**: comprueban que este cliente sabe leer lo que
 > escribe el Java. La dirección contraria —que el Java sepa leer lo que escribe este cliente— no
 > la cubre nadie todavía; es el asunto de

--- a/web/app/test/acheron-schema.json
+++ b/web/app/test/acheron-schema.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "types": [
+    {
+      "kind": "account",
+      "category": "accounts",
+      "fields": [
+        { "key": "username" },
+        { "key": "domain" },
+        { "key": "password", "secret": true }
+      ]
+    },
+    {
+      "kind": "creditcard",
+      "category": "creditcards",
+      "fields": [
+        { "key": "cardHolderName" },
+        { "key": "cardNumber", "secret": true },
+        { "key": "expirationDate" },
+        { "key": "cvv", "secret": true },
+        { "key": "postalCode" }
+      ]
+    },
+    {
+      "kind": "securenote",
+      "category": "securenotes",
+      "fields": [
+        { "key": "content" }
+      ]
+    },
+    {
+      "kind": "identity",
+      "category": "identities",
+      "fields": [
+        { "key": "fullName" },
+        { "key": "email" },
+        { "key": "phone" },
+        { "key": "address" },
+        { "key": "city" },
+        { "key": "country" },
+        { "key": "documentId", "secret": true }
+      ]
+    },
+    {
+      "kind": "bankaccount",
+      "category": "bankaccounts",
+      "fields": [
+        { "key": "bankName" },
+        { "key": "holder" },
+        { "key": "iban", "secret": true },
+        { "key": "swiftBic", "secret": true },
+        { "key": "accountNumber", "secret": true }
+      ]
+    },
+    {
+      "kind": "wifi",
+      "category": "wifinetworks",
+      "fields": [
+        { "key": "ssid" },
+        { "key": "password", "secret": true },
+        { "key": "securityType" }
+      ]
+    },
+    {
+      "kind": "license",
+      "category": "licenses",
+      "fields": [
+        { "key": "product" },
+        { "key": "licenseKey", "secret": true },
+        { "key": "licensedTo" },
+        { "key": "version" }
+      ]
+    }
+  ]
+}

--- a/web/app/test/acheron.schema.test.mjs
+++ b/web/app/test/acheron.schema.test.mjs
@@ -13,8 +13,17 @@
  *
  * Sin este test la separación sería un riesgo neto en lugar de una mejora.
  *
+ * Comprueba además que el esquema local no diverge de `AcheronSchema`, el
+ * repositorio donde vive el catálogo como contrato compartido con la API, la
+ * app Android y AcheronCore. La copia versionada de ese contrato está en
+ * `acheron-schema.json`; su procedencia, en el README de esta carpeta.
+ *
  *   node web/app/test/acheron.schema.test.mjs
  */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 
 import { STORABLE_SCHEMA } from '../src/acheron/storableSchema.js'
 import { STORABLE_LABELS } from '../src/acheron/storableLabels.js'
@@ -115,7 +124,32 @@ for (const type of STORABLE_SCHEMA) {
   }
 }
 
-/* ── 4) La vista compuesta sirve lo que el formulario espera ── */
+/* ── 4) El esquema local no diverge de AcheronSchema ── */
+
+// El catalogo vive tambien en la API (`storable_specs.py`), en la app Android
+// y en AcheronCore. AcheronSchema es la fuente de verdad comun; esta seccion
+// comprueba que la copia de la SPA no se ha ido por su cuenta.
+//
+// Se compara contra una copia versionada, no contra el repositorio remoto: la
+// suite esta sellada contra la red, y una comprobacion que necesite internet
+// no es una comprobacion, es una fuente de fallos intermitentes.
+const schemaPath = resolve(dirname(fileURLToPath(import.meta.url)), 'acheron-schema.json')
+const shared = JSON.parse(readFileSync(schemaPath, 'utf8'))
+
+const simplify = (types) =>
+  types.map((t) => ({
+    kind: t.kind,
+    category: t.category,
+    fields: t.fields.map((f) => (f.secret ? { key: f.key, secret: true } : { key: f.key })),
+  }))
+
+check(
+  'el esquema de la SPA coincide con AcheronSchema',
+  JSON.stringify(simplify(STORABLE_SCHEMA)) === JSON.stringify(simplify(shared.types)),
+  'diverge del contrato compartido; ver web/app/test/README.md',
+)
+
+/* ── 5) La vista compuesta sirve lo que el formulario espera ── */
 
 for (const type of STORABLE_TYPES) {
   const sinLabel = type.fields.filter((f) => !f.label).map((f) => f.key)


### PR DESCRIPTION
## Resumen

Segunda mitad de #473. La primera fue crear [**`ProjectEllysia/AcheronSchema`**](https://github.com/ProjectEllysia/AcheronSchema); ésta es la primera de las cuatro verificaciones que lo convierten en fuente de verdad y no en un quinto sitio donde escribir lo mismo.

## Contexto

El catálogo de tipos de la bóveda —qué es una «cuenta», qué campos tiene una «tarjeta», cuáles son sensibles— está escrito **cuatro veces, en cuatro lenguajes**:

| Dónde | Fichero |
|---|---|
| SPA web | `web/app/src/acheron/storableSchema.js` |
| API | `API/src/modules/features/acheron/storable_specs.py` |
| App Android | `AcheronMobile`, `StorableTypes.kt` |
| Motor Java | `AcheronCore`, las clases de `vault/storables/` |

Los cuatro tienen que coincidir en los nombres **exactos** de los campos (`cardHolderName`, `expirationDate`, `cvv`…) porque son las claves del JSON de la bóveda. Nada comprobaba que coincidieran: el fallo se descubre cuando un cliente no sabe leer lo que escribió otro.

## El repositorio nuevo

`AcheronSchema` contiene `schema.json`: el catálogo como datos puros, sin código y sin una sola cadena visible para el usuario. Eso último es lo que lo hace consumible desde Python, Kotlin y Java — y lo que sólo fue posible tras la separación de #492, porque antes el catálogo venía mezclado con etiquetas en castellano y pistas de formulario.

El fichero **se generó desde `storableSchema.js`**, no se transcribió a mano, así que es fiel por construcción: 7 tipos, 28 campos, 9 secretos.

Lleva un validador propio (`npm test`, 159 comprobaciones) que corre en su CI: forma del documento, unicidad de `kind`/`category`/claves de campo, que las claves sean identificadores —viajan literalmente al JSON, así que no admiten guiones ni espacios— y que no se cuele texto de interfaz. Se valida en el origen y no en cada consumidor, porque un error de forma no se manifiesta río abajo como un fallo limpio sino como un cliente que no encuentra un campo, o que deja de cifrar uno que debía cifrar.

Verificado que ese validador rechaza documentos malos: categoría duplicada, clave de campo repetida, etiqueta colándose, `secret` no booleano y clave con guion — los cinco salen con código 1.

## Qué cambia en este repositorio

- **`web/app/test/acheron-schema.json`** — copia versionada del contrato, de `AcheronSchema` @ `v1.0.0`.
- **`acheron.schema.test.mjs`** gana una sección que compara `storableSchema.js` contra esa copia.
- **`web/app/test/README.md`** anota la procedencia y el orden de actualización, igual que ya hacía con los vectores de interoperabilidad.

**Se compara contra una copia y no contra el repositorio remoto a propósito.** La suite no toca la red, y una comprobación que necesite internet no es una comprobación: es una fuente de fallos intermitentes que la gente acaba ignorando.

## Validación

```
node test/acheron.schema.test.mjs   →  115 OK, 0 fallidos
npm test                            →  exit 0, las nueve suites en verde
```

Y en `AcheronSchema`, CI en verde sobre `main` y sobre el tag `v1.0.0`.

Verificado que la comprobación nueva detecta deriva real, mutando el contrato:

| Divergencia | Resultado |
|---|---|
| El contrato añade un campo y la SPA no | `exit 1` |
| Un campo deja de estar marcado como secreto | `exit 1` |
| Un campo se renombra en el contrato | `exit 1` |
| Sin tocar nada | `exit 0` |

## Notas y alcance

- Las otras tres verificaciones van por separado: #474 (Python), #475 (Kotlin) y #476 (Java).
- La SPA **sigue teniendo su propio `storableSchema.js`**; aquí sólo se verifica que no diverja. Consumir el paquete de verdad, en lugar de mantener una copia, es #481, cuando `AcheronCoreWeb` se publique en GitHub Packages.
- `AcheronSchema` es privado como el resto de repositorios de la organización, y por eso el README documenta la instalación con `npm install github:...#v1.0.0`, que necesitará credenciales igual que las demás.

Refs #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
