### PR TITLE
test(acheron): el registro de storables de la API sigue a AcheronSchema

### DIFF
--- a/API/tests/unit/test_acheron_schema_contract.py
+++ b/API/tests/unit/test_acheron_schema_contract.py
@@ -1,0 +1,99 @@
+"""El registro de storables de la API tiene que seguir a ``AcheronSchema``.
+
+El catálogo de tipos de la bóveda de Acheron —qué es una «cuenta», qué campos
+tiene una «tarjeta»— está escrito en cuatro sitios y en cuatro lenguajes: aquí
+(``storable_specs.py``), en la SPA (``storableSchema.js``), en la app Android
+(``StorableTypes.kt``) y en ``AcheronCore``. Los cuatro tienen que coincidir en
+los nombres EXACTOS de los campos, porque esos nombres son las claves del JSON
+de la bóveda que los clientes cifran y se intercambian.
+
+El modo de fallo no es un error limpio. Si la API espera ``cardHolderName`` y
+un cliente escribe ``cardholderName``, el campo simplemente no llega: se pierde
+en silencio en un ``dict`` que nadie mira, y el usuario descubre que su tarjeta
+no tiene titular mucho después, sin ninguna traza que apunte al renombrado.
+
+``AcheronSchema`` es la fuente de verdad común, y este test convierte la
+divergencia en un fallo de CI. Sigue el patrón de ``test_caddy_api_routes.py``
+y ``test_config_view_paths.py``, que atan las otras parejas cruzadas del
+monorepo leyendo un fichero que vive lejos y comparando.
+
+El ORDEN de los campos no se comprueba, y merece decirse por qué: el JSON del
+vault es un objeto con los campos por nombre, no una tupla, así que ningún
+cliente depende de él para leer un storable. Hoy hay una divergencia real
+—``creditcard`` lleva ``postalCode`` antes que ``cvv`` aquí, y al revés en el
+esquema, en el motor Java y en la app— y no rompe nada. Si algún día el orden
+pasa a importar, el sitio donde decidirlo es ``AcheronSchema``, no este test.
+
+Deliberadamente NO se genera ``storable_specs.py`` desde el esquema. Ese
+registro ata además cada tipo a su modelo SQLAlchemy y a los nombres de
+atributo en ``snake_case``, que son información propia de la API y no
+pertenecen a un contrato compartido. Verificar basta, y es mucho menos invasivo.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.modules.features.acheron.storable_specs import STORABLE_SPECS
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# La copia versionada del contrato vive con la suite del SPA, que es su otro
+# consumidor; su procedencia está anotada en web/app/test/README.md. Se lee de
+# ahí en vez de duplicarla: una segunda copia sería un quinto sitio donde el
+# catálogo puede divergir, que es justo lo que este test existe para evitar.
+_SCHEMA = _REPO_ROOT / "web" / "app" / "test" / "acheron-schema.json"
+
+
+def _shared_schema() -> dict:
+    assert _SCHEMA.is_file(), (
+        f"No está la copia de AcheronSchema en {_SCHEMA}. "
+        "Se copia del repositorio AcheronSchema a un tag concreto; "
+        "ver web/app/test/README.md."
+    )
+    return json.loads(_SCHEMA.read_text(encoding="utf-8"))
+
+
+def test_the_api_knows_exactly_the_kinds_the_shared_schema_declares():
+    """Ni un tipo de más ni uno de menos."""
+    schema_kinds = {t["kind"] for t in _shared_schema()["types"]}
+    api_kinds = set(STORABLE_SPECS)
+
+    assert api_kinds == schema_kinds, (
+        f"faltan en la API: {sorted(schema_kinds - api_kinds)}; "
+        f"sobran en la API: {sorted(api_kinds - schema_kinds)}"
+    )
+
+
+def test_every_kind_maps_to_the_json_list_key_the_schema_declares():
+    """``json_list_key`` es la clave de lista dentro del JSON del vault.
+
+    Si la API la llama ``creditcards`` y el cliente escribe bajo ``cards``, la
+    API no ve ni un solo storable de ese tipo y no falla: lee una lista vacía.
+    """
+    for type_ in _shared_schema()["types"]:
+        spec = STORABLE_SPECS[type_["kind"]]
+        assert spec.json_list_key == type_["category"], (
+            f"{type_['kind']}: la API usa la clave de lista '{spec.json_list_key}' "
+            f"y el esquema declara '{type_['category']}'"
+        )
+
+
+def test_every_kind_declares_exactly_the_field_keys_of_the_shared_schema():
+    """Las claves JSON, comparadas en ambos sentidos.
+
+    Comprobar sólo que no falta ninguna dejaría pasar el campo de más, que es
+    el que aparece al borrar un campo del esquema sin tocar la API.
+    """
+    for type_ in _shared_schema()["types"]:
+        spec = STORABLE_SPECS[type_["kind"]]
+        schema_keys = {field["key"] for field in type_["fields"]}
+        api_keys = {json_key for _attribute, json_key in spec.fields}
+
+        assert api_keys == schema_keys, (
+            f"{type_['kind']}: faltan en la API {sorted(schema_keys - api_keys)}; "
+            f"sobran en la API {sorted(api_keys - schema_keys)}"
+        )


### PR DESCRIPTION
## Resumen

Segunda de las cuatro verificaciones contra [`AcheronSchema`](https://github.com/ProjectEllysia/AcheronSchema). Ésta ata `storable_specs.py`, el registro de la API.

## Por qué importa, y cuál es el modo de fallo

El catálogo de tipos de la bóveda está escrito en cuatro lenguajes, y los cuatro tienen que coincidir en los nombres **exactos** de los campos, porque son las claves del JSON que los clientes cifran y se intercambian.

Lo peligroso es cómo falla. Si la API espera `cardHolderName` y un cliente escribe `cardholderName`, **no hay error**: el campo simplemente no llega, se pierde en un `dict` que nadie mira, y el usuario descubre que su tarjeta no tiene titular mucho después, sin ninguna traza que apunte al renombrado.

## Qué comprueba

Tres cosas, todas en ambos sentidos:

1. **Los `kind`.** Ni un tipo de más ni uno de menos.
2. **La clave de lista del JSON del vault** (`json_list_key` ↔ `category`). Si la API la llama `creditcards` y el cliente escribe bajo `cards`, la API no ve ni un storable de ese tipo y **no falla**: lee una lista vacía.
3. **Las claves de campo.** Comprobar sólo que no falta ninguna dejaría pasar el campo de más, que es el que aparece al borrar un campo del esquema sin tocar la API.

Sigue el patrón que el repositorio ya usa para atar parejas cruzadas del monorepo: `test_caddy_api_routes.py` (Caddyfile ↔ blueprints ↔ router del SPA) y `test_config_view_paths.py` (`ConfigView.vue` ↔ `SecOpsConfig.json`). Lee un fichero que vive lejos y compara.

**Lee la copia del contrato que ya vive con la suite del SPA** en lugar de duplicarla en `API/tests/`. Una segunda copia sería un quinto sitio donde el catálogo puede divergir, que es exactamente lo que este test existe para evitar.

## Una decisión: no se genera, se verifica

Deliberadamente **no** se genera `storable_specs.py` desde el esquema. Ese registro ata además cada tipo a su modelo SQLAlchemy y a los nombres de atributo en `snake_case`, que son información propia de la API y no pertenecen a un contrato compartido con Kotlin y Java. Verificar basta y es mucho menos invasivo.

## Un hallazgo: el orden de `creditcard` diverge

Al escribir el test añadí una comprobación de orden y **falló**:

```
creditcard   API: [cardHolderName, cardNumber, expirationDate, postalCode, cvv]
             ESQ: [cardHolderName, cardNumber, expirationDate, cvv, postalCode]
             mismo conjunto: True
```

La API lleva `postalCode` antes que `cvv`; el esquema, la SPA, el motor Java y la app lo llevan al revés. Es una divergencia real que llevaba ahí desde siempre.

**Retiré la comprobación** en vez de forzar el arreglo, por dos razones. La primera es técnica: el JSON del vault es un objeto con los campos por nombre, no una tupla, así que ningún cliente depende del orden para leer un storable — no rompe nada. La segunda es de alcance: la issue pide verificar el contrato, y yo me había inventado un requisito de orden que el contrato no declara; hacerlo pasar habría exigido cambiar código de producción que nadie me pidió tocar.

La razón queda escrita en la cabecera del test, donde se lee, y si algún día el orden importa el sitio donde decidirlo es `AcheronSchema`.

También quité un cuarto test que había escrito: repetía la aserción del tercero con otro nombre y su único valor era el docstring. Un test cuyo único valor es su docstring no es un test — la explicación va en la cabecera del módulo.

## Validación

```
python -m pytest tests/unit/test_acheron_schema_contract.py -q   →  3 passed
```

Verificado que detecta deriva real, mutando la copia del contrato:

| Divergencia | Resultado |
|---|---|
| Un campo renombrado en el contrato | `exit 1` |
| Clave de lista distinta | `exit 1` |
| Tipo nuevo que la API no conoce | `exit 1` |
| Sin tocar nada | `exit 0` |

Va marcado como `pytest.mark.unit`, así que entra en la suite rápida y en el job `tests` del CI.

## Alcance

Quedan las dos verificaciones que viven en otros repositorios: #475 (`AcheronMobile`, Kotlin) y #476 (`AcheronCore`, Java).

Refs #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
