### PR TITLE
docs(acheron): corregir quién ordena creditcard de cada manera

### DIFF
--- a/API/tests/unit/test_acheron_schema_contract.py
+++ b/API/tests/unit/test_acheron_schema_contract.py
@@ -19,10 +19,15 @@ monorepo leyendo un fichero que vive lejos y comparando.
 
 El ORDEN de los campos no se comprueba, y merece decirse por qué: el JSON del
 vault es un objeto con los campos por nombre, no una tupla, así que ningún
-cliente depende de él para leer un storable. Hoy hay una divergencia real
-—``creditcard`` lleva ``postalCode`` antes que ``cvv`` aquí, y al revés en el
-esquema, en el motor Java y en la app— y no rompe nada. Si algún día el orden
-pasa a importar, el sitio donde decidirlo es ``AcheronSchema``, no este test.
+cliente depende de él para leer un storable. Hoy hay una divergencia real en
+``creditcard``, y el reparto es dos y dos:
+
+- ``… postalCode, cvv`` — esta API y el motor Java de ``AcheronCore``.
+- ``… cvv, postalCode`` — la SPA y la app Android.
+
+No rompe nada, y por eso se comparan conjuntos y no listas en los cuatro
+clientes. Si algún día el orden pasa a importar, el sitio donde decidirlo es
+``AcheronSchema``, no este test.
 
 Deliberadamente NO se genera ``storable_specs.py`` desde el esquema. Ese
 registro ata además cada tipo a su modelo SQLAlchemy y a los nombres de


### PR DESCRIPTION
## Resumen

Corrige una afirmación falsa que introduje en #496.

## Qué decía y qué es cierto

El docstring de `test_acheron_schema_contract.py` afirmaba que la divergencia de orden en `creditcard` era «la API contra el esquema, el motor Java y la app». Eso lo escribí infiriéndolo del esquema, que se generó desde la SPA, sin comprobar el lado Java.

Al escribir el test de contrato de `AcheronCore` ([AcheronCore#3](https://github.com/ProjectEllysia/AcheronCore/pull/3)) falló exactamente ahí y dio el mapa real:

| Orden | Quién |
|---|---|
| `… postalCode, cvv` | esta API **y el motor Java de AcheronCore** |
| `… cvv, postalCode` | la SPA y la app Android |

Es dos y dos, no uno contra tres.

## Por qué merece un commit

No cambia el comportamiento de nada: el orden sigue sin formar parte del contrato, porque el JSON de la bóveda es un objeto con los campos por nombre y no una tupla, y por eso los cuatro clientes comparan conjuntos.

Pero una nota que describe mal el código es peor que no tener nota. Alguien que llegue a decidir sobre este asunto —que es la razón de que la nota exista— partiría de un mapa equivocado de quién tendría que cambiar.

## Validación

```
python -m pytest tests/unit/test_acheron_schema_contract.py -q   →  3 passed
```

Sólo cambia un docstring.

Refs #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
