### PR TITLE
build(web): sonda de acceso al paquete privado desde CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,14 @@ jobs:
 
       # package-lock.json esta en .gitignore, asi que no hay lockfile que
       # cachear ni con el que hacer `npm ci`.
+      # El paquete @projectellysia/acheron-core-web vive en GitHub Packages y
+      # el repositorio es privado, asi que npm necesita credencial. El
+      # GITHUB_TOKEN del propio workflow la trae si el paquete concede acceso
+      # de lectura a este repositorio.
       - name: Install dependencies
         run: npm install --no-audit --no-fund
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Las nueve suites del SPA corren con node a secas y salen con codigo
       # distinto de cero al fallar. Entre ellas va test:acheron, que verifica

--- a/web/app/.npmrc
+++ b/web/app/.npmrc
@@ -1,0 +1,2 @@
+@projectellysia:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -23,7 +23,8 @@
     "pinia": "^3.0.4",
     "qrcode": "^1.5.4",
     "vue": "^3.5.34",
-    "vue-router": "^5.0.7"
+    "vue-router": "^5.0.7",
+    "@projectellysia/acheron-core-web": "2.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.6",


### PR DESCRIPTION
Sonda desechable: declara la dependencia del paquete publicado y comprueba si el `GITHUB_TOKEN` de este workflow puede instalarlo desde GitHub Packages. De la respuesta depende cómo se hace #481. No se mergea tal cual.