### PR TITLE
docs(readme): keep in sync with el token del registry y el build con pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,9 @@ npm run test:logs         # gzip log-payload decoding tests
 npm run test:themis       # scan-window tests
 ```
 
-The suites run on plain `node` — no framework, no browser — and exit non-zero on failure. They run in CI as the `SPA suites` job of `tests.yml`. That job installs with `npm install` rather than `npm ci` because `package-lock.json` is gitignored.
+The suites run on plain `node` — no framework, no browser — and exit non-zero on failure. They run in CI as the `SPA suites` job of `tests.yml`, which installs with **`pnpm install --frozen-lockfile`, exactly as `web/Dockerfile` does in production**, and then builds with Vite.
+
+That match is deliberate and was learnt the hard way. CI used to install with `npm install` and no lockfile while production built with pnpm and a frozen one: two resolvers, two possible dependency trees, and a green CI that did not mean the image would build. It did not — a dependency change left `pnpm-lock.yaml` stale and the production build would have aborted with `ERR_PNPM_OUTDATED_LOCKFILE`. Now a `package.json` that moves without its lockfile turns CI red instead of surfacing at deploy time.
 
 `test:acheron` no longer covers the crypto: that engine left this repository. It now lives in
 [AcheronCoreWeb](https://github.com/ProjectEllysia/AcheronCoreWeb), which the SPA consumes as `@projectellysia/acheron-core-web` at an exact
@@ -500,8 +502,9 @@ Then it polls the public health endpoint `https://<host>/system/say-hello` as a 
 Before the first automatic deploy works:
 
 1. **On the server** — a checkout of this repo in a fixed path (e.g. `~/ellysia`), a root `.env` with the real credentials (start from `.env.example`), and a SSH user that can run Docker without `sudo` (`usermod -aG docker <user>`). The API applies Alembic migrations automatically on startup, and the existing volumes (`ellysia_caddy_data` included) are reused, so a redeploy never re-issues certificates or drops data.
-2. **First boot is manual** — a fresh server needs `CREATE_DATABASE=True` in the server's `.env` for the *very first* `docker compose --profile container up -d --build` (it seeds the root user, its ABAC attributes and the awareness topics — it is **destructive**, set it back to `False` afterwards). From then on, deploys are fully automatic.
-3. **The checkout that deploy targets** — pin `DEPLOY_PATH` to the checkout the running containers came from:
+2. **A `NODE_AUTH_TOKEN` in the server's root `.env`** — the SPA image installs `@projectellysia/acheron-core-web` from GitHub Packages at build time, and that package is private. Use a token with `read:packages`. Without it, `pnpm install` fails with a 403 and the web image never builds, so the deploy dies before the containers start. Docker receives it as a **BuildKit secret**, never as an `ARG`: an `ARG` is baked into the image metadata and `docker history` shows it.
+3. **First boot is manual** — a fresh server needs `CREATE_DATABASE=True` in the server's `.env` for the *very first* `docker compose --profile container up -d --build` (it seeds the root user, its ABAC attributes and the awareness topics — it is **destructive**, set it back to `False` afterwards). From then on, deploys are fully automatic.
+4. **The checkout that deploy targets** — pin `DEPLOY_PATH` to the checkout the running containers came from:
    ```bash
    docker inspect Ellysia-Web --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}'
    ```


### PR DESCRIPTION
Commit único y propio del README, como pide la guía.

**Añade al *one-time setup* del despliegue el `NODE_AUTH_TOKEN`.** La imagen del SPA instala `@projectellysia/acheron-core-web` desde GitHub Packages en tiempo de build, y el paquete es privado. Sin un token con `read:packages` en el `.env` de la raíz del servidor, `pnpm install` falla con un 403 y la imagen no se construye: el despliegue muere antes de arrancar ningún contenedor. Es la única pieza del despliegue que no puede vivir en el repositorio.

Queda anotado también que Docker lo recibe como **secreto de BuildKit y nunca como `ARG`**, porque un `ARG` se graba en los metadatos de la imagen y `docker history` lo enseña.

**Y corrige la descripción de cómo instala la CI.** Decía `npm install`; ahora es `pnpm install --frozen-lockfile`, igual que producción, más el build de Vite. El párrafo explica por qué importa esa coincidencia, porque se aprendió fallando: dos resolutores distintos hacían que una CI en verde no significara que la imagen se construyera, y de hecho no se construía.

Refs #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
