### PR TITLE
hotfix: distinguir 'sin sensores' de 'es una máquina virtual' en Hygeia (P29)

### DIFF
--- a/API/alembic/versions/c8b1d4e6f9a2_hygeia_virtualizacion_del_host.py
+++ b/API/alembic/versions/c8b1d4e6f9a2_hygeia_virtualizacion_del_host.py
@@ -1,0 +1,48 @@
+"""hygeia: sistema y rol de virtualización del host
+
+Revision ID: c8b1d4e6f9a2
+Revises: f4a2b8c1d9e3
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c8b1d4e6f9a2'
+down_revision: Union[str, Sequence[str], None] = 'f4a2b8c1d9e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Dos columnas nullable, sin ``server_default``: un activo dado de alta
+    antes de esta migración (o un agente que aún no reporte estos campos)
+    no tiene forma legítima de rellenarlas — no es lo mismo "no se sabe" que
+    "no es una máquina virtual", así que ``NULL`` es el único valor honesto
+    para el histórico.
+    """
+    op.add_column(
+        "MonitoredAsset",
+        sa.Column("virtualization_system", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "MonitoredAsset",
+        sa.Column("virtualization_role", sa.String(length=32), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Se pierde la distinción entre "no hay sensores" y "es una máquina
+    virtual" para el mensaje de potencia; ningún otro dato de
+    ``MonitoredAsset`` se ve afectado.
+    """
+    op.drop_column("MonitoredAsset", "virtualization_role")
+    op.drop_column("MonitoredAsset", "virtualization_system")

--- a/API/src/modules/features/hygeia/managers.py
+++ b/API/src/modules/features/hygeia/managers.py
@@ -898,6 +898,14 @@ class HygeiaIngestManager:
             # conserva el último conocido. El uptime es estado instantáneo, así
             # que se sobreescribe siempre — un None ahí también es información.
             asset.kernel = payload["host"]["kernel"] or asset.kernel
+            # Mismo trato que el kernel (§P29): un agente que aún no reporte
+            # estos dos campos (versión anterior a esta necesidad) no debe
+            # borrar lo que ya se sabía.
+            host = payload["host"]
+            asset.virtualization_system = (
+                host["virtualizationSystem"] or asset.virtualization_system
+            )
+            asset.virtualization_role = host["virtualizationRole"] or asset.virtualization_role
             asset.uptime_sec = payload["host"]["uptimeSec"]
             # `inventory` es opcional (omitempty en el agente) y, cuando llega,
             # es el estado COMPLETO del software instalado, nunca un delta: se

--- a/API/src/modules/features/hygeia/model.py
+++ b/API/src/modules/features/hygeia/model.py
@@ -85,6 +85,16 @@ class MonitoredAsset(Base):
         kernel: Versión de kernel reportada por el agente, opcional. Es
             identidad del host, no una métrica: se conserva el último valor
             conocido si un heartbeat concreto no lo trae.
+        virtualization_system: Hipervisor o motor de contenedores detectado
+            por ``gopsutil`` (``"kvm"``, ``"vmware"``, ``"hyperv"``,
+            ``"docker"``...), opcional. Igual que ``kernel``, es identidad
+            del host y se conserva el último valor conocido.
+        virtualization_role: ``"guest"`` o ``"host"`` según lo detecte
+            ``gopsutil``, o cualquier otro valor (incluida una cadena que el
+            servidor no reconozca) para "desconocido" — solo el literal
+            ``"guest"`` activa el mensaje de máquina virtual de la métrica
+            de potencia (§P29); nunca se valida contra una lista cerrada,
+            para que un `gopsutil` más nuevo no rompa la ingesta.
         labels: Etiquetas libres del activo (entorno, rol, ubicación...).
         agent_key_id: Prefijo público de la clave de agente, único e indexado.
         agent_key_hash: Hash Argon2id del secreto de la clave de agente.
@@ -145,6 +155,8 @@ class MonitoredAsset(Base):
     hostname = Column(String(255), nullable=False)
     os       = Column(String(64), nullable=True)
     kernel   = Column(String(128), nullable=True)
+    virtualization_system = Column(String(32), nullable=True)
+    virtualization_role   = Column(String(32), nullable=True)
     labels   = Column(JSONB, nullable=True)
 
     agent_key_id   = Column(String(32), unique=True, index=True, nullable=False)
@@ -191,14 +203,17 @@ class MonitoredAsset(Base):
         con sufijo de zona horaria, igual que en el resto de módulos.
 
         Returns:
-            Diccionario con id, hostname, os, kernel, labels, tags, status,
-            isPersistent, lastSeenAt, uptimeSec, agentVersion y createdAt.
+            Diccionario con id, hostname, os, kernel, virtualizationSystem,
+            virtualizationRole, labels, tags, status, isPersistent,
+            lastSeenAt, uptimeSec, agentVersion y createdAt.
         """
         return {
             "id":           self.id,
             "hostname":     self.hostname,
             "os":           self.os,
             "kernel":       self.kernel,
+            "virtualizationSystem": self.virtualization_system,
+            "virtualizationRole":   self.virtualization_role,
             "labels":       self.labels or {},
             "tags":         [tag.to_dict() for tag in self.tags],
             "status":       self.status,

--- a/API/src/modules/features/hygeia/schemas.py
+++ b/API/src/modules/features/hygeia/schemas.py
@@ -90,6 +90,11 @@ class AssetSchema(Schema):
     hostname = fields.String()
     os = fields.String(allow_none=True)
     kernel = fields.String(allow_none=True)
+    # Identidad del host, no una métrica (§P29): null significa "el agente
+    # nunca lo ha reportado" (agente anterior a esta necesidad, o su
+    # `gopsutil` no supo detectarlo), no "no es una máquina virtual".
+    virtualizationSystem = fields.String(allow_none=True)
+    virtualizationRole = fields.String(allow_none=True)
     labels = fields.Dict()
     tags = fields.List(fields.Nested(TagSchema))
     status = fields.String()
@@ -140,6 +145,15 @@ class HostInfoSchema(_IngestSchema):
     os = fields.String(load_default=None, validate=validate.Length(max=64))
     kernel = fields.String(load_default=None, validate=validate.Length(max=128))
     uptimeSec = fields.Integer(load_default=None, validate=validate.Range(min=0))
+    # Texto libre en vez de un OneOf (§P29): gopsutil puede devolver valores
+    # nuevos que el servidor todavía no conoce, y un agente con una versión
+    # de gopsutil distinta no debe ver su heartbeat rechazado por eso. Solo
+    # el literal "guest" dispara el mensaje de máquina virtual; cualquier
+    # otro valor (incluido uno que no se reconozca) se trata como "host o
+    # desconocido" — la misma doctrina de "ante la duda, no se sabe" que ya
+    # sigue el comparador de versiones de agente.
+    virtualizationSystem = fields.String(load_default=None, validate=validate.Length(max=32))
+    virtualizationRole = fields.String(load_default=None, validate=validate.Length(max=32))
 
 
 class CpuMetricsSchema(_IngestSchema):

--- a/API/tests/integration/test_hygeia_ingest.py
+++ b/API/tests/integration/test_hygeia_ingest.py
@@ -316,3 +316,69 @@ def test_heartbeat_with_power_missing_estimated_is_rejected(client, app, regular
     )
 
     assert resp.status_code == 422
+
+
+# =============================================================================
+# VIRTUALIZACIÓN DEL HOST (P29) — distingue "sin sensores" de "es un invitado"
+# =============================================================================
+
+def test_heartbeat_records_virtualization_fields(client, app, regular_user):
+    asset_id, agent_key = _create_asset_with_key(app, regular_user)
+    payload = _heartbeat()
+    payload["host"]["virtualizationSystem"] = "kvm"
+    payload["host"]["virtualizationRole"] = "guest"
+
+    resp = client.post(
+        "/hygeia/ingest", json=payload,
+        headers={"Authorization": f"Bearer {agent_key}"},
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        with UnitOfWork() as uow:
+            asset = MonitoredAssetRepository(uow).get_by_id(asset_id)
+            assert asset.virtualization_system == "kvm"
+            assert asset.virtualization_role == "guest"
+
+
+def test_heartbeat_without_virtualization_fields_leaves_columns_null(client, app, regular_user):
+    """Un agente anterior a esta necesidad no debe romper, y no es lo mismo que 'no es una VM'."""
+    asset_id, agent_key = _create_asset_with_key(app, regular_user)
+
+    resp = client.post(
+        "/hygeia/ingest", json=_heartbeat(),
+        headers={"Authorization": f"Bearer {agent_key}"},
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        with UnitOfWork() as uow:
+            asset = MonitoredAssetRepository(uow).get_by_id(asset_id)
+            assert asset.virtualization_system is None
+            assert asset.virtualization_role is None
+
+
+def test_virtualization_fields_are_conserved_like_kernel(client, app, regular_user, monkeypatch):
+    """Son identidad del host: un heartbeat que no los traiga no debe borrar lo ya sabido."""
+    # Dos heartbeats seguidos del mismo activo: se levanta el suelo de
+    # cadencia (`_enforce_min_interval`), que si no rechazaría el segundo
+    # por llegar antes de los 5 s por defecto.
+    monkeypatch.setattr(hygeia_managers.CR, "hygeia_limits", lambda: hygeia_managers.CR.HygeiaLimits(min_interval_sec=0))
+    asset_id, agent_key = _create_asset_with_key(app, regular_user)
+
+    first = _heartbeat()
+    first["host"]["virtualizationSystem"] = "vmware"
+    first["host"]["virtualizationRole"] = "guest"
+    client.post(
+        "/hygeia/ingest", json=first, headers={"Authorization": f"Bearer {agent_key}"},
+    )
+
+    client.post(
+        "/hygeia/ingest", json=_heartbeat(), headers={"Authorization": f"Bearer {agent_key}"},
+    )
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            asset = MonitoredAssetRepository(uow).get_by_id(asset_id)
+            assert asset.virtualization_system == "vmware"
+            assert asset.virtualization_role == "guest"

--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Hygeia has two separate auth surfaces: standard OAuth for the user-facing endpoi
 
 **Outdated-agent warning.** `GET /hygeia/assets` adds `agentOutdated` to each asset: `true` when the agent's reported `agentVersion` is strictly below `features.hygeia.minAgentVersion` (default `"0.0.0"`, which flags nothing until an operator sets a real floor), `false` when it's at or above it, and `null` whenever the comparison can't be made in good faith — the asset never reported a version, or either version string doesn't parse as strict `X.Y.Z...` (the ingest contract only length-validates `agentVersion`, so a malformed value can't be told apart from outdated-but-well-formed data; the comparator resolves that ambiguity to "unknown" rather than guessing). It's advisory only — never blocks ingestion or changes presence status.
 
+**Virtual-machine awareness.** The ingest contract's `host` block accepts optional `virtualizationSystem`/`virtualizationRole` (populated by the agent's `gopsutil` detection), persisted the same way as `kernel` — nullable columns on `MonitoredAsset`, conserved across a heartbeat that doesn't report them. A guest has no power registers to read (they aren't virtualized), so that's not a hardware defect: when `virtualizationRole` is exactly `"guest"` and the asset has no power reading, the "no sensors" message becomes "this is a virtual machine — its host measures the power draw" instead. Any other role (`"host"`, unset, or a value the server doesn't recognize) falls back to the generic message; the comparison never requires `virtualizationRole` to match a closed list, so a newer `gopsutil` reporting an unfamiliar value can't break ingestion.
+
 ### Accounts — plans & organizations
 
 | Method | Endpoint | Description |

--- a/web/app/src/components/hygeia/AssetDetail.vue
+++ b/web/app/src/components/hygeia/AssetDetail.vue
@@ -110,6 +110,14 @@
             Consumo no disponible — este equipo no expone sensores de potencia compatibles.
           </p>
 
+          <!-- Un invitado no tiene registro de energía del procesador que
+               leer: no es un defecto de su hardware, así que el mensaje no
+               es el genérico de "sin sensores" (§P29). -->
+          <p v-else-if="powerState.state === 'virtual'" class="state-msg">
+            Consumo no disponible — esta es una máquina virtual{{ powerState.virtualizationSystem ? ` (${powerState.virtualizationSystem})` : '' }}.
+            El consumo eléctrico lo mide el equipo físico que la hospeda.
+          </p>
+
           <template v-else>
             <div class="power-reading">
               <span
@@ -538,7 +546,10 @@ const disks = computed(() =>
 const nets = computed(() => m.value?.network ?? [])
 
 /* ── Consumo eléctrico (Fase 3, P20/P25/P26) ── */
-const powerState = computed(() => classifyPower(m.value?.power ?? null))
+const powerState = computed(() => classifyPower(m.value?.power ?? null, {
+  role: props.asset?.virtualizationRole ?? null,
+  system: props.asset?.virtualizationSystem ?? null,
+}))
 const powerReading = computed(() => fmtWatts(powerState.value.watts))
 
 /** Etiquetas de cada bloque del resumen, en el orden en que se presentan. */

--- a/web/app/src/components/hygeia/format.js
+++ b/web/app/src/components/hygeia/format.js
@@ -136,27 +136,46 @@ export function fmtWatts(watts) {
 }
 
 /**
- * Clasifica una lectura de potencia en sus tres estados posibles (P20).
+ * Clasifica una lectura de potencia en sus cuatro estados posibles (P20, P29).
  *
- * La distinción se hace siempre sobre `estimated`, nunca sobre el contenido
- * de `source`: el servidor acepta cualquier cadena ahí para que el agente
- * pueda añadir fuentes nuevas sin coordinación, así que ramificar por su
- * valor se rompería con la primera fuente nueva.
+ * La distinción entre medición y estimación se hace siempre sobre
+ * `estimated`, nunca sobre el contenido de `source`: el servidor acepta
+ * cualquier cadena ahí para que el agente pueda añadir fuentes nuevas sin
+ * coordinación, así que ramificar por su valor se rompería con la primera
+ * fuente nueva.
+ *
+ * Sin potencia, el cuarto estado (`'virtual'`) distingue "esta máquina es
+ * un invitado, la mide su host" de "este equipo no tiene sensores": el
+ * registro de energía del procesador no se virtualiza, así que la ausencia
+ * de dato en un invitado no es un defecto de hardware, es la única
+ * respuesta posible. Se ramifica exactamente igual que `source`: solo el
+ * literal `"guest"` activa el mensaje, cualquier otro valor (`"host"`,
+ * ausente, o una cadena que el servidor no reconozca) cae en el genérico
+ * `'unavailable'` — nunca se le exige a `virtualizationRole` encajar en una
+ * lista cerrada.
  *
  * @param {{watts: number|null, estimated: boolean|null, source: string|null}|null} power
  *   Bloque de potencia tal como lo sirve `metrics.power` del último heartbeat.
- * @returns {{state: 'measured'|'estimated'|'unavailable', watts: number|null,
- *   estimated: boolean|null, source: string|null}}
+ * @param {{role: string|null, system: string|null}} [virtualization] - Identidad
+ *   de virtualización del activo (`asset.virtualizationRole`/`virtualizationSystem`).
+ * @returns {{state: 'measured'|'estimated'|'unavailable'|'virtual', watts: number|null,
+ *   estimated: boolean|null, source: string|null, virtualizationSystem: string|null}}
  */
-export function classifyPower(power) {
+export function classifyPower(power, virtualization = null) {
   if (!power || power.watts === null || power.watts === undefined) {
-    return { state: 'unavailable', watts: null, estimated: null, source: null }
+    const isGuest = virtualization?.role === 'guest'
+    return {
+      state: isGuest ? 'virtual' : 'unavailable',
+      watts: null, estimated: null, source: null,
+      virtualizationSystem: isGuest ? (virtualization?.system ?? null) : null,
+    }
   }
   return {
     state: power.estimated ? 'estimated' : 'measured',
     watts: power.watts,
     estimated: power.estimated ?? null,
     source: power.source ?? null,
+    virtualizationSystem: null,
   }
 }
 

--- a/web/app/test/hygeia.format.test.mjs
+++ b/web/app/test/hygeia.format.test.mjs
@@ -70,19 +70,37 @@ eq('sin dato', fmtWatts(null), NO_DATA)
 
 console.log('\nclassifyPower (P20)')
 eq('sin bloque de potencia: no disponible',
-  classifyPower(null), { state: 'unavailable', watts: null, estimated: null, source: null })
+  classifyPower(null),
+  { state: 'unavailable', watts: null, estimated: null, source: null, virtualizationSystem: null })
 eq('watts null: no disponible aunque el bloque exista',
   classifyPower({ watts: null, estimated: false, source: 'rapl' }),
-  { state: 'unavailable', watts: null, estimated: null, source: null })
+  { state: 'unavailable', watts: null, estimated: null, source: null, virtualizationSystem: null })
 eq('estimated false: medición',
   classifyPower({ watts: 187.5, estimated: false, source: 'rapl' }),
-  { state: 'measured', watts: 187.5, estimated: false, source: 'rapl' })
+  { state: 'measured', watts: 187.5, estimated: false, source: 'rapl', virtualizationSystem: null })
 eq('estimated true: estimación',
   classifyPower({ watts: 60, estimated: true, source: 'windows-model' }),
-  { state: 'estimated', watts: 60, estimated: true, source: 'windows-model' })
+  { state: 'estimated', watts: 60, estimated: true, source: 'windows-model', virtualizationSystem: null })
 eq('watts=0 es una medición, no una ausencia (el borde que sostiene la Fase 3)',
   classifyPower({ watts: 0, estimated: false, source: 'smart-plug' }),
-  { state: 'measured', watts: 0, estimated: false, source: 'smart-plug' })
+  { state: 'measured', watts: 0, estimated: false, source: 'smart-plug', virtualizationSystem: null })
+
+console.log('\nclassifyPower — virtualización (P29)')
+eq('invitado sin potencia: estado "virtual" con el hipervisor',
+  classifyPower(null, { role: 'guest', system: 'kvm' }),
+  { state: 'virtual', watts: null, estimated: null, source: null, virtualizationSystem: 'kvm' })
+eq('host sin potencia: sigue siendo el genérico "no disponible"',
+  classifyPower(null, { role: 'host', system: null }),
+  { state: 'unavailable', watts: null, estimated: null, source: null, virtualizationSystem: null })
+eq('rol desconocido (o ausente) sin potencia: genérico, nunca se exige una lista cerrada',
+  classifyPower(null, { role: null, system: null }),
+  { state: 'unavailable', watts: null, estimated: null, source: null, virtualizationSystem: null })
+eq('sin el segundo argumento: se comporta igual que antes de P29',
+  classifyPower(null),
+  { state: 'unavailable', watts: null, estimated: null, source: null, virtualizationSystem: null })
+eq('invitado CON potencia: la lectura manda, no es "virtual"',
+  classifyPower({ watts: 5.0, estimated: true, source: 'guest-model' }, { role: 'guest', system: 'kvm' }),
+  { state: 'estimated', watts: 5.0, estimated: true, source: 'guest-model', virtualizationSystem: null })
 
 console.log('\nfmtEnergy / fmtCost')
 eq('energía con dos decimales por debajo de 10', fmtEnergy(1.234), { text: '1.23', unit: 'kWh' })


### PR DESCRIPTION
## Summary

Hotfix sobre `main`: sube los tres commits de `v0.5` que quedaron fuera de la PR #541 (fusionada mientras esta segunda tanda de trabajo todavía estaba en curso). Es la parte de `EllysiaServer` de [P29](https://github.com/ProjectEllysia/EllysiaServer/issues/540) del proyecto [Hygeia — Consumo energético](https://github.com/orgs/ProjectEllysia/projects/7).

## Related Issue

Parte de #540 (P29) — la mitad del trabajo (`HygeiaAgent`, el collector que detecta y manda estos dos campos) sigue pendiente en el otro repositorio, así que el issue no se cierra con esta PR.

## Implementation

Ver la descripción completa en #544 (ya fusionada en `v0.5`, es la que trae estos tres commits):

- **Contrato e ingesta**: `HostInfoSchema` acepta `virtualizationSystem`/`virtualizationRole`, opcionales y sin formato cerrado — un `gopsutil` más nuevo en el agente que devuelva un valor que el servidor no reconozca no debe romper la ingesta.
- **Persistencia**: dos columnas nullable en `MonitoredAsset` (migración aditiva y reversible), con el mismo trato que `kernel` — identidad del host, se conserva el último valor conocido si un heartbeat no lo trae.
- **Interfaz**: el tercer estado de la métrica de potencia («sin sensores compatibles») distingue ahora el caso de una máquina virtual («esta es una máquina virtual (kvm); el consumo eléctrico lo mide el equipo físico que la hospeda»), activado solo cuando `virtualizationRole === 'guest'` y no hay lectura de potencia.

## Validation

Ya validado en #544 antes de fusionarse en `v0.5`: `pytest` completo en verde, `npm run test:hygeia` en verde, build del SPA sin errores nuevos, `pylint` sin regresiones.

## Notes

El issue #540 se queda abierto hasta que la parte de `HygeiaAgent` esté hecha — sin ella, el servidor nunca recibirá `virtualizationRole: "guest"` de verdad, así que el mensaje nuevo no se activa todavía en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)