### PR TITLE
fix(iris): checkpoint mailbox ingestion per message before advancing the sync cursor

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -283,6 +283,7 @@
       "maxMessageBytes": 10485760,
       "maxConnectionsPerUser": 5,
       "maxIngestedPerDay": 200,
+      "maxInboxAttempts": 5,
       "pollIntervalMinutes": 5,
       "prompts": {
         "summary": {

--- a/API/alembic/versions/08ef8f772404_add_iris_mailbox_inbox.py
+++ b/API/alembic/versions/08ef8f772404_add_iris_mailbox_inbox.py
@@ -1,0 +1,61 @@
+"""iris: IrisMailboxInbox (B01 -- checkpoint de ingesta por mensaje)
+
+``IrisMailboxManager._finish_sync`` confirmaba el cursor del proveedor
+(``sync_cursor``) tanto si el lote de mensajes se ingería entero como si no.
+Una cuota agotada o un fallo a mitad de lote perdían en silencio los mensajes
+que quedaban sin procesar, porque ni Gmail ni Graph vuelven a devolver un
+mensaje una vez el cursor avanza más allá de él.
+
+``IrisMailboxInbox`` es la cola intermedia que resuelve esto: cada mensaje
+que devuelve ``list_new`` se encola aquí antes de intentar ingerirlo, y el
+cursor del proveedor solo se confirma cuando la cola de la conexión queda
+vacía (ver ``IrisMailboxManager._sync_connection``/``_finish_sync``). Una
+referencia que agota ``iris.maxInboxAttempts`` pasa a ``status="dead"``
+-- visible, pero ya no bloquea el avance del cursor.
+
+Revision ID: 08ef8f772404
+Revises: c8b1d4e6f9a2
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '08ef8f772404'
+down_revision: Union[str, Sequence[str], None] = 'c8b1d4e6f9a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'IrisMailboxInbox',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('connection_id', sa.Integer(), nullable=False),
+        sa.Column('provider_message_id', sa.String(length=255), nullable=False),
+        sa.Column('raw_ref', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('attempts', sa.Integer(), nullable=False),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['connection_id'], ['IrisMailboxConnection.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('connection_id', 'provider_message_id',
+                             name='uq_iris_mailbox_inbox_connection_message'),
+    )
+    op.create_index(
+        op.f('ix_IrisMailboxInbox_connection_id'), 'IrisMailboxInbox', ['connection_id'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_IrisMailboxInbox_connection_id'), table_name='IrisMailboxInbox')
+    op.drop_table('IrisMailboxInbox')

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -38,9 +38,11 @@ from ..exceptions import (
     IrisMailboxQuotaExceededError,
 )
 from .analysis import IrisManager
-from ..model import IrisMailboxConnection
-from ..repositories import IrisMailboxConnectionRepository
-from ..services.mailbox import MAILBOX_CONNECTORS, MailboxConnector, get_connector
+from ..model import IrisMailboxConnection, IrisMailboxInbox
+from ..repositories import (
+    IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
+)
+from ..services.mailbox import MAILBOX_CONNECTORS, MailboxConnector, MessageRef, get_connector
 from ..services.parsers import build_subject_title
 
 logger = logging.getLogger(__name__)
@@ -338,29 +340,108 @@ class IrisMailboxManager(TaskTrackingMixin):
             self._record_sync_error(connection_id, str(e))
             return
 
+        # B01: el mensaje entra en la cola de checkpoint antes de intentar
+        # ingerirlo -- así una cuota agotada o un fallo a mitad de lote no lo
+        # pierden, sino que lo dejan pendiente para el próximo sondeo.
+        self._enqueue_pending(connection_id, refs)
+
         max_per_day = CR.iris_config().max_ingested_per_day
         ingested_today, reset_date = self._current_daily_counter(connection)
+        ingested_today = self._drain_pending(
+            connection, connector, access_token, ingested_today, max_per_day,
+        )
 
-        for ref in refs:
+        # El cursor del proveedor solo se confirma cuando la cola queda
+        # vacía: confirmarlo con referencias pendientes las perdería para
+        # siempre, porque ni Gmail ni Graph vuelven a listar un mensaje una
+        # vez el cursor avanza más allá de él.
+        advance_cursor = not build_repository(IrisMailboxInboxRepository).has_pending(connection_id)
+        self._finish_sync(connection_id, new_cursor, ingested_today, reset_date, advance_cursor)
+
+    @staticmethod
+    def _enqueue_pending(connection_id: int, refs: list[MessageRef]) -> None:
+        """Encola cada mensaje nuevo en ``IrisMailboxInbox``, saltando los que
+        ya estaban en cola de un sondeo anterior (pendientes o ``dead``)."""
+        if not refs:
+            return
+        with UnitOfWork() as uow:
+            repo = IrisMailboxInboxRepository(uow)
+            existing_ids = repo.get_existing_provider_ids(
+                connection_id, [ref.provider_message_id for ref in refs],
+            )
+            for ref in refs:
+                if ref.provider_message_id in existing_ids:
+                    continue
+                repo.save(IrisMailboxInbox(
+                    connection_id=connection_id,
+                    provider_message_id=ref.provider_message_id,
+                    raw_ref=ref.raw or None,
+                ))
+
+    def _drain_pending(
+        self, connection: IrisMailboxConnection, connector: MailboxConnector,
+        access_token: str, ingested_today: int, max_per_day: int,
+    ) -> int:
+        """Procesa la cola de checkpoint (mensajes recién encolados y los que
+        quedaron pendientes de sondeos anteriores) hasta agotar la cuota
+        diaria. Devuelve el contador de ingeridos actualizado."""
+        connection_id = connection.id
+        inbox_repo = build_repository(IrisMailboxInboxRepository)
+        analysis_repo = build_repository(IrisAnalysisRepository)
+
+        for entry in inbox_repo.get_pending(connection_id):
             if ingested_today >= max_per_day:
                 logger.warning(
                     f"Conexión {connection_id} alcanzó la cuota diaria ({max_per_day}); "
-                    "el resto de mensajes nuevos se procesará en el próximo sondeo."
+                    "el resto de mensajes pendientes se procesará en el próximo sondeo."
                 )
                 break
+
+            if analysis_repo.exists_by_source(connection_id, entry.provider_message_id):
+                # Ya se aceptó en un intento anterior (p.ej. un fallo entre
+                # el commit del análisis y el borrado de esta entrada) --
+                # resolver sin reintentar ni contarlo de nuevo.
+                self._resolve_inbox_entry(entry.id)
+                continue
+
+            ref = MessageRef(provider_message_id=entry.provider_message_id, raw=entry.raw_ref or {})
             try:
                 self._ingest_message(connection, connector, access_token, ref)
                 ingested_today += 1
+                self._resolve_inbox_entry(entry.id)
             except Exception as e:
-                # Un mensaje roto (parseo, red, o un reintento duplicado que
-                # choca con la UNIQUE constraint de idempotencia) no debe
-                # tumbar el resto del lote.
+                # Un mensaje roto (parseo, red) no debe tumbar el resto del
+                # lote -- queda pendiente (o dead-letter tras demasiados
+                # intentos) para no bloquear el resto de la cola para siempre.
                 logger.error(
-                    f"Fallo analizando el mensaje {ref.provider_message_id} "
+                    f"Fallo analizando el mensaje {entry.provider_message_id} "
                     f"de la conexión {connection_id}: {e}", exc_info=True,
                 )
+                self._retry_or_deadletter(entry.id, str(e))
 
-        self._finish_sync(connection_id, new_cursor, ingested_today, reset_date)
+        return ingested_today
+
+    @staticmethod
+    def _resolve_inbox_entry(entry_id: int) -> None:
+        with UnitOfWork() as uow:
+            repo = IrisMailboxInboxRepository(uow)
+            entry = repo.get_by_id(entry_id)
+            if entry is not None:
+                repo.delete(entry)
+
+    @staticmethod
+    def _retry_or_deadletter(entry_id: int, error: str) -> None:
+        max_attempts = CR.iris_config().max_inbox_attempts
+        with UnitOfWork() as uow:
+            repo = IrisMailboxInboxRepository(uow)
+            entry = repo.get_by_id(entry_id)
+            if entry is None:
+                return
+            entry.attempts += 1
+            entry.last_error = error[:2000]
+            if entry.attempts >= max_attempts:
+                entry.status = "dead"
+            repo.update(entry)
 
     def _ingest_message(self, connection: IrisMailboxConnection, connector: MailboxConnector,
                          access_token: str, ref) -> None:
@@ -423,13 +504,17 @@ class IrisMailboxManager(TaskTrackingMixin):
         return 0, today
 
     @staticmethod
-    def _finish_sync(connection_id: int, new_cursor: str, ingested_today: int, reset_date: date) -> None:
+    def _finish_sync(
+        connection_id: int, new_cursor: str, ingested_today: int, reset_date: date,
+        advance_cursor: bool = True,
+    ) -> None:
         with UnitOfWork() as uow:
             repo = IrisMailboxConnectionRepository(uow)
             fresh = repo.get_by_id(connection_id)
             if fresh is None:
                 return
-            fresh.sync_cursor = new_cursor
+            if advance_cursor:
+                fresh.sync_cursor = new_cursor
             fresh.ingested_today = ingested_today
             fresh.ingested_reset_date = reset_date
             fresh.last_sync_at = utcnow_naive()

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -179,6 +179,8 @@ class IrisMailboxConnection(Base):
         created_at: When the connection was established.
         user: SQLAlchemy relationship to User.
         analyses: Analyses ingested through this connection.
+        inbox_entries: Cola de checkpoint de mensajes descubiertos y aún no
+                 resueltos (ver ``IrisMailboxInbox`` / B01).
     """
     __tablename__ = "IrisMailboxConnection"
 
@@ -205,10 +207,65 @@ class IrisMailboxConnection(Base):
 
     user = relationship("User")
     analyses = relationship("IrisAnalysis", back_populates="connection")
+    inbox_entries = relationship(
+        "IrisMailboxInbox", back_populates="connection",
+        cascade="all, delete-orphan",
+    )
 
     __table_args__ = (
         UniqueConstraint("user_id", "provider", "account_email",
                           name="uq_iris_mailbox_connection_user_provider_email"),
+    )
+
+
+class IrisMailboxInbox(Base):
+    """Cola de checkpoint por mensaje entre el listado del proveedor y su ingesta.
+
+    ``IrisMailboxManager._sync_connection`` confirmaba el cursor del
+    proveedor tanto si el lote se ingería entero como si no: una cuota
+    agotada o un fallo a mitad de lote perdían en silencio los mensajes que
+    quedaban sin procesar, porque el proveedor nunca los vuelve a devolver
+    una vez el cursor avanza (B01). Cada mensaje que devuelve ``list_new``
+    se encola aquí antes de intentar ingerirlo, y el cursor del proveedor
+    solo avanza cuando la cola de la conexión queda vacía.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        connection_id: FK a la IrisMailboxConnection que descubrió el
+                 mensaje. ``ondelete="CASCADE"``: la cola de una conexión
+                 borrada no tiene sentido sin ella.
+        provider_message_id: Id opaco del proveedor -- mismo valor que
+                 ``IrisAnalysis.source_message_uid`` una vez ingerido.
+        raw_ref: Datos crudos que ``list_new`` ya trajo sin round-trip extra
+                 (``MessageRef.raw``) -- necesarios para reintentar sin
+                 volver a listar (p.ej. Graph guarda aquí las cabeceras).
+        status: "pending" (reintentable) | "dead" (agotó los reintentos de
+                 ``iris.maxInboxAttempts``; queda visible pero ya no
+                 bloquea el avance del cursor -- una única referencia rota
+                 no puede detener la ingesta del resto para siempre).
+        attempts: Intentos de ingesta fallidos.
+        last_error: Motivo del último fallo, si alguno.
+        created_at: Cuándo se encoló.
+        updated_at: Cuándo se tocó por última vez (reintento o dead-letter).
+    """
+    __tablename__ = "IrisMailboxInbox"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    connection_id = Column(Integer, ForeignKey("IrisMailboxConnection.id", ondelete="CASCADE"),
+                            nullable=False, index=True)
+    provider_message_id = Column(String(255), nullable=False)
+    raw_ref = Column(JSONB, nullable=True)
+    status = Column(String(20), nullable=False, default="pending")
+    attempts = Column(Integer, nullable=False, default=0)
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    updated_at = Column(DateTime, nullable=False, default=utcnow_naive, onupdate=utcnow_naive)
+
+    connection = relationship("IrisMailboxConnection", back_populates="inbox_entries")
+
+    __table_args__ = (
+        UniqueConstraint("connection_id", "provider_message_id",
+                          name="uq_iris_mailbox_inbox_connection_message"),
     )
 
 

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -16,7 +16,9 @@ from sqlalchemy.orm import joinedload
 from src.modules.infrastructure import BaseRepository, DocumentRepository
 from src.modules.shared import utcnow_naive
 
-from .model import IrisAnalysis, IrisMailboxConnection, IrisRuleResult, IrisDocument
+from .model import (
+    IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox, IrisRuleResult, IrisDocument,
+)
 
 
 class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
@@ -112,6 +114,24 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         )
         return items, total
 
+    def exists_by_source(self, connection_id: int, source_message_uid: str) -> bool:
+        """Si ya existe un análisis para este (connection_id, source_message_uid).
+
+        Usado por la cola de checkpoint del sync de buzón (B01) para
+        reconocer un mensaje ya aceptado en un intento anterior -- p.ej. tras
+        un fallo entre el commit de ``IrisAnalysis`` y el borrado de su
+        entrada en ``IrisMailboxInbox`` -- de forma que un reintento nunca
+        confunda la ``UniqueConstraint`` de idempotencia con un fallo real.
+        """
+        return (
+            self._session.query(IrisAnalysis.id)
+            .filter(
+                IrisAnalysis.connection_id == connection_id,
+                IrisAnalysis.source_message_uid == source_message_uid,
+            )
+            .first()
+        ) is not None
+
 
 class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):
     """Data-access layer for IrisMailboxConnection records."""
@@ -166,6 +186,59 @@ class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):
             )
             .all()
         )
+
+
+class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
+    """Data-access layer for IrisMailboxInbox -- la cola de checkpoint por
+    mensaje que B01 introduce delante del cursor del proveedor."""
+
+    _MODEL = IrisMailboxInbox
+
+    def get_pending(self, connection_id: int) -> List[IrisMailboxInbox]:
+        """Referencias sin resolver de una conexión, en orden de llegada
+        (FIFO) -- el orden importa porque es el mismo en que el proveedor
+        las devolvió."""
+        return (
+            self._session.query(IrisMailboxInbox)
+            .filter(
+                IrisMailboxInbox.connection_id == connection_id,
+                IrisMailboxInbox.status == "pending",
+            )
+            .order_by(IrisMailboxInbox.id.asc())
+            .all()
+        )
+
+    def has_pending(self, connection_id: int) -> bool:
+        """Si quedan referencias sin resolver.
+
+        Mientras esto sea True, ``_finish_sync`` no puede confirmar el
+        cursor del proveedor (B01) -- avanzarlo perdería esas referencias
+        para siempre, porque el proveedor no las vuelve a listar.
+        """
+        return (
+            self._session.query(IrisMailboxInbox.id)
+            .filter(
+                IrisMailboxInbox.connection_id == connection_id,
+                IrisMailboxInbox.status == "pending",
+            )
+            .first()
+        ) is not None
+
+    def get_existing_provider_ids(self, connection_id: int, provider_message_ids: List[str]) -> set:
+        """De una lista de ids candidatos, cuáles ya están en la cola
+        (pendientes o ya marcados ``dead``) -- evita volver a encolar una
+        fila que un sync anterior ya conoce."""
+        if not provider_message_ids:
+            return set()
+        rows = (
+            self._session.query(IrisMailboxInbox.provider_message_id)
+            .filter(
+                IrisMailboxInbox.connection_id == connection_id,
+                IrisMailboxInbox.provider_message_id.in_(provider_message_ids),
+            )
+            .all()
+        )
+        return {row[0] for row in rows}
 
 
 class IrisRuleResultRepository(BaseRepository[IrisRuleResult]):

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1805,6 +1805,15 @@ class IrisConfig:  # pylint: disable=too-many-instance-attributes
     poder generar análisis sin límite — ver roadmap-ellysia.md §8.1.
     """
 
+    max_inbox_attempts: int = 5
+    """Reintentos de ingesta antes de marcar una referencia de
+    ``IrisMailboxInbox`` como ``dead`` (B01).
+
+    Sin tope, un mensaje irrecuperablemente roto (parseo, permisos) bloquea
+    para siempre el avance del cursor del proveedor de esa conexión — el
+    checkpoint no confirma el cursor mientras queden referencias pendientes.
+    """
+
     prompts: dict = field(default_factory=dict)
     """Prompts de ``IrisAIWriter`` (IA1): ``summary.{system,userTemplate}``."""
 

--- a/API/tests/integration/test_iris_mailbox_manager.py
+++ b/API/tests/integration/test_iris_mailbox_manager.py
@@ -21,8 +21,10 @@ from src.modules.features.iris.exceptions import (
 )
 import src.modules.features.iris.managers.analysis as analysis_managers_mod
 from src.modules.features.iris.managers.mailbox import IrisMailboxManager
-from src.modules.features.iris.model import IrisAnalysis, IrisMailboxConnection
-from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisMailboxConnectionRepository
+from src.modules.features.iris.model import IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox
+from src.modules.features.iris.repositories import (
+    IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
+)
 from src.modules.features.iris.services.mailbox.base import MessageRef, TokenSet
 from src.modules.infrastructure import UnitOfWork
 from src.modules.shared import decrypt_at_rest, encrypt_at_rest, utcnow_naive
@@ -119,6 +121,33 @@ class _FakeConnector:
         self.revoked_tokens.append(refresh_token)
         if self._revoke_raises:
             raise RuntimeError("provider is down")
+
+
+class _QueueTestConnector(_FakeConnector):
+    """Doble para los tests de checkpoint (B01): lista un lote fijo de
+    mensajes y puede fallar la ingesta de ids concretos un número de veces
+    controlado antes de empezar a tener éxito -- simula un fallo transitorio
+    (el mensaje se recupera) o uno permanente (nunca se agota el contador)."""
+
+    def __init__(self, refs, cursor_after="cursor-2", fail_times=None):
+        super().__init__()
+        self._refs = refs
+        self._cursor_after = cursor_after
+        self._fail_times = dict(fail_times or {})
+        self._attempts_used: dict[str, int] = {}
+
+    def list_new(self, access_token, cursor):
+        if cursor is None:
+            return [], "cursor-1"
+        return self._refs, self._cursor_after
+
+    def fetch_headers(self, access_token, message_ref):
+        remaining = self._fail_times.get(message_ref.provider_message_id, 0)
+        used = self._attempts_used.get(message_ref.provider_message_id, 0)
+        if used < remaining:
+            self._attempts_used[message_ref.provider_message_id] = used + 1
+            raise RuntimeError(f"fallo transitorio en {message_ref.provider_message_id}")
+        return f"From: a@b.com\r\nSubject: {message_ref.provider_message_id}\r\n"
 
 
 def _connection(user_id, **overrides) -> IrisMailboxConnection:
@@ -376,6 +405,152 @@ def test_sync_connection_stops_at_daily_quota(app, regular_user, monkeypatch):
 
         with UnitOfWork() as uow:
             assert IrisAnalysisRepository(uow).get_by_user(regular_user.id) == []
+
+            # B01: la cuota agotada deja el mensaje en cola para el próximo
+            # sondeo -- confirmar el cursor ahora lo perdería para siempre.
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-0"
+            pending = IrisMailboxInboxRepository(uow).get_pending(connection_id)
+            assert [entry.provider_message_id for entry in pending] == ["msg-1"]
+            assert pending[0].attempts == 0
+
+
+# --------------------------------------------------------- B01: checkpoint por mensaje
+
+def test_sync_connection_defers_cursor_and_pending_message_when_quota_is_hit(app, regular_user, monkeypatch):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        refs = [MessageRef(provider_message_id="msg-1"), MessageRef(provider_message_id="msg-2")]
+        connector = _QueueTestConnector(refs)
+
+        fake_queue = _FakeTaskQueue()
+        monkeypatch.setattr(
+            mailbox_managers_mod.CR, "iris_config",
+            lambda: CR.IrisConfig(max_ingested_per_day=1),
+        )
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            # msg-2 se quedó fuera por cuota: el cursor no se confirma.
+            assert conn.sync_cursor == "cursor-0"
+            assert conn.ingested_today == 1
+            pending = IrisMailboxInboxRepository(uow).get_pending(connection_id)
+            assert [entry.provider_message_id for entry in pending] == ["msg-2"]
+
+        # Próximo sondeo con cuota libre: el proveedor vuelve a listar el
+        # mismo lote (el cursor no avanzó) pero msg-1 nunca se duplica.
+        monkeypatch.setattr(
+            mailbox_managers_mod.CR, "iris_config",
+            lambda: CR.IrisConfig(max_ingested_per_day=10),
+        )
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-2"
+            analyses = IrisAnalysisRepository(uow).get_by_user(regular_user.id)
+            assert sorted(a.source_message_uid for a in analyses) == ["msg-1", "msg-2"]
+            assert IrisMailboxInboxRepository(uow).get_pending(connection_id) == []
+
+
+def test_sync_connection_retries_transient_failure_without_duplicating_prior_success(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        refs = [MessageRef(provider_message_id="msg-1"), MessageRef(provider_message_id="msg-2")]
+        connector = _QueueTestConnector(refs, fail_times={"msg-2": 1})
+
+        fake_queue = _FakeTaskQueue()
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-0"
+            analyses = IrisAnalysisRepository(uow).get_by_user(regular_user.id)
+            assert [a.source_message_uid for a in analyses] == ["msg-1"]
+            pending = IrisMailboxInboxRepository(uow).get_pending(connection_id)
+            assert [entry.provider_message_id for entry in pending] == ["msg-2"]
+            assert pending[0].attempts == 1
+            assert "fallo transitorio" in pending[0].last_error
+
+        # El proveedor todavía no ve el cursor avanzar, así que vuelve a
+        # devolver ambos mensajes -- msg-2 ahora sí se ingiere (ya no falla)
+        # y msg-1 (aceptado en el sondeo anterior) nunca se duplica.
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-2"
+            analyses = IrisAnalysisRepository(uow).get_by_user(regular_user.id)
+            assert sorted(a.source_message_uid for a in analyses) == ["msg-1", "msg-2"]
+            assert IrisMailboxInboxRepository(uow).get_pending(connection_id) == []
+
+
+def test_sync_connection_moves_permanently_failing_message_to_dead_after_max_attempts(app, regular_user, monkeypatch):
+    monkeypatch.setattr(
+        mailbox_managers_mod.CR, "iris_config",
+        lambda: CR.IrisConfig(max_inbox_attempts=2),
+    )
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        connector = _QueueTestConnector(
+            [MessageRef(provider_message_id="msg-broken")], fail_times={"msg-broken": 999},
+        )
+
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector):
+            IrisMailboxManager()._sync_connection(connection_id)
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            # La entrada "dead" ya no bloquea el avance del cursor.
+            assert conn.sync_cursor == "cursor-2"
+
+            repo = IrisMailboxInboxRepository(uow)
+            assert repo.get_pending(connection_id) == []
+            entries = repo.get_all_by_field("connection_id", connection_id)
+            assert len(entries) == 1
+            assert entries[0].status == "dead"
+            assert entries[0].attempts == 2
+            assert "fallo transitorio" in entries[0].last_error
+            assert IrisAnalysisRepository(uow).get_by_user(regular_user.id) == []
+
+
+def test_sync_connection_resolves_inbox_entry_for_already_ingested_message(app, regular_user):
+    """Simula un fallo entre el commit del análisis y el borrado de su
+    entrada en el inbox (p.ej. el proceso muere justo ahí): el siguiente
+    sondeo debe resolver la entrada sin duplicar el análisis ni tratarlo
+    como un fallo real."""
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+
+        with UnitOfWork() as uow:
+            IrisAnalysisRepository(uow).save(IrisAnalysis(
+                raw_headers="From: a@b.com\r\nSubject: Hi\r\n", user_id=regular_user.id,
+                status="finished", connection_id=connection_id, source_message_uid="msg-1",
+            ))
+            IrisMailboxInboxRepository(uow).save(
+                IrisMailboxInbox(connection_id=connection_id, provider_message_id="msg-1")
+            )
+
+        connector = _QueueTestConnector([], cursor_after="cursor-2")
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=connector):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            assert IrisMailboxInboxRepository(uow).get_pending(connection_id) == []
+            analyses = IrisAnalysisRepository(uow).get_by_user(regular_user.id)
+            assert len(analyses) == 1
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-2"
 
 
 def test_sync_connection_marks_reauth_required_on_revoked_token(app, regular_user):

--- a/API/tests/integration/test_iris_mailbox_model.py
+++ b/API/tests/integration/test_iris_mailbox_model.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
-from src.modules.features.iris.model import IrisAnalysis, IrisMailboxConnection
+from src.modules.features.iris.model import IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox
 from src.modules.features.iris.repositories import (
-    IrisAnalysisRepository, IrisMailboxConnectionRepository,
+    IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
 )
 from src.modules.infrastructure import UnitOfWork
 
@@ -148,3 +148,68 @@ def test_a_long_opaque_cursor_survives_a_round_trip(app, regular_user):
             fetched = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
             assert fetched.sync_cursor == cursor
             assert len(fetched.sync_cursor) > 255
+
+
+# --------------------------------------------------------------- B01: IrisMailboxInbox
+
+def test_create_and_fetch_inbox_entry(app, regular_user):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            conn = _make_connection(regular_user.id)
+            IrisMailboxConnectionRepository(uow).save(conn)
+            conn_id = conn.id
+
+        with UnitOfWork() as uow:
+            entry = IrisMailboxInbox(
+                connection_id=conn_id, provider_message_id="msg-1", raw_ref={"foo": "bar"},
+            )
+            IrisMailboxInboxRepository(uow).save(entry)
+            entry_id = entry.id
+
+        with UnitOfWork() as uow:
+            fetched = IrisMailboxInboxRepository(uow).get_by_id(entry_id)
+            assert fetched is not None
+            assert fetched.status == "pending"
+            assert fetched.attempts == 0
+            assert fetched.raw_ref == {"foo": "bar"}
+
+
+def test_inbox_entry_unique_per_connection_and_provider_message(app, regular_user):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            conn = _make_connection(regular_user.id)
+            IrisMailboxConnectionRepository(uow).save(conn)
+            conn_id = conn.id
+
+        with UnitOfWork() as uow:
+            IrisMailboxInboxRepository(uow).save(
+                IrisMailboxInbox(connection_id=conn_id, provider_message_id="msg-1")
+            )
+
+        with pytest.raises(SQLAlchemyError):
+            with UnitOfWork() as uow:
+                IrisMailboxInboxRepository(uow).save(
+                    IrisMailboxInbox(connection_id=conn_id, provider_message_id="msg-1")
+                )
+
+
+def test_deleting_connection_cascades_to_inbox_entries(app, regular_user):
+    """La cola de checkpoint de una conexión borrada no tiene sentido sin
+    ella -- ``ondelete="CASCADE"`` en el FK se encarga."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            conn = _make_connection(regular_user.id)
+            IrisMailboxConnectionRepository(uow).save(conn)
+            conn_id = conn.id
+            IrisMailboxInboxRepository(uow).save(
+                IrisMailboxInbox(connection_id=conn_id, provider_message_id="msg-1")
+            )
+
+        with UnitOfWork() as uow:
+            IrisMailboxConnectionRepository(uow).delete(
+                IrisMailboxConnectionRepository(uow).get_by_id(conn_id)
+            )
+
+        with UnitOfWork() as uow:
+            remaining = IrisMailboxInboxRepository(uow).get_pending(conn_id)
+            assert remaining == []


### PR DESCRIPTION
## Summary

Closes #217 ([B01] Checkpoint de ingesta por mensaje, no solo por lote), part 1 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

`IrisMailboxManager._sync_connection` lists a batch of new messages from Gmail/Graph, tries to ingest each one, and then confirms the provider's cursor (`sync_cursor`) in `_finish_sync` — but it did that **unconditionally**, whether or not every message in the batch actually got ingested. If the connection's daily quota ran out partway through the batch, or an individual message failed to parse, the cursor still advanced past it. Neither Gmail's history API nor Microsoft Graph's delta API will ever return a message again once the cursor has moved past it, so those messages were lost permanently and silently — no error, no trace, the mail simply never got analyzed.

## What changed

Added `IrisMailboxInbox`, a checkpoint queue that sits between "the provider told us about this message" and "Iris has accepted it":

- Every message `list_new` returns is enqueued in `IrisMailboxInbox` (status `pending`) before ingestion is attempted, deduplicated by `(connection_id, provider_message_id)`.
- The provider's cursor only advances once a connection's queue is fully drained — every message either ingested successfully or moved to a terminal `dead` state. This is the core fix: a partial batch can no longer silently disappear.
- A message that fails to ingest (parse error, transient network issue) stays `pending` and is retried on the next sync. After `iris.maxInboxAttempts` (default 5, new config key) failed attempts, it's marked `dead` — visible in the table, but no longer blocking the rest of the queue (so one permanently broken message can't stall a connection forever).
- A quota-exhausted message is left untouched (`attempts` stays 0) rather than counted as a failed attempt, since nothing about the message itself failed.
- `IrisAnalysisRepository.exists_by_source()` is new: before retrying a queued message, the drain loop checks whether an `IrisAnalysis` for that `(connection_id, source_message_uid)` already exists. This covers the case where the process crashes *between* the analysis commit and the queue-entry cleanup — without this check, a retry would hit the existing idempotency `UniqueConstraint` and be misread as a real failure (eventually dead-lettering a message that had, in fact, already been accepted).

New migration `08ef8f772404_add_iris_mailbox_inbox.py` creates the table, with `ondelete="CASCADE"` on the FK to `IrisMailboxConnection` (mirrored at the ORM level with `cascade="all, delete-orphan"` on `IrisMailboxConnection.inbox_entries`, same pattern as `IrisDocument`, so the cascade also holds under SQLite in tests, not just Postgres).

## Implementation

- `API/src/modules/features/iris/model.py` — `IrisMailboxInbox` model + `IrisMailboxConnection.inbox_entries` relationship.
- `API/src/modules/features/iris/repositories.py` — `IrisMailboxInboxRepository` (`get_pending`, `has_pending`, `get_existing_provider_ids`) and `IrisAnalysisRepository.exists_by_source()`.
- `API/src/modules/features/iris/managers/mailbox.py` — `_sync_connection` now enqueues before ingesting and only confirms the cursor when the queue is empty; new `_enqueue_pending`, `_drain_pending`, `_resolve_inbox_entry`, `_retry_or_deadletter` helpers; `_finish_sync` gained an `advance_cursor` flag.
- `API/src/modules/system/config_reading.py` + `API/SecOpsConfig.json` — new `iris.maxInboxAttempts` config field (default 5).
- `API/alembic/versions/08ef8f772404_add_iris_mailbox_inbox.py` — new migration (hand-written to match the model exactly; autogenerate wasn't available without a live Postgres instance in this environment — worth double-checking with `alembic upgrade head` against a real dev DB before merging further up the chain).

## Validation

- `pytest tests/ -k iris` — 481 passed, 2 skipped (pre-existing, unrelated).
- New/extended integration tests cover the issue's own closure criterion directly: quota exhaustion defers the unprocessed message and the cursor (`test_sync_connection_defers_cursor_and_pending_message_when_quota_is_hit`), a transient failure is retried on the next sync without ever duplicating the message that already succeeded (`test_sync_connection_retries_transient_failure_without_duplicating_prior_success`), a permanently failing message is dead-lettered after `maxInboxAttempts` without blocking the cursor forever (`test_sync_connection_moves_permanently_failing_message_to_dead_after_max_attempts`), and the crash-between-commit-and-cleanup race is covered explicitly (`test_sync_connection_resolves_inbox_entry_for_already_ingested_message`).
- New model tests in `test_iris_mailbox_model.py` cover the unique constraint and the cascade delete.
- `pytest tests/unit/test_config_shape.py` — 185 passed (covers the new `maxInboxAttempts` config key).
- `pylint` on the touched files — diffed against a pre-change baseline; the only new findings are two pre-existing lint *categories* applying to new code that already follows the same pattern as its siblings (`too-few-public-methods` on the new plain ORM model class, same as every other model in the file; `too-many-lines` growing by the size of the diff) — no new line-too-long or other issues.

## Notes

- Out of scope for this PR (left for later issues in the same Fase 1 sequence, per the approved plan on the umbrella issue): `B02` (per-connection sync lock) and `B09` (atomic/idempotent quota consumption) touch the same file and are explicitly called out in the roadmap doc as sharing this surface, but are separate issues/PRs.
- The migration was written by hand rather than via `alembic revision --autogenerate`, since no local Postgres instance was available in this session (Docker Desktop wasn't running). It matches the model 1:1, but it'd be good to sanity-check with `alembic upgrade head` against a real dev DB before this reaches `v0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)