### PR TITLE
fix(iris): add self-healing distributed lock for concurrent mailbox syncs

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -284,6 +284,7 @@
       "maxConnectionsPerUser": 5,
       "maxIngestedPerDay": 200,
       "maxInboxAttempts": 5,
+      "mailboxSyncLockTtlSeconds": 900,
       "pollIntervalMinutes": 5,
       "prompts": {
         "summary": {

--- a/API/alembic/versions/55b8d888d404_add_iris_mailbox_sync_started_fields.py
+++ b/API/alembic/versions/55b8d888d404_add_iris_mailbox_sync_started_fields.py
@@ -1,0 +1,36 @@
+"""iris: IrisMailboxConnection.sync_started_at/sync_job_id (B02 -- lock de sync)
+
+``IrisMailboxManager`` no exponía si una conexión tenía un sync en curso en
+ese momento -- la UI no tenía forma de distinguir "acaba de terminar" de
+"está sincronizando ahora mismo" sin adivinarlo. Estas dos columnas se
+rellenan al adquirir el lock distribuido de sync (``services/mailbox/locks.py``)
+y se limpian al terminar, éxito o error.
+
+Revision ID: 55b8d888d404
+Revises: 08ef8f772404
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '55b8d888d404'
+down_revision: Union[str, Sequence[str], None] = '08ef8f772404'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisMailboxConnection', sa.Column('sync_started_at', sa.DateTime(), nullable=True))
+    op.add_column('IrisMailboxConnection', sa.Column('sync_job_id', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisMailboxConnection', 'sync_job_id')
+    op.drop_column('IrisMailboxConnection', 'sync_started_at')

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -552,6 +552,7 @@ def _serialize_connection(connection) -> dict:
         "status": connection.status,
         "lastSyncAt": connection.last_sync_at,
         "lastError": connection.last_error,
+        "syncStartedAt": connection.sync_started_at,
         "createdAt": connection.created_at,
     }
 

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -43,6 +43,7 @@ from ..repositories import (
     IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
 )
 from ..services.mailbox import MAILBOX_CONNECTORS, MailboxConnector, MessageRef, get_connector
+from ..services.mailbox.locks import MailboxSyncLock
 from ..services.parsers import build_subject_title
 
 logger = logging.getLogger(__name__)
@@ -315,48 +316,87 @@ class IrisMailboxManager(TaskTrackingMixin):
     @staticmethod
     def execute_sync_connection(connection_id: int) -> None:
         """Entry point submitted to the TaskQueue for a background sync."""
-        with job_context():
-            IrisMailboxManager()._sync_connection(connection_id)
+        with job_context() as job:
+            IrisMailboxManager()._sync_connection(connection_id, job_id=job.id)
 
-    def _sync_connection(self, connection_id: int) -> None:
+    def _sync_connection(self, connection_id: int, job_id: Optional[str] = None) -> None:
         connection = build_repository(IrisMailboxConnectionRepository).get_by_id(connection_id)
         if connection is None or connection.status != "active":
             return
 
+        # B02: serializa los syncs de una misma conexión. El job_id
+        # determinista de TaskQueue ya evita reencolar mientras el anterior
+        # sigue "started", pero ese estado no se autorrecupera si el worker
+        # muere a mitad de sync -- este lock sí, por TTL.
+        lock = MailboxSyncLock(connection_id, CR.iris_config().mailbox_sync_lock_ttl_seconds)
+        if not lock.acquire():
+            logger.info(f"Sync de la conexión {connection_id} ya en curso; se omite este sondeo.")
+            return
+
         try:
-            access_token, connector = self._ensure_access_token(connection)
-        except _ReauthRequiredError as e:
-            self._mark_reauth_required(connection_id, str(e))
-            return
-        except Exception as e:
-            logger.error(f"Fallo refrescando token de la conexión {connection_id}: {e}", exc_info=True)
-            self._record_sync_error(connection_id, str(e))
-            return
+            self._mark_sync_started(connection_id, job_id)
 
-        try:
-            refs, new_cursor = connector.list_new(access_token, connection.sync_cursor)
-        except Exception as e:
-            logger.error(f"Fallo listando mensajes nuevos de la conexión {connection_id}: {e}", exc_info=True)
-            self._record_sync_error(connection_id, str(e))
-            return
+            try:
+                access_token, connector = self._ensure_access_token(connection)
+            except _ReauthRequiredError as e:
+                self._mark_reauth_required(connection_id, str(e))
+                return
+            except Exception as e:
+                logger.error(
+                    f"Fallo refrescando token de la conexión {connection_id}: {e}", exc_info=True,
+                )
+                self._record_sync_error(connection_id, str(e))
+                return
 
-        # B01: el mensaje entra en la cola de checkpoint antes de intentar
-        # ingerirlo -- así una cuota agotada o un fallo a mitad de lote no lo
-        # pierden, sino que lo dejan pendiente para el próximo sondeo.
-        self._enqueue_pending(connection_id, refs)
+            try:
+                refs, new_cursor = connector.list_new(access_token, connection.sync_cursor)
+            except Exception as e:
+                logger.error(
+                    f"Fallo listando mensajes nuevos de la conexión {connection_id}: {e}", exc_info=True,
+                )
+                self._record_sync_error(connection_id, str(e))
+                return
 
-        max_per_day = CR.iris_config().max_ingested_per_day
-        ingested_today, reset_date = self._current_daily_counter(connection)
-        ingested_today = self._drain_pending(
-            connection, connector, access_token, ingested_today, max_per_day,
-        )
+            # B01: el mensaje entra en la cola de checkpoint antes de intentar
+            # ingerirlo -- así una cuota agotada o un fallo a mitad de lote no
+            # lo pierden, sino que lo dejan pendiente para el próximo sondeo.
+            self._enqueue_pending(connection_id, refs)
 
-        # El cursor del proveedor solo se confirma cuando la cola queda
-        # vacía: confirmarlo con referencias pendientes las perdería para
-        # siempre, porque ni Gmail ni Graph vuelven a listar un mensaje una
-        # vez el cursor avanza más allá de él.
-        advance_cursor = not build_repository(IrisMailboxInboxRepository).has_pending(connection_id)
-        self._finish_sync(connection_id, new_cursor, ingested_today, reset_date, advance_cursor)
+            max_per_day = CR.iris_config().max_ingested_per_day
+            ingested_today, reset_date = self._current_daily_counter(connection)
+            ingested_today = self._drain_pending(
+                connection, connector, access_token, ingested_today, max_per_day, lock,
+            )
+
+            # El cursor del proveedor solo se confirma cuando la cola queda
+            # vacía: confirmarlo con referencias pendientes las perdería para
+            # siempre, porque ni Gmail ni Graph vuelven a listar un mensaje
+            # una vez el cursor avanza más allá de él.
+            advance_cursor = not build_repository(IrisMailboxInboxRepository).has_pending(connection_id)
+            self._finish_sync(connection_id, new_cursor, ingested_today, reset_date, advance_cursor)
+        finally:
+            self._clear_sync_started(connection_id)
+            lock.release()
+
+    @staticmethod
+    def _mark_sync_started(connection_id: int, job_id: Optional[str]) -> None:
+        with UnitOfWork() as uow:
+            repo = IrisMailboxConnectionRepository(uow)
+            fresh = repo.get_by_id(connection_id)
+            if fresh is not None:
+                fresh.sync_started_at = utcnow_naive()
+                fresh.sync_job_id = job_id
+                repo.update(fresh)
+
+    @staticmethod
+    def _clear_sync_started(connection_id: int) -> None:
+        with UnitOfWork() as uow:
+            repo = IrisMailboxConnectionRepository(uow)
+            fresh = repo.get_by_id(connection_id)
+            if fresh is not None:
+                fresh.sync_started_at = None
+                fresh.sync_job_id = None
+                repo.update(fresh)
 
     @staticmethod
     def _enqueue_pending(connection_id: int, refs: list[MessageRef]) -> None:
@@ -378,9 +418,9 @@ class IrisMailboxManager(TaskTrackingMixin):
                     raw_ref=ref.raw or None,
                 ))
 
-    def _drain_pending(
+    def _drain_pending(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self, connection: IrisMailboxConnection, connector: MailboxConnector,
-        access_token: str, ingested_today: int, max_per_day: int,
+        access_token: str, ingested_today: int, max_per_day: int, lock: MailboxSyncLock,
     ) -> int:
         """Procesa la cola de checkpoint (mensajes recién encolados y los que
         quedaron pendientes de sondeos anteriores) hasta agotar la cuota
@@ -390,6 +430,11 @@ class IrisMailboxManager(TaskTrackingMixin):
         analysis_repo = build_repository(IrisAnalysisRepository)
 
         for entry in inbox_repo.get_pending(connection_id):
+            # B02: un lote grande puede tardar más que el TTL inicial del
+            # lock -- renovarlo en cada mensaje evita que otro sync lo dé
+            # por huérfano mientras éste sigue trabajando de verdad.
+            lock.renew()
+
             if ingested_today >= max_per_day:
                 logger.warning(
                     f"Conexión {connection_id} alcanzó la cuota diaria ({max_per_day}); "

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -176,6 +176,13 @@ class IrisMailboxConnection(Base):
                  (successful or not — used to schedule the next poll).
         last_error: Human-readable last error, if any (e.g. why the
                  connection is ``reauth_required``).
+        sync_started_at: Cuándo empezó el sync actualmente en curso; NULL
+                 cuando no hay ninguno. Se limpia al terminar (éxito o
+                 error) -- no confundir con ``last_sync_at``, que registra el
+                 último intento *terminado*. Existe para que la UI sepa que
+                 hay un sync en marcha sin tener que adivinarlo (B02).
+        sync_job_id: Id del job de TaskQueue que sostiene el lock de sync
+                 actual; NULL cuando no hay ninguno en curso (B02).
         created_at: When the connection was established.
         user: SQLAlchemy relationship to User.
         analyses: Analyses ingested through this connection.
@@ -203,6 +210,8 @@ class IrisMailboxConnection(Base):
     ingested_reset_date = Column(Date, nullable=True)
     last_sync_at = Column(DateTime, nullable=True)
     last_error = Column(Text, nullable=True)
+    sync_started_at = Column(DateTime, nullable=True)
+    sync_job_id = Column(String(64), nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow_naive)
 
     user = relationship("User")

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -419,6 +419,7 @@ class IrisMailboxConnectionItemSchema(Schema):
     status = fields.String()
     lastSyncAt = UTCDateTime(allow_none=True)
     lastError = fields.String(allow_none=True)
+    syncStartedAt = UTCDateTime(allow_none=True)
     createdAt = UTCDateTime(allow_none=True)
 
 

--- a/API/src/modules/features/iris/services/mailbox/locks.py
+++ b/API/src/modules/features/iris/services/mailbox/locks.py
@@ -1,0 +1,94 @@
+"""
+Lock distribuido por conexión para el sync de buzón de Iris (B02).
+
+``IrisMailboxManager.submit_sync()`` ya evita reencolar un job mientras el
+anterior sigue "started" (mismo ``job_id`` determinista, ver
+``TaskQueue.submit``), pero esa protección depende de que RQ mantenga el
+estado del job al día -- un worker que muere a mitad de sync deja la fila
+"started" en Redis para siempre, sin nada que la libere. Este lock es la
+capa que sí se autorrecupera: un ``SET NX EX`` con TTL propio, renovado
+mientras el sync avanza (ver ``IrisMailboxManager._drain_pending``) y
+liberado explícitamente al terminar -- si nadie lo libera, expira solo.
+
+Cada adquisición lleva un token propio para que liberar/renovar solo actúe
+sobre el lock que el titular actual sostiene: si el TTL ya expiró y otro
+sync lo adquirió mientras tanto, un ``finally`` tardío del titular anterior
+no debe poder borrar el lock del nuevo titular.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+from src.modules.system.taskqueue.connection import RedisConnectionFactory
+
+logger = logging.getLogger(__name__)
+
+_LOCK_KEY_PREFIX = "iris:mailbox-sync:"
+
+# Solo borra/renueva si el token todavía coincide con el titular actual --
+# sin esto, un release() o renew() tardío (el proceso se quedó colgado más
+# allá del TTL) podría pisar el lock de quien lo adquirió después.
+_RELEASE_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+_RENEW_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("expire", KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+
+class MailboxSyncLock:
+    """Un único sync activo por conexión, con TTL autorrecuperable.
+
+    Typical usage::
+
+        lock = MailboxSyncLock(connection_id, ttl_seconds=900)
+        if not lock.acquire():
+            return  # ya hay un sync en curso -- no-op idempotente
+        try:
+            ...  # trabajo del sync; lock.renew() en cada mensaje procesado
+        finally:
+            lock.release()
+    """
+
+    def __init__(self, connection_id: int, ttl_seconds: int) -> None:
+        self._key = f"{_LOCK_KEY_PREFIX}{connection_id}"
+        self._ttl_seconds = ttl_seconds
+        self._token = secrets.token_hex(16)
+        self._redis = RedisConnectionFactory.decoded()
+
+    def acquire(self) -> bool:
+        """Intenta adquirir el lock. True si tuvo éxito."""
+        return bool(self._redis.set(self._key, self._token, nx=True, ex=self._ttl_seconds))
+
+    def renew(self) -> None:
+        """Extiende el TTL mientras el titular sigue trabajando.
+
+        No-op silencioso si el lock ya expiró (Redis caído, TTL agotado) --
+        el sync en curso simplemente deja de estar protegido a partir de ahí,
+        que es preferible a tumbar un sync que ya iba bien encaminado.
+        """
+        try:
+            self._redis.eval(_RENEW_SCRIPT, 1, self._key, self._token, self._ttl_seconds)
+        except Exception:
+            logger.warning("No se pudo renovar el lock de sync %s", self._key, exc_info=True)
+
+    def release(self) -> None:
+        """Libera el lock si todavía es el titular. No-op si ya expiró."""
+        try:
+            self._redis.eval(_RELEASE_SCRIPT, 1, self._key, self._token)
+        except Exception:
+            logger.warning(
+                "No se pudo liberar el lock de sync %s; expirará solo por TTL.",
+                self._key, exc_info=True,
+            )

--- a/API/src/modules/features/iris/services/mailbox/scheduling.py
+++ b/API/src/modules/features/iris/services/mailbox/scheduling.py
@@ -69,7 +69,16 @@ class IrisMailboxScheduler:
         interval = CR.iris_config().poll_interval_minutes
         due = build_repository(IrisMailboxConnectionRepository).get_due_for_sync(interval)
         manager = IrisMailboxManager()
+        queued = 0
         for connection in due:
-            manager.submit_sync(connection.id)
-        if due:
-            logger.info("Sondeo de buzones de Iris: %d conexión(es) encolada(s)", len(due))
+            try:
+                manager.submit_sync(connection.id)
+                queued += 1
+            except Exception as e:
+                # B02: una conexión que no se puede encolar (p.ej. ya hay un
+                # job "started" con el mismo job_id determinista) no debe
+                # tumbar el resto del sondeo -- cada conexión es
+                # independiente de sus vecinas en la lista de vencidas.
+                logger.warning(f"No se pudo encolar el sync de la conexión {connection.id}: {e}")
+        if queued:
+            logger.info("Sondeo de buzones de Iris: %d conexión(es) encolada(s)", queued)

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1814,6 +1814,16 @@ class IrisConfig:  # pylint: disable=too-many-instance-attributes
     checkpoint no confirma el cursor mientras queden referencias pendientes.
     """
 
+    mailbox_sync_lock_ttl_seconds: int = 900
+    """TTL del lock Redis por conexión que serializa los sync (B02).
+
+    Un lock huérfano (worker muerto a mitad de sync, sin liberar) debe
+    autorrecuperarse por TTL en vez de bloquear la conexión para siempre —
+    ``_drain_pending`` renueva el TTL en cada mensaje procesado, así que este
+    valor solo acota cuánto puede tardar un mensaje suelto sin actividad, no
+    el sync entero.
+    """
+
     prompts: dict = field(default_factory=dict)
     """Prompts de ``IrisAIWriter`` (IA1): ``summary.{system,userTemplate}``."""
 

--- a/API/tests/integration/test_iris_mailbox_manager.py
+++ b/API/tests/integration/test_iris_mailbox_manager.py
@@ -13,6 +13,7 @@ from itsdangerous import BadSignature
 
 import src.modules.system.config_reading as CR
 import src.modules.features.iris.managers.mailbox as mailbox_managers_mod
+import src.modules.features.iris.services.mailbox.locks as mailbox_locks_mod
 from src.modules.features.iris.exceptions import (
     IrisMailboxConnectionNotFoundError,
     IrisMailboxInvalidProviderError,
@@ -66,6 +67,50 @@ def _fake_state_redis():
     así que se dobla aquí -- misma idea que _FakeTaskQueue de abajo."""
     with mock.patch.object(mailbox_managers_mod, "RedisConnectionFactory", _FakeStateRedisFactory()):
         yield
+
+
+class _FakeLockRedis:
+    """Doble en memoria de RedisConnectionFactory.decoded() para
+    MailboxSyncLock (B02): SET NX EX más los dos scripts Lua de
+    renovación/liberación condicionados al token del titular."""
+
+    def __init__(self):
+        self._values: dict[str, str] = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self._values:
+            return None
+        self._values[key] = value
+        return True
+
+    def eval(self, script, numkeys, key, token, *rest):
+        if self._values.get(key) != token:
+            return 0
+        if "del(" in script or "\"del\"" in script:
+            self._values.pop(key, None)
+        return 1
+
+    def expire_orphan(self, key):
+        """Ayuda de test: simula que Redis expiró el lock por su cuenta."""
+        self._values.pop(key, None)
+
+
+class _FakeLockRedisFactory:
+    def __init__(self):
+        self.redis = _FakeLockRedis()
+
+    def decoded(self):
+        return self.redis
+
+
+@pytest.fixture(autouse=True)
+def _fake_lock_redis():
+    """``MailboxSyncLock`` (B02) importa su propio ``RedisConnectionFactory``
+    en el namespace de ``locks.py`` -- se dobla aquí para todos los tests de
+    este fichero, ya que ``_sync_connection`` adquiere el lock siempre."""
+    factory = _FakeLockRedisFactory()
+    with mock.patch.object(mailbox_locks_mod, "RedisConnectionFactory", factory):
+        yield factory
 
 
 class _FakeTaskQueue:
@@ -608,3 +653,96 @@ def test_trigger_sync_submits_task_with_correct_category(app, regular_user):
     assert len(fake_queue.submitted) == 1
     assert fake_queue.submitted[0]["category"] == "iris.ingest"
     assert fake_queue.submitted[0]["args"] == (connection_id,)
+
+
+# --------------------------------------------------------- B02: lock de sync
+
+def test_sync_connection_is_a_no_op_when_lock_already_held(app, regular_user, _fake_lock_redis):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        # Simula que otro worker ya sostiene el lock de esta conexión.
+        _fake_lock_redis.redis.set(f"iris:mailbox-sync:{connection_id}", "other-token", nx=True, ex=900)
+
+        with mock.patch.object(mailbox_managers_mod, "get_connector") as get_connector:
+            IrisMailboxManager()._sync_connection(connection_id)
+        get_connector.assert_not_called()
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-0"
+            assert conn.sync_started_at is None
+
+
+def test_sync_connection_recovers_from_an_orphaned_lock(app, regular_user, _fake_lock_redis):
+    """Un lock huérfano (worker muerto a mitad de sync, sin liberar) se
+    autorrecupera por TTL en vez de bloquear la conexión para siempre."""
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        key = f"iris:mailbox-sync:{connection_id}"
+        _fake_lock_redis.redis.set(key, "stale-token", nx=True, ex=900)
+        _fake_lock_redis.redis.expire_orphan(key)  # Redis ya lo habría expirado solo
+
+        fake_queue = _FakeTaskQueue()
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=_FakeConnector()), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_cursor == "cursor-2"
+
+
+def test_sync_connection_releases_lock_even_when_token_refresh_fails(app, regular_user, _fake_lock_redis):
+    with app.app_context():
+        connection_id = _save(app, _connection(
+            regular_user.id, access_token_enc=None, access_token_expires_at=None,
+        ))
+        fake_connector = _FakeConnector(refresh_raises_reauth=True)
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            IrisMailboxManager()._sync_connection(connection_id)
+
+        key = f"iris:mailbox-sync:{connection_id}"
+        assert key not in _fake_lock_redis.redis._values
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_started_at is None
+
+
+def test_sync_connection_marks_sync_started_during_and_clears_after(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id, sync_cursor="cursor-0"))
+        captured = {}
+
+        class _CapturingConnector(_FakeConnector):
+            def fetch_headers(self, access_token, message_ref):
+                with UnitOfWork() as uow:
+                    conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+                    captured["sync_started_at"] = conn.sync_started_at
+                    captured["sync_job_id"] = conn.sync_job_id
+                return super().fetch_headers(access_token, message_ref)
+
+        fake_queue = _FakeTaskQueue()
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=_CapturingConnector()), \
+             mock.patch.object(analysis_managers_mod.TaskQueue, "get_instance", return_value=fake_queue):
+            IrisMailboxManager()._sync_connection(connection_id, job_id="job-123")
+
+        assert captured["sync_started_at"] is not None
+        assert captured["sync_job_id"] == "job-123"
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.sync_started_at is None
+            assert conn.sync_job_id is None
+
+
+def test_execute_sync_connection_passes_the_current_job_id(app, regular_user):
+    """``execute_sync_connection`` es el entry point real de TaskQueue --
+    fuera de un worker RQ, ``job_context()`` no-opea y ``job.id`` es None."""
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id))
+        with mock.patch.object(
+            mailbox_managers_mod.IrisMailboxManager, "_sync_connection",
+        ) as sync_connection:
+            IrisMailboxManager.execute_sync_connection(connection_id)
+        sync_connection.assert_called_once_with(connection_id, job_id=None)

--- a/API/tests/integration/test_iris_mailbox_scheduling.py
+++ b/API/tests/integration/test_iris_mailbox_scheduling.py
@@ -1,0 +1,52 @@
+"""Tests de integración de IrisMailboxScheduler -- sondeo periódico de
+conexiones de buzón."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.features.iris.managers.mailbox import IrisMailboxManager
+from src.modules.features.iris.model import IrisMailboxConnection
+from src.modules.features.iris.repositories import IrisMailboxConnectionRepository
+from src.modules.features.iris.services.mailbox.scheduling import IrisMailboxScheduler
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared import encrypt_at_rest
+
+pytestmark = pytest.mark.integration
+
+
+def _connection(user_id: int, account_email: str) -> IrisMailboxConnection:
+    return IrisMailboxConnection(
+        user_id=user_id, provider="gmail", account_email=account_email,
+        scopes="gmail.metadata",
+        refresh_token_enc=encrypt_at_rest("token", purpose="iris_mailbox"),
+        status="active",
+    )
+
+
+def test_poll_connections_continues_after_one_connection_fails_to_enqueue(app, regular_user, admin_user):
+    """B02: ``submit_sync()`` puede levantar (p.ej. ya hay un job "started"
+    con el mismo job_id determinista para esa conexión) -- eso no debe
+    impedir que el resto de conexiones vencidas se encolen en el mismo
+    sondeo. Antes de este fix, una excepción a mitad del bucle abortaba el
+    resto silenciosamente (solo quedaba en el log del ``scheduler_job``
+    exterior)."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = IrisMailboxConnectionRepository(uow)
+            repo.save(_connection(regular_user.id, "a@gmail.com"))
+            repo.save(_connection(admin_user.id, "b@gmail.com"))
+
+        calls = []
+
+        def _fake_submit_sync(self, connection_id):
+            calls.append(connection_id)
+            if len(calls) == 1:
+                raise RuntimeError("ya hay una tarea en ejecución")
+
+        with mock.patch.object(IrisMailboxManager, "submit_sync", _fake_submit_sync):
+            IrisMailboxScheduler._poll_connections()
+
+        assert len(calls) == 2


### PR DESCRIPTION
## Summary

Closes #218 ([B02] Lock distribuido por conexión y deduplicación de sync), part 2 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

`IrisMailboxManager` only relied on `TaskQueue`'s deterministic job naming (`IrisMailboxSync-<connection_id>`) to keep two syncs of the same connection from running at once — `TaskQueue.submit()` already refuses to re-enqueue a job while a job with the same id is `"started"` (raises `IllegalStateError`, 409). That's a real protection, but it depends entirely on RQ's own bookkeeping staying accurate: if a worker process dies partway through a sync (OOM, restart, deploy), nothing ever marks that job finished. The job stays `"started"` in Redis forever, and every future sync attempt for that connection — scheduled or manual — gets rejected indefinitely, with no way to recover short of someone manually clearing Redis state.

## What changed

- **`MailboxSyncLock`** (`API/src/modules/features/iris/services/mailbox/locks.py`, new): a Redis `SET NX EX` lock per connection (`iris:mailbox-sync:<connection_id>`), acquired at the start of `_sync_connection`. Each acquisition carries its own random token; `release()`/`renew()` only act on the key if the token still matches (a Lua script does the compare-and-act atomically), so a call that runs late — past the TTL, after someone else has acquired the lock — can't step on the new holder. Unlike the job-status check, **this self-heals**: if nothing releases it, it simply expires.
- `_sync_connection` calls `lock.renew()` once per message processed in `_drain_pending`, so a large batch doesn't outlive the lock's base TTL (`iris.mailboxSyncLockTtlSeconds`, default 900s) while still failing over quickly if a worker actually dies.
- If the lock is already held, `_sync_connection` is a no-op — it returns immediately without touching the connector, cursor, or quota. This is the actual concurrency-safety mechanism (the job_id check remains as a secondary guard at the enqueue layer).
- `IrisMailboxConnection` gained `sync_started_at`/`sync_job_id`, set while a sync is in flight and cleared in a `finally` block regardless of outcome — so the UI/admin tooling can tell "syncing right now" from "just idle" without guessing. Wired into `GET /iris/mailbox/connections` and the `PATCH` response (`syncStartedAt` field, `_serialize_connection`).
- **Found while implementing this**: `IrisMailboxScheduler._poll_connections()` queued each due connection's sync in a plain `for` loop with no per-iteration error handling. If `submit_sync()` raised for one connection (exactly the `IllegalStateError` case above), every connection *after* it in that poll cycle silently never got its sync submitted — the exception propagated up to the outer `@scheduler_job` wrapper, which just logs and swallows it once for the whole cycle. Fixed by wrapping each `submit_sync()` call individually so one connection's failure doesn't starve the rest.

## Implementation

- `API/src/modules/features/iris/services/mailbox/locks.py` — new `MailboxSyncLock`.
- `API/src/modules/features/iris/managers/mailbox.py` — `_sync_connection` acquires/releases the lock (`try`/`finally`), threads the RQ job id through from `execute_sync_connection`; `_drain_pending` renews the lock per message; new `_mark_sync_started`/`_clear_sync_started` helpers.
- `API/src/modules/features/iris/services/mailbox/scheduling.py` — `_poll_connections()` now catches per-connection.
- `API/src/modules/features/iris/model.py` — `IrisMailboxConnection.sync_started_at`/`sync_job_id`.
- `API/src/modules/features/iris/schemas.py` + `endpoints.py` — `syncStartedAt` exposed via `_serialize_connection`.
- `API/src/modules/system/config_reading.py` + `API/SecOpsConfig.json` — new `iris.mailboxSyncLockTtlSeconds` (default 900).
- `API/alembic/versions/55b8d888d404_add_iris_mailbox_sync_started_fields.py` — new migration (hand-written, same caveat as the previous PR: no local Postgres available in this environment to run `--autogenerate` against).

## Validation

- `pytest tests/ -k iris` — 488 passed, 2 skipped (pre-existing, unrelated).
- New tests cover the lock directly: a held lock makes the sync a no-op (`test_sync_connection_is_a_no_op_when_lock_already_held`), an orphaned lock (simulated TTL expiry) lets the next sync through (`test_sync_connection_recovers_from_an_orphaned_lock`), the lock releases even on an early-return error path (`test_sync_connection_releases_lock_even_when_token_refresh_fails`), `sync_started_at`/`sync_job_id` are actually set mid-sync and cleared after (`test_sync_connection_marks_sync_started_during_and_clears_after`, observed via a connector callback), and the RQ job id is threaded through correctly (`test_execute_sync_connection_passes_the_current_job_id`).
- New `tests/integration/test_iris_mailbox_scheduling.py` covers the scheduler-loop fix directly: one connection's `submit_sync()` failure doesn't stop the next connection's from being attempted.
- `pytest tests/unit/test_config_shape.py` — 186 passed (covers `mailboxSyncLockTtlSeconds`).
- `pylint` on all touched files, diffed against a pre-change baseline — no new warning categories; the few new instances (line-length, lazy-%-logging) match the same categories the surrounding code in these files already carries.

## Notes

- Same caveat as the previous PR in this sequence: the migration wasn't generated via `alembic revision --autogenerate` since Docker Desktop wasn't running in this session — worth a sanity check with `alembic upgrade head` against a real dev DB before this reaches `v0.5`.
- Left the existing `IllegalStateError`/409 behavior on a manual `trigger_sync()` double-call as-is (it's an existing, reasonable "already in progress" signal to the caller); the new lock is the layer that matters for the actual data-race concern this issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)