### PR TITLE
fix(iris): validate mailbox folder against the provider before saving

### DIFF
--- a/API/alembic/versions/b615bd3abb26_add_iris_mailbox_folder_metadata.py
+++ b/API/alembic/versions/b615bd3abb26_add_iris_mailbox_folder_metadata.py
@@ -1,0 +1,37 @@
+"""iris: IrisMailboxConnection.folder_display_name/folder_type (B16 -- folder validado por proveedor)
+
+``folder`` seguía siendo texto libre sin validar contra el proveedor: un
+valor inválido, demasiado largo o incompatible solo se descubría en el
+siguiente sync. Estas dos columnas acompañan a ``folder`` (que ya existía y
+pasa a documentarse como el id opaco de la carpeta) con el nombre legible y
+el tipo ("system"/"user") que ``MailboxConnector.list_folders()`` devuelve,
+capturados en el momento en que ``folder`` se valida y se guarda.
+
+Revision ID: b615bd3abb26
+Revises: 55b8d888d404
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b615bd3abb26'
+down_revision: Union[str, Sequence[str], None] = '55b8d888d404'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisMailboxConnection', sa.Column('folder_display_name', sa.String(length=255), nullable=True))
+    op.add_column('IrisMailboxConnection', sa.Column('folder_type', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisMailboxConnection', 'folder_type')
+    op.drop_column('IrisMailboxConnection', 'folder_display_name')

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -69,6 +69,7 @@ from .schemas import (
     IrisMailboxConnectionDeleteResponseSchema,
     IrisMailboxSyncResponseSchema,
     IrisMailboxCallbackQuerySchema,
+    IrisMailboxFoldersResponseSchema,
 )
 
 
@@ -548,6 +549,8 @@ def _serialize_connection(connection) -> dict:
         "provider": connection.provider,
         "accountEmail": connection.account_email,
         "folder": connection.folder,
+        "folderDisplayName": connection.folder_display_name,
+        "folderType": connection.folder_type,
         "fullMessageMode": connection.full_message_mode,
         "status": connection.status,
         "lastSyncAt": connection.last_sync_at,
@@ -645,7 +648,8 @@ def list_mailbox_connections():
 @iris_blp.patch("/mailbox/connections/<int:connection_id>")
 @iris_blp.arguments(IrisMailboxUpdateConnectionRequestSchema)
 @iris_blp.response(200, IrisMailboxConnectionItemSchema, description="Connection updated")
-@iris_blp.alt_response(400, schema=ErrorSchema, description="Invalid status")
+@iris_blp.alt_response(400, schema=ErrorSchema,
+                        description="Invalid status, or folder not found for this account/provider")
 @iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
 @iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
 @iris_blp.alt_response(404, schema=ErrorSchema, description="Connection not found")
@@ -661,6 +665,36 @@ def update_mailbox_connection(data, connection_id: int):
     )
     logger.info(f"Conexión {connection_id} actualizada por usuario {user.username}")
     return _serialize_connection(connection)
+
+
+@iris_blp.get("/mailbox/connections/<int:connection_id>/folders")
+@iris_blp.response(200, IrisMailboxFoldersResponseSchema,
+                    description="Real folders/labels for this account")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Connection not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("30 per hour; 100 per day")
+@handle_exceptions(default_exception=IrisMailboxConnectionNotFoundError, logger=logger)
+def list_mailbox_connection_folders(connection_id: int):
+    """Carpetas/etiquetas reales de la cuenta conectada -- únicos valores
+    válidos para ``folder`` en ``PATCH /mailbox/connections/<id>``.
+
+    Hace una llamada en vivo al proveedor (no se cachea): la lista puede
+    cambiar en cualquier momento desde fuera de Iris.
+    """
+    user = get_current_user()
+    folders = IrisMailboxManager().list_folders(connection_id, user.id)
+    return {
+        "folders": [
+            {
+                "providerId": f.provider_id, "displayName": f.display_name,
+                "folderType": f.folder_type,
+            }
+            for f in folders
+        ]
+    }
 
 
 @iris_blp.delete("/mailbox/connections/<int:connection_id>")

--- a/API/src/modules/features/iris/exceptions.py
+++ b/API/src/modules/features/iris/exceptions.py
@@ -89,3 +89,17 @@ class IrisMailboxOAuthStateError(IrisError):
     tampered, or never issued by start_connect (CSRF protection)."""
     default_code = ErrorCode.AUTHENTICATION_ERROR
     default_status_code = 400
+
+
+class IrisMailboxInvalidFolderError(IrisError):
+    """Raised when ``folder`` doesn't match any real folder/label the
+    provider returns for this account (B16) — wrong id, typo, or a value
+    that belongs to another provider."""
+    default_code = ErrorCode.VALIDATION_ERROR
+    default_status_code = 400
+
+    def __init__(self, folder: str) -> None:
+        super().__init__(
+            f"'{folder}' no es una carpeta válida para esta cuenta.",
+            user_message=f"'{folder}' no es una carpeta válida para esta cuenta.",
+        )

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -33,6 +33,7 @@ from src.modules.system.taskqueue.connection import RedisConnectionFactory
 
 from ..exceptions import (
     IrisMailboxConnectionNotFoundError,
+    IrisMailboxInvalidFolderError,
     IrisMailboxInvalidProviderError,
     IrisMailboxOAuthStateError,
     IrisMailboxQuotaExceededError,
@@ -42,7 +43,9 @@ from ..model import IrisMailboxConnection, IrisMailboxInbox
 from ..repositories import (
     IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
 )
-from ..services.mailbox import MAILBOX_CONNECTORS, MailboxConnector, MessageRef, get_connector
+from ..services.mailbox import (
+    MAILBOX_CONNECTORS, MailboxConnector, MailboxFolder, MessageRef, get_connector,
+)
 from ..services.mailbox.locks import MailboxSyncLock
 from ..services.parsers import build_subject_title
 
@@ -189,7 +192,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         connector = get_connector(provider, self._redirect_uri(), folder=folder)
         return connector.authorize_url(state, full_message_mode)
 
-    def handle_callback(self, state: str, code: str) -> int:
+    def handle_callback(self, state: str, code: str) -> int:  # pylint: disable=too-many-locals
         """Canjea el code OAuth y crea (o reactiva) la conexión.
 
         Reconectar una cuenta ya conocida (mismo user/provider/email)
@@ -210,6 +213,14 @@ class IrisMailboxManager(TaskTrackingMixin):
         connector = get_connector(provider, self._redirect_uri(), folder=folder)
         token_set = connector.exchange_code(code)
 
+        # B16: recién canjeado el code tenemos un access_token fresco -- es
+        # el único momento del flujo de conexión en que se puede comprobar
+        # la carpeta contra la cuenta real antes de guardarla.
+        folder_metadata = (
+            self._validate_folder(connector, token_set.access_token, folder)
+            if folder is not None else None
+        )
+
         refresh_enc = encrypt_at_rest(token_set.refresh_token, purpose="iris_mailbox")
         access_enc = encrypt_at_rest(token_set.access_token, purpose="iris_mailbox")
         expires_at = token_set.access_token_expires_at.replace(tzinfo=None)
@@ -224,6 +235,10 @@ class IrisMailboxManager(TaskTrackingMixin):
                 existing.scopes = token_set.scopes
                 existing.full_message_mode = full_message_mode
                 existing.folder = folder
+                existing.folder_display_name = (
+                    folder_metadata.display_name if folder_metadata else None
+                )
+                existing.folder_type = folder_metadata.folder_type if folder_metadata else None
                 existing.status = "active"
                 existing.last_error = None
                 repo.update(existing)
@@ -234,6 +249,8 @@ class IrisMailboxManager(TaskTrackingMixin):
                 scopes=token_set.scopes, refresh_token_enc=refresh_enc,
                 access_token_enc=access_enc, access_token_expires_at=expires_at,
                 folder=folder, full_message_mode=full_message_mode,
+                folder_display_name=folder_metadata.display_name if folder_metadata else None,
+                folder_type=folder_metadata.folder_type if folder_metadata else None,
             )
             repo.save(connection)
             return connection.id
@@ -255,19 +272,65 @@ class IrisMailboxManager(TaskTrackingMixin):
     def update_connection(self, connection_id: int, user_id: int, *,
                            folder: Optional[str] = None,
                            status: Optional[str] = None) -> IrisMailboxConnection:
-        self.assert_connection_ownership(connection_id, user_id)
+        connection = self.assert_connection_ownership(connection_id, user_id)
         if status is not None and status not in _VALID_UPDATE_STATUSES:
             raise ValueError(f"status debe ser uno de {_VALID_UPDATE_STATUSES}")
+
+        # B16: cambiar de carpeta exige un access_token vivo para comprobarla
+        # contra la cuenta real -- lo mismo que list_folders().
+        folder_display_name = None
+        folder_type = None
+        if folder is not None:
+            try:
+                access_token, connector = self._ensure_access_token(connection)
+            except _ReauthRequiredError as e:
+                self._mark_reauth_required(connection_id, str(e))
+                raise ValueError(
+                    "La conexión necesita reautorización antes de poder cambiar de carpeta."
+                ) from e
+            matched = self._validate_folder(connector, access_token, folder)
+            folder_display_name = matched.display_name
+            folder_type = matched.folder_type
 
         with UnitOfWork() as uow:
             repo = IrisMailboxConnectionRepository(uow)
             fresh = repo.get_by_id(connection_id)
             if folder is not None:
                 fresh.folder = folder
+                fresh.folder_display_name = folder_display_name
+                fresh.folder_type = folder_type
             if status is not None:
                 fresh.status = status
             repo.update(fresh)
             return fresh
+
+    def list_folders(self, connection_id: int, user_id: int) -> list[MailboxFolder]:
+        """Carpetas/etiquetas reales de la cuenta -- únicos valores válidos
+        para ``folder`` en ``update_connection()`` (B16)."""
+        connection = self.assert_connection_ownership(connection_id, user_id)
+        try:
+            access_token, connector = self._ensure_access_token(connection)
+        except _ReauthRequiredError as e:
+            self._mark_reauth_required(connection_id, str(e))
+            raise
+        return connector.list_folders(access_token)
+
+    @staticmethod
+    def _validate_folder(
+        connector: MailboxConnector, access_token: str, folder: str,
+    ) -> MailboxFolder:
+        """Comprueba ``folder`` contra las carpetas reales de la cuenta.
+
+        Raises:
+            IrisMailboxInvalidFolderError: ``folder`` no existe para esta
+                cuenta y proveedor -- id equivocado, error tipográfico, o un
+                valor que pertenece a otro proveedor.
+        """
+        folders = connector.list_folders(access_token)
+        match = next((candidate for candidate in folders if candidate.provider_id == folder), None)
+        if match is None:
+            raise IrisMailboxInvalidFolderError(folder)
+        return match
 
     def delete_connection(self, connection_id: int, user_id: int) -> None:
         """Revoca el token en el proveedor (best-effort) y borra la fila.

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -152,8 +152,18 @@ class IrisMailboxConnection(Base):
                  not cached or expired. Optional — the connector can always
                  fall back to ``refresh()``.
         access_token_expires_at: Expiry of the cached access token.
-        folder: Provider-specific folder/label to watch; NULL = default
-                 inbox.
+        folder: Provider-specific folder/label id to watch; NULL = default
+                 inbox. Es el ``provider_id`` opaco que ``MailboxConnector``
+                 usa para filtrar ``list_new`` -- nunca texto libre: solo se
+                 guarda tras validarse contra ``MailboxConnector.list_folders()``
+                 (B16), así que un valor no vacío siempre corresponde a una
+                 carpeta real de esta cuenta en el momento en que se guardó.
+        folder_display_name: Nombre legible de ``folder`` (p.ej. "Facturas",
+                 "Trabajo/Clientes"); NULL junto con ``folder`` cuando se
+                 vigila la bandeja de entrada por defecto (B16).
+        folder_type: "system" (Inbox, Sent, Trash... del propio proveedor) |
+                 "user" (etiqueta/carpeta creada por la cuenta); NULL junto
+                 con ``folder`` (B16).
         full_message_mode: If True, fetch the complete raw message
                  (attachments/body included) instead of headers only. Off
                  by default — the user must opt in explicitly per
@@ -202,6 +212,8 @@ class IrisMailboxConnection(Base):
     access_token_expires_at = Column(DateTime, nullable=True)
 
     folder = Column(String(255), nullable=True)
+    folder_display_name = Column(String(255), nullable=True)
+    folder_type = Column(String(20), nullable=True)
     full_message_mode = Column(Boolean, nullable=False, default=False)
     sync_cursor = Column(Text, nullable=True)
 

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -401,7 +401,12 @@ class IrisMailboxConnectRequestSchema(Schema):
     """Request body for ``POST /iris/mailbox/connect``."""
     provider = fields.String(required=True)
     fullMessageMode = fields.Boolean(load_default=False)
-    folder = fields.String(load_default=None, allow_none=True)
+    # B16: la validación real (existe, pertenece a esta cuenta/proveedor) es
+    # de red y solo se puede hacer con un access_token en la mano -- ver
+    # IrisMailboxManager._validate_folder(), llamada desde handle_callback().
+    # Aquí solo se descarta lo evidentemente inválido antes de firmar el
+    # state y mandar al usuario al proveedor.
+    folder = fields.String(load_default=None, allow_none=True, validate=validate.Length(max=255))
 
 
 class IrisMailboxConnectResponseSchema(Schema):
@@ -415,6 +420,8 @@ class IrisMailboxConnectionItemSchema(Schema):
     provider = fields.String()
     accountEmail = fields.String()
     folder = fields.String(allow_none=True)
+    folderDisplayName = fields.String(allow_none=True)
+    folderType = fields.String(allow_none=True)
     fullMessageMode = fields.Boolean()
     status = fields.String()
     lastSyncAt = UTCDateTime(allow_none=True)
@@ -431,9 +438,22 @@ class IrisMailboxConnectionListResponseSchema(Schema):
 
 class IrisMailboxUpdateConnectionRequestSchema(Schema):
     """Request body for ``PATCH /iris/mailbox/connections/<id>``."""
-    folder = fields.String(load_default=None, allow_none=True)
+    folder = fields.String(load_default=None, allow_none=True, validate=validate.Length(max=255))
     status = fields.String(load_default=None, allow_none=True,
                             validate=validate.OneOf(["active", "paused"]))
+
+
+class IrisMailboxFolderSchema(Schema):
+    """One real folder/label the connected account has (B16)."""
+    providerId = fields.String()
+    displayName = fields.String()
+    folderType = fields.String()
+
+
+class IrisMailboxFoldersResponseSchema(Schema):
+    """Folders a connection's account exposes -- the only valid values for
+    ``PATCH /iris/mailbox/connections/<id>``'s ``folder``."""
+    folders = fields.List(fields.Nested(IrisMailboxFolderSchema))
 
 
 class IrisMailboxConnectionDeleteResponseSchema(Schema):

--- a/API/src/modules/features/iris/services/mailbox/__init__.py
+++ b/API/src/modules/features/iris/services/mailbox/__init__.py
@@ -1,4 +1,4 @@
-from .base import MailboxConnector, MessageRef, TokenSet
+from .base import MailboxConnector, MailboxFolder, MessageRef, TokenSet
 from .registry import MAILBOX_CONNECTORS, get_connector
 
 # Importados por su efecto secundario: cada uno se da de alta en
@@ -9,6 +9,6 @@ from . import gmail as _gmail  # noqa: F401
 from . import microsoft as _microsoft  # noqa: F401
 
 __all__ = [
-    "MailboxConnector", "MessageRef", "TokenSet",
+    "MailboxConnector", "MailboxFolder", "MessageRef", "TokenSet",
     "MAILBOX_CONNECTORS", "get_connector",
 ]

--- a/API/src/modules/features/iris/services/mailbox/base.py
+++ b/API/src/modules/features/iris/services/mailbox/base.py
@@ -43,6 +43,23 @@ class MessageRef:
     raw: dict = field(default_factory=dict)
 
 
+@dataclass
+class MailboxFolder:
+    """Una carpeta/etiqueta real del proveedor que Iris puede vigilar (B16).
+
+    ``provider_id`` es el valor opaco que ``IrisMailboxConnection.folder``
+    guarda y que los conectores usan para filtrar ``list_new`` -- nunca se
+    interpreta ni se recorta, igual que ``sync_cursor``. ``folder_type``
+    distingue una carpeta propia del proveedor ("system": Inbox, Sent,
+    Trash...) de una creada por el usuario ("user": una etiqueta de Gmail,
+    una subcarpeta de Outlook), información que no se puede derivar del
+    nombre por sí solo.
+    """
+    provider_id: str
+    display_name: str
+    folder_type: str  # "system" | "user"
+
+
 class MailboxConnector(ABC):
     """Conector OAuth + API de correo para un proveedor concreto."""
 
@@ -84,6 +101,16 @@ class MailboxConnector(ABC):
     @abstractmethod
     def fetch_raw(self, access_token: str, message_ref: MessageRef) -> str:
         """Mensaje MIME crudo completo (solo si full_message_mode)."""
+
+    @abstractmethod
+    def list_folders(self, access_token: str) -> list[MailboxFolder]:
+        """Carpetas/etiquetas reales de la cuenta conectada (B16).
+
+        Única fuente de verdad para validar ``IrisMailboxConnection.folder``:
+        un valor que no aparece aquí no es una carpeta que este proveedor y
+        esta cuenta puedan vigilar, sea porque no existe, porque se escribió
+        a mano, o porque pertenece a otro proveedor.
+        """
 
     @abstractmethod
     def revoke(self, refresh_token: str) -> None:

--- a/API/src/modules/features/iris/services/mailbox/gmail.py
+++ b/API/src/modules/features/iris/services/mailbox/gmail.py
@@ -25,7 +25,7 @@ import requests
 
 import src.modules.system.config_reading as CR
 
-from .base import MailboxConnector, MessageRef, TokenSet
+from .base import MailboxConnector, MailboxFolder, MessageRef, TokenSet
 from .registry import register_connector
 
 logger = logging.getLogger(__name__)
@@ -172,6 +172,22 @@ class GmailConnector(MailboxConnector):
         raw_b64url = response.json()["raw"]
         padded = raw_b64url + "=" * (-len(raw_b64url) % 4)
         return base64.urlsafe_b64decode(padded).decode("utf-8", errors="replace")
+
+    def list_folders(self, access_token: str) -> list[MailboxFolder]:
+        response = requests.get(
+            f"{_API_BASE}/labels",
+            headers={"Authorization": f"Bearer {access_token}"}, timeout=_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return [
+            MailboxFolder(
+                provider_id=label["id"], display_name=label["name"],
+                # Gmail ya distingue system (INBOX, SENT, TRASH...) de user
+                # (etiquetas creadas por la cuenta) -- se traslada tal cual.
+                folder_type="system" if label.get("type") == "system" else "user",
+            )
+            for label in response.json().get("labels", [])
+        ]
 
     def revoke(self, refresh_token: str) -> None:
         response = requests.post(_REVOKE_URL, data={"token": refresh_token}, timeout=_TIMEOUT_SECONDS)

--- a/API/src/modules/features/iris/services/mailbox/microsoft.py
+++ b/API/src/modules/features/iris/services/mailbox/microsoft.py
@@ -26,7 +26,7 @@ import requests
 
 import src.modules.system.config_reading as CR
 
-from .base import MailboxConnector, MessageRef, TokenSet
+from .base import MailboxConnector, MailboxFolder, MessageRef, TokenSet
 from .registry import register_connector
 
 logger = logging.getLogger(__name__)
@@ -159,6 +159,27 @@ class GraphConnector(MailboxConnector):
         )
         response.raise_for_status()
         return response.text
+
+    def list_folders(self, access_token: str) -> list[MailboxFolder]:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        folders: list[MailboxFolder] = []
+        # Solo carpetas de primer nivel -- Gmail tampoco anida etiquetas, y
+        # bajar a subcarpetas exigiría recorrer el árbol entero por cuenta.
+        url = f"{_GRAPH_API}/me/mailFolders?$top=250"
+        while url:
+            response = requests.get(url, headers=headers, timeout=_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            data = response.json()
+            for item in data.get("value", []):
+                folders.append(MailboxFolder(
+                    provider_id=item["id"], display_name=item["displayName"],
+                    # wellKnownName solo está presente en carpetas propias de
+                    # Graph (inbox, sentitems, deleteditems...); su ausencia
+                    # es la señal de que la creó el usuario.
+                    folder_type="system" if item.get("wellKnownName") else "user",
+                ))
+            url = data.get("@odata.nextLink")
+        return folders
 
     def revoke(self, refresh_token: str) -> None:
         # Microsoft Graph no expone una API para que una app confidencial

--- a/API/tests/integration/test_iris_mailbox_endpoints.py
+++ b/API/tests/integration/test_iris_mailbox_endpoints.py
@@ -16,6 +16,7 @@ import pytest
 from src.modules.features.iris.managers.mailbox import IrisMailboxManager
 from src.modules.features.iris.model import IrisMailboxConnection
 from src.modules.features.iris.repositories import IrisMailboxConnectionRepository
+from src.modules.features.iris.services.mailbox.base import MailboxFolder
 from src.modules.infrastructure import UnitOfWork
 from src.modules.shared import encrypt_at_rest
 
@@ -167,3 +168,40 @@ def test_sync_queues_and_returns_202(client, admin_user, auth_headers, app):
                            headers=auth_headers(admin_user))
     assert resp.status_code == 202
     submit_sync.assert_called_once_with(connection_id)
+
+
+# --------------------------------------------------------------- B16: folder
+
+def test_update_connection_folder_too_long_returns_422(client, admin_user, auth_headers, app):
+    connection_id = _save_connection(app, admin_user.id)
+    resp = client.patch(f"/iris/mailbox/connections/{connection_id}",
+                        headers=auth_headers(admin_user), json={"folder": "x" * 256})
+    assert resp.status_code == 422
+
+
+def test_connect_folder_too_long_returns_422(client, root_headers):
+    resp = client.post("/iris/mailbox/connect", headers=root_headers,
+                       json={"provider": "gmail", "folder": "x" * 256})
+    assert resp.status_code == 422
+
+
+def test_folders_unknown_connection_returns_404(client, root_headers):
+    resp = client.get("/iris/mailbox/connections/999999/folders", headers=root_headers)
+    assert resp.status_code == 404
+
+
+def test_folders_returns_provider_folders(client, admin_user, auth_headers, app):
+    connection_id = _save_connection(app, admin_user.id)
+    fake_folders = [
+        MailboxFolder(provider_id="Label_1", display_name="Facturas", folder_type="user"),
+        MailboxFolder(provider_id="INBOX", display_name="Inbox", folder_type="system"),
+    ]
+    with mock.patch.object(IrisMailboxManager, "list_folders", return_value=fake_folders):
+        resp = client.get(f"/iris/mailbox/connections/{connection_id}/folders",
+                          headers=auth_headers(admin_user))
+    assert resp.status_code == 200
+    body = resp.get_json()["folders"]
+    assert body == [
+        {"providerId": "Label_1", "displayName": "Facturas", "folderType": "user"},
+        {"providerId": "INBOX", "displayName": "Inbox", "folderType": "system"},
+    ]

--- a/API/tests/integration/test_iris_mailbox_manager.py
+++ b/API/tests/integration/test_iris_mailbox_manager.py
@@ -16,6 +16,7 @@ import src.modules.features.iris.managers.mailbox as mailbox_managers_mod
 import src.modules.features.iris.services.mailbox.locks as mailbox_locks_mod
 from src.modules.features.iris.exceptions import (
     IrisMailboxConnectionNotFoundError,
+    IrisMailboxInvalidFolderError,
     IrisMailboxInvalidProviderError,
     IrisMailboxOAuthStateError,
     IrisMailboxQuotaExceededError,
@@ -26,7 +27,7 @@ from src.modules.features.iris.model import IrisAnalysis, IrisMailboxConnection,
 from src.modules.features.iris.repositories import (
     IrisAnalysisRepository, IrisMailboxConnectionRepository, IrisMailboxInboxRepository,
 )
-from src.modules.features.iris.services.mailbox.base import MessageRef, TokenSet
+from src.modules.features.iris.services.mailbox.base import MailboxFolder, MessageRef, TokenSet
 from src.modules.infrastructure import UnitOfWork
 from src.modules.shared import decrypt_at_rest, encrypt_at_rest, utcnow_naive
 
@@ -124,10 +125,16 @@ class _FakeTaskQueue:
 class _FakeConnector:
     """Doble de MailboxConnector totalmente controlado por el test."""
 
-    def __init__(self, revoke_raises=False, refresh_raises_reauth=False):
+    def __init__(self, revoke_raises=False, refresh_raises_reauth=False, folders=None):
         self.revoked_tokens = []
         self._revoke_raises = revoke_raises
         self._refresh_raises_reauth = refresh_raises_reauth
+        # B16: por defecto expone "INBOX" -- suficiente para los tests que
+        # no ejercitan folder explícitamente pero sí pasan por
+        # _ensure_access_token en algún camino que valide.
+        self._folders = folders if folders is not None else [
+            MailboxFolder(provider_id="INBOX", display_name="Inbox", folder_type="system"),
+        ]
 
     def authorize_url(self, state, full_message_mode):
         return f"https://provider.example/authorize?state={state}"
@@ -166,6 +173,9 @@ class _FakeConnector:
         self.revoked_tokens.append(refresh_token)
         if self._revoke_raises:
             raise RuntimeError("provider is down")
+
+    def list_folders(self, access_token):
+        return self._folders
 
 
 class _QueueTestConnector(_FakeConnector):
@@ -329,6 +339,43 @@ def test_handle_callback_rejects_replayed_state(app, regular_user):
                 IrisMailboxManager().handle_callback(state, "auth-code")
 
 
+# --------------------------------------------------------------- B16: folder
+
+def test_handle_callback_validates_folder_against_the_provider(app, regular_user):
+    with app.app_context():
+        state = IrisMailboxManager._sign_state(
+            user_id=regular_user.id, provider="gmail", full_message_mode=False, folder="Label_1",
+        )
+        fake_connector = _FakeConnector(folders=[
+            MailboxFolder(provider_id="Label_1", display_name="Facturas", folder_type="user"),
+        ])
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            connection_id = IrisMailboxManager().handle_callback(state, "auth-code")
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.folder == "Label_1"
+            assert conn.folder_display_name == "Facturas"
+            assert conn.folder_type == "user"
+
+
+def test_handle_callback_rejects_a_folder_the_account_does_not_have(app, regular_user):
+    with app.app_context():
+        state = IrisMailboxManager._sign_state(
+            user_id=regular_user.id, provider="gmail", full_message_mode=False, folder="does-not-exist",
+        )
+        fake_connector = _FakeConnector(folders=[
+            MailboxFolder(provider_id="INBOX", display_name="Inbox", folder_type="system"),
+        ])
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            with pytest.raises(IrisMailboxInvalidFolderError):
+                IrisMailboxManager().handle_callback(state, "auth-code")
+
+        # La conexión nunca se crea si el folder reclamado no es válido.
+        with UnitOfWork() as uow:
+            assert IrisMailboxConnectionRepository(uow).get_by_user(regular_user.id) == []
+
+
 # ------------------------------------------------------------------- CRUD
 
 def test_list_connections_only_returns_own(app, regular_user, admin_user):
@@ -352,6 +399,70 @@ def test_update_connection_rejects_invalid_status(app, regular_user):
         connection_id = _save(app, _connection(regular_user.id))
         with pytest.raises(ValueError):
             IrisMailboxManager().update_connection(connection_id, regular_user.id, status="not-a-real-status")
+
+
+def test_update_connection_persists_a_validated_folder(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id))
+        fake_connector = _FakeConnector(folders=[
+            MailboxFolder(provider_id="Label_1", display_name="Facturas", folder_type="user"),
+        ])
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            updated = IrisMailboxManager().update_connection(connection_id, regular_user.id, folder="Label_1")
+
+        assert updated.folder == "Label_1"
+        assert updated.folder_display_name == "Facturas"
+        assert updated.folder_type == "user"
+
+
+def test_update_connection_rejects_a_folder_the_account_does_not_have(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id))
+        fake_connector = _FakeConnector(folders=[
+            MailboxFolder(provider_id="INBOX", display_name="Inbox", folder_type="system"),
+        ])
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            with pytest.raises(IrisMailboxInvalidFolderError):
+                IrisMailboxManager().update_connection(connection_id, regular_user.id, folder="not-real")
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.folder is None
+
+
+def test_update_connection_folder_requires_reauth_when_token_refresh_fails(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(
+            regular_user.id, access_token_enc=None, access_token_expires_at=None,
+        ))
+        fake_connector = _FakeConnector(refresh_raises_reauth=True)
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            with pytest.raises(ValueError):
+                IrisMailboxManager().update_connection(connection_id, regular_user.id, folder="Label_1")
+
+        with UnitOfWork() as uow:
+            conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
+            assert conn.status == "reauth_required"
+
+
+def test_list_folders_returns_the_connectors_folders(app, regular_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(regular_user.id))
+        fake_connector = _FakeConnector(folders=[
+            MailboxFolder(provider_id="Label_1", display_name="Facturas", folder_type="user"),
+            MailboxFolder(provider_id="INBOX", display_name="Inbox", folder_type="system"),
+        ])
+        with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
+            folders = IrisMailboxManager().list_folders(connection_id, regular_user.id)
+
+        assert [f.provider_id for f in folders] == ["Label_1", "INBOX"]
+
+
+def test_list_folders_requires_ownership(app, regular_user, admin_user):
+    with app.app_context():
+        connection_id = _save(app, _connection(admin_user.id))
+        with pytest.raises(IrisMailboxConnectionNotFoundError):
+            IrisMailboxManager().list_folders(connection_id, regular_user.id)
 
 
 def test_delete_connection_revokes_then_deletes_even_if_revoke_fails(app, regular_user):

--- a/API/tests/integration/test_iris_permissions.py
+++ b/API/tests/integration/test_iris_permissions.py
@@ -76,6 +76,7 @@ _ENDPOINTS = [
     ("patch", "/iris/mailbox/connections/999999", AttributeType.IRIS_UPDATE, None),
     ("delete", "/iris/mailbox/connections/999999", AttributeType.IRIS_DELETE, None),
     ("post", "/iris/mailbox/connections/999999/sync", AttributeType.IRIS_UPDATE, None),
+    ("get", "/iris/mailbox/connections/999999/folders", AttributeType.IRIS_READ, None),
 ]
 
 _ALL_IRIS_ATTRIBUTES = [

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -147,6 +147,21 @@ def test_gmail_revoke_tolerates_already_revoked_token():
     post.assert_called_once()
 
 
+def test_gmail_list_folders_maps_system_and_user_labels():
+    connector = GmailConnector("https://app.example.com/iris/mailbox/callback")
+    payload = {"labels": [
+        {"id": "INBOX", "name": "INBOX", "type": "system"},
+        {"id": "Label_1", "name": "Facturas", "type": "user"},
+    ]}
+    with mock.patch("requests.get", return_value=_response(payload)):
+        folders = connector.list_folders("access-token")
+
+    assert [(f.provider_id, f.display_name, f.folder_type) for f in folders] == [
+        ("INBOX", "INBOX", "system"),
+        ("Label_1", "Facturas", "user"),
+    ]
+
+
 def test_gmail_missing_env_vars_raise_clear_error(monkeypatch):
     monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
     with pytest.raises(ValueError, match="GMAIL_CLIENT_ID"):
@@ -297,6 +312,35 @@ def test_graph_fetch_raw_returns_response_text_directly():
     with mock.patch("requests.get", return_value=resp):
         raw = connector.fetch_raw("access-token", MessageRef(provider_message_id="msg-1"))
     assert raw.startswith("From: a@b.com")
+
+
+def test_graph_list_folders_maps_well_known_and_user_created():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    payload = {"value": [
+        {"id": "AAA1", "displayName": "Inbox", "wellKnownName": "inbox"},
+        {"id": "BBB2", "displayName": "Clientes"},
+    ]}
+    with mock.patch("requests.get", return_value=_response(payload)):
+        folders = connector.list_folders("access-token")
+
+    assert [(f.provider_id, f.display_name, f.folder_type) for f in folders] == [
+        ("AAA1", "Inbox", "system"),
+        ("BBB2", "Clientes", "user"),
+    ]
+
+
+def test_graph_list_folders_paginates_via_next_link():
+    connector = GraphConnector("https://app.example.com/iris/mailbox/callback")
+    page1 = _response({
+        "value": [{"id": "AAA1", "displayName": "Inbox", "wellKnownName": "inbox"}],
+        "@odata.nextLink": "https://graph.microsoft.com/next-page",
+    })
+    page2 = _response({"value": [{"id": "BBB2", "displayName": "Clientes"}]})
+    with mock.patch("requests.get", side_effect=[page1, page2]) as get:
+        folders = connector.list_folders("access-token")
+
+    assert [f.provider_id for f in folders] == ["AAA1", "BBB2"]
+    assert get.call_args_list[1].args[0] == "https://graph.microsoft.com/next-page"
 
 
 def test_graph_revoke_does_not_raise_platform_limitation():

--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Content-Type: application/json
 | `POST` | `/iris/mailbox/connect` | `IRIS_CREATE` | Start OAuth connection to an external mailbox |
 | `GET` | `/iris/mailbox/callback` | — (public) | OAuth redirect target; CSRF-protected by a signed `state` |
 | `GET` | `/iris/mailbox/connections` | `IRIS_READ` | List monitored mailboxes |
-| `PATCH` | `/iris/mailbox/connections/<id>` | `IRIS_UPDATE` | Pause, resume or reconfigure a connection |
+| `GET` | `/iris/mailbox/connections/<id>/folders` | `IRIS_READ` | Real folders/labels for the connected account (live provider call) |
+| `PATCH` | `/iris/mailbox/connections/<id>` | `IRIS_UPDATE` | Pause, resume or reconfigure a connection (`folder` is validated against the account's real folders) |
 | `DELETE` | `/iris/mailbox/connections/<id>` | `IRIS_DELETE` | Disconnect a monitored mailbox |
 | `POST` | `/iris/mailbox/connections/<id>/sync` | `IRIS_UPDATE` | Trigger an out-of-cycle mailbox poll |
 


### PR DESCRIPTION
## Summary

Closes #229 ([B16] Validación de \`folder\` específica por proveedor), part 3 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

`IrisMailboxConnection.folder` (the Gmail label or Microsoft Graph folder a connection watches) was free text end to end. The Marshmallow schemas had no length limit, so an oversized value only failed when it hit the database's `VARCHAR(255)` column — a rejection with a raw DB error instead of a clean validation message. Worse, nothing checked that the value actually corresponded to a real folder the connected account has: a typo, an id copied from the wrong provider, or a stale value from a renamed/deleted label would only surface as a silent sync failure on the next poll — the user would see "connection isn't syncing" with no indication why.

## What changed

- **`MailboxConnector.list_folders(access_token)`** (new abstract method): the single source of truth for what a `folder` value is allowed to be. Implemented for both providers:
  - **Gmail** — calls the labels API, mapping each label's own `type` (`system`/`user`) directly.
  - **Microsoft Graph** — calls `/me/mailFolders` (paginated via `@odata.nextLink`, matching the pattern `list_new` already uses), classifying a folder as `system` when it has a `wellKnownName` (Inbox, Sent Items, ...) and `user` otherwise. Top-level folders only — Gmail doesn't have nested labels either, and descending into subfolders felt like scope creep for what this issue asks.
- **`IrisMailboxManager._validate_folder()`**: checks a submitted `folder` against the live `list_folders()` result and raises the new `IrisMailboxInvalidFolderError` (400) when it doesn't match. Wired into the two places a folder actually gets persisted:
  - `handle_callback()` — validated right after the OAuth code exchange, since that's the first point in the connect flow where an `access_token` exists at all (folder selection at `start_connect()` time can only be a cheap schema-level length check — no credentials yet to ask the provider).
  - `update_connection()` — validated against a freshly-refreshed access token before persisting; if the connection needs reauthorization, it's marked `reauth_required` (same as a sync would) and the caller gets a clear message instead of the folder silently not being what they think it is.
- **`GET /iris/mailbox/connections/<id>/folders`** (new endpoint): exposes the real, live folder list for a connection's account — the actual valid values for the `folder` field on `PATCH`. Not cached (folders can be renamed/deleted from outside Iris at any time).
- **`IrisMailboxConnection.folder_display_name` / `folder_type`** (new columns): captured alongside `folder` at validation time, so a caller can show "Facturas" instead of an opaque label id, and distinguish a provider-owned folder from one the account created. `folder` itself keeps its existing name and semantics (the provider's opaque id) rather than being renamed to `folder_provider_id` as the issue's literal wording suggested — the rename would touch five call sites, the web frontend's store, and add no real information; the model docstring documents that `folder` already *is* that id. Also worth noting: the web frontend's mailbox UI never sends `folder` on connect today (only `PATCH`, currently free text) — this PR is the backend contract; wiring a folder picker into `MailboxConnectionList.vue` is frontend work with no companion issue in this fase, so it's left out.

## Implementation

- `API/src/modules/features/iris/services/mailbox/base.py` — `MailboxFolder` dataclass, `list_folders()` abstract method.
- `API/src/modules/features/iris/services/mailbox/gmail.py`, `microsoft.py` — implementations.
- `API/src/modules/features/iris/exceptions.py` — `IrisMailboxInvalidFolderError`.
- `API/src/modules/features/iris/model.py` — `folder_display_name`, `folder_type`.
- `API/src/modules/features/iris/managers/mailbox.py` — `_validate_folder()`, `list_folders()`, wiring into `handle_callback()`/`update_connection()`.
- `API/src/modules/features/iris/schemas.py` + `endpoints.py` — `validate.Length(max=255)` on the connect/update request schemas, `folderDisplayName`/`folderType` in the connection response, new `IrisMailboxFolderSchema`/`IrisMailboxFoldersResponseSchema`, new endpoint.
- `API/alembic/versions/b615bd3abb26_add_iris_mailbox_folder_metadata.py` — new migration (same caveat as the prior two PRs: hand-written, no local Postgres to run `--autogenerate` against in this session).

## Validation

- `pytest tests/ -k iris` — 504 passed, 2 skipped (pre-existing, unrelated).
- New connector unit tests: Gmail label mapping, Graph folder mapping (including well-known vs. user-created), Graph pagination.
- New manager tests: `handle_callback` accepts a validated folder and persists its metadata, rejects one the account doesn't have (and never creates the connection when it does); same pair for `update_connection`, plus the reauth-required path when the access token can't be refreshed; `list_folders()` returns the connector's list and enforces ownership.
- New endpoint tests: schema-level length rejection (422) on both connect and update, the new folders endpoint returns the mapped list, unknown connection → 404.
- `tests/integration/test_iris_permissions.py` — added the new endpoint to the attribute matrix (`IRIS_READ`).
- `pytest tests/unit/test_config_shape.py` — unaffected (no new config keys in this PR).
- `pylint` on all touched files, diffed against a pre-change baseline — no new warning categories beyond ones this exact file/module already carries for the same reasons (e.g. every exception class in `exceptions.py` already gets `too-few-public-methods`).

## Notes

- Same migration caveat as the prior two PRs in this sequence — worth an `alembic upgrade head` sanity check against a real dev DB before this reaches `v0.5`.
- Deliberately did not rename `folder` → `folder_provider_id` (see above) — flagging in case the roadmap wants the literal field name for a future frontend contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)