### PR TITLE
fix(iris): consume quota atomically and check idempotency before charging

### DIFF
--- a/API/src/modules/accounts/services/quotas.py
+++ b/API/src/modules/accounts/services/quotas.py
@@ -130,6 +130,32 @@ class QuotaManager:
         else:
             self._consume_counter(entitlement, amount)
 
+    def consume_many(self, user_id: int, keys: list[LimitKey], amount: int = 1) -> None:
+        """Consume varias claves como una única operación: todas o ninguna (B09).
+
+        Encadenar ``consume()`` a pelo dos veces deja un cobro a medias si la
+        segunda llamada falla -- el caso real es ``generate_ai_summary()``,
+        que cobraba ``IRIS_AI_SUMMARIES`` y luego ``AI_REQUESTS``: si la
+        segunda no tenía cupo, la primera se quedaba cobrada por un trabajo
+        que nunca se encolaba. Aquí, si cualquier clave falla (sin cupo,
+        plan que no la incluye), las que ya se cobraron en esta llamada se
+        reembolsan antes de relanzar -- el balance neto siempre es "cobrado
+        todo" o "cobrado nada", nunca un punto intermedio.
+
+        El orden de ``keys`` importa: si más de una fallaría, la excepción
+        que ve el llamante es la de la primera en agotarse, no una elegida al
+        azar por el orden de iteración interno.
+        """
+        consumed: list[LimitKey] = []
+        try:
+            for key in keys:
+                self.consume(user_id, key, amount)
+                consumed.append(key)
+        except Exception:
+            for key in reversed(consumed):
+                self.refund(user_id, key, amount)
+            raise
+
     def refund(self, user_id: int, key: LimitKey, amount: int = 1) -> None:
         """Devuelve ``amount`` usos ya apuntados de ``key``.
 

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -20,9 +20,10 @@ import logging
 from dataclasses import replace
 from typing import Any, Dict, List, Optional
 
-import src.modules.system.config_reading as CR
 from sqlalchemy import and_, or_, update
+from sqlalchemy.exc import SQLAlchemyError
 
+import src.modules.system.config_reading as CR
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
@@ -141,13 +142,17 @@ class IrisManager(TaskTrackingMixin):
                          the original, still-default flow.
             source_message_uid: Provider-specific message id, set only
                          together with connection_id. The (connection_id,
-                         source_message_uid) pair is UNIQUE at the DB level,
-                         so a mailbox sync retry that resubmits the same
-                         message raises instead of duplicating the analysis.
+                         source_message_uid) pair is UNIQUE at the DB level.
+                         A mailbox sync retry that resubmits the same
+                         message never duplicates the analysis nor pays
+                         quota for it twice (B09) — see the idempotency
+                         check below.
 
         Returns:
-            The new IrisAnalysis primary key (``analysis_id``).  The
-            caller should store this to later poll status or fetch the
+            The IrisAnalysis primary key (``analysis_id``) — either the one
+            just created, or the existing one when ``(connection_id,
+            source_message_uid)`` was already accepted by a previous call.
+            The caller should store this to later poll status or fetch the
             full report.
 
         Raises:
@@ -164,15 +169,36 @@ class IrisManager(TaskTrackingMixin):
 
         self._validate_headers_pre(raw_input)
 
+        # B09: comprobar idempotencia ANTES de cobrar cuota -- un reintento
+        # de sync de buzón (Gmail/Graph pueden repetir un mensaje) para algo
+        # ya aceptado no debe volver a cobrar ni crear un segundo análisis.
+        # El propio checkpoint de mailbox (B01) ya evita llegar hasta aquí
+        # en el caso común; esto cubre además la llamada directa.
+        if connection_id is not None and source_message_uid is not None:
+            existing = build_repository(IrisAnalysisRepository).get_by_source(
+                connection_id, source_message_uid,
+            )
+            if existing is not None:
+                return existing.id
+
         # Después de validar la entrada: un correo mal pegado no gasta cuota.
         # Aquí y no en el endpoint, porque por este método entra también la
         # ingesta desde un buzón conectado (mailbox sync), que no pasa por HTTP.
         QuotaManager().consume(user_id, LimitKey.IRIS_ANALYSES)
 
-        analysis_id = self._create_analysis_record(
-            raw_input, user_id, title=title,
-            connection_id=connection_id, source_message_uid=source_message_uid,
-        )
+        try:
+            analysis_id = self._create_analysis_record(
+                raw_input, user_id, title=title,
+                connection_id=connection_id, source_message_uid=source_message_uid,
+            )
+        except SQLAlchemyError:
+            # Carrera perdida contra otra llamada para el mismo mensaje: la
+            # comprobación de arriba y este insert no son atómicos entre sí,
+            # así que la UniqueConstraint sigue siendo la defensa final. Se
+            # reembolsa la cuota que se acaba de cobrar por un análisis que
+            # nunca llegó a crearse -- nunca se cobra por un duplicado.
+            QuotaManager().refund(user_id, LimitKey.IRIS_ANALYSES)
+            raise
         logger.info(f"Iris analysis {analysis_id} created for user {user_id}")
 
         if self.TASK_CATEGORY is None:
@@ -511,11 +537,12 @@ class IrisManager(TaskTrackingMixin):
             return "running"
 
         # La concreta y el techo agregado de IA, en ese orden, para que el 402
-        # nombre lo que el usuario estaba pidiendo.
-        quota_manager = QuotaManager()
+        # nombre lo que el usuario estaba pidiendo. consume_many() (B09) las
+        # cobra como una sola operación: si AI_REQUESTS no tiene cupo tras
+        # haber cobrado IRIS_AI_SUMMARIES, la reembolsa antes de relanzar --
+        # antes se quedaba cobrada sin nada que la explicara.
         try:
-            quota_manager.consume(user_id, LimitKey.IRIS_AI_SUMMARIES)
-            quota_manager.consume(user_id, LimitKey.AI_REQUESTS)
+            QuotaManager().consume_many(user_id, [LimitKey.IRIS_AI_SUMMARIES, LimitKey.AI_REQUESTS])
         except Exception:
             # Sin cupo no hay trabajo: se suelta la reserva para que el
             # análisis no se quede en `running` para siempre y el usuario

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -114,23 +114,30 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         )
         return items, total
 
-    def exists_by_source(self, connection_id: int, source_message_uid: str) -> bool:
-        """Si ya existe un análisis para este (connection_id, source_message_uid).
+    def get_by_source(self, connection_id: int, source_message_uid: str) -> Optional[IrisAnalysis]:
+        """El análisis ya aceptado para este (connection_id, source_message_uid),
+        si existe.
 
-        Usado por la cola de checkpoint del sync de buzón (B01) para
-        reconocer un mensaje ya aceptado en un intento anterior -- p.ej. tras
-        un fallo entre el commit de ``IrisAnalysis`` y el borrado de su
-        entrada en ``IrisMailboxInbox`` -- de forma que un reintento nunca
+        Usado tanto por la cola de checkpoint del sync de buzón (B01, que
+        solo necesita saber si existe) como por ``IrisManager.analyze()``
+        (B09, que necesita el id para devolverlo sin cobrar cuota de nuevo)
+        -- reconocer un mensaje ya aceptado en un intento anterior, p.ej.
+        tras un fallo entre el commit de ``IrisAnalysis`` y el borrado de su
+        entrada en ``IrisMailboxInbox``, de forma que un reintento nunca
         confunda la ``UniqueConstraint`` de idempotencia con un fallo real.
         """
         return (
-            self._session.query(IrisAnalysis.id)
+            self._session.query(IrisAnalysis)
             .filter(
                 IrisAnalysis.connection_id == connection_id,
                 IrisAnalysis.source_message_uid == source_message_uid,
             )
             .first()
-        ) is not None
+        )
+
+    def exists_by_source(self, connection_id: int, source_message_uid: str) -> bool:
+        """Si ya existe un análisis para este (connection_id, source_message_uid)."""
+        return self.get_by_source(connection_id, source_message_uid) is not None
 
 
 class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):

--- a/API/tests/integration/test_iris_ai_summary.py
+++ b/API/tests/integration/test_iris_ai_summary.py
@@ -70,6 +70,19 @@ class _CountingQuota:
     def consume(self, user_id, key, amount=1):
         type(self).consumed.append(key.db_name)
 
+    def consume_many(self, user_id, keys, amount=1):
+        # Mismo comportamiento que el QuotaManager real (B09): si alguna
+        # clave falla, reembolsa las que esta llamada ya cobró.
+        consumed = []
+        try:
+            for key in keys:
+                self.consume(user_id, key, amount)
+                consumed.append(key)
+        except Exception:
+            for key in reversed(consumed):
+                self.refund(user_id, key, amount)
+            raise
+
     def refund(self, user_id, key, amount=1):
         type(self).refunded.append(key.db_name)
 

--- a/API/tests/integration/test_iris_quota_idempotency.py
+++ b/API/tests/integration/test_iris_quota_idempotency.py
@@ -1,0 +1,129 @@
+"""B09: IrisManager.analyze() cobra cuota exactamente por los análisis que de
+verdad se crean -- ni por un reintento de Gmail/Graph que reenvía el mismo
+mensaje, ni por una carrera perdida contra la UniqueConstraint de
+idempotencia.
+
+``QuotaManager.consume_many()`` (el otro artefacto de B09, la generación de
+IA que cobra dos claves) tiene su propia cobertura en test_quotas.py.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as analysis_mod
+from src.modules.accounts.services.limits import LimitKey
+from src.modules.accounts.services.quotas import QuotaManager
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+
+class _NoopQueue:
+    def submit(self, **kwargs):
+        return None
+
+
+_HEADERS = "From: a@b.com\r\nSubject: Hi\r\n"
+
+
+def test_analyze_returns_the_existing_id_for_a_known_source_without_charging(
+    app, regular_user, set_plan_limits,
+):
+    """El escenario real del issue: un reintento de sync (Gmail/Graph
+    repitiendo un mensaje) para un (connection_id, source_message_uid) ya
+    aceptado no debe cobrar una segunda vez ni crear un segundo análisis."""
+    set_plan_limits({LimitKey.IRIS_ANALYSES: 1})
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            existing = IrisAnalysis(
+                raw_headers=_HEADERS, user_id=regular_user.id,
+                status="finished", connection_id=99, source_message_uid="msg-1",
+            )
+            IrisAnalysisRepository(uow).save(existing)
+            existing_id = existing.id
+
+        # La cuota ya está agotada (límite 1, y este análisis se creó a
+        # mano sin gastarla) -- si analyze() cobrara de nuevo, cortaría.
+        QuotaManager().consume(regular_user.id, LimitKey.IRIS_ANALYSES)
+
+        with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+            returned_id = IrisManager().analyze(
+                raw_headers=_HEADERS, user_id=regular_user.id,
+                connection_id=99, source_message_uid="msg-1",
+            )
+
+        assert returned_id == existing_id
+        assert QuotaManager().state(regular_user.id, LimitKey.IRIS_ANALYSES).used == 1
+
+        with UnitOfWork() as uow:
+            analyses = IrisAnalysisRepository(uow).get_by_user(regular_user.id)
+            assert len(analyses) == 1
+
+
+def test_analyze_charges_quota_normally_for_a_new_message(app, regular_user, set_plan_limits):
+    set_plan_limits({LimitKey.IRIS_ANALYSES: 5})
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+            IrisManager().analyze(
+                raw_headers=_HEADERS, user_id=regular_user.id,
+                connection_id=99, source_message_uid="msg-1",
+            )
+
+        assert QuotaManager().state(regular_user.id, LimitKey.IRIS_ANALYSES).used == 1
+
+
+def test_analyze_refunds_quota_when_it_loses_the_race_against_the_unique_constraint(
+    app, regular_user, set_plan_limits, monkeypatch,
+):
+    """Simula la carrera que la comprobación de idempotencia por sí sola no
+    puede cerrar: dos llamadas leen "no existe" casi a la vez, y solo una
+    gana la UniqueConstraint. La perdedora debe quedar en cuota cero, no
+    cobrada por un análisis que nunca se creó."""
+    set_plan_limits({LimitKey.IRIS_ANALYSES: 5})
+
+    with app.app_context():
+        # La fila ya existe de verdad en la base de datos...
+        with UnitOfWork() as uow:
+            IrisAnalysisRepository(uow).save(IrisAnalysis(
+                raw_headers=_HEADERS, user_id=regular_user.id,
+                status="finished", connection_id=99, source_message_uid="msg-1",
+            ))
+
+        # ...pero se fuerza a analyze() a no verla en su comprobación previa,
+        # como si esta llamada hubiera leído justo antes de que la otra
+        # confirmara -- lo único que la protege ahora es la constraint.
+        monkeypatch.setattr(IrisAnalysisRepository, "get_by_source", lambda self, *a, **k: None)
+
+        with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+            with pytest.raises(Exception):
+                IrisManager().analyze(
+                    raw_headers=_HEADERS, user_id=regular_user.id,
+                    connection_id=99, source_message_uid="msg-1",
+                )
+
+        assert QuotaManager().state(regular_user.id, LimitKey.IRIS_ANALYSES).used == 0
+
+
+def test_analyze_manual_submissions_are_unaffected_by_the_idempotency_check(
+    app, regular_user, set_plan_limits,
+):
+    """Sin connection_id/source_message_uid (el envío manual, el flujo
+    original) la comprobación de idempotencia no se ejecuta -- dos envíos
+    manuales del mismo texto son dos análisis distintos, como siempre."""
+    set_plan_limits({LimitKey.IRIS_ANALYSES: 5})
+
+    with app.app_context():
+        with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+            first_id = IrisManager().analyze(raw_headers=_HEADERS, user_id=regular_user.id)
+            second_id = IrisManager().analyze(raw_headers=_HEADERS, user_id=regular_user.id)
+
+        assert first_id != second_id
+        assert QuotaManager().state(regular_user.id, LimitKey.IRIS_ANALYSES).used == 2

--- a/API/tests/integration/test_quotas.py
+++ b/API/tests/integration/test_quotas.py
@@ -84,6 +84,69 @@ def test_consume_accepts_an_amount(app, regular_user, set_plan_limits):
         assert QuotaManager().state(regular_user.id, LimitKey.AI_REQUESTS).used == 4
 
 
+# ------------------------------------------------------------------ consume_many
+
+def test_consume_many_charges_every_key(app, regular_user, set_plan_limits):
+    set_plan_limits({LimitKey.IRIS_AI_SUMMARIES: 5, LimitKey.AI_REQUESTS: 5})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume_many(regular_user.id, [LimitKey.IRIS_AI_SUMMARIES, LimitKey.AI_REQUESTS])
+
+        assert manager.state(regular_user.id, LimitKey.IRIS_AI_SUMMARIES).used == 1
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 1
+
+
+def test_consume_many_refunds_the_first_key_when_the_second_has_no_room(
+    app, regular_user, set_plan_limits
+):
+    """B09: antes de esto, generate_ai_summary() encadenaba dos consume()
+    sueltos -- si el segundo no tenía cupo, el primero se quedaba cobrado
+    por un trabajo que nunca se hizo. consume_many() debe dejar el balance
+    neto en cero cuando cualquier clave de la lista falla."""
+    set_plan_limits({LimitKey.IRIS_AI_SUMMARIES: 5, LimitKey.AI_REQUESTS: 1})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.AI_REQUESTS)  # agota AI_REQUESTS de antemano
+
+        with pytest.raises(QuotaExceededError):
+            manager.consume_many(regular_user.id, [LimitKey.IRIS_AI_SUMMARIES, LimitKey.AI_REQUESTS])
+
+        # IRIS_AI_SUMMARIES se cobró dentro de esta llamada y se reembolsó
+        # al fallar AI_REQUESTS -- el usuario no paga nada por una
+        # operación que falló (AI_REQUESTS sigue en 1: el cobro previo al
+        # test, no algo que consume_many añadiera).
+        assert manager.state(regular_user.id, LimitKey.IRIS_AI_SUMMARIES).used == 0
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 1
+
+
+def test_consume_many_raises_the_first_failing_keys_error(app, regular_user, set_plan_limits):
+    """El orden de la lista manda: si la primera clave no tiene cupo, el
+    error nombra esa, no una elegida por casualidad de iteración."""
+    set_plan_limits({LimitKey.IRIS_AI_SUMMARIES: 1, LimitKey.AI_REQUESTS: 5})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume(regular_user.id, LimitKey.IRIS_AI_SUMMARIES)  # agota la primera clave
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            manager.consume_many(regular_user.id, [LimitKey.IRIS_AI_SUMMARIES, LimitKey.AI_REQUESTS])
+        assert exc_info.value.details.get("limitKey") == LimitKey.IRIS_AI_SUMMARIES.db_name
+
+
+def test_consume_many_accepts_an_amount(app, regular_user, set_plan_limits):
+    set_plan_limits({LimitKey.IRIS_AI_SUMMARIES: 10, LimitKey.AI_REQUESTS: 10})
+
+    with app.app_context():
+        manager = QuotaManager()
+        manager.consume_many(
+            regular_user.id, [LimitKey.IRIS_AI_SUMMARIES, LimitKey.AI_REQUESTS], amount=3,
+        )
+        assert manager.state(regular_user.id, LimitKey.IRIS_AI_SUMMARIES).used == 3
+        assert manager.state(regular_user.id, LimitKey.AI_REQUESTS).used == 3
+
+
 def test_quotas_are_per_user(app, make_user, set_plan_limits):
     """Dos usuarios con el mismo plan no comparten bolsa. La compartirán los
     miembros de una misma organización, y eso llega en la fase 5."""

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -847,6 +847,7 @@ def test_generate_ai_summary_submits_task_for_finished_analysis(monkeypatch):
 
     class _FreeQuota:
         def consume(self, user_id, key, amount=1): pass
+        def consume_many(self, user_id, keys, amount=1): pass
         def refund(self, user_id, key, amount=1): pass
 
     monkeypatch.setattr(analysis_mod, "QuotaManager", _FreeQuota)


### PR DESCRIPTION
## Summary

Closes #227 ([B09] Consumo de cuota atómico e idempotencia antes de cobrar), part 4 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

Two related bugs in how Iris charges its usage-based quotas:

1. **`IrisManager.analyze()`** consumed `IRIS_ANALYSES` quota *before* creating the `IrisAnalysis` row. The `(connection_id, source_message_uid)` `UniqueConstraint` — the thing that's supposed to make a mailbox sync retry harmless — only fires at the insert, which happens *after* the charge. So a Gmail/Graph retry that resubmits a message Iris already accepted (this happens: both providers can redeliver on a sync that was interrupted) paid for an analysis that was rejected as a duplicate a few lines later, with nothing to refund it.
2. **`IrisManager.generate_ai_summary()`** had the identical shape but with two quota keys charged back to back: `IRIS_AI_SUMMARIES` then `AI_REQUESTS`. If a plan had room for the specific limit but not the aggregate AI one (or vice versa), the first call's charge stuck even though the second one meant the whole operation was rejected and never queued.

## What changed

- **`IrisManager.analyze()`**: when `connection_id`/`source_message_uid` are given, it now calls the new `IrisAnalysisRepository.get_by_source()` *before* touching quota. A known pair returns the existing analysis's id directly — no new row, no charge, which is exactly what "this is a retry, not a new message" should mean. The DB constraint remains the final backstop for the race that a plain existence check can't close on its own (two calls reading "not found" before either commits) — if the insert still collides after the check passed, the quota that was just consumed gets refunded before the exception propagates.
- **`QuotaManager.consume_many()`** (new): takes a list of `LimitKey`s and consumes them as one logical charge — order matters (the first key to run out is the one whose error the caller sees, preserving the existing "name the specific limit before the aggregate one" behavior). If any key in the list fails, every key already consumed *by this call* is refunded before re-raising, so the net result is always "charged everything" or "charged nothing," never a partial state. `generate_ai_summary()` now uses this for `IRIS_AI_SUMMARIES` + `AI_REQUESTS` instead of two bare `consume()` calls.
- `IrisAnalysisRepository.get_by_source()` is new (B01's `exists_by_source()`, added for the mailbox checkpoint queue, now delegates to it instead of duplicating the query).

## Implementation

- `API/src/modules/accounts/services/quotas.py` — `QuotaManager.consume_many()`.
- `API/src/modules/features/iris/managers/analysis.py` — idempotency check + refund-on-conflict in `analyze()`; `generate_ai_summary()` switched to `consume_many()`.
- `API/src/modules/features/iris/repositories.py` — `IrisAnalysisRepository.get_by_source()`, `exists_by_source()` now delegates to it.

## Validation

- `pytest tests/ -k "iris or quota"` — 537 passed, 2 skipped (pre-existing, unrelated).
- New `tests/integration/test_iris_quota_idempotency.py`: a duplicate `(connection_id, source_message_uid)` returns the existing id and never re-charges (even with quota already fully consumed, which would raise if `analyze()` tried to charge again); a genuinely new message still charges normally; the TOCTOU race is exercised directly by monkeypatching `get_by_source()` to miss a row that already exists in the DB, confirming the constraint still catches it and the quota lands back at zero; manual submissions (`connection_id=None`) are confirmed unaffected — same message submitted twice manually is still two analyses, as always.
- New tests in `test_quotas.py` for `consume_many()`: charges every key on success, refunds the first key when a later one fails (leaving both back to their pre-call state), and preserves ordering so the exception names the first key that ran out.
- Updated the `_FreeQuota`/`_CountingQuota` test doubles in `test_iris_rules.py`/`test_iris_ai_summary.py` to implement `consume_many()` (mirroring the real class's refund-on-failure logic in `_CountingQuota`'s case) — these are `QuotaManager` stand-ins used across the existing AI-summary test suite, which all still pass unchanged.
- `pylint` on the touched files, diffed against a pre-change baseline — one real fix (import-order: `sqlalchemy.exc.SQLAlchemyError` needed to sort before the first-party imports), otherwise no new warning categories.

## Notes

- Per the issue's own "Dependencias y orden" note, this lands after B01 (checkpoint) and before B08 (outbox), which is next in the approved sequence for this fase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)