### PR TITLE
feat(taskqueue): add transactional outbox for analysis creation and ingestion

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -47,7 +47,8 @@
     "taskqueue": {
       "history_max_items": 200,
       "history_ttl_seconds": 3600,
-      "max_workers": 4
+      "max_workers": 4,
+      "outbox_sweep_interval_seconds": 60
     }
   },
   "tools": {

--- a/API/alembic/versions/af1b51ec6c76_add_task_dispatch_outbox.py
+++ b/API/alembic/versions/af1b51ec6c76_add_task_dispatch_outbox.py
@@ -1,0 +1,57 @@
+"""system: TaskDispatch outbox table (B08)
+
+``analyze()`` (y cualquier otro create-then-enqueue) hacía commit de su
+entidad antes de publicar el job en TaskQueue -- si la API se reiniciaba o
+Redis fallaba justo en esa ventana, la fila quedaba en BD sin ningún trabajo
+que la fuera a procesar. TaskDispatch persiste la intención de publicar en
+la MISMA transacción que la entidad; ``OutboxDispatcher`` (system/taskqueue/
+outbox.py) la publica después, con reintento vía barrido periódico y
+reconciliación de arranque.
+
+Revision ID: af1b51ec6c76
+Revises: b615bd3abb26
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'af1b51ec6c76'
+down_revision: Union[str, Sequence[str], None] = 'b615bd3abb26'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'TaskDispatch',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('func_path', sa.String(length=255), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('category', sa.String(length=64), nullable=False),
+        sa.Column('args', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('kwargs', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('external_id', sa.String(length=255), nullable=True),
+        sa.Column('timeout', sa.Integer(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('attempts', sa.Integer(), nullable=False),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('dispatched_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_TaskDispatch_status'), 'TaskDispatch', ['status'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_TaskDispatch_status'), table_name='TaskDispatch')
+    op.drop_table('TaskDispatch')

--- a/API/run.py
+++ b/API/run.py
@@ -165,6 +165,13 @@ def _run_shutdown_cleanup() -> None:
     except Exception as e:
         _logger.error(f"Error deteniendo scheduler de buzones de Iris: {e}")
 
+    _logger.info("[Shutdown] Deteniendo scheduler de outbox de TaskQueue...")
+    try:
+        from src.modules.system.taskqueue.scheduling import TaskDispatchScheduler
+        TaskDispatchScheduler.stop()
+    except Exception as e:
+        _logger.error(f"Error deteniendo scheduler de outbox de TaskQueue: {e}")
+
     _logger.info("[Shutdown] Cerrando sesiones de base de datos...")
     try:
         unit_of_work.close_all()
@@ -434,6 +441,7 @@ def _configure_scheduling() -> None:
     from src.modules.features.iris.services.mailbox.scheduling import IrisMailboxScheduler
     from src.modules.accounts.services.scheduling import AccountsScheduler
     from src.modules.users.services.scheduling import UsersScheduler
+    from src.modules.system.taskqueue.scheduling import TaskDispatchScheduler
 
     _logger.info("Reconciliando escaneos huérfanos...")
     try:
@@ -453,6 +461,15 @@ def _configure_scheduling() -> None:
     except Exception as e:
         _logger.warning("No se pudo reconciliar análisis Iris huérfanos: %s", e)
 
+    _logger.info("Publicando TaskDispatch pendientes de la outbox...")
+    try:
+        from src.modules.system.taskqueue.outbox import OutboxDispatcher
+        dispatched = OutboxDispatcher.dispatch_pending()
+        if dispatched:
+            _logger.info("Se publicaron %d TaskDispatch pendiente(s) al arrancar", dispatched)
+    except Exception as e:
+        _logger.warning("No se pudo publicar la outbox de TaskQueue al arrancar: %s", e)
+
     _logger.info("Arrancando scheduler de tareas programadas...")
     ThemisScheduler.start()
 
@@ -467,6 +484,9 @@ def _configure_scheduling() -> None:
 
     _logger.info("Arrancando scheduler de recordatorios MFA...")
     UsersScheduler.start()
+
+    _logger.info("Arrancando scheduler de outbox de TaskQueue...")
+    TaskDispatchScheduler.start()
 
 
 def _run_migrations() -> None:

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -29,6 +29,9 @@ from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
 from src.modules.shared import assert_owned, utcnow_naive, isoformat_utc, CANCELLABLE_STATES as _CANCELLABLE_STATES
 from src.modules.system.taskqueue import TaskQueue, TaskTrackingMixin, job_context
+from src.modules.system.taskqueue.dispatcher import OutboxDispatcher
+from src.modules.system.taskqueue.outbox import build_dispatch
+from src.modules.system.taskqueue.outbox_repository import TaskDispatchRepository
 
 from ..exceptions import (
     IrisAnalysisNotFoundError,
@@ -186,11 +189,37 @@ class IrisManager(TaskTrackingMixin):
         # ingesta desde un buzón conectado (mailbox sync), que no pasa por HTTP.
         QuotaManager().consume(user_id, LimitKey.IRIS_ANALYSES)
 
+        if self.TASK_CATEGORY is None:
+            QuotaManager().refund(user_id, LimitKey.IRIS_ANALYSES)
+            raise IrisExecutionError("Task category is not defined for IrisManager.")
+
+        analysis = IrisAnalysis(
+            raw_headers=raw_input,
+            user_id=user_id,
+            title=title.strip()[:120] if title and title.strip() else None,
+            status="pending",
+            connection_id=connection_id,
+            source_message_uid=source_message_uid,
+        )
         try:
-            analysis_id = self._create_analysis_record(
-                raw_input, user_id, title=title,
-                connection_id=connection_id, source_message_uid=source_message_uid,
-            )
+            with UnitOfWork() as uow:
+                IrisAnalysisRepository(uow).save(analysis)
+                analysis_id = analysis.id
+                # B08: la intención de publicar se guarda en la MISMA
+                # transacción que el análisis -- si la API muere o Redis
+                # falla justo después del commit, el barrido periódico de
+                # la outbox (o la reconciliación de arranque) publica el
+                # job más tarde en vez de dejar la fila huérfana para
+                # siempre (ver system/taskqueue/outbox.py).
+                dispatch = TaskDispatchRepository(uow).save(build_dispatch(
+                    func=IrisManager.execute_iris_analysis,
+                    name=f"IrisAnalysis-{analysis_id}",
+                    category=self.TASK_CATEGORY,
+                    args=(analysis_id, raw_input),
+                    external_id=self.external_id_for(analysis_id),
+                ))
+                # Durable antes de intentar publicar: el worker corre en otro proceso.
+                uow.commit_for_handoff()
         except SQLAlchemyError:
             # Carrera perdida contra otra llamada para el mismo mensaje: la
             # comprobación de arriba y este insert no son atómicos entre sí,
@@ -201,16 +230,11 @@ class IrisManager(TaskTrackingMixin):
             raise
         logger.info(f"Iris analysis {analysis_id} created for user {user_id}")
 
-        if self.TASK_CATEGORY is None:
-            raise IrisExecutionError("Task category is not defined for IrisManager.")
-
-        self._task_queue.submit(
-            func=IrisManager.execute_iris_analysis,
-            args=(analysis_id, raw_input),
-            name=f"IrisAnalysis-{analysis_id}",
-            category=self.TASK_CATEGORY,
-            external_id=self.external_id_for(analysis_id),
-        )
+        # Camino feliz: publicar ahora mismo en vez de esperar al barrido
+        # periódico, para que el análisis arranque sin latencia añadida en
+        # el caso normal (Redis arriba). Si falla, la fila queda `pending`
+        # y algo la recogerá más tarde -- nunca se pierde el trabajo.
+        OutboxDispatcher.dispatch(dispatch.id, task_queue=self._task_queue)
 
         return analysis_id
 
@@ -778,25 +802,6 @@ class IrisManager(TaskTrackingMixin):
     # =========================================================================
     # INTERNAL
     # =========================================================================
-
-    def _create_analysis_record(self, raw_headers: str, user_id: int, title: str | None = None,
-                                 connection_id: int | None = None,
-                                 source_message_uid: str | None = None) -> int:
-        """Persist a new IrisAnalysis row in ``pending`` state."""
-        analysis = IrisAnalysis(
-            raw_headers=raw_headers,
-            user_id=user_id,
-            title=title.strip()[:120] if title and title.strip() else None,
-            status="pending",
-            connection_id=connection_id,
-            source_message_uid=source_message_uid,
-        )
-        with UnitOfWork() as uow:
-            repo = IrisAnalysisRepository(uow)
-            repo.save(analysis)
-            # Durable antes de encolar: el worker corre en otro proceso.
-            uow.commit_for_handoff()
-        return analysis.id # type: ignore
 
     @staticmethod
     def _validate_headers_pre(raw_headers: str) -> None:

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -1602,6 +1602,15 @@ class TaskQueueConfig:
     )
     history_max_items: int = field(default=200, metadata={"key": "history_max_items"})
 
+    outbox_sweep_interval_seconds: int = field(
+        default=60, metadata={"key": "outbox_sweep_interval_seconds"},
+    )
+    """Cada cuánto ``TaskDispatchScheduler`` reintenta publicar los
+    ``TaskDispatch`` que sigan ``pending`` (B08) -- la red de seguridad para
+    cuando Redis estuvo caído justo en el momento del intento inmediato tras
+    el commit. No confundir con un timeout: un intento fallido no cuenta
+    como agotado, se reintenta indefinidamente en el próximo barrido."""
+
     @property
     def max_workers(self) -> int:
         """Procesos worker a levantar.

--- a/API/src/modules/system/taskqueue/__init__.py
+++ b/API/src/modules/system/taskqueue/__init__.py
@@ -5,7 +5,9 @@ Public API for the RQ-backed background task queue system.
 """
 
 from .deadline import JobDeadlineExceeded
+from .dispatcher import OutboxDispatcher
 from .job_context import JobHandle, job_context
+from .outbox import TaskDispatch, build_dispatch
 from .queue import DEFAULT_QUEUE, ITaskQueue, QueueRegistry, TaskQueue
 from .task import Task, TaskStatus
 from .tracking import TaskTrackingMixin
@@ -16,10 +18,13 @@ __all__ = [
     "JobDeadlineExceeded",
     "JobHandle",
     "job_context",
+    "OutboxDispatcher",
     "Task",
+    "TaskDispatch",
     "TaskQueue",
     "TaskStatus",
     "TaskTrackingMixin",
+    "build_dispatch",
     "ping_redis",
     "QueueRegistry",
     "DEFAULT_QUEUE",

--- a/API/src/modules/system/taskqueue/dispatcher.py
+++ b/API/src/modules/system/taskqueue/dispatcher.py
@@ -1,0 +1,107 @@
+"""
+OutboxDispatcher — publica en TaskQueue las filas de ``TaskDispatch``
+pendientes (B08). Ver ``outbox.py`` para el porqué de la tabla y el diseño
+general; este módulo es la mitad que sí toca Redis.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.infrastructure.session import build_repository
+from src.modules.shared import utcnow_naive
+from src.modules.shared._exceptions import IllegalStateError
+
+from .outbox import decode_func
+from .outbox_repository import TaskDispatchRepository
+from .queue import ITaskQueue, TaskQueue
+
+logger = logging.getLogger(__name__)
+
+
+class OutboxDispatcher:
+    """Publica en TaskQueue las filas de ``TaskDispatch`` pendientes."""
+
+    @staticmethod
+    def dispatch(dispatch_id: int, task_queue: Optional[ITaskQueue] = None) -> bool:
+        """Intenta publicar una fila concreta de ``TaskDispatch`` en TaskQueue.
+
+        Efectos secundarios sobre la fila:
+            - Éxito: ``status="dispatched"``, ``dispatched_at`` a ahora.
+            - Ya publicada por un intento anterior (``IllegalStateError`` con
+              el job todavía "started"): se marca ``dispatched`` sin volver a
+              publicar -- ver el docstring de ``outbox.py``.
+            - Cualquier otro fallo (típicamente Redis caído): ``attempts`` y
+              ``last_error`` se actualizan, la fila se queda ``pending`` para
+              el próximo intento.
+
+        Args:
+            dispatch_id: Primary key de la fila ``TaskDispatch`` a publicar.
+            task_queue: ``ITaskQueue`` a usar para publicar. Por defecto
+                ``None``, que resuelve a ``TaskQueue.get_instance()`` (el
+                singleton real respaldado por Redis) -- pásalo explícitamente
+                para reutilizar el mismo ``ITaskQueue`` inyectado del manager
+                llamante (p.ej. en tests) o para publicar contra un doble.
+
+        Returns:
+            bool: ``True`` si la fila quedó ``dispatched`` (ahora mismo, o ya
+                lo estaba de un intento anterior); ``False`` si el intento de
+                publicar falló y la fila sigue ``pending``, o si
+                ``dispatch_id`` no existe.
+        """
+        with UnitOfWork() as uow:
+            repo = TaskDispatchRepository(uow)
+            dispatch = repo.get_by_id(dispatch_id)
+            if dispatch is None:
+                return False
+            if dispatch.status == "dispatched":
+                return True
+
+            try:
+                func = decode_func(dispatch.func_path)
+                (task_queue or TaskQueue.get_instance()).submit(
+                    func=func, name=dispatch.name, category=dispatch.category,
+                    args=tuple(dispatch.args or []), kwargs=dict(dispatch.kwargs or {}),
+                    external_id=dispatch.external_id, timeout=dispatch.timeout,
+                )
+            except IllegalStateError:
+                pass
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                dispatch.attempts += 1
+                dispatch.last_error = str(e)[:2000]
+                repo.update(dispatch)
+                logger.warning(
+                    "No se pudo publicar TaskDispatch %s (%s intento(s)): %s",
+                    dispatch_id, dispatch.attempts, e,
+                )
+                return False
+
+            dispatch.status = "dispatched"
+            dispatch.dispatched_at = utcnow_naive()
+            repo.update(dispatch)
+            return True
+
+    @staticmethod
+    def dispatch_pending(limit: int = 100) -> int:
+        """Barrido: publica todas las filas de ``TaskDispatch`` que sigan
+        ``pending``, hasta ``limit``.
+
+        Se llama al arrancar la API (reconcilia lo que quedó de una caída
+        anterior) y periódicamente mientras vive (``TaskDispatchScheduler``),
+        para recuperarse de una caída de Redis sin esperar a un reinicio.
+
+        Args:
+            limit: Máximo de filas ``pending`` a procesar en esta pasada. Por
+                defecto ``100`` -- una cota, no una promesa de que se vacíe
+                la cola entera de una vez si hay más pendientes que eso.
+
+        Returns:
+            int: Cuántas filas quedaron ``dispatched`` en esta pasada
+                (incluye las que ya lo estaban de un intento anterior).
+        """
+        pending_ids = [
+            row.id for row in build_repository(TaskDispatchRepository).get_pending(limit)
+        ]
+        return sum(1 for dispatch_id in pending_ids if OutboxDispatcher.dispatch(dispatch_id))

--- a/API/src/modules/system/taskqueue/outbox.py
+++ b/API/src/modules/system/taskqueue/outbox.py
@@ -1,0 +1,203 @@
+"""
+Outbox transaccional para TaskQueue (B08) -- modelo y (de)serialización.
+
+**El problema**: varios managers seguían el patrón "crear entidad → confirmar
+en BD → encolar en Redis" con el ``submit()`` fuera de la transacción de la
+entidad. Entre esos dos pasos hay una ventana real: si la API se reinicia o
+Redis falla justo ahí, la fila queda en BD en estado ``pending`` sin ningún
+trabajo que la vaya a procesar nunca -- y nada lo nota hasta que alguien mira
+esa fila y se pregunta por qué no avanza. La caída de B04 (Fase 0) atendía la
+mitad de esto -- reconciliar un job que sí se encoló pero cuyo estado quedó
+inconsistente --, no la mitad en la que el ``submit()`` nunca llegó a pasar.
+
+**La solución**: ``TaskDispatch`` es la intención de publicar, persistida en
+la MISMA transacción que la entidad que la origina (mismo commit, o ninguno
+de los dos). ``OutboxDispatcher`` (``dispatcher.py``) la publica después:
+
+    with UnitOfWork() as uow:
+        EntityRepository(uow).save(entity)
+        dispatch = TaskDispatchRepository(uow).save(build_dispatch(
+            func=MyManager.execute_something,
+            name=f"MyThing-{entity.id}",
+            category="mymodule.something",
+            args=(entity.id,),
+        ))
+        uow.commit_for_handoff()
+
+    OutboxDispatcher.dispatch(dispatch.id, task_queue=self._task_queue)
+
+La llamada a ``dispatch()`` de después del ``with`` es el camino feliz: en el
+caso normal (Redis arriba) publica al instante, así que el trabajo arranca
+sin esperar a nada. Si falla -- Redis caído en ese momento concreto -- la
+fila se queda ``pending`` y la recoge más tarde el barrido periódico
+(``TaskDispatchScheduler``, en ``scheduling.py``) o la reconciliación de
+arranque, sin que el llamante tenga que hacer nada más.
+
+**Por qué esto es "al menos una vez", no "exactamente una vez".** Publicar es
+idempotente por construcción -- ``TaskQueue.submit()`` usa ``name`` como
+job_id determinista de RQ, así que reencolar una fila que en realidad ya se
+publicó no crea un segundo job mientras el primero siga en cola o corriendo
+(RQ lo detecta y lo rechaza o lo sustituye, según el caso). Queda una rendija
+angosta de verdad: si el proceso muere en el instante exacto entre que
+``submit()`` devuelve con éxito y que esta fila se marca ``dispatched``, un
+barrido posterior encontraría el job ya **terminado** y lo repetiría. Los
+consumidores de esta primera aplicación (``IrisManager.execute_iris_analysis``)
+recalculan y sobrescriben por ``analysis_id`` en vez de crear filas nuevas,
+así que una repetición ahí es trabajo de más, no un dato duplicado -- pero
+quien añada un nuevo consumidor de outbox debe poder decir lo mismo del suyo.
+
+**Alcance de esta primera aplicación (B08).** El propio issue #240 pide
+aplicarlo primero a análisis e ingesta y dejar para después el PDF, el
+resumen de IA y las notificaciones -- todos siguen el mismo patrón
+create-then-enqueue y son candidatos igual de válidos, pero mezclarlos aquí
+habría triplicado el tamaño de este cambio sin necesidad.
+
+**Por qué el dispatcher vive en un fichero aparte** (``dispatcher.py``): este
+módulo es la base (modelo + (de)serialización) que ``outbox_repository.py``
+importa; el dispatcher necesita el repositorio para leer/actualizar filas, así
+que si viviera aquí este módulo tendría que importar de vuelta
+``outbox_repository.py`` -- un ciclo real entre los dos ficheros, no solo un
+rodeo de import diferido.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable, Optional
+
+from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from src.modules.shared import Base, utcnow_naive
+
+
+class TaskDispatch(Base):
+    """Intención de publicar un job en TaskQueue, persistida antes de que exista.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        func_path: Referencia importable al callable a ejecutar
+                 (``"modulo.paquete:Clase.metodo"``, ver ``encode_func``/
+                 ``decode_func``) -- JSON no sabe serializar funciones, así
+                 que se guarda como texto y se reconstruye al publicar.
+        name: Id determinista del job en RQ (mismo valor que ``name=`` en
+                 ``TaskQueue.submit()``) -- es lo que hace idempotente un
+                 reintento de publicación.
+        category: Categoría de cola registrada en ``QueueRegistry``.
+        args / kwargs: Argumentos posicionales/nombrados para ``func``, tal
+                 cual se le pasarían a ``TaskQueue.submit()``. Deben ser
+                 JSON-serializables (ids, texto, listas/dicts simples) --
+                 nunca objetos ORM ni closures.
+        external_id: Id lógico de dominio, igual que en ``submit()``.
+        timeout: Timeout del job en segundos.
+        status: "pending" (sin publicar todavía) | "dispatched" (ya se
+                 publicó, con éxito o porque un intento anterior lo hizo).
+                 No hay estado terminal de fallo: un ``TaskDispatch`` sin
+                 publicar es casi siempre un síntoma de infraestructura
+                 (Redis caído), no de datos rotos, así que se reintenta
+                 indefinidamente en vez de darlo por muerto.
+        attempts: Cuántas veces falló un intento de publicación.
+        last_error: Motivo del último fallo, si alguno.
+        created_at: Cuándo se creó la intención (misma transacción que la
+                 entidad que la origina).
+        dispatched_at: Cuándo se publicó con éxito; NULL mientras siga
+                 ``pending``.
+    """
+    __tablename__ = "TaskDispatch"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    func_path = Column(String(255), nullable=False)
+    name = Column(String(255), nullable=False)
+    category = Column(String(64), nullable=False)
+    args = Column(JSONB, nullable=False, default=list)
+    kwargs = Column(JSONB, nullable=False, default=dict)
+    external_id = Column(String(255), nullable=True)
+    timeout = Column(Integer, nullable=False, default=600)
+    status = Column(String(20), nullable=False, default="pending", index=True)
+    attempts = Column(Integer, nullable=False, default=0)
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    dispatched_at = Column(DateTime, nullable=True)
+
+
+def encode_func(func: Callable) -> str:
+    """Convierte un callable en la referencia importable que se guarda en
+    ``TaskDispatch.func_path``, para poder reconstruirlo en otro proceso o
+    después de un reinicio (JSON no sabe serializar funciones).
+
+    ``__qualname__`` incluye el nombre de la clase para un ``@staticmethod``
+    (p.ej. ``"IrisManager.execute_iris_analysis"``), que es exactamente lo
+    que ``decode_func`` necesita para volver a resolverlo con ``getattr``.
+
+    Args:
+        func: Callable a codificar. Debe ser importable por referencia
+            (un ``@staticmethod`` de un manager, o una función a nivel de
+            módulo) -- nunca una lambda ni un closure, que no tienen un
+            ``__qualname__`` resoluble desde otro proceso.
+
+    Returns:
+        str: Cadena con formato ``"modulo.paquete:Clase.metodo"`` (o
+            ``"modulo.paquete:nombre_funcion"`` para una función suelta).
+    """
+    return f"{func.__module__}:{func.__qualname__}"
+
+
+def decode_func(path: str) -> Callable:
+    """Inversa de ``encode_func``: reconstruye el callable a partir de su
+    referencia importable.
+
+    Args:
+        path: Cadena con el formato que produce ``encode_func`` --
+            ``"modulo.paquete:Clase.metodo"`` o ``"modulo.paquete:funcion"``.
+
+    Returns:
+        Callable: El mismo objeto función/staticmethod que se codificó,
+            siempre que el módulo y el atributo sigan existiendo.
+
+    Raises:
+        ImportError: El módulo de ``path`` ya no existe o no se puede importar.
+        AttributeError: El módulo existe pero ya no tiene ese atributo (p.ej.
+            el método se renombró o se borró después de encolar la fila).
+    """
+    module_path, qualname = path.split(":", 1)
+    target: Any = importlib.import_module(module_path)
+    for part in qualname.split("."):
+        target = getattr(target, part)
+    return target
+
+
+def build_dispatch(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    func: Callable, *, name: str, category: str, args: tuple = (),
+    kwargs: Optional[dict] = None, external_id: Optional[str] = None,
+    timeout: int = 600,
+) -> TaskDispatch:
+    """Construye (sin guardar) la fila de outbox para una futura llamada a
+    ``TaskQueue.submit()`` con los mismos argumentos.
+
+    Args:
+        func: Callable que ejecutará el worker -- ver ``encode_func`` para
+            las restricciones (debe ser importable por referencia).
+        name: Id determinista del job en RQ, igual que ``name=`` en
+            ``TaskQueue.submit()``.
+        category: Categoría de cola registrada en ``QueueRegistry`` (p.ej.
+            ``"iris.analyze"``); si no está registrada, ``TaskQueue`` la
+            enruta a ``"default"`` al publicarla.
+        args: Argumentos posicionales para ``func``, JSON-serializables.
+            Por defecto, ninguno.
+        kwargs: Argumentos nombrados para ``func``, JSON-serializables. Por
+            defecto ninguno (se guarda como diccionario vacío, nunca ``None``).
+        external_id: Id lógico de dominio para localizar el job más tarde
+            (p.ej. ``"iris-analysis:42"``); ``None`` si no aplica.
+        timeout: Timeout del job en segundos una vez publicado. Por defecto
+            ``600``.
+
+    Returns:
+        TaskDispatch: Instancia sin persistir -- el llamante la guarda con
+            un repositorio, típicamente en la misma transacción que la
+            entidad que la origina.
+    """
+    return TaskDispatch(
+        func_path=encode_func(func), name=name, category=category,
+        args=list(args), kwargs=dict(kwargs or {}), external_id=external_id,
+        timeout=timeout,
+    )

--- a/API/src/modules/system/taskqueue/outbox_repository.py
+++ b/API/src/modules/system/taskqueue/outbox_repository.py
@@ -1,0 +1,38 @@
+"""
+Data-access layer for TaskDispatch (B08 outbox). Ver ``outbox.py`` para el
+porqué de esta tabla y cómo se usa.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.modules.infrastructure import BaseRepository
+
+from .outbox import TaskDispatch
+
+
+class TaskDispatchRepository(BaseRepository[TaskDispatch]):
+    """Data-access layer for TaskDispatch records."""
+
+    _MODEL = TaskDispatch
+
+    def get_pending(self, limit: int = 100) -> List[TaskDispatch]:
+        """Filas sin publicar, en orden de creación -- el orden en que se
+        crearon es el orden en que sus jobs deberían empezar a intentarse.
+
+        Args:
+            limit: Máximo de filas a devolver. Por defecto ``100``.
+
+        Returns:
+            List[TaskDispatch]: Filas con ``status="pending"``, ordenadas
+                por ``id`` ascendente (más antigua primero). Vacía si no
+                queda ninguna por publicar.
+        """
+        return (
+            self._session.query(TaskDispatch)
+            .filter(TaskDispatch.status == "pending")
+            .order_by(TaskDispatch.id.asc())
+            .limit(limit)
+            .all()
+        )

--- a/API/src/modules/system/taskqueue/scheduling.py
+++ b/API/src/modules/system/taskqueue/scheduling.py
@@ -1,0 +1,69 @@
+"""
+TaskDispatchScheduler — reintenta periódicamente los ``TaskDispatch`` que
+sigan ``pending`` (B08 outbox, ver ``outbox.py``).
+
+El intento inmediato tras el commit (``OutboxDispatcher.dispatch()`` llamado
+desde el propio manager) cubre el caso normal. Este scheduler es la red de
+seguridad para cuando ese intento falló porque Redis estaba caído justo en
+ese momento: sin este barrido, la fila se quedaría ``pending`` hasta el
+próximo reinicio de la API (que sí reconcilia al arrancar, ver
+``run.py::_configure_scheduling``), y un despliegue puede pasar horas sin
+reiniciarse.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+import src.modules.system.config_reading as CR
+from src.modules.infrastructure.scheduling import make_background_scheduler, scheduler_job
+
+from .dispatcher import OutboxDispatcher
+
+logger = logging.getLogger(__name__)
+
+
+class TaskDispatchScheduler:
+    """Ciclo de vida del scheduler de barrido de la outbox de TaskQueue."""
+
+    _scheduler: Optional[BackgroundScheduler] = None
+
+    @classmethod
+    def start(cls) -> None:
+        """Arranca el scheduler y registra el job de barrido. Idempotente."""
+        if cls._scheduler is not None:
+            return
+
+        interval = CR.taskqueue_config().outbox_sweep_interval_seconds
+        cls._scheduler = make_background_scheduler()
+        cls._scheduler.add_job(
+            func=cls._sweep,
+            trigger="interval",
+            seconds=interval,
+            id="taskqueue_outbox_sweep",
+            replace_existing=True,
+            max_instances=1,
+            name="TaskQueue outbox sweep",
+        )
+        cls._scheduler.start()
+        logger.info("Scheduler de outbox de TaskQueue iniciado (cada %ds)", interval)
+
+    @classmethod
+    def stop(cls) -> None:
+        """Detiene el scheduler. Idempotente."""
+        if cls._scheduler is None:
+            return
+        cls._scheduler.shutdown(wait=True)
+        cls._scheduler = None
+        logger.info("Scheduler de outbox de TaskQueue detenido")
+
+    @staticmethod
+    @scheduler_job(logger, "Error en el barrido de la outbox de TaskQueue")
+    def _sweep() -> None:
+        """Entry point del job (aislamiento de errores y cierre de sesión vía ``scheduler_job``)."""
+        dispatched = OutboxDispatcher.dispatch_pending()
+        if dispatched:
+            logger.info("Barrido de outbox: %d job(s) publicado(s)", dispatched)

--- a/API/tests/integration/test_taskqueue_outbox.py
+++ b/API/tests/integration/test_taskqueue_outbox.py
@@ -1,0 +1,259 @@
+"""B08: la outbox transaccional de TaskQueue.
+
+``TaskDispatch`` es la intención de publicar un job, guardada en la misma
+transacción que la entidad que la origina. Estos tests cubren el
+``OutboxDispatcher`` de forma aislada (con un ``ITaskQueue`` doble, sin Redis
+real) y, al final, el escenario íntegro que el issue pide: la API puede
+reiniciarse entre el commit del análisis y la publicación del job sin perder
+el trabajo ni duplicarlo.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.accounts.services.limits import LimitKey
+from src.modules.accounts.services.quotas import QuotaManager
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared._exceptions import IllegalStateError
+from src.modules.system.taskqueue.dispatcher import OutboxDispatcher
+from src.modules.system.taskqueue.outbox import build_dispatch, decode_func, encode_func
+from src.modules.system.taskqueue.outbox_repository import TaskDispatchRepository
+
+pytestmark = pytest.mark.integration
+
+
+class _RecordingQueue:
+    """Doble de ITaskQueue que apunta lo que se le publica, sin Redis real."""
+
+    def __init__(self) -> None:
+        self.submitted: list[dict] = []
+
+    def submit(self, **kwargs):
+        self.submitted.append(kwargs)
+
+
+class _RejectingQueue:
+    """Simula Redis caído: cualquier submit() falla."""
+
+    def submit(self, **kwargs):
+        raise ConnectionError("Redis no disponible")
+
+
+class _AlreadyStartedQueue:
+    """Simula que un intento anterior sí llegó a publicar el job y ya está
+    "started" -- exactamente lo que TaskQueue.submit() señaliza con
+    IllegalStateError cuando el job_id determinista ya está en marcha."""
+
+    def submit(self, **kwargs):
+        raise IllegalStateError(
+            "ya en ejecución", expected_state="not_started", current_state="started",
+        )
+
+
+def _save_dispatch(app, **overrides) -> int:
+    defaults = dict(
+        func=IrisManager.execute_iris_analysis,
+        name="Outbox-Test-1", category="iris.analyze",
+        args=(1, "raw"), external_id="outbox-test:1",
+    )
+    defaults.update(overrides)
+    with app.app_context():
+        with UnitOfWork() as uow:
+            dispatch = TaskDispatchRepository(uow).save(build_dispatch(**defaults))
+            return dispatch.id
+
+
+# ------------------------------------------------------------ encode/decode
+
+def test_encode_decode_func_roundtrips_a_real_staticmethod():
+    path = encode_func(IrisManager.execute_iris_analysis)
+    assert decode_func(path) is IrisManager.execute_iris_analysis
+
+
+def test_decode_func_raises_for_a_path_that_no_longer_resolves():
+    with pytest.raises((ImportError, AttributeError)):
+        decode_func("src.modules.features.iris.managers.analysis:IrisManager.does_not_exist")
+
+
+# --------------------------------------------------------------- dispatch()
+
+def test_dispatch_publishes_a_pending_row(app):
+    dispatch_id = _save_dispatch(app)
+    queue = _RecordingQueue()
+
+    with app.app_context():
+        published = OutboxDispatcher.dispatch(dispatch_id, task_queue=queue)
+
+        assert published is True
+        assert len(queue.submitted) == 1
+        assert queue.submitted[0]["name"] == "Outbox-Test-1"
+        assert queue.submitted[0]["func"] is IrisManager.execute_iris_analysis
+        assert queue.submitted[0]["args"] == (1, "raw")
+
+        with UnitOfWork() as uow:
+            row = TaskDispatchRepository(uow).get_by_id(dispatch_id)
+            assert row.status == "dispatched"
+            assert row.dispatched_at is not None
+
+
+def test_dispatch_leaves_the_row_pending_when_redis_is_down(app):
+    dispatch_id = _save_dispatch(app)
+
+    with app.app_context():
+        published = OutboxDispatcher.dispatch(dispatch_id, task_queue=_RejectingQueue())
+
+        assert published is False
+        with UnitOfWork() as uow:
+            row = TaskDispatchRepository(uow).get_by_id(dispatch_id)
+            assert row.status == "pending"
+            assert row.attempts == 1
+            assert "Redis" in row.last_error
+
+
+def test_dispatch_retries_a_previously_failed_row(app):
+    """Cada intento fallido suma -- así se puede ver cuántas veces lleva
+    reintentando una fila concreta sin tener que mirar los logs."""
+    dispatch_id = _save_dispatch(app)
+
+    with app.app_context():
+        OutboxDispatcher.dispatch(dispatch_id, task_queue=_RejectingQueue())
+        OutboxDispatcher.dispatch(dispatch_id, task_queue=_RejectingQueue())
+
+        queue = _RecordingQueue()
+        published = OutboxDispatcher.dispatch(dispatch_id, task_queue=queue)
+
+        assert published is True
+        assert len(queue.submitted) == 1
+        with UnitOfWork() as uow:
+            row = TaskDispatchRepository(uow).get_by_id(dispatch_id)
+            assert row.status == "dispatched"
+
+
+def test_dispatch_is_a_no_op_once_already_dispatched(app):
+    """Reintentar una fila ya publicada no debe volver a llamar a submit() --
+    es la mitad de la garantía "nunca lo duplica": una vez marcada, se queda
+    marcada."""
+    dispatch_id = _save_dispatch(app)
+    first_queue = _RecordingQueue()
+
+    with app.app_context():
+        OutboxDispatcher.dispatch(dispatch_id, task_queue=first_queue)
+        assert len(first_queue.submitted) == 1
+
+        second_queue = _RecordingQueue()
+        published = OutboxDispatcher.dispatch(dispatch_id, task_queue=second_queue)
+
+        assert published is True
+        assert second_queue.submitted == []
+
+
+def test_dispatch_treats_an_already_started_job_as_dispatched(app):
+    """La rendija que TaskQueue.submit() por sí solo no cierra: un intento
+    anterior sí publicó el job (ya está "started" con el mismo id
+    determinista) pero el proceso murió antes de marcar esta fila. El
+    siguiente intento no debe tratarlo como un fallo ni reintentar publicar
+    -- eso sí duplicaría el trabajo si el job ya hubiera terminado para
+    cuando llega el reintento (ver el docstring de outbox.py)."""
+    dispatch_id = _save_dispatch(app)
+
+    with app.app_context():
+        published = OutboxDispatcher.dispatch(dispatch_id, task_queue=_AlreadyStartedQueue())
+
+        assert published is True
+        with UnitOfWork() as uow:
+            row = TaskDispatchRepository(uow).get_by_id(dispatch_id)
+            assert row.status == "dispatched"
+            assert row.attempts == 0
+            assert row.last_error is None
+
+
+def test_dispatch_unknown_id_returns_false(app):
+    with app.app_context():
+        assert OutboxDispatcher.dispatch(999999, task_queue=_RecordingQueue()) is False
+
+
+# ----------------------------------------------------------- dispatch_pending()
+
+def test_dispatch_pending_publishes_every_pending_row(app, monkeypatch):
+    first_id = _save_dispatch(app, name="Outbox-Test-A", external_id="outbox-test:a")
+    second_id = _save_dispatch(app, name="Outbox-Test-B", external_id="outbox-test:b")
+
+    with app.app_context():
+        import src.modules.system.taskqueue.dispatcher as dispatcher_mod
+        queue = _RecordingQueue()
+        monkeypatch.setattr(dispatcher_mod.TaskQueue, "get_instance", staticmethod(lambda: queue))
+        dispatched = OutboxDispatcher.dispatch_pending()
+
+        assert dispatched == 2
+        assert {s["name"] for s in queue.submitted} == {"Outbox-Test-A", "Outbox-Test-B"}
+
+        with UnitOfWork() as uow:
+            repo = TaskDispatchRepository(uow)
+            assert repo.get_by_id(first_id).status == "dispatched"
+            assert repo.get_by_id(second_id).status == "dispatched"
+
+
+def test_dispatch_pending_skips_rows_already_dispatched(app, monkeypatch):
+    dispatch_id = _save_dispatch(app)
+
+    with app.app_context():
+        OutboxDispatcher.dispatch(dispatch_id, task_queue=_RecordingQueue())
+
+        import src.modules.system.taskqueue.dispatcher as dispatcher_mod
+        queue = _RecordingQueue()
+        monkeypatch.setattr(dispatcher_mod.TaskQueue, "get_instance", staticmethod(lambda: queue))
+        dispatched = OutboxDispatcher.dispatch_pending()
+
+        assert dispatched == 0
+        assert queue.submitted == []
+
+
+# --------------------------------------------------- escenario íntegro (B08)
+
+def test_analyze_survives_a_restart_between_commit_and_publish(
+    app, regular_user, set_plan_limits, monkeypatch,
+):
+    """El criterio de cierre del issue, de punta a punta: se crea el
+    análisis con Redis caído en ese instante (simulando el momento exacto en
+    que la API podría reiniciarse o Redis fallar), y luego una llamada
+    aparte -- como la reconciliación de arranque en run.py -- termina de
+    publicarlo. Nunca se pierde, y publicarlo dos veces (aquí, y en un
+    hipotético segundo arranque) no lo duplica."""
+    set_plan_limits({LimitKey.IRIS_ANALYSES: 5})
+
+    with app.app_context():
+        manager = IrisManager(task_queue=_RejectingQueue())
+        analysis_id = manager.analyze(
+            raw_headers="From: a@b.com\r\nSubject: Hi\r\n", user_id=regular_user.id,
+        )
+
+        # El análisis existe -- no se perdió nada aunque el submit fallara.
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysisRepository(uow).get_by_id(analysis_id)
+            assert analysis is not None
+            assert analysis.status == "pending"
+
+        with UnitOfWork() as uow:
+            pending = TaskDispatchRepository(uow).get_pending()
+            assert len(pending) == 1
+            assert pending[0].args == [analysis_id, "From: a@b.com\r\nSubject: Hi\r\n"]
+
+        # "Reinicio": la reconciliación de arranque (u otro barrido) publica
+        # lo que quedó pendiente, ahora con Redis arriba.
+        recovery_queue = _RecordingQueue()
+        import src.modules.system.taskqueue.dispatcher as dispatcher_mod
+        monkeypatch.setattr(dispatcher_mod.TaskQueue, "get_instance", staticmethod(lambda: recovery_queue))
+        dispatched = OutboxDispatcher.dispatch_pending()
+
+        assert dispatched == 1
+        assert len(recovery_queue.submitted) == 1
+
+        # Un segundo "reinicio" que barriera otra vez no vuelve a publicar:
+        # la fila ya quedó `dispatched` en el primero.
+        dispatched_again = OutboxDispatcher.dispatch_pending()
+
+        assert dispatched_again == 0
+        assert len(recovery_queue.submitted) == 1

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -765,6 +765,10 @@ class _FakeTaskQueue:
 
 
 def test_reanalyze_submits_the_same_stored_raw_input(monkeypatch):
+    """reanalyze() delega en analyze() con el raw_headers guardado -- sus
+    propios internos (cuota, outbox, TaskQueue) ya tienen cobertura directa
+    en test_iris_quota_idempotency.py y test_iris.py, así que aquí basta con
+    comprobar qué le pasa reanalyze() a analyze()."""
     from types import SimpleNamespace
 
     raw = "From: a@b.com\r\nSubject: Hi\r\n\r\n"
@@ -773,15 +777,21 @@ def test_reanalyze_submits_the_same_stored_raw_input(monkeypatch):
         IrisManager, "assert_analysis_ownership",
         classmethod(lambda cls, analysis_id, user_id: fake_analysis),
     )
-    monkeypatch.setattr(IrisManager, "_create_analysis_record",
-                        lambda self, r, uid, title=None, connection_id=None, source_message_uid=None: 99)
-    monkeypatch.setattr(IrisManager, "_validate_headers_pre", staticmethod(lambda r: None))
 
-    fake_queue = _FakeTaskQueue()
-    new_id = IrisManager(task_queue=fake_queue).reanalyze(analysis_id=5, user_id=1)
+    captured = {}
+
+    def _fake_analyze(self, raw_headers, user_id, title=None, **kwargs):
+        captured["raw_headers"] = raw_headers
+        captured["user_id"] = user_id
+        return 99
+
+    monkeypatch.setattr(IrisManager, "analyze", _fake_analyze)
+
+    new_id = IrisManager().reanalyze(analysis_id=5, user_id=1)
 
     assert new_id == 99
-    assert fake_queue.submitted["args"] == (99, raw)
+    assert captured["raw_headers"] == raw
+    assert captured["user_id"] == 1
 
 
 def test_reanalyze_title_references_the_original():
@@ -790,18 +800,14 @@ def test_reanalyze_title_references_the_original():
     captured_titles = []
 
     class _Manager(IrisManager):
-        def _create_analysis_record(self, raw, uid, title=None, connection_id=None, source_message_uid=None):
+        def analyze(self, raw_headers, user_id, title=None, **kwargs):
             captured_titles.append(title)
             return 100
-
-        @staticmethod
-        def _validate_headers_pre(raw):
-            return None
 
     fake_analysis = SimpleNamespace(id=7, title="Factura pendiente", raw_headers="From: a@b.com\r\n\r\n")
     _Manager.assert_analysis_ownership = classmethod(lambda cls, analysis_id, user_id: fake_analysis)
 
-    _Manager(task_queue=_FakeTaskQueue()).reanalyze(analysis_id=7, user_id=1)
+    _Manager().reanalyze(analysis_id=7, user_id=1)
 
     assert captured_titles == ["Factura pendiente (reanálisis)"]
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Each entry point is a `@staticmethod` on the owning module's manager class — p
 - **Progress reporting**: workers update `job.meta["progress"]` via `_Task(progress_callback=...)`.
 - **Cooperative cancellation**: set Redis key `taskqueue:cancel:{job_id}`; workers check via `_Task.wait(cancel_check=...)` and terminate the subprocess tree.
 - The `max_workers` setting is read at worker startup only — changes via `PUT /system/tasks/config` apply on the next worker restart.
+- **Transactional outbox** (`system/taskqueue/outbox.py`): the naive "commit the entity, then `submit()` the job" sequence leaves a window where an API restart or a Redis blip strands the entity with no job to process it. `IrisManager.analyze()` closes that window for analysis creation and mailbox ingestion by writing a `TaskDispatch` row in the same transaction as the entity and publishing it right after, falling back to a periodic sweep (`TaskDispatchScheduler`) and a startup reconciliation pass if the immediate publish fails. Not yet applied to the other categories in the table above.
 - Admin REST surface: `/system/tasks/*` (status, list, detail, cancel).
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

Closes #240 ([B08] Outbox fiable entre PostgreSQL y TaskQueue), part 5 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

`IrisManager.analyze()` created and committed the new `IrisAnalysis` row, then separately called `TaskQueue.submit()` to queue the background job that actually runs the rule engine on it. Those two steps aren't one transaction — there's a real window between them, and if the API restarted or Redis failed exactly in that window, the row was left sitting in the database in `pending` state with no job ever queued to process it. Nothing would ever pick it up again; the user would just see an analysis stuck at "pending" forever, with no error anywhere pointing at why. The same shape exists for mailbox ingestion, since ingestion is just `analyze()` called with a `connection_id`. B04 (Fase 0, already merged) covered a related-but-different half of this: reconciling a job whose *status* drifted after it was genuinely queued. It never covered the case where the queue call itself never happened.

## What changed

**`TaskDispatch`** (new table, `system/taskqueue/outbox.py`) is the fix: instead of calling `TaskQueue.submit()` directly, a manager now writes a `TaskDispatch` row — the *intention* to publish a job, with everything `submit()` needs (the callable, args, category, name, external_id) — in the **same transaction** as the entity it belongs to. Either both commit, or neither does.

- `encode_func()`/`decode_func()` turn a callable like `IrisManager.execute_iris_analysis` into an importable string (`"module.path:Class.method"`) and back — needed because a database row can't hold a live Python function reference, and this has to survive a process restart.
- **`OutboxDispatcher`** (`dispatcher.py`) is what actually talks to TaskQueue: `dispatch(id)` tries to publish one row, and `dispatch_pending()` sweeps everything still `pending`. `analyze()` calls `dispatch()` right after the commit as the happy path — in the normal case (Redis up) this adds no latency, the job starts immediately. If that call fails, the row is simply left `pending`; nothing about the entity is lost.
- Two safety nets pick up whatever the happy path missed: **`TaskDispatchScheduler`** (new, sixth scheduler alongside Themis/Hygeia/Iris-mailbox/Accounts/Users) sweeps pending rows every `taskqueue.outboxSweepIntervalSeconds` (default 60s) while the API is running, and `run.py`'s startup reconciliation (next to the existing orphaned-scan/orphaned-analysis reconciliation) sweeps once at boot — covering the case where Redis was down for longer than the API stayed alive between restarts.
- **Publishing is idempotent, not just retried blindly.** `TaskQueue.submit()` already uses a deterministic `job_id` (the `name` you pass it) — re-submitting a row that's still queued or already running doesn't create a second execution; RQ itself rejects or reconciles it. `OutboxDispatcher.dispatch()` explicitly treats that "already running" signal (`IllegalStateError`) as success rather than a retryable failure, since a prior attempt clearly did get through. The one gap this can't close completely — a crash in the exact instant between `submit()` succeeding and the row being marked `dispatched` — would at worst re-run an already-*finished* job; `execute_iris_analysis` recomputes and overwrites by `analysis_id` rather than creating new rows, so that's wasted work, not a duplicate. This is a known, standard limitation of the outbox pattern ("at least once", not "exactly once") and is called out explicitly in the module's docstring for whoever plugs a new consumer into it later.

**Scope**: applied only to `IrisManager.analyze()` (which covers both manual submission and mailbox ingestion, since ingestion is `analyze()` with a `connection_id`) — matching the issue's own explicit phasing ("aplicarlo primero a análisis e ingesta; después a PDF, IA y notificaciones"). `generate_ai_summary()`, PDF generation (`managers/reports.py`), and phishing notifications follow the identical create-then-enqueue shape and are deliberately untouched here.

**Also opened, not part of this PR**: [#551](https://github.com/ProjectEllysia/EllysiaServer/issues/551) — a follow-up asking for an audit of the rest of the codebase for the same pattern. A quick grep during this session found it replicated almost identically across five Themis scanner managers (Nmap/Nikto/Nuclei/Traceroute/Lybra) plus Aegis campaigns/pills and Hygeia — none of that is Iris-specific and none of it belongs in this PR, but it's real and worth tracking on its own.

## Implementation

- `API/src/modules/system/taskqueue/outbox.py` — `TaskDispatch` model, `encode_func`/`decode_func`, `build_dispatch()`.
- `API/src/modules/system/taskqueue/outbox_repository.py` — `TaskDispatchRepository`.
- `API/src/modules/system/taskqueue/dispatcher.py` — `OutboxDispatcher` (kept in its own module rather than alongside the model, since the model-repository-dispatcher relationship would otherwise be a real import cycle, not just a deferred one).
- `API/src/modules/system/taskqueue/scheduling.py` — `TaskDispatchScheduler`.
- `API/run.py` — registers the new scheduler (start/stop) and adds the startup outbox sweep next to the existing reconciliation calls.
- `API/src/modules/features/iris/managers/analysis.py` — `analyze()` rewritten to write the entity and its `TaskDispatch` row in one transaction and call `OutboxDispatcher.dispatch()` after; the old standalone `_create_analysis_record()` helper is folded in.
- `API/src/modules/system/config_reading.py` + `SecOpsConfig.json` — new `infrastructure.taskqueue.outbox_sweep_interval_seconds` (default 60).
- `API/alembic/versions/af1b51ec6c76_add_task_dispatch_outbox.py` — new migration (same caveat as every migration in this PR sequence: hand-written, no local Postgres available in this session to run `--autogenerate` against).

## Validation

- `pytest tests/ -k "iris or quota or taskqueue"` — 583 passed, 2 skipped (pre-existing, unrelated). One test in `test_taskqueue_deadline.py` failed once under full-suite load due to real wall-clock timing sensitivity in a pre-existing test unrelated to this change, and passed cleanly on every isolated and repeated run — flagging it here rather than silently re-running until green.
- New `tests/integration/test_taskqueue_outbox.py` (11 tests): `encode_func`/`decode_func` round-trip a real staticmethod; `dispatch()` publishes a pending row, leaves it pending and records the error when the queue rejects it, retries a previously-failed row, is a no-op once already dispatched, treats an already-"started" job as success rather than retrying it, and returns false for an unknown id; `dispatch_pending()` publishes every pending row and skips ones already dispatched; and the end-to-end scenario the issue's closure criterion describes — `analyze()` with a queue that always fails, confirming the analysis row exists and its `TaskDispatch` is `pending`, then a separate `dispatch_pending()` call (standing in for the startup reconciliation on a "restart") publishes it exactly once, and a second sweep doesn't publish it again.
- Two existing unit tests in `test_iris_rules.py` that monkeypatched the now-removed `_create_analysis_record()` were rewritten to monkeypatch `analyze()` itself instead, since that's the boundary `reanalyze()` (what they actually test) delegates to.
- `pytest tests/unit/test_config_shape.py` — passes (covers the new `outboxSweepIntervalSeconds` key).
- `pylint` on all touched/new files, diffed against a pre-change baseline — caught and fixed a real cyclic import (`outbox.py` <-> `outbox_repository.py`) by moving `OutboxDispatcher` into its own module rather than suppressing the warning; no other new warning categories beyond ones the codebase already tolerates for the same reasons (e.g. `too-few-public-methods` on every plain ORM model/repository class).

## Notes

- Same migration caveat as the rest of this PR sequence — worth an `alembic upgrade head` sanity check against a real dev DB before this reaches `v0.5`.
- `IrisManager(task_queue=...)`'s existing constructor injection (used by `generate_ai_summary()`/`reanalyze()` tests) is preserved and still threaded through: `analyze()` passes `self._task_queue` into `OutboxDispatcher.dispatch()` for the immediate happy-path attempt, so injecting a fake queue still works for that call; the periodic sweep and startup reconciliation, which have no "current manager instance" to inject into, use the real `TaskQueue.get_instance()` singleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
