### PR TITLE
fix(iris): make analysis state transitions atomic against cancellation

### DIFF
--- a/API/alembic/versions/ce173ee66b76_add_iris_analysis_cancel_requested_at.py
+++ b/API/alembic/versions/ce173ee66b76_add_iris_analysis_cancel_requested_at.py
@@ -1,0 +1,40 @@
+"""iris: IrisAnalysis.cancel_requested_at (B07 -- transiciones de estado atómicas)
+
+``cancel_analysis()`` señalizaba TaskQueue y escribía ``status="cancelled"``
+sin condicionar al estado actual de la fila. Si el worker terminaba el
+análisis justo en ese instante, cualquiera de las dos escrituras podía ganar
+la carrera, y el resultado final dependía de quién escribiera último en vez
+de reflejar la decisión real del usuario o del pipeline.
+
+Esta columna no forma parte de la corrección de la carrera en sí (eso lo
+hace ``IrisAnalysisRepository.transition_if_state()``, una transición SQL
+condicionada) -- registra que el usuario pidió cancelar, incluso cuando el
+worker gana la carrera y el análisis acaba ``finished`` en vez de
+``cancelled``. Sin esta columna esa intención se perdía sin dejar rastro.
+
+Revision ID: ce173ee66b76
+Revises: af1b51ec6c76
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ce173ee66b76'
+down_revision: Union[str, Sequence[str], None] = 'af1b51ec6c76'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisAnalysis', sa.Column('cancel_requested_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisAnalysis', 'cancel_requested_at')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -124,45 +124,50 @@ class IrisManager(TaskTrackingMixin):
         connection_id: int | None = None,
         source_message_uid: str | None = None,
     ) -> int:
-        """Submit raw email headers (or a full message) for background analysis.
+        """Envía cabeceras de correo crudas (o un mensaje completo) a análisis
+        en segundo plano.
 
-        Creates an IrisAnalysis record in ``pending`` state and enqueues
-        a TaskQueue task (category ``"iris.analyze"``) that runs every
-        registered rule, aggregates scores, and persists the results.
+        Crea una fila ``IrisAnalysis`` en estado ``pending`` y encola una
+        tarea de TaskQueue (categoría ``"iris.analyze"``) que ejecuta todas
+        las reglas registradas, agrega las puntuaciones y persiste los
+        resultados.
 
         Args:
-            raw_headers: Headers-only block as plain text (legacy input).
-            user_id:     Primary key of the requesting user.
-            title:       Optional user-defined label for quick
-                         identification in history.
-            raw_message: Full raw ``.eml`` message as plain text (Fase 2).
-                         Takes priority over ``raw_headers`` when both are
-                         given, since it's a superset of the header data.
-                         Rules that need body/links/attachments only see
-                         them when this is provided.
-            connection_id: IrisMailboxConnection this message was ingested
-                         through (Fase 3-4). None for manual submissions —
-                         the original, still-default flow.
-            source_message_uid: Provider-specific message id, set only
-                         together with connection_id. The (connection_id,
-                         source_message_uid) pair is UNIQUE at the DB level.
-                         A mailbox sync retry that resubmits the same
-                         message never duplicates the analysis nor pays
-                         quota for it twice (B09) — see the idempotency
-                         check below.
+            raw_headers: Bloque de solo cabeceras como texto plano (entrada
+                original, previa a Fase 2).
+            user_id: Primary key del usuario que solicita el análisis.
+            title: Etiqueta opcional definida por el usuario para
+                identificarlo rápido en el histórico. Por defecto ``None``.
+            raw_message: Mensaje ``.eml`` crudo completo como texto plano
+                (Fase 2). Tiene prioridad sobre ``raw_headers`` cuando se dan
+                los dos, porque es un superconjunto de los datos de
+                cabecera. Las reglas que necesitan cuerpo/enlaces/adjuntos
+                solo los ven cuando se proporciona este campo. Por defecto
+                ``None``.
+            connection_id: IrisMailboxConnection por la que se ingirió este
+                mensaje (Fase 3-4). ``None`` para envíos manuales -- el
+                flujo original, que sigue siendo el que no requiere
+                conexión. Por defecto ``None``.
+            source_message_uid: Id del mensaje específico del proveedor,
+                solo se da junto con ``connection_id``. El par
+                ``(connection_id, source_message_uid)`` es UNIQUE a nivel de
+                base de datos. Un reintento de sync de buzón que reenvía el
+                mismo mensaje nunca duplica el análisis ni cobra cuota dos
+                veces (B09) -- ver la comprobación de idempotencia más abajo.
+                Por defecto ``None``.
 
         Returns:
-            The IrisAnalysis primary key (``analysis_id``) — either the one
-            just created, or the existing one when ``(connection_id,
-            source_message_uid)`` was already accepted by a previous call.
-            The caller should store this to later poll status or fetch the
-            full report.
+            int: La primary key del ``IrisAnalysis`` (``analysis_id``) --
+                bien el que se acaba de crear, bien el ya existente cuando
+                ``(connection_id, source_message_uid)`` ya había sido
+                aceptado por una llamada anterior. El llamante debe guardarlo
+                para consultar más tarde el estado o pedir el informe completo.
 
         Raises:
-            IrisInvalidInputError: If neither input is given, or the
-                content contains fewer than the minimum required header
-                lines (configurable via ``iris.min_headers`` in
-                SecOpsConfig.json).
+            IrisInvalidInputError: Si no se da ninguna de las dos entradas, o
+                si el contenido tiene menos líneas de cabecera que el mínimo
+                requerido (configurable vía ``iris.min_headers`` en
+                ``SecOpsConfig.json``).
         """
         raw_input = raw_message or raw_headers
         if not raw_input:
@@ -673,23 +678,39 @@ class IrisManager(TaskTrackingMixin):
                     IrisManager._refund_ai_summary_quota(user_id)
 
     def cancel_analysis(self, analysis_id: int, user_id: int) -> bool:
-        """Cancel a running or pending analysis.
+        """Cancela un análisis ``pending`` o ``running``.
 
-        Signals the TaskQueue task to stop and marks the database record
-        as ``cancelled``.
+        Señaliza la tarea de TaskQueue para que pare y marca la fila como
+        ``cancelled`` en la base de datos -- pero solo si el worker no ha
+        alcanzado ya un estado terminal por su cuenta mientras tanto. Que
+        ``_task_queue.cancel()`` lea "sigue en marcha" y que este método
+        escriba en la base de datos no son un único paso atómico: el worker
+        puede llamar a ``_persist_analysis_results()`` y confirmar
+        ``finished`` justo en ese hueco. B07: la escritura real de
+        ``status`` pasa por ``IrisAnalysisRepository.transition_if_state()``,
+        un ``UPDATE ... WHERE status IN (...)`` condicionado que solo uno de
+        los dos escritores en competencia puede ganar, así que una
+        cancelación que llega después de que el análisis ya terminara nunca
+        puede sobreescribir su resultado.
 
         Args:
-            analysis_id: Primary key of the analysis to cancel.
-            user_id:     Owner ID (must match the record's owner).
+            analysis_id: Primary key del análisis a cancelar.
+            user_id: Id del propietario (debe coincidir con el dueño de la fila).
 
         Returns:
-            True if the cancellation was successful.
+            bool: ``True`` si esta llamada transicionó de verdad el análisis
+                a ``cancelled``. ``False`` si no había ninguna tarea activa
+                que cancelar, o si el worker ya había persistido un estado
+                terminal (``finished``/``failed``) para cuando esto intentó
+                escribir -- en ese caso el resultado real del análisis queda
+                intacto, y el hecho de que se pidió cancelar queda igualmente
+                registrado en ``cancel_requested_at`` para quien lo consulte.
 
         Raises:
-            IrisAnalysisNotFoundError: If the analysis does not exist
-                or does not belong to this user.
-            IrisInvalidStateError: If the analysis is not in a
-                cancellable state (``pending`` or ``running``).
+            IrisAnalysisNotFoundError: Si el análisis no existe o no
+                pertenece a este usuario.
+            IrisInvalidStateError: Si el análisis no está en un estado
+                cancelable (``pending`` o ``running``).
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
 
@@ -703,11 +724,34 @@ class IrisManager(TaskTrackingMixin):
             logger.warning(f"No active task found for analysis {analysis_id}")
             return False
 
-        was_cancelled = self._task_queue.cancel(queued_task.id)
-        if was_cancelled:
-            self._update_analysis(analysis_id, status="cancelled", finished_at=utcnow_naive())
-            logger.info(f"Analysis {analysis_id} cancelled by user {user_id}")
-        return was_cancelled
+        if not self._task_queue.cancel(queued_task.id):
+            # RQ ya sabía que el job había terminado -- ni siquiera merece la
+            # pena intentar la transición condicionada.
+            return False
+
+        with UnitOfWork() as uow:
+            repo = IrisAnalysisRepository(uow)
+            # Se registra siempre que se pidió cancelar, gane o no la carrera
+            # contra el worker -- es la traza de la intención del usuario,
+            # independiente del resultado (ver docstring de la columna).
+            uow.session.execute(
+                update(IrisAnalysis)
+                .where(IrisAnalysis.id == analysis_id)
+                .values(cancel_requested_at=utcnow_naive())
+            )
+            transitioned = repo.transition_if_state(
+                analysis_id, list(_CANCELLABLE_STATES),
+                status="cancelled", finished_at=utcnow_naive(),
+            )
+
+        if transitioned:
+            logger.info(f"Análisis {analysis_id} cancelado por el usuario {user_id}")
+        else:
+            logger.info(
+                f"Análisis {analysis_id}: la cancelación llegó tarde -- el worker ya "
+                "había terminado el análisis, su resultado no se sobreescribe."
+            )
+        return transitioned
 
     def delete_analysis(self, analysis_id: int) -> bool:
         """Permanently delete an analysis and its rule results.
@@ -997,14 +1041,27 @@ class IrisManager(TaskTrackingMixin):
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
                                    verdict: str, total_score: float, gate_reasons: list[str],
                                    quality: AnalysisQuality, detector: str) -> None:
-        """Persist every rule row and the final analysis state in one transaction.
+        """Persiste todas las filas de regla y el estado final del análisis
+        en una única transacción.
 
-        Previously each rule opened (and committed) its own
-        ``UnitOfWork`` — ~40 commits per analysis, and a cancellation
-        mid-loop left the already-committed rows of a ``cancelled``
-        analysis dangling (C2/C3). One transaction for the whole batch
-        fixes both: it's atomic, and a ``return`` before this point
-        (cancellation) now leaves nothing committed at all.
+        Antes cada regla abría (y confirmaba) su propio ``UnitOfWork`` --
+        unos 40 commits por análisis, y una cancelación a mitad de bucle
+        dejaba huérfanas las filas ya confirmadas de un análisis
+        ``cancelled`` (C2/C3). Una sola transacción para todo el lote
+        arregla las dos cosas: es atómica, y un ``return`` antes de este
+        punto (cancelación) ya no deja nada confirmado.
+
+        B07: la escritura final de ``status="finished"`` (junto con los
+        campos de score/veredicto que la acompañan) pasa por
+        ``IrisAnalysisRepository.transition_if_state()``, que solo la
+        aplica si la fila sigue ``running``. Sin esa condición, una
+        cancelación que ``cancel_analysis()`` confirme en el hueco estrecho
+        entre que este método lee la fila y este método confirma su propia
+        transacción se sobreescribiría en silencio de vuelta a ``finished``
+        -- exactamente la carrera que este issue viene a cerrar. Las filas
+        de regla de arriba se escriben de todos modos: son ciertas pase lo
+        que pase, y nunca quedan huérfanas gracias al agrupado en una sola
+        transacción que ya describe este docstring.
         """
         with UnitOfWork() as uow:
             rule_repo = IrisRuleResultRepository(uow)
@@ -1021,18 +1078,18 @@ class IrisManager(TaskTrackingMixin):
                 ))
 
             analysis_repo = IrisAnalysisRepository(uow)
-            analysis = analysis_repo.get_by_id(analysis_id)
-            if analysis is None:
-                return
-            analysis.status = "finished"
-            analysis.total_score = total_score
-            analysis.verdict = verdict
-            analysis.gate_reasons = gate_reasons
-            analysis.analysis_quality = quality.quality
-            analysis.failed_rules = quality.failed_rules or None
-            analysis.detector_version = detector
-            analysis.finished_at = utcnow_naive()
-            analysis_repo.update(analysis)
+            transitioned = analysis_repo.transition_if_state(
+                analysis_id, ["running"],
+                status="finished", total_score=total_score, verdict=verdict,
+                gate_reasons=gate_reasons, analysis_quality=quality.quality,
+                failed_rules=quality.failed_rules or None, detector_version=detector,
+                finished_at=utcnow_naive(),
+            )
+            if not transitioned:
+                logger.info(
+                    f"Análisis {analysis_id} ya no estaba running al terminar de "
+                    "evaluar las reglas (probablemente cancelado) -- no se sobreescribe."
+                )
 
     @staticmethod
     def _aggregate_score(rules_defs: List[dict], results: List[RuleResult]) -> float:

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -70,6 +70,13 @@ class IrisAnalysis(Base):
                  que ``detector_version`` para las reglas).
         started_at: Timestamp when the analysis was created.
         finished_at: Timestamp when the analysis reached a terminal state.
+        cancel_requested_at: Cuándo el usuario pidió cancelar, si alguna vez
+                 lo hizo; NULL si nunca se pidió. Se registra siempre que se
+                 llama a ``cancel_analysis()``, gane o no la carrera contra
+                 el worker -- es la traza de la intención del usuario, no del
+                 resultado, así que no se borra ni se sobreescribe aunque el
+                 worker termine primero y el análisis acabe ``finished`` en
+                 vez de ``cancelled`` (B07).
         user_id: Foreign key to the owning User.
         user: SQLAlchemy relationship to User.
         rule_results: Ordered list of IrisRuleResult (per-rule outcomes).
@@ -105,6 +112,7 @@ class IrisAnalysis(Base):
     ai_summary_prompt_version = Column(String(32), nullable=True)
     started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     finished_at = Column(DateTime, nullable=True)
+    cancel_requested_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow_naive)
 
     user_id = Column(Integer, ForeignKey("User.id"), nullable=False)

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -8,9 +8,9 @@ IrisRuleResult models.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
-from sqlalchemy import asc, desc, nullslast
+from sqlalchemy import and_, asc, desc, nullslast, update
 from sqlalchemy.orm import joinedload
 
 from src.modules.infrastructure import BaseRepository, DocumentRepository
@@ -138,6 +138,49 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
     def exists_by_source(self, connection_id: int, source_message_uid: str) -> bool:
         """Si ya existe un análisis para este (connection_id, source_message_uid)."""
         return self.get_by_source(connection_id, source_message_uid) is not None
+
+    def transition_if_state(self, analysis_id: int, from_states: list[str], **fields: Any) -> bool:
+        """Aplica ``fields`` sobre un análisis solo si su ``status`` actual
+        está en ``from_states`` -- transición SQL condicionada, no un
+        leer-decidir-escribir (B07).
+
+        El caso real: el usuario cancela un análisis a la vez que el worker
+        termina de procesarlo. Sin esta condición dentro del propio UPDATE,
+        cancel_analysis() y _persist_analysis_results() compiten por
+        escribir la misma fila -- running->cancelled uno, running->finished
+        el otro -- y gana quien confirme último en vez de ganar quien tenga
+        razón. Con la condición en el ``WHERE``, la base de datos serializa
+        los dos UPDATE: solo el primero en llegar afecta a la fila (y su
+        ``rowcount`` es 1); el segundo no cambia nada (``rowcount`` 0), y
+        quien lo invoque sabe por el valor de retorno que perdió la carrera
+        y no debe fiarse de que su transición se aplicó. Mismo patrón que
+        ``_claim_ai_summary()`` (B10), generalizado a cualquier conjunto de
+        campos en vez de una sola columna.
+
+        Args:
+            analysis_id: Primary key del ``IrisAnalysis`` a transicionar.
+            from_states: Estados de ``status`` en los que debe estar la fila
+                para que la transición se aplique (p.ej. ``["running"]``, o
+                los dos estados no terminales `_CANCELLABLE_STATES`). Una
+                lista vacía nunca coincide con nada.
+            **fields: Columnas a escribir si la condición se cumple --
+                normalmente incluye ``status`` con el nuevo valor, más
+                cualquier otro campo que deba cambiar en el mismo commit
+                (``finished_at``, ``total_score``, ``verdict``...).
+
+        Returns:
+            bool: ``True`` si la fila estaba en uno de ``from_states`` y la
+                transición se aplicó (``fields`` ya están escritos). ``False``
+                si el análisis no existe, o si su ``status`` ya había
+                cambiado a otra cosa -- en ese caso ningún campo de
+                ``fields`` se ha tocado.
+        """
+        result = self._session.execute(
+            update(IrisAnalysis)
+            .where(and_(IrisAnalysis.id == analysis_id, IrisAnalysis.status.in_(from_states)))
+            .values(**fields)
+        )
+        return bool(result.rowcount)
 
 
 class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):

--- a/API/tests/integration/test_iris_cancellation.py
+++ b/API/tests/integration/test_iris_cancellation.py
@@ -1,0 +1,233 @@
+"""B07: transiciones de estado atómicas frente a cancelación concurrente.
+
+``cancel_analysis()`` señaliza TaskQueue y ``_persist_analysis_results()``
+(el worker, al terminar de evaluar las reglas) escriben el ``status`` final
+del mismo ``IrisAnalysis`` desde dos sitios distintos. Antes de este arreglo
+ninguno de los dos comprobaba el estado actual de la fila antes de escribir
+-- si el usuario cancelaba justo cuando el worker terminaba (o viceversa),
+ganaba quien confirmara el commit último, no quien tuviera razón. Estos
+tests ponen una barrera explícita entre "se decide cancelar/terminar" y "se
+escribe en la base de datos" para demostrar que la transición condicionada
+(``IrisAnalysisRepository.transition_if_state()``) cierra esa carrera en los
+dos sentidos.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import src.modules.features.iris.managers.analysis as managers_mod
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisRuleResultRepository
+from src.modules.features.iris.services.quality import AnalysisQuality
+from src.modules.features.iris.services.registry import RuleResult
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared import utcnow_naive
+from src.modules.system.taskqueue import Task, TaskStatus
+
+pytestmark = pytest.mark.integration
+
+
+def _make_analysis(app, user_id, status="running") -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(
+                raw_headers="From: a@b.com\r\nSubject: Hi\r\n", user_id=user_id, status=status,
+            )
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+def _reload(app, analysis_id) -> IrisAnalysis:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            return IrisAnalysisRepository(uow).get_by_id(analysis_id)
+
+
+class _FakeCancelQueue:
+    """Cola fake para cancel_analysis(): siempre encuentra una tarea
+    "started" y deja que el test decida qué pasa cuando se pide cancelarla
+    -- incluyendo, para la prueba de la carrera, ejecutar código arbitrario
+    justo en ese instante (simulando al worker terminando en paralelo)."""
+
+    def __init__(self, on_cancel=None, cancel_returns: bool = True):
+        self._on_cancel = on_cancel
+        self._cancel_returns = cancel_returns
+
+    def get_task_by_external_id(self, external_id, category=None):
+        return Task(id="job1", name="job1", category=category or "iris.analyze",
+                    external_id=external_id, status=TaskStatus.RUNNING)
+
+    def cancel(self, task_id: str) -> bool:
+        if self._on_cancel is not None:
+            self._on_cancel()
+        return self._cancel_returns
+
+
+def _cancel(app, queue, analysis_id, user_id) -> bool:
+    with app.app_context():
+        with mock.patch.object(managers_mod.TaskQueue, "get_instance", return_value=queue):
+            return IrisManager(task_queue=queue).cancel_analysis(analysis_id, user_id)
+
+
+# --------------------------------------------------------------- transition_if_state
+
+def test_transition_if_state_applies_when_the_row_matches(app, regular_user):
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            applied = IrisAnalysisRepository(uow).transition_if_state(
+                analysis_id, ["running"], status="finished", verdict="Legitimate",
+            )
+        assert applied is True
+
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "finished"
+    assert reloaded.verdict == "Legitimate"
+
+
+def test_transition_if_state_is_a_no_op_when_the_row_does_not_match(app, regular_user):
+    """Si el estado ya cambió, ni `status` ni ningún otro campo del intento
+    perdedor se escriben -- no solo `status` se queda como estaba."""
+    analysis_id = _make_analysis(app, regular_user.id, status="cancelled")
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            applied = IrisAnalysisRepository(uow).transition_if_state(
+                analysis_id, ["running"], status="finished", verdict="Phishing",
+            )
+        assert applied is False
+
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "cancelled"
+    assert reloaded.verdict is None
+
+
+def test_transition_if_state_returns_false_for_a_missing_analysis(app):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            applied = IrisAnalysisRepository(uow).transition_if_state(
+                999999, ["running"], status="finished",
+            )
+        assert applied is False
+
+
+# ------------------------------------------------------------- cancel_analysis()
+
+def test_cancel_analysis_transitions_a_running_analysis(app, regular_user):
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    result = _cancel(app, _FakeCancelQueue(), analysis_id, regular_user.id)
+
+    assert result is True
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "cancelled"
+    assert reloaded.finished_at is not None
+    assert reloaded.cancel_requested_at is not None
+
+
+def test_cancel_analysis_returns_false_when_the_queue_says_it_already_finished(app, regular_user):
+    """TaskQueue.cancel() devuelve False si RQ ya sabe que el job terminó --
+    ni siquiera merece la pena intentar la transición condicionada."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    result = _cancel(app, _FakeCancelQueue(cancel_returns=False), analysis_id, regular_user.id)
+
+    assert result is False
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "running"  # sin tocar
+    assert reloaded.cancel_requested_at is None  # ni se intentó escribir nada
+
+
+def test_cancel_analysis_does_not_overwrite_a_result_the_worker_wins_the_race_to_persist(
+    app, regular_user,
+):
+    """La barrera del issue, en el sentido "el worker gana": justo cuando
+    cancel_analysis() pide a TaskQueue que cancele el job (que todavía
+    reporta "started"), el worker consigue persistir su resultado antes de
+    que la transición de cancel_analysis() llegue a ejecutarse. El usuario
+    pidió cancelar de buena fe -- eso se registra -- pero el resultado real
+    del análisis no se pierde ni se sobreescribe con "cancelled"."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    def _worker_wins_the_race():
+        with app.app_context():
+            with UnitOfWork() as uow:
+                IrisAnalysisRepository(uow).transition_if_state(
+                    analysis_id, ["running"], status="finished", verdict="Legitimate",
+                    total_score=95.0, finished_at=utcnow_naive(),
+                )
+
+    queue = _FakeCancelQueue(on_cancel=_worker_wins_the_race)
+    result = _cancel(app, queue, analysis_id, regular_user.id)
+
+    assert result is False
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "finished"
+    assert reloaded.verdict == "Legitimate"
+    assert reloaded.total_score == 95.0
+    # La intención de cancelar se registra igualmente, aunque perdiera la carrera.
+    assert reloaded.cancel_requested_at is not None
+
+
+# --------------------------------------------------------- _persist_analysis_results()
+
+def test_persist_analysis_results_does_not_overwrite_a_cancellation(app, regular_user):
+    """La barrera al revés: el usuario cancela justo antes de que el worker
+    termine de evaluar las reglas y llame a _persist_analysis_results(). Las
+    filas de reglas se escriben igual (son un hecho, ocurrieron), pero el
+    veredicto/score calculados no deben aterrizar sobre un análisis que el
+    usuario ya dio por cancelado."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            cancelled = IrisAnalysisRepository(uow).transition_if_state(
+                analysis_id, ["running"], status="cancelled", finished_at=utcnow_naive(),
+            )
+        assert cancelled is True
+
+        IrisManager._persist_analysis_results(
+            analysis_id,
+            rules_defs=[{"name": "SPF", "category": "auth"}],
+            results=[RuleResult(
+                score=-10.0, verdict="fail", details={}, recommendation="revisa SPF",
+            )],
+            verdict="Phishing", total_score=10.0, gate_reasons=[],
+            quality=AnalysisQuality(quality="complete"), detector="test:1",
+        )
+
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "cancelled"
+    assert reloaded.verdict is None
+    assert reloaded.total_score is None
+    assert reloaded.detector_version is None
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            rules = IrisRuleResultRepository(uow).get_by_analysis(analysis_id)
+            assert len(rules) == 1
+            assert rules[0].rule_name == "SPF"
+
+
+def test_persist_analysis_results_finishes_a_still_running_analysis(app, regular_user):
+    """Camino normal (sin carrera): la transición sí se aplica."""
+    analysis_id = _make_analysis(app, regular_user.id, status="running")
+
+    with app.app_context():
+        IrisManager._persist_analysis_results(
+            analysis_id,
+            rules_defs=[{"name": "SPF", "category": "auth"}],
+            results=[RuleResult(score=2.0, verdict="pass", details={})],
+            verdict="Legitimate", total_score=90.0, gate_reasons=[],
+            quality=AnalysisQuality(quality="complete"), detector="test:1",
+        )
+
+    reloaded = _reload(app, analysis_id)
+    assert reloaded.status == "finished"
+    assert reloaded.verdict == "Legitimate"
+    assert reloaded.total_score == 90.0


### PR DESCRIPTION
## Summary

Closes #226 ([B07] Transiciones de estado atómicas frente a cancelación concurrente), part 6 of 11 for the Fase 1 roadmap (see the umbrella issue #201).

Two different code paths write `IrisAnalysis.status`: `cancel_analysis()` (a user asking to stop a running analysis) and `_persist_analysis_results()` (the background worker finishing the rule engine and writing the final verdict). Both did it unconditionally — read nothing, check nothing, just set the field and commit. If the user cancels at almost the same moment the worker finishes, there's a genuine race: whichever transaction commits last wins, and the loser's intent is silently discarded. Concretely, this can go two ways: the worker finishes normally and commits `finished` with a real verdict, and then the user's stale cancellation request lands on top of it and turns a legitimate result back into `cancelled`; or the user cancels first, and then the worker — which already checks `job.cancelled()` mid-loop but had already passed that check before the signal arrived — commits `finished` right over the cancellation, so the user's own decision just disappears.

There was already a partial mitigation: `_persist_analysis_results()` batches every rule row plus the final status into one transaction, so a cancellation mid-loop never leaves orphaned rule rows behind. That solved "no partial rule data," not "which final status is the true one" — this PR is the second half.

## What changed

**`IrisAnalysisRepository.transition_if_state(analysis_id, from_states, **fields)`** is new: a conditional `UPDATE ... WHERE id = :id AND status IN (:from_states)`. The condition lives inside the `WHERE` clause of the UPDATE itself, not in a separate read-then-decide-then-write step — so under real concurrency, the database serializes the two competing UPDATEs and only the one that still finds the row in the expected state actually changes anything (`rowcount` tells the caller which one it was). This is the exact same shape as the existing `_claim_ai_summary()` conditional-UPDATE pattern from B10, generalized from a single column to an arbitrary set of fields.

- `cancel_analysis()` now writes `status="cancelled"` through `transition_if_state(analysis_id, _CANCELLABLE_STATES, ...)` — it only applies if the analysis is still `pending`/`running` at the instant the UPDATE runs. If the worker already committed `finished` by then, this is a no-op: the real result stands, and the method returns `False` instead of pretending the cancellation took effect.
- `_persist_analysis_results()` now writes `status="finished"` (plus `total_score`, `verdict`, `gate_reasons`, and the rest of the result fields) through `transition_if_state(analysis_id, ["running"], ...)` — it only applies if the analysis is still `running`. If the user cancelled in the meantime, none of the computed result fields land on top of that decision.
- **`cancel_requested_at`** (new column) is set unconditionally every time `cancel_analysis()` is called, regardless of whether its own transition wins the race. This is deliberate: the user's intent to cancel is a fact that happened, separate from whatever the final `status` ends up being — without it, a cancellation that lost the race left literally no trace that it was ever requested.

## Implementation

- `API/src/modules/features/iris/repositories.py` — `IrisAnalysisRepository.transition_if_state()`.
- `API/src/modules/features/iris/managers/analysis.py` — `cancel_analysis()` and `_persist_analysis_results()` rewritten around the conditional transition; `cancel_analysis()`'s return value now reflects whether the DB transition actually applied, not just whether TaskQueue accepted the cancel signal (no existing test pinned the old semantics, since this method had no dedicated test coverage before this PR).
- `API/src/modules/features/iris/model.py` — `IrisAnalysis.cancel_requested_at`.
- `API/alembic/versions/ce173ee66b76_add_iris_analysis_cancel_requested_at.py` — new migration (same caveat as every migration in this PR sequence: hand-written, no local Postgres available in this session to run `--autogenerate` against).

## Validation

- `pytest tests/ -k iris` — 516 passed, 2 skipped (pre-existing, unrelated).
- New `tests/integration/test_iris_cancellation.py` (8 tests) is built around the issue's own closure criterion — a test with an explicit barrier between "decide to cancel/finish" and "write to the database":
  - `transition_if_state()` on its own: applies when the row matches, is a true no-op (no field touched, not just `status`) when it doesn't, and returns `False` for a missing row.
  - The actual race, worker-wins direction: `cancel_analysis()` is called with a fake TaskQueue whose `cancel()` — standing in for the exact window between RQ confirming the job "is still running" and this method's own database write — runs code that persists a real `finished` result first. The assertion is that `cancel_analysis()` returns `False`, the analysis keeps its real verdict/score, and `cancel_requested_at` is still set.
  - The race, user-wins direction: an analysis is cancelled directly, then `_persist_analysis_results()` is called with a worked-out verdict/score for it. The assertion is that the analysis stays `cancelled` with no verdict/score attached, while the rule-result rows are still written (they're accurate regardless of the final status).
  - Plus the ordinary non-racing paths for both methods, and the "TaskQueue already knows the job is over" fast-path in `cancel_analysis()`.
- `pylint` on all touched files, diffed against a pre-change baseline — no new warning categories beyond ones this exact file already carries for the same reasons (e.g. `logging-fstring-interpolation` on `logger.info(f"...")`, already used throughout this file).

## Notes

- While in this file for this issue, also translated the docstrings of `cancel_analysis()`, `_persist_analysis_results()`, and `analyze()` (the last one extended by an earlier PR in this sequence, #550, while still following the file's pre-existing English convention) to Spanish, per this repository's documentation convention. The rest of `managers/analysis.py`'s many other pre-existing English docstrings are left as they are — that's a much larger, separate cleanup this PR isn't the place for.
- Same migration caveat as the rest of this PR sequence — worth an `alembic upgrade head` sanity check against a real dev DB before this reaches `v0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
