### PR TITLE
refactor: unify encryption at rest on EncryptedText

### DIFF
--- a/API/alembic/versions/c4a1e7b93d20_mfa_totp_secret_encrypted_text.py
+++ b/API/alembic/versions/c4a1e7b93d20_mfa_totp_secret_encrypted_text.py
@@ -1,0 +1,64 @@
+"""users: renombra MFATotpCredential.secret_encrypted a totp_secret (EncryptedText)
+
+El secreto TOTP se cifraba a mano, en los cuatro puntos del manager de MFA
+que lo leen o lo escriben (``encrypt_totp_secret``/``decrypt_totp_secret``).
+Ahora lo cifra el propio tipo de columna, ``EncryptedText``, que aplica el
+mismo Fernet con el mismo ``purpose="mfa"`` -- de modo que el contenido de
+la columna **no cambia**: lo que hay guardado hoy lo descifra el tipo nuevo
+tal cual y esta migración no reescribe ni una fila.
+
+Cambian dos cosas, y las dos son de esquema:
+
+- **El nombre.** Con ``EncryptedText`` el atributo de Python contiene el
+  secreto en claro, así que un nombre acabado en ``_encrypted`` describe la
+  fila pero miente sobre lo que lee el código. Pasa a ``totp_secret``.
+- **El tipo.** ``EncryptedText`` se apoya en ``Text``; la columna era
+  ``String(512)``. En PostgreSQL es un ensanchamiento (``varchar`` ->
+  ``text``) que no reescribe la tabla.
+
+Revision ID: c4a1e7b93d20
+Revises: 3a7f74c514d5
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4a1e7b93d20'
+down_revision: Union[str, Sequence[str], None] = '3a7f74c514d5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('MFATotpCredential') as batch_op:
+        batch_op.alter_column(
+            'secret_encrypted',
+            new_column_name='totp_secret',
+            existing_type=sa.String(length=512),
+            type_=sa.Text(),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Estrecha la columna de vuelta a ``String(512)``. El ciphertext Fernet de
+    un secreto TOTP en Base32 ronda los 150 caracteres, así que cabe de
+    sobra; se deja escrito porque un ``text`` -> ``varchar(n)`` sí puede
+    fallar en PostgreSQL si alguna fila no entrara.
+    """
+    with op.batch_alter_table('MFATotpCredential') as batch_op:
+        batch_op.alter_column(
+            'totp_secret',
+            new_column_name='secret_encrypted',
+            existing_type=sa.Text(),
+            type_=sa.String(length=512),
+            existing_nullable=False,
+        )

--- a/API/alembic/versions/d8b3f2c05e91_iris_mailbox_tokens_encrypted_text.py
+++ b/API/alembic/versions/d8b3f2c05e91_iris_mailbox_tokens_encrypted_text.py
@@ -1,0 +1,49 @@
+"""iris: renombra los tokens de IrisMailboxConnection a refresh_token/access_token
+
+Segunda mitad de la unificación del cifrado en reposo (la primera fue el
+secreto TOTP de MFA, ``c4a1e7b93d20``). Los tokens de OAuth del conector de
+buzón se cifraban a mano en seis puntos de ``managers/mailbox.py``; ahora lo
+hace el tipo de columna ``EncryptedText`` con el mismo Fernet y el mismo
+``purpose="iris_mailbox"``, así que **el contenido de las columnas no
+cambia** y esta migración no reescribe ni una fila.
+
+Tampoco cambia el tipo: ambas eran ya ``Text``, que es sobre lo que se apoya
+``EncryptedText``. Lo único que cambia es el nombre, y por una razón
+concreta: con el tipo nuevo el atributo de Python contiene el token **en
+claro**, de modo que un sufijo ``_enc`` describe correctamente la fila pero
+miente sobre lo que lee el código que la usa.
+
+Revision ID: d8b3f2c05e91
+Revises: c4a1e7b93d20
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd8b3f2c05e91'
+down_revision: Union[str, Sequence[str], None] = 'c4a1e7b93d20'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('IrisMailboxConnection') as batch_op:
+        batch_op.alter_column('refresh_token_enc', new_column_name='refresh_token',
+                              existing_type=sa.Text(), existing_nullable=False)
+        batch_op.alter_column('access_token_enc', new_column_name='access_token',
+                              existing_type=sa.Text(), existing_nullable=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('IrisMailboxConnection') as batch_op:
+        batch_op.alter_column('refresh_token', new_column_name='refresh_token_enc',
+                              existing_type=sa.Text(), existing_nullable=False)
+        batch_op.alter_column('access_token', new_column_name='access_token_enc',
+                              existing_type=sa.Text(), existing_nullable=True)

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -610,8 +610,10 @@ def delete_document(document_id: int):
 # =============================================================================
 
 def _serialize_connection(connection) -> dict:
-    """Never includes refresh_token_enc/access_token_enc — those must not
-    leave the server under any circumstance."""
+    """Never includes refresh_token/access_token — those must not leave the
+    server under any circumstance. Ambas columnas son ``deferred``, así que
+    no serializarlas aquí es además lo que evita que se lleguen a leer de la
+    base de datos al montar la respuesta."""
     return {
         "connectionId": connection.id,
         "provider": connection.provider,

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -28,7 +28,7 @@ import src.modules.system.config_reading as CR
 from src.modules.accounts import LimitKey, QuotaManager
 from src.modules.infrastructure import UnitOfWork
 from src.modules.infrastructure.session import build_repository
-from src.modules.shared import assert_owned, decrypt_at_rest, encrypt_at_rest, utcnow_naive
+from src.modules.shared import assert_owned, utcnow_naive
 from src.modules.system.taskqueue import TaskTrackingMixin, job_context
 from src.modules.system.taskqueue.connection import RedisConnectionFactory
 
@@ -244,16 +244,14 @@ class IrisMailboxManager(TaskTrackingMixin):
             if folder is not None else None
         )
 
-        refresh_enc = encrypt_at_rest(token_set.refresh_token, purpose="iris_mailbox")
-        access_enc = encrypt_at_rest(token_set.access_token, purpose="iris_mailbox")
         expires_at = token_set.access_token_expires_at.replace(tzinfo=None)
 
         with UnitOfWork() as uow:
             repo = IrisMailboxConnectionRepository(uow)
             existing = repo.get_by_user_provider_email(user_id, provider, token_set.account_email)
             if existing is not None:
-                existing.refresh_token_enc = refresh_enc
-                existing.access_token_enc = access_enc
+                existing.refresh_token = token_set.refresh_token
+                existing.access_token = token_set.access_token
                 existing.access_token_expires_at = expires_at
                 existing.scopes = token_set.scopes
                 existing.full_message_mode = full_message_mode
@@ -269,8 +267,8 @@ class IrisMailboxManager(TaskTrackingMixin):
 
             connection = IrisMailboxConnection(
                 user_id=user_id, provider=provider, account_email=token_set.account_email,
-                scopes=token_set.scopes, refresh_token_enc=refresh_enc,
-                access_token_enc=access_enc, access_token_expires_at=expires_at,
+                scopes=token_set.scopes, refresh_token=token_set.refresh_token,
+                access_token=token_set.access_token, access_token_expires_at=expires_at,
                 folder=folder, full_message_mode=full_message_mode,
                 folder_display_name=folder_metadata.display_name if folder_metadata else None,
                 folder_type=folder_metadata.folder_type if folder_metadata else None,
@@ -428,9 +426,8 @@ class IrisMailboxManager(TaskTrackingMixin):
         connection = self.assert_connection_ownership(connection_id, user_id)
 
         try:
-            refresh_token = decrypt_at_rest(connection.refresh_token_enc, purpose="iris_mailbox")
             connector = get_connector(connection.provider, self._redirect_uri(), folder=connection.folder)
-            connector.revoke(refresh_token)
+            connector.revoke(connection.refresh_token)
         except Exception as e:
             logger.warning(f"No se pudo revocar el token de la conexión {connection_id} en el proveedor: {e}")
 
@@ -678,13 +675,12 @@ class IrisMailboxManager(TaskTrackingMixin):
         connector = get_connector(connection.provider, self._redirect_uri(), folder=connection.folder)
 
         now = utcnow_naive()
-        if (connection.access_token_enc and connection.access_token_expires_at
+        if (connection.access_token and connection.access_token_expires_at
                 and connection.access_token_expires_at > now):
-            return decrypt_at_rest(connection.access_token_enc, purpose="iris_mailbox"), connector
+            return connection.access_token, connector
 
-        refresh_token = decrypt_at_rest(connection.refresh_token_enc, purpose="iris_mailbox")
         try:
-            token_set = connector.refresh(refresh_token)
+            token_set = connector.refresh(connection.refresh_token)
         except requests.HTTPError as e:
             status = e.response.status_code if e.response is not None else None
             if status in (400, 401):
@@ -697,8 +693,8 @@ class IrisMailboxManager(TaskTrackingMixin):
             repo = IrisMailboxConnectionRepository(uow)
             fresh = repo.get_by_id(connection.id)
             if fresh is not None:
-                fresh.access_token_enc = encrypt_at_rest(token_set.access_token, purpose="iris_mailbox")
-                fresh.refresh_token_enc = encrypt_at_rest(token_set.refresh_token, purpose="iris_mailbox")
+                fresh.access_token = token_set.access_token
+                fresh.refresh_token = token_set.refresh_token
                 fresh.access_token_expires_at = token_set.access_token_expires_at.replace(tzinfo=None)
                 repo.update(fresh)
 

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
     SmallInteger, String, Text, UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import deferred, relationship
 
 from src.modules.shared import Base, Document, EncryptedText, utcnow_naive
 
@@ -231,7 +231,7 @@ class IrisMailboxConnection(Base):
     Stores the minimum needed to re-request access later — never the
     mailbox content itself. See ``plans/feature/iris/iris-mailbox-connector.md``
     Fase 2/3 for the full design rationale (why this can't live in Acheron,
-    why the refresh token is encrypted with ``shared._crypto`` instead).
+    why the refresh token is encrypted at rest instead).
 
     Attributes:
         id: Primary key, auto-incrementing integer.
@@ -240,12 +240,19 @@ class IrisMailboxConnection(Base):
         account_email: The connected mailbox's address (plaintext — not a
                  secret, needed to show "which account is this").
         scopes: Space-separated OAuth scopes actually granted.
-        refresh_token_enc: Refresh token, encrypted at rest
-                 (``shared._crypto.encrypt_at_rest(..., purpose="iris_mailbox")``).
-                 Never returned by any endpoint.
-        access_token_enc: Cached access token, encrypted at rest; NULL when
-                 not cached or expired. Optional — the connector can always
-                 fall back to ``refresh()``.
+        refresh_token: Refresh token de OAuth. La columna es
+                 ``EncryptedText`` (``purpose="iris_mailbox"``), así que en
+                 Python es siempre el token en claro y lo cifrado es la fila.
+                 Nunca lo devuelve ningún endpoint.
+        access_token: Access token cacheado, con el mismo cifrado; NULL
+                 cuando no está cacheado o ha caducado. Opcional -- el
+                 conector siempre puede recurrir a ``refresh()``.
+                 Junto con ``refresh_token`` se declara ``deferred`` en el
+                 grupo ``oauth_tokens``: la mayoría de las cargas de esta
+                 fila (listados, health check, planificación del sondeo) no
+                 miran los tokens, y tocar cualquiera de los dos trae los
+                 dos en una sola consulta, que es como los usa
+                 ``_ensure_access_token``.
         access_token_expires_at: Expiry of the cached access token.
         folder: Provider-specific folder/label id to watch; NULL = default
                  inbox. Es el ``provider_id`` opaco que ``MailboxConnector``
@@ -331,8 +338,10 @@ class IrisMailboxConnection(Base):
     account_email = Column(String(320), nullable=False)
     scopes = Column(String(512), nullable=False)
 
-    refresh_token_enc = Column(Text, nullable=False)
-    access_token_enc = Column(Text, nullable=True)
+    refresh_token = deferred(
+        Column(EncryptedText(purpose="iris_mailbox"), nullable=False), group="oauth_tokens")
+    access_token = deferred(
+        Column(EncryptedText(purpose="iris_mailbox"), nullable=True), group="oauth_tokens")
     access_token_expires_at = Column(DateTime, nullable=True)
 
     folder = Column(String(255), nullable=True)

--- a/API/src/modules/shared/_crypto.py
+++ b/API/src/modules/shared/_crypto.py
@@ -41,23 +41,43 @@ class EncryptedText(TypeDecorator):
     """Columna de texto que se cifra al escribir y se descifra al leer, de
     forma transparente para quien la usa.
 
-    Introducida para ``IrisRawMessage.content`` (M09/B19): el motor de
-    reglas de Iris lee el raw de un mensaje en más de diez puntos distintos
-    de ``managers/analysis.py``, y repetir ``encrypt_at_rest``/
-    ``decrypt_at_rest`` a mano en cada uno de ellos convertía cada lectura en
-    una oportunidad de olvidarse de descifrar (o de cifrar antes de guardar).
-    Con este tipo, ``modelo.campo`` es siempre el texto plano en Python; lo
-    único que cambia es lo que llega a la fila de la base de datos.
+    **Es la única forma de cifrar en reposo que hay en el repositorio.**
+    Todo secreto que la aplicación necesite poder leer se declara con este
+    tipo; no queda ni un solo sitio que llame a ``encrypt_at_rest``/
+    ``decrypt_at_rest`` a mano sobre una columna, y añadir uno volvería a
+    dejar dos maneras distintas de hacer lo mismo conviviendo -- que era
+    exactamente el problema. Quien añada un campo sensible nuevo no tiene
+    que elegir patrón: copia el de al lado.
+    ``tests/unit/test_shared_crypto.py`` lo comprueba columna a columna.
 
-    Ver el issue de seguimiento sobre si el resto de columnas cifradas a
-    mano del repositorio (``IrisMailboxConnection.refresh_token_enc``/
-    ``access_token_enc``, el secreto TOTP de MFA) deberían migrar a este
-    mismo patrón para no dejar dos formas de hacer lo mismo conviviendo.
+    Con este tipo, ``modelo.campo`` es siempre el texto plano en Python; lo
+    único que cambia es lo que llega a la fila de la base de datos. Eso
+    quita de en medio el modo de fallo que motivó el tipo: el motor de
+    reglas de Iris lee el raw de un mensaje en más de diez puntos distintos
+    de ``managers/analysis.py``, y repetir el descifrado a mano en cada uno
+    convertía cada lectura en una oportunidad de olvidarse.
+
+    El coste que hay que conocer: el descifrado pasa a ocurrir **al cargar
+    la fila**, no en el punto donde se usa el valor. Para los secretos que
+    la mayoría de las consultas no miran (los tokens de OAuth de un buzón,
+    el secreto TOTP) la columna se declara además ``deferred``, de modo que
+    solo se descifra cuando alguien toca el atributo -- ver
+    ``IrisMailboxConnection.refresh_token`` y
+    ``MFATotpCredential.totp_secret``.
 
     Uso: ``Column(EncryptedText(purpose="mi_proposito"), nullable=False)`` --
     el ``purpose`` es el mismo concepto que ya usan ``encrypt_at_rest``/
-    ``decrypt_at_rest``: cada uno tiene su propia clave, así que comprometer
-    una no compromete las demás.
+    ``decrypt_at_rest``: cada uno tiene su propia clave (variable de entorno
+    ``<PURPOSE>_ENCRYPTION_KEY``), así que comprometer una no compromete las
+    demás y cada una se puede rotar por separado.
+
+    Attributes:
+        purpose: Identificador de la clave Fernet con la que se cifra esta
+            columna, tal y como lo resuelve
+            ``config_reading.get_encryption_key``. Cadena en minúsculas y
+            snake_case (``"mfa"``, ``"iris_mailbox"``,
+            ``"iris_raw_message"``); no es un valor libre, tiene que existir
+            como variable de entorno o el primer acceso a la columna lanza.
     """
 
     impl = Text

--- a/API/src/modules/users/managers.py
+++ b/API/src/modules/users/managers.py
@@ -64,8 +64,6 @@ from .services import (
     hash_password,
     hash_password_with_salt,
     verify_password,
-    encrypt_totp_secret,
-    decrypt_totp_secret,
     generate_totp_secret,
     totp_provisioning_uri,
     verify_totp_code,
@@ -1308,9 +1306,11 @@ class MFAManager:
     the recovery-code fallback.
 
     All database access goes through UnitOfWork + MFARepository. The TOTP
-    secret is encrypted at rest (services.encrypt_totp_secret) since, unlike
-    Acheron, the server must be able to compute the current code to verify
-    it — this is NOT zero-knowledge.
+    secret is encrypted at rest by its own column type
+    (``MFATotpCredential.totp_secret`` is an ``EncryptedText``), so this code
+    only ever handles the plaintext secret. Unlike Acheron, the server must
+    be able to compute the current code to verify it — this is NOT
+    zero-knowledge.
 
     Example:
     >>> manager = MFAManager()
@@ -1368,10 +1368,10 @@ class MFAManager:
                 raise MfaAlreadyEnabledError()
 
             if existing is not None:
-                existing.secret_encrypted = encrypt_totp_secret(secret)
+                existing.totp_secret = secret
             else:
                 repo.save_totp_credential(
-                    MFATotpCredential(user_id=user_id, secret_encrypted=encrypt_totp_secret(secret))
+                    MFATotpCredential(user_id=user_id, totp_secret=secret)
                 )
 
         return {
@@ -1401,7 +1401,7 @@ class MFAManager:
             if cred is None:
                 raise MfaNotEnabledError()
 
-            secret = decrypt_totp_secret(cred.secret_encrypted)
+            secret = cred.totp_secret
             if not verify_totp_code(secret, code):
                 raise InvalidMfaCodeError()
 
@@ -1473,7 +1473,7 @@ class MFAManager:
         if code:
             cred = repo.get_totp_credential(user_id)
             if cred is not None and cred.confirmed_at is not None:
-                secret = decrypt_totp_secret(cred.secret_encrypted)
+                secret = cred.totp_secret
                 if verify_totp_code(secret, code):
                     return True
 

--- a/API/src/modules/users/model.py
+++ b/API/src/modules/users/model.py
@@ -17,9 +17,9 @@ Example:
 """
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import deferred, relationship
 
-from src.modules.shared import Base, utcnow_naive
+from src.modules.shared import Base, EncryptedText, utcnow_naive
 
 
 # =========================================================================
@@ -288,10 +288,12 @@ class MFATotpCredential(Base):
     """
     TOTP (Time-based One-Time Password) credential for a user.
 
-    One row per user (unique ``user_id``). ``secret_encrypted`` holds the
-    shared TOTP secret, encrypted at rest with a server-side key — unlike
-    Acheron this is NOT zero-knowledge, since the server must be able to
-    compute the current code to verify a login attempt.
+    One row per user (unique ``user_id``). ``totp_secret`` holds the shared
+    TOTP secret; la columna es ``EncryptedText``, así que en Python siempre
+    se lee y se escribe en claro y lo que llega a la fila es texto cifrado
+    con Fernet. A diferencia de Acheron esto NO es zero-knowledge: el
+    servidor tiene que poder calcular el código actual para verificar un
+    intento de login.
 
     ``confirmed_at`` is NULL until the user proves control of the secret by
     submitting a valid code during setup; MFA only counts as "enabled" once
@@ -299,7 +301,11 @@ class MFATotpCredential(Base):
 
     Attributes:
         user_id: Foreign key to User.id (unique — one credential per user).
-        secret_encrypted: Fernet-encrypted Base32 TOTP secret.
+        totp_secret: Secreto TOTP en Base32, en claro para quien lo lee desde
+            Python y cifrado en la base de datos (``purpose="mfa"``). Se
+            declara ``deferred``: la mayoría de las cargas de esta fila solo
+            miran ``confirmed_at`` (¿tiene MFA activo?) y no necesitan pagar
+            un descifrado para responder a eso.
         confirmed_at: When the user confirmed enrollment (None = pending).
         created_at: When the credential was created (setup started).
     """
@@ -307,7 +313,7 @@ class MFATotpCredential(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey("User.id"), nullable=False, unique=True)
-    secret_encrypted = Column(String(512), nullable=False)
+    totp_secret = deferred(Column(EncryptedText(purpose="mfa"), nullable=False))
     confirmed_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=utcnow_naive)
 

--- a/API/src/modules/users/model.py
+++ b/API/src/modules/users/model.py
@@ -289,11 +289,10 @@ class MFATotpCredential(Base):
     TOTP (Time-based One-Time Password) credential for a user.
 
     One row per user (unique ``user_id``). ``totp_secret`` holds the shared
-    TOTP secret; la columna es ``EncryptedText``, así que en Python siempre
-    se lee y se escribe en claro y lo que llega a la fila es texto cifrado
-    con Fernet. A diferencia de Acheron esto NO es zero-knowledge: el
-    servidor tiene que poder calcular el código actual para verificar un
-    intento de login.
+    TOTP secret; the column is an ``EncryptedText``, so in Python it is
+    always read and written in plaintext and what reaches the row is Fernet
+    ciphertext. Unlike Acheron this is NOT zero-knowledge: the server must
+    be able to compute the current code to verify a login attempt.
 
     ``confirmed_at`` is NULL until the user proves control of the secret by
     submitting a valid code during setup; MFA only counts as "enabled" once
@@ -301,11 +300,11 @@ class MFATotpCredential(Base):
 
     Attributes:
         user_id: Foreign key to User.id (unique — one credential per user).
-        totp_secret: Secreto TOTP en Base32, en claro para quien lo lee desde
-            Python y cifrado en la base de datos (``purpose="mfa"``). Se
-            declara ``deferred``: la mayoría de las cargas de esta fila solo
-            miran ``confirmed_at`` (¿tiene MFA activo?) y no necesitan pagar
-            un descifrado para responder a eso.
+        totp_secret: Base32 TOTP secret — plaintext to whoever reads it from
+            Python, encrypted in the database (``purpose="mfa"``). Declared
+            ``deferred``: most loads of this row only look at
+            ``confirmed_at`` to answer "is MFA enabled?", and should not pay
+            for a decryption to do that.
         confirmed_at: When the user confirmed enrollment (None = pending).
         created_at: When the credential was created (setup started).
     """

--- a/API/src/modules/users/services/__init__.py
+++ b/API/src/modules/users/services/__init__.py
@@ -3,8 +3,6 @@ from .secrets import (
     hash_password,
     hash_password_with_salt,
     verify_password,
-    encrypt_totp_secret,
-    decrypt_totp_secret,
     generate_opaque_token,
     hash_opaque_token,
     verify_opaque_token,
@@ -30,8 +28,6 @@ __all__ = [
     'hash_password',
     'hash_password_with_salt',
     'verify_password',
-    'encrypt_totp_secret',
-    'decrypt_totp_secret',
 
     'generate_totp_secret',
     'totp_provisioning_uri',

--- a/API/src/modules/users/services/mfa.py
+++ b/API/src/modules/users/services/mfa.py
@@ -1,9 +1,9 @@
 """
 TOTP and recovery-code primitives for MFA.
 
-Pure functions only — no DB access, no encryption-at-rest (that lives in
-services.secrets.encrypt_totp_secret / decrypt_totp_secret, called by the
-manager layer around these).
+Pure functions only — no DB access, no encryption-at-rest (that is the
+job of the ``MFATotpCredential.totp_secret`` column, an ``EncryptedText``
+that ciphers on write and deciphers on read).
 
 Functions:
     generate_totp_secret    — Random Base32 secret for a new TOTP enrollment.

--- a/API/src/modules/users/services/secrets.py
+++ b/API/src/modules/users/services/secrets.py
@@ -20,7 +20,6 @@ from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError, VerificationError, InvalidHashError
 
 import src.modules.system.config_reading as CR
-from src.modules.shared._crypto import decrypt_at_rest, encrypt_at_rest
 
 
 def _get_hasher() -> PasswordHasher:
@@ -82,25 +81,6 @@ def generate_salt() -> str:
 def hash_password_with_salt(password: str, salt: str) -> str:
     """SHA-256 hash of salt+password. Used only to verify legacy stored hashes."""
     return hashlib.sha256((salt + password).encode("utf-8")).hexdigest()
-
-
-# ---------------------------------------------------------------------------
-# TOTP secret encryption at rest.
-#
-# Unlike Acheron (zero-knowledge — the server never sees plaintext secrets),
-# the server MUST be able to read the TOTP secret to compute the current code
-# and verify a login attempt. "Encrypted at rest" here means protected against
-# someone reading the database directly, not hidden from the application.
-# ---------------------------------------------------------------------------
-
-def encrypt_totp_secret(secret: str) -> str:
-    """Encrypt a TOTP secret for storage, using the server-side MFA_ENCRYPTION_KEY."""
-    return encrypt_at_rest(secret, purpose="mfa")
-
-
-def decrypt_totp_secret(token: str) -> str:
-    """Decrypt a TOTP secret previously produced by encrypt_totp_secret()."""
-    return decrypt_at_rest(token, purpose="mfa")
 
 
 # =========================================================================

--- a/API/tests/integration/test_account_deletion.py
+++ b/API/tests/integration/test_account_deletion.py
@@ -71,7 +71,7 @@ def _seed_user_data(app, user_id: int) -> None:
             session.add(AuthorizedTarget(user_id=user_id, target="10.0.0.1"))
             session.add(IrisMailboxConnection(
                 user_id=user_id, provider="gmail", account_email="a@b.test",
-                scopes="", refresh_token_enc="x",
+                scopes="", refresh_token="x",
             ))
             session.add(AegisOrgProfile(user_id=user_id))
             distribution_list = DistributionList(user_id=user_id, name="Lista")

--- a/API/tests/integration/test_iris_mailbox_endpoints.py
+++ b/API/tests/integration/test_iris_mailbox_endpoints.py
@@ -27,7 +27,7 @@ def _save_connection(app, user_id, **overrides) -> int:
     defaults = dict(
         user_id=user_id, provider="gmail", account_email="victim@example.com",
         scopes="gmail.metadata",
-        refresh_token_enc=encrypt_at_rest("refresh-token", purpose="iris_mailbox"),
+        refresh_token="refresh-token",
         status="active",
     )
     defaults.update(overrides)

--- a/API/tests/integration/test_iris_mailbox_health.py
+++ b/API/tests/integration/test_iris_mailbox_health.py
@@ -117,7 +117,7 @@ class _FakeConnector:
 def _connection(user_id, **overrides) -> IrisMailboxConnection:
     defaults = dict(
         user_id=user_id, provider="gmail", account_email="victim@example.com",
-        scopes="gmail.metadata", refresh_token_enc=encrypt_at_rest("refresh-token", purpose="iris_mailbox"),
+        scopes="gmail.metadata", refresh_token="refresh-token",
         status="active", sync_cursor="cursor-0",
     )
     defaults.update(overrides)

--- a/API/tests/integration/test_iris_mailbox_manager.py
+++ b/API/tests/integration/test_iris_mailbox_manager.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import pytest
 from itsdangerous import BadSignature
+from sqlalchemy import text
 
 import src.modules.system.config_reading as CR
 import src.modules.features.iris.managers.mailbox as mailbox_managers_mod
@@ -29,7 +30,7 @@ from src.modules.features.iris.repositories import (
 )
 from src.modules.features.iris.services.mailbox.base import MailboxFolder, MessageRef, TokenSet
 from src.modules.infrastructure import UnitOfWork
-from src.modules.shared import decrypt_at_rest, encrypt_at_rest, utcnow_naive
+from src.modules.shared import decrypt_at_rest, utcnow_naive
 
 pytestmark = pytest.mark.integration
 
@@ -208,7 +209,7 @@ class _QueueTestConnector(_FakeConnector):
 def _connection(user_id, **overrides) -> IrisMailboxConnection:
     defaults = dict(
         user_id=user_id, provider="gmail", account_email="victim@example.com",
-        scopes="gmail.metadata", refresh_token_enc=encrypt_at_rest("old-refresh-token", purpose="iris_mailbox"),
+        scopes="gmail.metadata", refresh_token="old-refresh-token",
         status="active",
     )
     defaults.update(overrides)
@@ -298,9 +299,18 @@ def test_handle_callback_creates_connection(app, regular_user):
             conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
             assert conn.account_email == "victim@example.com"
             assert conn.status == "active"
-            # El refresh token nunca se guarda en claro.
-            assert conn.refresh_token_enc != "new-refresh-token"
-            assert decrypt_at_rest(conn.refresh_token_enc, purpose="iris_mailbox") == "new-refresh-token"
+            assert conn.refresh_token == "new-refresh-token"
+
+            # El refresh token nunca se guarda en claro. Hay que mirar la
+            # columna cruda: quien cifra es el tipo ``EncryptedText``, así
+            # que ``conn.refresh_token`` ya viene descifrado y la
+            # comprobación pasaría igual aunque el cifrado desapareciera.
+            stored = uow.session.execute(
+                text('SELECT refresh_token FROM "IrisMailboxConnection" WHERE id = :id'),
+                {"id": connection_id},
+            ).scalar()
+            assert stored != "new-refresh-token"
+            assert decrypt_at_rest(stored, purpose="iris_mailbox") == "new-refresh-token"
 
 
 def test_handle_callback_reconnect_updates_existing_row(app, regular_user):
@@ -433,7 +443,7 @@ def test_update_connection_rejects_a_folder_the_account_does_not_have(app, regul
 def test_update_connection_folder_requires_reauth_when_token_refresh_fails(app, regular_user):
     with app.app_context():
         connection_id = _save(app, _connection(
-            regular_user.id, access_token_enc=None, access_token_expires_at=None,
+            regular_user.id, access_token=None, access_token_expires_at=None,
         ))
         fake_connector = _FakeConnector(refresh_raises_reauth=True)
         with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
@@ -713,7 +723,7 @@ def test_sync_connection_marks_reauth_required_on_revoked_token(app, regular_use
     with app.app_context():
         connection_id = _save(app, _connection(
             regular_user.id,
-            access_token_enc=None, access_token_expires_at=None,
+            access_token=None, access_token_expires_at=None,
         ))
         fake_connector = _FakeConnector(refresh_raises_reauth=True)
         with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):
@@ -729,7 +739,7 @@ def test_sync_connection_reuses_cached_unexpired_access_token(app, regular_user)
     with app.app_context():
         connection_id = _save(app, _connection(
             regular_user.id,
-            access_token_enc=encrypt_at_rest("cached-access-token", purpose="iris_mailbox"),
+            access_token="cached-access-token",
             access_token_expires_at=utcnow_naive() + timedelta(minutes=30),
             sync_cursor="cursor-0",
         ))
@@ -806,7 +816,7 @@ def test_sync_connection_recovers_from_an_orphaned_lock(app, regular_user, _fake
 def test_sync_connection_releases_lock_even_when_token_refresh_fails(app, regular_user, _fake_lock_redis):
     with app.app_context():
         connection_id = _save(app, _connection(
-            regular_user.id, access_token_enc=None, access_token_expires_at=None,
+            regular_user.id, access_token=None, access_token_expires_at=None,
         ))
         fake_connector = _FakeConnector(refresh_raises_reauth=True)
         with mock.patch.object(mailbox_managers_mod, "get_connector", return_value=fake_connector):

--- a/API/tests/integration/test_iris_mailbox_model.py
+++ b/API/tests/integration/test_iris_mailbox_model.py
@@ -20,7 +20,7 @@ def _make_connection(user_id: int, account_email: str = "victim@gmail.com") -> I
         provider="gmail",
         account_email=account_email,
         scopes="gmail.metadata",
-        refresh_token_enc="encrypted-token",
+        refresh_token="encrypted-token",
     )
 
 

--- a/API/tests/integration/test_iris_mailbox_scheduling.py
+++ b/API/tests/integration/test_iris_mailbox_scheduling.py
@@ -22,7 +22,7 @@ def _connection(user_id: int, account_email: str) -> IrisMailboxConnection:
     return IrisMailboxConnection(
         user_id=user_id, provider="gmail", account_email=account_email,
         scopes="gmail.metadata",
-        refresh_token_enc=encrypt_at_rest("token", purpose="iris_mailbox"),
+        refresh_token="token",
         status="active",
     )
 

--- a/API/tests/integration/test_iris_notification_scheduling.py
+++ b/API/tests/integration/test_iris_notification_scheduling.py
@@ -31,7 +31,7 @@ def _save_connection(app, user_id: int, **overrides) -> int:
     defaults = dict(
         user_id=user_id, provider="gmail", account_email="victim@example.com",
         scopes="gmail.metadata",
-        refresh_token_enc=encrypt_at_rest("token", purpose="iris_mailbox"),
+        refresh_token="token",
         status="active",
     )
     defaults.update(overrides)

--- a/API/tests/integration/test_iris_notifications.py
+++ b/API/tests/integration/test_iris_notifications.py
@@ -50,7 +50,7 @@ def _save_connection(app, user_id: int, **overrides) -> int:
     defaults = dict(
         user_id=user_id, provider="gmail", account_email="victim@example.com",
         scopes="gmail.metadata",
-        refresh_token_enc=encrypt_at_rest("token", purpose="iris_mailbox"),
+        refresh_token="token",
         status="active",
     )
     defaults.update(overrides)

--- a/API/tests/integration/test_iris_results_filtering.py
+++ b/API/tests/integration/test_iris_results_filtering.py
@@ -39,7 +39,7 @@ def _seed_connection(app, user_id: int) -> int:
             connection = IrisMailboxConnection(
                 user_id=user_id, provider="gmail", account_email="victim@example.com",
                 scopes="gmail.metadata",
-                refresh_token_enc=encrypt_at_rest("token", purpose="iris_mailbox"),
+                refresh_token="token",
                 status="active",
             )
             IrisMailboxConnectionRepository(uow).save(connection)

--- a/API/tests/integration/test_mfa.py
+++ b/API/tests/integration/test_mfa.py
@@ -2,6 +2,10 @@
 
 import pyotp
 import pytest
+from sqlalchemy import text
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared._crypto import decrypt_at_rest
 
 pytestmark = pytest.mark.integration
 
@@ -249,3 +253,29 @@ def test_disable_totp_with_valid_code_disables_mfa(client, regular_user, auth_he
     })
     assert login.status_code == 200
     assert "mfaRequired" not in login.get_json()
+
+
+# ── Cifrado en reposo del secreto ─────────────────────────────────────────
+
+
+def test_the_totp_secret_is_encrypted_in_the_database(app, client, regular_user, auth_headers):
+    """El secreto que devuelve /setup nunca debe llegar tal cual a la fila.
+
+    Lo cifra el tipo de columna (``EncryptedText``), no el manager, así que
+    la única forma de comprobarlo es saltarse el ORM y mirar el valor crudo:
+    leyendo ``credential.totp_secret`` se vería ya descifrado y el test
+    pasaría aunque el cifrado hubiera desaparecido.
+    """
+    headers = auth_headers(regular_user)
+    secret = client.post("/users/mfa/totp/setup", headers=headers).get_json()["secret"]
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            row = uow.session.execute(
+                text('SELECT totp_secret FROM "MFATotpCredential" WHERE user_id = :id'),
+                {"id": regular_user.id},
+            ).first()
+
+    stored = row[0]
+    assert stored != secret
+    assert decrypt_at_rest(stored, purpose="mfa") == secret

--- a/API/tests/postgres/test_schema_invariants.py
+++ b/API/tests/postgres/test_schema_invariants.py
@@ -41,7 +41,7 @@ def _user(pg_session, username: str = "postgres-tester") -> User:
 def _connection(pg_session, user: User, email: str = "buzon@outlook.example") -> IrisMailboxConnection:
     connection = IrisMailboxConnection(
         user_id=user.id, provider="microsoft", account_email=email,
-        scopes="Mail.Read", refresh_token_enc="cifrado",
+        scopes="Mail.Read", refresh_token="cifrado",
     )
     pg_session.add(connection)
     pg_session.commit()

--- a/API/tests/unit/test_shared_crypto.py
+++ b/API/tests/unit/test_shared_crypto.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import pathlib
+import re
+
 import pytest
 
-from src.modules.shared._crypto import decrypt_at_rest, encrypt_at_rest
+from src.modules.shared._crypto import EncryptedText, decrypt_at_rest, encrypt_at_rest
 
 pytestmark = pytest.mark.unit
 
@@ -29,3 +32,69 @@ def test_unknown_purpose_raises_clear_error(monkeypatch):
     monkeypatch.delenv("SOMETHING_UNCONFIGURED_ENCRYPTION_KEY", raising=False)
     with pytest.raises(ValueError, match="SOMETHING_UNCONFIGURED_ENCRYPTION_KEY"):
         encrypt_at_rest("x", purpose="something_unconfigured")
+
+
+# ---------------------------------------------------------------------------
+# Un solo patrón de cifrado en reposo
+#
+# El repositorio llegó a tener dos formas de cifrar una columna conviviendo:
+# el tipo ``EncryptedText`` en unos sitios y llamadas sueltas a
+# ``encrypt_at_rest``/``decrypt_at_rest`` repartidas por los managers en
+# otros. Quien añadía un campo sensible no tenía ninguna señal de cuál
+# imitar. Los dos tests de esta sección son lo que impide que vuelva a
+# pasar: uno fija qué columnas están cifradas y con qué clave, y el otro
+# corta de raíz que reaparezca una llamada manual.
+# ---------------------------------------------------------------------------
+
+# (modelo, columna, purpose) de cada columna cifrada en reposo del proyecto.
+# Añadir un campo sensible nuevo implica añadirlo aquí.
+_ENCRYPTED_COLUMNS = [
+    ("src.modules.users.model", "MFATotpCredential", "totp_secret", "mfa"),
+    ("src.modules.features.iris.model", "IrisMailboxConnection", "refresh_token", "iris_mailbox"),
+    ("src.modules.features.iris.model", "IrisMailboxConnection", "access_token", "iris_mailbox"),
+    ("src.modules.features.iris.model", "IrisRawMessage", "content", "iris_raw_message"),
+]
+
+
+@pytest.mark.parametrize("module_path,model_name,column_name,purpose", _ENCRYPTED_COLUMNS)
+def test_every_secret_column_is_an_encrypted_text(module_path, model_name, column_name, purpose):
+    """Cada columna sensible declara ``EncryptedText`` y su ``purpose``.
+
+    Comprueba el tipo declarado, no un round-trip: un test de round-trip
+    seguiría pasando si alguien devolviera la columna a ``Text`` y volviera a
+    cifrar a mano en el manager, que es justo la regresión que aquí importa.
+    """
+    import importlib
+
+    model = getattr(importlib.import_module(module_path), model_name)
+    column_type = model.__table__.c[column_name].type
+
+    assert isinstance(column_type, EncryptedText), (
+        f"{model_name}.{column_name} guarda un secreto y debe declararse "
+        f"EncryptedText, no {type(column_type).__name__}"
+    )
+    assert column_type._purpose == purpose
+
+
+def test_no_column_is_encrypted_by_hand_any_more():
+    """Nadie vuelve a cifrar una columna llamando a mano a ``encrypt_at_rest``.
+
+    Fuera de ``_crypto.py`` (que las define) y de las migraciones de Alembic
+    (que sí trabajan con la fila cruda, sin ORM que aplique el tipo), estas
+    dos funciones no deben aparecer en ``src/``: si un manager las llama es
+    que alguien ha vuelto al patrón viejo.
+    """
+    source_root = pathlib.Path(__file__).resolve().parents[2] / "src"
+    call_pattern = re.compile(r"(?<![\w.])(?:en|de)crypt_at_rest\s*\(")
+
+    offenders = []
+    for path in source_root.rglob("*.py"):
+        if path.name == "_crypto.py":
+            continue
+        if call_pattern.search(path.read_text(encoding="utf-8")):
+            offenders.append(str(path.relative_to(source_root)))
+
+    assert not offenders, (
+        "Cifrado manual en reposo fuera de _crypto.py; usa el tipo de columna "
+        f"EncryptedText en su lugar: {offenders}"
+    )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,15 @@ Lo mismo con `themis/services/reports/`, que es paquete (`base.py`, `creator.py`
   sesiones fuera de los repositorios.
 - **`shared/`** — modelo base, excepciones, `handle_exceptions`, rate limiter, `Document` base,
   `DocumentManager`, `assert_owned`, cripto, white-label.
+  **Cifrado en reposo: siempre `EncryptedText`, nunca a mano.** Un secreto que la aplicación
+  necesite poder leer se declara como `Column(EncryptedText(purpose="..."), ...)` y punto; en
+  Python se lee y se escribe en claro, y lo cifrado es la fila. Llamar a `encrypt_at_rest`/
+  `decrypt_at_rest` desde un manager es el patrón viejo: convivieron los dos y quien añadía un
+  campo sensible no tenía forma de saber cuál imitar. `tests/unit/test_shared_crypto.py` ata las
+  dos mitades — qué columnas están cifradas y con qué `purpose`, y que no reaparezca ninguna
+  llamada manual en `src/`. Cada `purpose` tiene su clave (`<PURPOSE>_ENCRYPTION_KEY` en `.env`).
+  Como el descifrado pasa a ocurrir al cargar la fila, los secretos que la mayoría de las
+  consultas no miran se declaran además `deferred`.
 - **`tools/scribe/`** — capa de estrategias enchufables de **generación IA** (Ollama / OpenAI /
   Google). El consumidor le pasa entradas; scribe no sabe nada de ellas. Estrategia elegida por
   módulo en `SecOpsConfig.json` → `tools.scribe.modules`.


### PR DESCRIPTION
## Resumen

Este PR deja **una sola forma** de cifrar un dato en reposo en todo el repositorio, que es lo que pedía el issue #556.

Un poco de contexto para quien no haya tocado esta parte. Hay secretos que el servidor necesita poder *leer* — el secreto TOTP con el que se verifica un código de MFA, los tokens de OAuth con los que Iris se conecta a un buzón —, así que no pueden guardarse cifrados de forma que ni el propio servidor los entienda (eso sí lo hace Acheron, pero ahí el usuario aporta la clave). Lo que se hace en su lugar es "cifrado en reposo": la fila de la base de datos guarda texto cifrado con Fernet, de modo que quien consiga leer la base de datos directamente no se lleva nada útil, pero la aplicación sí puede descifrarlo cuando lo necesita.

Hasta ahora eso se hacía de dos maneras distintas a la vez:

1. **A mano**, llamando a `encrypt_at_rest`/`decrypt_at_rest` en el punto exacto del código donde se lee o se escribe la fila. Así estaban el secreto TOTP y los tokens de buzón de Iris.
2. **Con un tipo de columna**, `EncryptedText`, que cifra al escribir y descifra al leer sin que el código que la usa se entere. Se introdujo con el trabajo de separación de raw de Iris (#557) para `IrisRawMessage.content`.

Dos patrones para lo mismo es peor que cualquiera de los dos por separado: quien añade un campo sensible nuevo no tiene ninguna señal de cuál imitar. Este PR toma el camino 1 del issue — **migrar todo a `EncryptedText`** — y añade lo que impide que la decisión se deshaga sola.

## Issue relacionado

Closes #556.

## Por qué migrar salía casi gratis

El hallazgo que decidió el enfoque: `EncryptedText` usa **exactamente el mismo** Fernet y el mismo sistema de claves por `purpose` que las llamadas manuales. El texto cifrado que hay hoy en la base de datos lo lee el tipo nuevo tal cual, así que **ninguna de las dos migraciones reescribe una sola fila** — no hay backfill, no hay ventana en la que los datos estén a medias, y un rollback es igual de barato.

También conviene decir qué *no* resultó ser cierto: el issue contemplaba revertir `EncryptedText` si complicaba "los tests que hoy mockean `encrypt_at_rest`/`decrypt_at_rest`". Al mirarlo, **ningún test los mockea** — los llaman de verdad para construir fixtures. Con el cambio esas fixtures pasan a escribir texto plano, que es más simple, así que el argumento principal en contra no se sostenía.

## Implementación

**Fase 1 — el secreto TOTP de MFA** (`b35e111c`). Cuatro puntos del manager de MFA cifraban o descifraban a mano a través de dos envoltorios (`encrypt_totp_secret`/`decrypt_totp_secret`), que desaparecen. La columna pasa de `secret_encrypted` a `totp_secret` y de `String(512)` a `Text`.

**Fase 2 — los tokens de OAuth del buzón de Iris** (`35c2df71`). Seis puntos de `managers/mailbox.py` — al guardar una conexión, al reconectar una existente, al revocarla, al refrescar el token y al leer el access token cacheado. Las columnas pasan de `refresh_token_enc`/`access_token_enc` a `refresh_token`/`access_token`; el tipo no cambia, ya eran `Text`.

**Fase 3 — sellar la decisión** (`3ff6c2db`). El docstring de `EncryptedText` deja de remitir a un issue de seguimiento y enuncia la regla ya decidida, más una línea en `CLAUDE.md`, más dos tests guardianes.

### Por qué el renombrado no es cosmético

Es consecuencia directa del tipo. Con cifrado manual, `refresh_token_enc` contenía texto cifrado también en Python, y el sufijo `_enc` era verdad. Con `EncryptedText` el atributo de Python contiene el token **en claro** y lo cifrado es únicamente la fila: el nombre seguiría describiendo bien la base de datos mientras miente sobre lo que lee el código que lo usa. Es además lo que pide la regla de nombres del proyecto ("el nombre aclara el tipo").

### La contrapartida, y cómo se acota

Mover el cifrado al tipo de columna tiene un coste que conviene tener escrito: el descifrado pasa a ocurrir **al cargar la fila**, no en el punto donde se usa el valor. Es decir, cualquier `SELECT` de una conexión de buzón descifraría dos columnas aunque el endpoint jamás mire los tokens — un listado de conexiones, el health check, el planificador del sondeo.

Por eso las tres columnas de secretos se declaran `deferred`: SQLAlchemy no las trae en la consulta inicial y solo se descifran cuando alguien toca el atributo. Las dos de Iris comparten grupo (`oauth_tokens`), así que tocar una trae las dos en una sola consulta, que es exactamente como las usa `_ensure_access_token`. Todos los accesos ocurren con el objeto vivo en su sesión, así que no hay riesgo de `DetachedInstanceError`.

### Los tests guardianes

Son dos porque hacen falta los dos, y cada uno cubre un agujero distinto:

- El primero recorre las cuatro columnas cifradas del proyecto y comprueba que cada una declara `EncryptedText` con su `purpose`. Mira el **tipo declarado**, no un round-trip: un round-trip seguiría pasando si alguien devolviera la columna a `Text` y volviera a cifrar a mano en el manager, que es justo la regresión que aquí importa.
- El segundo recorre `src/` y falla si reaparece una llamada a `encrypt_at_rest`/`decrypt_at_rest` fuera de `_crypto.py`, que es donde se definen. Las migraciones de Alembic sí las usan legítimamente (trabajan con la fila cruda, sin ORM que aplique el tipo) y quedan fuera del barrido a propósito.

Los tests que comprueban que un secreto no se guarda en claro leen la columna por **SQL crudo**. A través del ORM el valor ya viene descifrado, así que mirar el atributo pasaría igual aunque el cifrado desapareciera del todo.

## Validación

- `pytest` completo: **3037 tests, en verde** (exit 0), sobre el estado final del código.
- `pytest -m unit`: en verde.
- Suites tocadas ejecutadas por separado tras cada fase: MFA, conector de buzón de Iris (manager, endpoints, health, modelo, scheduling), notificaciones, filtrado de resultados y borrado de cuenta.
- El test guardián se verificó **en negativo**: con un fichero señuelo que llamaba a `encrypt_at_rest` en `src/`, falla; sin él, pasa. (Detectó de paso un falso negativo propio, un byte de retroceso literal colado en el patrón, ya corregido.)
- `pylint` sobre los módulos tocados: sin avisos nuevos.

## Notas

- **Las dos migraciones no se han ejecutado contra un PostgreSQL real**: no hay instancia levantada en este checkout, y no me pareció correcto arrancar la base de datos de desarrollo por mi cuenta (contiene el backfill de la base de conocimiento NVD/KEV/EPSS). Alembic sí carga y encadena los scripts correctamente — `alembic heads` resuelve a una única cabeza, `d8b3f2c05e91`. Por el mismo motivo, `tests/postgres/` (marcados `postgres`) no se han ejecutado, aunque el fichero de invariantes está actualizado al nombre nuevo de la columna.
- **`README.md` no cambia.** Se revisó como pide la guía: no hay endpoints, claves de configuración, variables de entorno, categorías de TaskQueue ni puertos afectados. Las tres variables `*_ENCRYPTION_KEY` que el README documenta siguen siendo las mismas, porque los `purpose` no cambian.
- El PR va contra **`v0.5`**, no contra `develope`: esa rama se retiró y la guía del repositorio marca la rama de versión como rama de integración.
- Queda fuera de alcance, como se acordó: cachear las instancias `Fernet` por `purpose` (hoy `_get_fernet` reconstruye una por valor, y con el descifrado en la ruta de carga de fila eso es algo más visible) y cualquier mecanismo de rotación de claves. Merecen su propio issue.
- No relacionado con este cambio, visto de paso: `users/services/secrets.py` tiene un `import os` sin usar que ya venía de antes. No lo he tocado para no mezclar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
