### PR TITLE
Quitar del código las referencias a issues y a documentos de plans/

### DIFF
--- a/API/src/modules/accounts/__init__.py
+++ b/API/src/modules/accounts/__init__.py
@@ -3,8 +3,6 @@ Capa comercial de Ellysia: planes, cuotas y organizaciones.
 
 Módulo transversal, no una herramienta: por eso no lleva nombre de deidad y
 vive junto a ``users``, ``system``, ``shared`` e ``infrastructure``.
-
-Diseño completo en ``plans/feature/general/planes-y-organizaciones.md``.
 """
 
 from .model import (

--- a/API/src/modules/accounts/model.py
+++ b/API/src/modules/accounts/model.py
@@ -1,8 +1,7 @@
 """
 Modelos de la capa comercial: catálogo de planes, suscripciones y organizaciones.
 
-Diseño completo en ``plans/feature/general/planes-y-organizaciones.md``. Tres
-grupos de tablas:
+Tres grupos de tablas:
 
 - **Catálogo**: ``Plan`` y ``PlanLimit`` — qué se vende y cuánto incluye.
 - **Titularidad**: ``Subscription`` — quién tiene qué y hasta cuándo.

--- a/API/src/modules/features/aegis/managers/__init__.py
+++ b/API/src/modules/features/aegis/managers/__init__.py
@@ -6,7 +6,7 @@ Managers del módulo Aegis (concienciación en ciberseguridad).
 - ``CampaignManager`` (``campaigns.py``): listas de distribución, campañas
   y el quiz público.
 
-D3 en ``plans/deuda-tecnica-y-calidad.md``: este paquete sustituye al
+Este paquete sustituye al
 antiguo ``managers.py`` de 42 KB, cuyo docstring justificaba tener los tres
 "en este único fichero por convención" — pero la convención del proyecto,
 desde que Themis pasó a paquete, es la contraria. Las tres

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -1,6 +1,5 @@
 """
-CampaignManager — campañas de concienciación (D3 en
-plans/deuda-tecnica-y-calidad.md).
+CampaignManager — campañas de concienciación.
 
 CRUD de listas de distribución y sus destinatarios, y el ciclo de vida de
 una campaña: creación (draft), lanzamiento (snapshot del quiz + tokens
@@ -225,7 +224,7 @@ class CampaignManager(TaskTrackingMixin):
             repo = CampaignRepository(uow)
             repo.launch_campaign(campaign_id, questions_snapshot, campaign_recipients)
             # La intención de encolar va en la MISMA transacción que el
-            # lanzamiento (#551). Antes el submit caía fuera, y si Redis fallaba
+            # lanzamiento. Antes el submit caía fuera, y si Redis fallaba
             # justo ahí la campaña quedaba lanzada —snapshot congelado, tokens
             # acuñados, cuota cobrada— pero sin un solo correo enviado y sin
             # nada que lo reintentase: no hay reconciliación de campañas.

--- a/API/src/modules/features/aegis/managers/org_profile.py
+++ b/API/src/modules/features/aegis/managers/org_profile.py
@@ -1,6 +1,5 @@
 """
-AegisOrgProfileManager — perfil de organización (D3 en
-plans/deuda-tecnica-y-calidad.md).
+AegisOrgProfileManager — perfil de organización.
 
 Los valores estables de generación (empresa, contacto, tono, tamaño,
 jurisdicción, productos vigilados): devolverlos con defaults si el usuario

--- a/API/src/modules/features/aegis/managers/pills.py
+++ b/API/src/modules/features/aegis/managers/pills.py
@@ -1,6 +1,5 @@
 """
-AegisManager — generación de píldoras de concienciación (D3 en
-plans/deuda-tecnica-y-calidad.md).
+AegisManager — generación de píldoras de concienciación.
 
 Crea documentos pendientes y lanza el workflow de generación en la
 TaskQueue, persiste el contenido (tips en AegisTip, avisos en
@@ -661,7 +660,7 @@ class AegisManager(TaskTrackingMixin):
     def _create_pending_document_and_dispatch(self, topic_id: int, tweaks: dict) -> tuple[int, int]:
         """Crea el ``AegisDocument`` 'pending' y su intención de encolado, juntos.
 
-        Las dos filas viajan en la misma transacción (#551). Antes el documento
+        Las dos filas viajan en la misma transacción. Antes el documento
         se confirmaba aquí y el ``submit()`` caía fuera, sin ningún try/except:
         si Redis fallaba justo ahí, la píldora se quedaba en ``pending`` para
         siempre —un "Generando..." que nunca termina— con las dos cuotas ya

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -13,7 +13,7 @@ Managers del módulo Iris (análisis de correo).
 - ``IrisNotificationPreferenceManager`` (``notifications.py``): lectura y
   escritura de las preferencias de notificación de un usuario (M08).
 
-D4 en ``plans/deuda-tecnica-y-calidad.md``: Iris era el único módulo con
+Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el
 segundo fichero más grande del repositorio) y ``mailbox_managers.py``,
 este último además suelto mientras el resto del conector de buzón vivía

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -8,8 +8,8 @@ Coordinates the analysis lifecycle:
    determines a verdict, and persists results.
 4. Provides status queries and cancellation support.
 
-D4 en ``plans/deuda-tecnica-y-calidad.md``: extraído del ``managers.py``
-de 64 KB que reunía este manager y el de informes.
+Extraído del antiguo ``managers.py`` de 64 KB, que reunía este manager y el
+de informes.
 """
 
 from __future__ import annotations
@@ -666,7 +666,7 @@ class IrisManager(TaskTrackingMixin):
             # ni la reserva ni el cobro tienen sentido.
             #
             # Es la razón por la que este sitio se quedó fuera de la outbox
-            # transaccional al auditarlo en #551: la compensación ya existe y
+            # transaccional: la compensación ya existe y
             # es completa -- el análisis no se queda en `running` y el usuario
             # recupera su cuota, así que puede reintentar. Lo único que la
             # outbox añadiría es ejecutar el resumen solo en vez de que el

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -1,7 +1,6 @@
 """
 IrisMailboxManager — OAuth connect/callback, connection CRUD, and background
-mailbox sync for the Iris mailbox connector (Fase 4 del plan
-plans/feature/iris/iris-mailbox-connector.md).
+mailbox sync for the Iris mailbox connector.
 
 Fichero separado de ``managers.py`` (que ya tiene 1080+ líneas con
 IrisManager + IrisReportManager) siguiendo el precedente de módulos grandes
@@ -457,7 +456,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         antes del ``submit()``, así que no hay huérfano que prevenir, y un
         encolado perdido se repara solo en la siguiente pasada del
         ``IrisMailboxScheduler``, que sondea periódicamente todas las
-        conexiones. Se revisó con los demás en #551 y se dejó así.
+        conexiones.
         """
         self._task_queue.submit(
             func=IrisMailboxManager.execute_sync_connection,

--- a/API/src/modules/features/iris/managers/reports.py
+++ b/API/src/modules/features/iris/managers/reports.py
@@ -1,9 +1,9 @@
 """
 IrisReportManager — ciclo de vida de IrisDocument y generación asíncrona
-del informe PDF (D4 en ``plans/deuda-tecnica-y-calidad.md``).
+del informe PDF.
 
 El CRUD y la comprobación de propiedad los comparte con Themis vía
-``DocumentManager`` (A3); aquí queda solo lo propio de Iris: crear el
+``DocumentManager``; aquí queda solo lo propio de Iris: crear el
 ``IrisDocument`` y renderizar su PDF con :class:`IrisPDFCreator`.
 """
 

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -229,9 +229,12 @@ class IrisMailboxConnection(Base):
     automatic Iris ingestion.
 
     Stores the minimum needed to re-request access later — never the
-    mailbox content itself. See ``plans/feature/iris/iris-mailbox-connector.md``
-    Fase 2/3 for the full design rationale (why this can't live in Acheron,
-    why the refresh token is encrypted at rest instead).
+    mailbox content itself.
+
+    The refresh token cannot live in an Acheron vault: vault fields are only
+    ever decrypted on the client, and the background sync needs the server
+    to use the token on its own, with no user present. So it is stored here
+    instead, encrypted at rest with a server-side key.
 
     Attributes:
         id: Primary key, auto-incrementing integer.

--- a/API/src/modules/features/iris/services/text.py
+++ b/API/src/modules/features/iris/services/text.py
@@ -1,7 +1,6 @@
 """
-Utilidades de texto/dominio compartidas entre las reglas de Iris (D6 en
-plans/deuda-tecnica-y-calidad.md — antes mezclado con wordlists.py en un
-único shared.py de 957 líneas).
+Utilidades de texto/dominio compartidas entre las reglas de Iris (antes
+mezcladas con wordlists.py en un único shared.py de 957 líneas).
 
 Extracción de dominios/hosts, distancia de edición, homóglifos, y el
 análisis de URL completo (``analyze_url``) que usan tanto Body Links (sobre

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -1,7 +1,7 @@
 """
 Datasets de detección (marcas, dominios, keywords, extensiones…) compartidos
-entre las reglas de Iris (D6 en plans/deuda-tecnica-y-calidad.md — antes
-mezclado con text.py en un único shared.py de 957 líneas).
+entre las reglas de Iris (antes mezclados con text.py en un único shared.py
+de 957 líneas).
 
 Los datasets se leen de ``SecOpsConfig.json`` (bloque ``features.iris.data.*``)
 a través de ``config_reading.get_iris_data``. Cada dataset tiene un default

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -485,7 +485,7 @@ def get_false_positives():
     Cada uno es una muestra etiquetada gratis: dice contra qué check y contra
     qué producto se equivoca el motor. Es la entrada que convierte el marcado
     de falsos positivos en un bucle de mejora en vez de una casilla de
-    interfaz — el banco de medición (#278) y el ranking de qué familias fallan
+    interfaz — el banco de falsos positivos y el ranking de qué familias fallan
     más se alimentan de aquí.
     """
     user = get_current_user()

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -96,8 +96,8 @@ _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
 # checks de higiene de certificado, no cómo se habla con ellos. La lista es una
 # red de seguridad barata, no una verdad: un TLS en un puerto que no esté aquí
 # se sondea igual de bien (el esquema se observa), pero no recibe los checks de
-# certificado. Ampliarla es gratis; hacerla innecesaria es #283, que ataca la
-# misma enfermedad —decidir por número de puerto— desde el otro lado.
+# certificado. Ampliarla es gratis; lo que la haría innecesaria es decidir la
+# candidatura observando el servicio en vez de mirar su número de puerto.
 _TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986, 636, 3269}
 
 # APIs de administración que hablan HTTP y publican su versión en un JSON sin

--- a/API/src/modules/features/themis/lybra/distro.py
+++ b/API/src/modules/features/themis/lybra/distro.py
@@ -24,8 +24,8 @@ y su ``confirmed=false``. Callar es la respuesta correcta cuando no se sabe.
 La señal más fuerte no es el banner sino la **revisión del propio paquete**:
 ``1:2.4.49-1ubuntu1`` sólo lo escribe Ubuntu, ``2.4.49-1~deb11u1`` sólo Debian
 (y dice hasta la versión), ``2.4.49-r0`` sólo Alpine, ``2.4.49-1.el8`` sólo la
-familia de Red Hat. Eso ya lo extrae :func:`~.kb.split_distro_version` desde
-#267 — aquí sólo se lee.
+familia de Red Hat. Eso ya lo extrae :func:`~.kb.split_distro_version`; aquí
+sólo se lee.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
@@ -35,8 +35,9 @@ que la ruta rápida de los servicios en su puerto de siempre no paga nada:
 
 La lista de intentos es **dato derivado del registro**, no una lista paralela:
 un dissector nuevo entra en la cascada por declarar sus dos capacidades, sin
-que este módulo cambie. Ése es justamente el error que #272 documentó — un mapa
-escrito a mano que se quedó con dos entradas mientras el módulo definía once.
+que este módulo cambie. Una lista paralela es justo lo que se queda atrás: hubo
+un mapa escrito a mano que se quedó con dos entradas mientras el módulo definía
+once.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/tls.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/tls.py
@@ -3,7 +3,7 @@
 Reads the negotiated protocol version and the self-signed/expiry status of the
 certificate.
 
-**JARM: archivado, no pendiente** (L24, 2026-09-02). Este módulo hace **un**
+**JARM: archivado, no pendiente** (2026-09-02). Este módulo hace **un**
 handshake, y de ahí salen la versión de protocolo, el autofirmado y la
 caducidad. JARM haría diez saludos deliberadamente distintos y hashearía el
 conjunto para identificar la *pila* TLS, no el producto.
@@ -15,14 +15,16 @@ puede buscar en ningún catálogo. Y comprobar esa coincidencia exige un
 laboratorio con varias pilas TLS distintas (OpenSSL, BoringSSL, Schannel,
 JSSE), que no existe aquí.
 
-A eso se suma que no es requisito de ninguna definición de hecho —la Fase F se
-cierra con la concordancia frente a Nmap, no con JARM—, que su prioridad medida
-es la más baja del backlog, y que diez saludos por servicio TLS es la sonda más
-cara del catálogo a cambio de un dato que nadie consultaría.
+A eso se suma que nada del fingerprinting depende de él —su medida de éxito es
+la concordancia frente a Nmap, no JARM—, que es de lo menos prioritario que hay
+pendiente, y que diez saludos por servicio TLS es la sonda más cara del
+catálogo a cambio de un dato que nadie consultaría.
 
-La decisión está escrita, con qué haría falta para reabrirla, en la sección
-Fase F de ``plans/feature/themis/lybra-engine-roadmap.md``. No es un "todavía
-no": es un "no, y por esto".
+Qué haría falta para reabrirlo: un laboratorio con al menos cuatro pilas TLS
+distintas contra el que comprobar que el hash coincide con el de la
+implementación de referencia, y alguien que de verdad vaya a consumir el hash
+—un catálogo de JARMs conocidos, o la necesidad de reconocer infraestructura
+que no dice nada de sí misma—. No es un "todavía no": es un "no, y por esto".
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -223,7 +223,7 @@ def kb_feed_version(state: Dict[str, Optional[datetime]]) -> str:
     Spelled out rather than hashed on purpose: the point is that someone
     reading a finding a year from now can tell what it was resolved against,
     and a hash only says "not the same as that other one" — it needs a lookup
-    table that does not exist yet (#302). A source with no date reports
+    table that does not exist. A source with no date reports
     ``none``, which is honest: an empty knowledge source is exactly the thing
     this mark exists to make visible.
 

--- a/API/src/modules/features/themis/managers/lybra/__init__.py
+++ b/API/src/modules/features/themis/managers/lybra/__init__.py
@@ -1,4 +1,4 @@
-"""Piezas de Lybra que sí necesitan el ORM (D1 en plans/deuda-tecnica-y-calidad.md).
+"""Piezas de Lybra que sí necesitan el ORM.
 
 ``LybraEngineManager`` (``engine.py``) y ``ServiceSource``/``DiscoveryProbes``
 (``sources.py``) vivían sueltos en ``managers/`` con nombres con prefijo

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -213,7 +213,7 @@ class LybraEngineManager(ScanManager):
 
         ``services`` acepta tanto ``Service`` como el dict equivalente, y por el
         mismo motivo de compatibilidad: desde que ``run_scan`` encola por la
-        outbox (#551) los argumentos se guardan en JSONB, así que llegan como
+        outbox transaccional los argumentos se guardan en JSONB, así que llegan como
         dicts. Un job pickleado por RQ antes de ese cambio sigue trayendo
         dataclasses, y esos se dejan pasar tal cual.
         """
@@ -245,8 +245,9 @@ class LybraEngineManager(ScanManager):
             services: Lista de servicios tal como viajó en el job, o ``None``
                 si el escaneo es de autodescubrimiento (Lybra descubre los
                 puertos él mismo y no recibe payload). Cada elemento puede ser
-                un dict —lo normal desde #551— o ya un ``Service``, que es como
-                viaja un job pickleado por RQ antes de ese cambio o una llamada
+                un dict —lo normal desde que se encola por la outbox— o ya un
+                ``Service``, que es como viaja un job pickleado por RQ antes de
+                ese cambio o una llamada
                 directa desde un test.
 
         Returns:
@@ -519,7 +520,7 @@ class LybraEngineManager(ScanManager):
             self.update_scan_status(scan_id, ScanStatus.FAILED, scan_failure.reason)
         # La sentencia de muerte de la cola. Hereda de ``BaseException`` para
         # que ningún ``except Exception`` la confunda con un fallo de red
-        # (#395), y el efecto colateral era que tampoco la veía el único sitio
+        # y se la trague, y el efecto colateral era que tampoco la veía el único sitio
         # que sabe qué fila hay que cerrar: la fila se quedaba en `running`
         # para siempre y el panel decía «escaneando» un día después. Se captura
         # explícitamente, se cierra la fila y **se vuelve a lanzar**, para que
@@ -1191,7 +1192,7 @@ class LybraEngineManager(ScanManager):
         Cada uno es **una muestra etiquetada gratis**, que es lo que convierte
         esta necesidad de una casilla de interfaz en un bucle de mejora: dicen
         contra qué check y contra qué producto se equivoca el motor, que es
-        exactamente la entrada que el banco de falsos positivos (#278) tiene
+        exactamente la entrada que el banco de falsos positivos tiene
         que aprender a consumir y lo que permite rankear qué familia falla más.
 
         Hasta L35 esa señal no existía: el usuario sólo podía decir "acepto el

--- a/API/src/modules/features/themis/managers/nikto.py
+++ b/API/src/modules/features/themis/managers/nikto.py
@@ -1,5 +1,5 @@
-"""NiktoScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: ver el docstring de nmap.py para el porqué)."""
+"""NiktoScanManager — extraído del antiguo thirdparty_scans_managers.py (ver el
+docstring de nmap.py para el porqué)."""
 
 import logging
 from typing import Optional

--- a/API/src/modules/features/themis/managers/nmap.py
+++ b/API/src/modules/features/themis/managers/nmap.py
@@ -1,8 +1,10 @@
-"""NmapScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: el fichero unificaba Nmap/Nikto/Nuclei
-"porque cada uno era pequeño y compartía la misma forma"; con A4 (base
-_create_scan_record) y A6 (base _previous_findings_map) ya no comparten
-apenas cuerpo, así que la unificación dejó de pagarse sola)."""
+"""NmapScanManager — extraído del antiguo thirdparty_scans_managers.py.
+
+Aquel fichero unificaba Nmap/Nikto/Nuclei "porque cada uno era pequeño y
+compartía la misma forma"; desde que la creación del registro
+(``_create_scan_record``) y el mapa de hallazgos previos
+(``_previous_findings_map``) viven en la clase base, ya no comparten apenas
+cuerpo, así que la unificación dejó de pagarse sola."""
 
 import logging
 from typing import Optional

--- a/API/src/modules/features/themis/managers/nuclei.py
+++ b/API/src/modules/features/themis/managers/nuclei.py
@@ -1,5 +1,5 @@
-"""NucleiScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: ver el docstring de nmap.py para el porqué)."""
+"""NucleiScanManager — extraído del antiguo thirdparty_scans_managers.py (ver el
+docstring de nmap.py para el porqué)."""
 
 import logging
 from typing import Callable, Optional

--- a/API/src/modules/features/themis/managers/scan.py
+++ b/API/src/modules/features/themis/managers/scan.py
@@ -442,8 +442,8 @@ class ScanManager(TaskTrackingMixin, ABC):
         la clave ``rq:worker:<name>`` sobrevive con su TTL completo a una
         muerte abrupta, así que su mera existencia no prueba nada.
 
-        Mismo arreglo que Iris hizo en su reconciliación (#208); el defecto era
-        literalmente el mismo porque este método fue el espejo del que se copió.
+        Mismo arreglo que ya tenía la reconciliación de Iris; el defecto era
+        literalmente el mismo porque aquélla se copió de este método.
 
         Returns:
             Número de escaneos marcados como FAILED.
@@ -563,7 +563,7 @@ class ScanManager(TaskTrackingMixin, ABC):
 
         # El mismo plazo agotado que recoge ``LybraEngineManager._run_lybra``,
         # aquí para los tres escáneres que sí lanzan un subproceso. Hereda de
-        # ``BaseException`` (#395) para que no lo capture ningún ``except
+        # ``BaseException`` para que no lo capture ningún ``except
         # Exception``, y el precio era que la fila se quedaba en `running`
         # eternamente cuando la cola mataba el trabajo. Se cierra la fila y se
         # vuelve a lanzar, para que RQ siga viendo un trabajo fallido.

--- a/API/src/modules/features/themis/managers/traceroute.py
+++ b/API/src/modules/features/themis/managers/traceroute.py
@@ -98,7 +98,7 @@ class TracerouteManager(TaskTrackingMixin):
         así que no existe el huérfano que la outbox previene. Un fallo de
         encolado deja simplemente un fallo de caché — el cliente sigue
         sondeando, no encuentra resultado fresco y la siguiente petición vuelve
-        a encolar. Se revisó con los demás en #551 y se decidió dejarlo así.
+        a encolar.
         """
         key = self._trace_key(user_id, target)
         timeout = int(CR.traceroute_config().timeout) + 30

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -901,7 +901,7 @@ class Finding(Base):
     # Quality / provenance
     source       = Column(String(32), index=True)
     check_id     = Column(String(128))
-    # 64 y no 32: desde #270 la marca de la detección por versión describe el
+    # 64 y no 32: la marca de la detección por versión describe el
     # estado de la base de conocimiento ("lybra-kb:nvd=2026-08-29,kev=...,
     # epss=..."), que ocupa hasta 54 caracteres. Se escribe entera en vez de
     # resumirla en un hash para que un hallazgo guardado siga diciendo, por sí

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -1257,8 +1257,7 @@ class KbRepository(BaseRepository[CveEntry]):
         tell those two apart after the fact.
 
         Read from the data itself rather than from a sync log, because there is
-        no sync log — recording when each source was last synchronised is
-        #302. These dates are the closest honest proxy: not "when did we last
+        no sync log. These dates are the closest honest proxy: not "when did we last
         ask NVD", but "how recent is the newest thing we know". A source with
         no rows, or whose rows carry no date, reports ``None``, which is
         information too and must not be dressed up as a date.

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -50,7 +50,7 @@ class NmapAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
-    # Tope de puertos detallados que viajan al prompt (#118): un host con
+    # Tope de puertos detallados que viajan al prompt: un host con
     # cientos de puertos abiertos (mala configuración, o un rango escaneado
     # como si fuera un solo host) podía generar un 'ports_json' sin límite.
     # '{{total_ports}}' sigue reportando el recuento real (no el recortado),
@@ -527,12 +527,12 @@ class LybraAIWriter:
     # completo (confirmados + KEV + cola), no solo a la cola: un scan con más
     # de _MAX_HIGHLIGHTED_FINDINGS hallazgos confirmados/KEV podía generar un
     # payload sin límite real pese a este tope, porque antes solo recortaba
-    # "rest" (Issue #118). El rollup por servicio cubre igualmente los que no
+    # "rest". El rollup por servicio cubre igualmente los que no
     # entran, así que un host con cientos de CVEs sigue describiéndose entero.
     _MAX_HIGHLIGHTED_FINDINGS = 25
     _MAX_DESCRIPTION_CHARS = 300
 
-    # Tope de grupos del rollup por servicio (#118): un objetivo con muchos
+    # Tope de grupos del rollup por servicio: un objetivo con muchos
     # productos/puertos distintos (un rango de red, no un solo host) podía
     # generar un 'services_json' sin límite pese a que ya es una compresión
     # de los hallazgos. Ordenado por severidad (ver _build_service_rollup),
@@ -611,7 +611,7 @@ class LybraAIWriter:
         # repositorio) para que, al recortar, sobrevivan los más graves —
         # y se recortan igual que la cola: antes solo _rest_ tenía tope, así
         # que un scan con más de _MAX_HIGHLIGHTED_FINDINGS confirmados/KEV
-        # generaba un payload sin límite real pese a la constante (#118).
+        # generaba un payload sin límite real pese a la constante.
         priority = list({id(finding): finding for finding in findings
                           if finding.get("confirmed") or finding.get("in_kev")}.values())
         priority.sort(key=self._sort_key)

--- a/API/src/modules/features/themis/services/reports/__init__.py
+++ b/API/src/modules/features/themis/services/reports/__init__.py
@@ -12,13 +12,13 @@ Generación de informes PDF de Themis.
     lybra.py     LybraPrintingStrategy
     nuclei.py    NucleiPrintingStrategy
 
-D5 en ``plans/deuda-tecnica-y-calidad.md``: este paquete sustituye al
+Este paquete sustituye al
 ``reports.py`` de 85 KB, el fichero más grande del repositorio. Su
 estructura interna ya era buena —el registro ``@PrintingStrategy.register``
 estaba bien hecho— y el problema era puramente de tamaño: tocar la paleta
 de un escáner obligaba a abrir un fichero de 2.000 líneas, y dos cambios en
 escáneres distintos colisionaban siempre en el mismo sitio. Es la misma
-Fase 3 que ya se aplicó a ``themis/managers.py``.
+partición que ya se aplicó a ``themis/managers.py``.
 
 Las cuatro estrategias se importan aquí por su **efecto secundario**: cada
 una se da de alta en ``PrintingStrategy._registry`` con su decorador al

--- a/API/src/modules/features/themis/services/reports/base.py
+++ b/API/src/modules/features/themis/services/reports/base.py
@@ -4,8 +4,6 @@
 Cada tipo de escaneo se da de alta con ``@PrintingStrategy.register(...)``
 junto a su propia clase; ``resolve_printing_strategy`` despacha por ese
 registro, así que añadir un tipo nuevo no toca este fichero.
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import logging

--- a/API/src/modules/features/themis/services/reports/creator.py
+++ b/API/src/modules/features/themis/services/reports/creator.py
@@ -1,7 +1,5 @@
 """
 ``PDFCreator``: arma el documento PDF a partir de la estrategia del escaneo.
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import os

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -1,8 +1,6 @@
 """
 ``FindingsPrintingStrategy``: base compartida por los tipos de escaneo que
 viven enteramente en ``Finding`` (Lybra y Nuclei).
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import logging

--- a/API/src/modules/infrastructure/document_repository.py
+++ b/API/src/modules/infrastructure/document_repository.py
@@ -1,6 +1,5 @@
 """
-Repositorio base para las entidades ``Document`` (A9 en
-plans/deuda-tecnica-y-calidad.md).
+Repositorio base para las entidades ``Document``.
 
 Los tres repositorios de documentos del proyecto —Themis (informes PDF de
 escaneo), Iris (informes PDF de análisis) y Aegis (píldoras de

--- a/API/src/modules/shared/_documents.py
+++ b/API/src/modules/shared/_documents.py
@@ -83,7 +83,7 @@ def submit_report_generation(task_queue, document_id: int, repo_cls: Type, **sub
     devolviendo el mismo error al cliente.
 
     Este manejo es la razón por la que los informes de Themis e Iris se
-    quedaron **fuera** de la outbox transaccional al auditarlos en #551, aunque
+    quedaron **fuera** de la outbox transaccional, aunque
     siguen el mismo patrón create-then-enqueue que Themis y Aegis sí migraron:
     un encolado fallido no deja el documento colgado en ``running`` para
     siempre, lo marca ``error``, y el usuario ve el fallo y puede volver a
@@ -148,7 +148,7 @@ class DocumentManager(TaskTrackingMixin):
     """CRUD y ownership compartidos por el ciclo de vida de un documento.
 
     ``ThemisReportManager`` e ``IrisReportManager`` eran el mismo manager con
-    los nombres cambiados (A3 en ``plans/deuda-tecnica-y-calidad.md``): esta
+    los nombres cambiados: esta
     base concentra lo que de verdad era idéntico. La generación en sí
     (``generate_report``/``_generate_pdf_async``/``execute_report_generation``)
     se queda en cada subclase porque el ``render`` y el disparador difieren

--- a/API/src/modules/shared/report_theme.py
+++ b/API/src/modules/shared/report_theme.py
@@ -1,8 +1,8 @@
 """
 Tema visual de los informes PDF: paleta y estilos.
 
-Nació en Themis (D5 en ``plans/deuda-tecnica-y-calidad.md``, extraído del
-``reports.py`` de 85 KB, el fichero más grande del repositorio) y vive aquí
+Nació en Themis (extraído del antiguo ``reports.py`` de 85 KB, el fichero más
+grande del repositorio) y vive aquí
 desde que Hygeia también imprime. No sabe nada de escaneos ni de activos: solo
 importa ``reportlab``, así que cualquier módulo que genere un PDF puede
 heredarlo y salir con la misma cara que el resto del producto.

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -615,8 +615,7 @@ class ScribeConfig(_StrategySelection):
 
     max_input_tokens: int = 24000
     """Tope de tokens estimados del prompt (system + examples + user) que
-    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia (Issue
-    #118).
+    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia.
 
     Sin esto, un writer de dominio (p.ej. ``LybraAIWriter`` con un scan de
     muchos hallazgos) podía generar un payload que OpenAI rechazaba con un

--- a/API/src/modules/system/taskqueue/outbox.py
+++ b/API/src/modules/system/taskqueue/outbox.py
@@ -46,11 +46,11 @@ recalculan y sobrescriben por ``analysis_id`` en vez de crear filas nuevas,
 así que una repetición ahí es trabajo de más, no un dato duplicado -- pero
 quien añada un nuevo consumidor de outbox debe poder decir lo mismo del suyo.
 
-**Alcance de esta primera aplicación (B08).** El propio issue #240 pide
-aplicarlo primero a análisis e ingesta y dejar para después el PDF, el
-resumen de IA y las notificaciones -- todos siguen el mismo patrón
-create-then-enqueue y son candidatos igual de válidos, pero mezclarlos aquí
-habría triplicado el tamaño de este cambio sin necesidad.
+**Dónde se aplica.** Donde una fila confirmada antes de encolar puede quedarse
+huérfana o, peor, ser el guardia que impide volver a intentarlo: los escaneos
+de Themis, las campañas y píldoras de Aegis, el análisis de Iris y los avisos
+con guardia anti-duplicado de Iris y Hygeia. Los sitios que siguen llamando a
+``submit()`` directamente explican por qué junto a esa llamada.
 
 **Por qué el dispatcher vive en un fichero aparte** (``dispatcher.py``): este
 módulo es la base (modelo + (de)serialización) que ``outbox_repository.py``

--- a/API/src/modules/tools/scribe/exceptions.py
+++ b/API/src/modules/tools/scribe/exceptions.py
@@ -46,7 +46,7 @@ class AIResponseError(EllysiaException):
 
 
 class AIPayloadTooLargeError(EllysiaException):
-    """El prompt estimado supera el tope de tokens configurado (Issue #118).
+    """El prompt estimado supera el tope de tokens configurado.
 
     Se lanza *antes* de invocar la estrategia — nunca es transitorio (el mismo
     prompt sobredimensionado fallaría igual en cada reintento), así que

--- a/API/src/modules/tools/scribe/generator.py
+++ b/API/src/modules/tools/scribe/generator.py
@@ -85,7 +85,7 @@ class AIGenerator:
             self._failures += 1
             self._last_failure_time = time.time()
 
-    # ── Guardarraíl de tamaño (Issue #118) ──────────────────────────────────
+    # ── Guardarraíl de tamaño ───────────────────────────────────────────────
 
     @staticmethod
     def _check_payload_size(ai_input: AIInput) -> None:
@@ -131,7 +131,7 @@ class AIGenerator:
             CircuitBreakerOpenError: Si el breaker del backend está abierto.
             AIPayloadTooLargeError: Si el prompt estimado supera el tope
                 configurado — se comprueba antes de llamar a la estrategia y
-                no se reintenta (Issue #118): un prompt sobredimensionado
+                no se reintenta: un prompt sobredimensionado
                 falla igual en cada intento, así que reintentarlo solo
                 desperdicia llamadas y tiempo.
             AIFallbackExhaustedError: Si se agotan los reintentos.

--- a/API/src/modules/tools/scribe/inputs.py
+++ b/API/src/modules/tools/scribe/inputs.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # tiktoken, que además tokeniza distinto por modelo/backend). ~4 es la cifra
 # que la propia documentación de OpenAI da como regla general para texto en
 # inglés/español; de sobra para un guardarraín de "no mandes un payload
-# disparatado" — no hace falta precisión exacta para eso (Issue #118).
+# disparatado" — no hace falta precisión exacta para eso.
 _CHARS_PER_TOKEN = 4
 
 
@@ -95,7 +95,7 @@ class AIInput:
         return messages
 
     def estimated_tokens(self) -> int:
-        """Estimación heurística del tamaño del prompt completo (Issue #118).
+        """Estimación heurística del tamaño del prompt completo.
 
         Suma sobre todos los mensajes que ``to_messages`` enviaría — no solo
         el último — porque es el total lo que un backend factura contra su

--- a/API/tests/integration/test_aegis_outbox.py
+++ b/API/tests/integration/test_aegis_outbox.py
@@ -219,7 +219,7 @@ def test_generating_a_pill_with_redis_down_leaves_a_recoverable_dispatch(
 ):
     """La píldora se crea en ``pending`` y su generación queda en la outbox.
 
-    Antes de #551 este era el peor de los dos casos de Aegis: sin outbox, sin
+    Antes era el peor de los dos casos de Aegis: sin outbox, sin
     try/except y sin reconciliación, el documento se quedaba en ``pending`` para
     siempre con las dos cuotas de IA ya cobradas.
     """

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -699,7 +699,8 @@ def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, 
     Lo que se sustituye es el **socket**, no la sesión: el ``NetworkSession``
     real hace su trabajo, saludo incluido. Un doble por encima de la sesión
     entrega respuestas que el transporte real no produce, y eso fue justo lo
-    que ocultó el bug de #265 (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
+    que ocultó que los dos checks ``network`` no podían dispararse contra un
+    servidor real (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.lybra import checks as checks_mod
 
@@ -823,7 +824,7 @@ class _FrozenClock:
 def test_a_scan_that_runs_out_of_clock_stops_probing_and_finishes_partial(app, admin_user, monkeypatch):
     """El plazo del panel acota el escaneo entero, no sólo su primera fase.
 
-    El descubrimiento de puertos tenía presupuesto de reloj desde #395, pero las
+    El descubrimiento de puertos ya tenía presupuesto de reloj, pero las
     fases siguientes no tenían ninguno: un «plazo por operación» limita lo que
     tarda cada sonda, no cuántas sondas se hacen, y cuántas se hacen lo decide
     cuántos puertos abiertos tenga el objetivo. Con un rango ancho el

--- a/API/tests/integration/test_themis_reconciliation.py
+++ b/API/tests/integration/test_themis_reconciliation.py
@@ -14,7 +14,7 @@ Lo que veía el usuario era una contradicción: el escaneo aparecía como fallid
 y, minutos más tarde, el worker terminaba y escribía ``finished`` encima de esa
 misma fila.
 
-Es el mismo defecto que Iris arregló en #208, y no por casualidad: esta
+Es el mismo defecto que Iris ya arregló en la suya, y no por casualidad: esta
 reconciliación fue el original del que aquélla se copió. Estos tests son el
 espejo de ``test_iris_reconciliation.py``, con la diferencia de que aquí el
 método es un ``classmethod`` sobre una clase abstracta que barre los escaneos de

--- a/API/tests/integration/test_themis_scan_outbox.py
+++ b/API/tests/integration/test_themis_scan_outbox.py
@@ -184,7 +184,7 @@ class TestLybraServicesSurviveJsonb:
         assert LybraEngineManager._rehydrate_services(payload) == [original]
 
     def test_rehydrate_passes_through_dataclasses_and_none(self):
-        """Compatibilidad: un job pickleado por RQ antes de #551 trae ``Service``
+        """Compatibilidad: un job pickleado por RQ antes de la outbox trae ``Service``
         ya construidos, y el modo autodescubrimiento no trae ninguno."""
         original = Service(port=22, protocol="tcp", name="ssh")
 

--- a/API/tests/oracle/_docker_helpers.py
+++ b/API/tests/oracle/_docker_helpers.py
@@ -90,7 +90,7 @@ def remember_container(port: int, name: str) -> None:
 
     Sin este apunte, los esperadores de este módulo sólo pueden informar de que
     un puerto no contestó, que es el síntoma y nunca la causa. Con él pueden
-    mirar si el contenedor sigue vivo y adjuntar su log. Ver #455: el objetivo
+    mirar si el contenedor sigue vivo y adjuntar su log. Ya pasó: el objetivo
     de ProFTPD moría al arrancar y el banco lo comunicaba como un timeout de
     cuatro minutos contra un puerto, sin una sola línea sobre el contenedor.
     """

--- a/API/tests/oracle/_nmap_oracle.py
+++ b/API/tests/oracle/_nmap_oracle.py
@@ -79,7 +79,7 @@ def _docker_args(docker_path: str) -> List[str]:
     host dentro y **termina con código 0**. Nada lanzaba, el banco leía «Nmap
     no identificó nada» y lo apuntaba como desacuerdo de fingerprint. Tres
     tests de concordancia fallaban cada noche por una discrepancia que no
-    existía (#455).
+    existía.
 
     En Docker Desktop la bandera es redundante pero inocua: mapea a la misma
     puerta de enlace que ya estaba puesta.
@@ -143,7 +143,7 @@ def assert_target_was_scanned(document: str, error_output: str, target: str) -> 
     """Comprobar que el oráculo llegó a mirar el objetivo, y no a otra cosa.
 
     Hay dos formas muy distintas de que ``run_nmap_sv`` devuelva un mapa vacío,
-    y confundirlas es lo que tuvo el banco nocturno en rojo tres noches (#455):
+    y confundirlas es lo que tuvo el banco nocturno en rojo tres noches:
 
     - **El puerto no está abierto.** Es un resultado legítimo, y el que la
       documentación de :func:`parse_nmap_xml` describe: Nmap habló con el

--- a/API/tests/oracle/_security_headers.py
+++ b/API/tests/oracle/_security_headers.py
@@ -4,13 +4,13 @@ Los bancos necesitan saber qué es un acierto y qué es un falso positivo, y par
 la familia de cabeceras esa lista estaba escrita a mano **dos veces**: una en
 ``test_lybra_precision_bench.py`` y otra en ``test_lybra_oracle_bench.py``, las
 dos con los mismos tres identificadores. Cuando el feed creció de 28 a 55 checks
-(#296) y aparecieron CSP, ``Referrer-Policy`` y ``Permissions-Policy``, ninguna
+y aparecieron CSP, ``Referrer-Policy`` y ``Permissions-Policy``, ninguna
 de las dos se enteró. Los tres checks nuevos son detecciones **correctas** —un
 nginx recién sacado de la caja no manda ninguna de esas cabeceras— pero como el
 catálogo no los listaba como esperados, se contaron como falsos positivos en los
-diecisiete objetivos HTTP del banco y hundieron la precisión de la Fase R a
+diecisiete objetivos HTTP del banco y hundieron la precisión del banco a
 0,557 frente a un umbral de 0,90. El banco nocturno llevaba tres noches en rojo
-por eso (#455).
+por eso.
 
 La lección es la del repositorio de siempre: una lista que hay que acordarse de
 actualizar a mano se desincroniza, y lo hace en silencio. Así que aquí no se

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -39,7 +39,7 @@ SNMP). Los cuatro fallos están documentados uno a uno más abajo con
 arregle su test pasará a XPASS y habrá que quitarle el marcador — la convención
 del repositorio para un bug documentado.
 
-Requiere Docker. Marcado ``oracle``, fuera del run por defecto de CI (#280).
+Requiere Docker. Marcado ``oracle``, fuera del run por defecto de CI.
 """
 
 from __future__ import annotations
@@ -136,8 +136,8 @@ def _wait_for_http(port: int, timeout: float = 240.0) -> None:
 def _wait_for_greeting(port: int, expect: bytes, timeout: float = 240.0) -> None:
     """Esperar a que el servidor emita **su** saludo, no a que el puerto acepte.
 
-    Es la lección que dejó #265 en la Fase 0 y aquí vuelve a hacer falta: el
-    proxy de Docker acepta la conexión TCP en cuanto existe el espacio de red
+    Es una lección que ya dejaron los checks ``network`` y que aquí vuelve a
+    hacer falta: el proxy de Docker acepta la conexión TCP en cuanto existe el espacio de red
     del contenedor, mucho antes de que el servidor de dentro haya terminado de
     instalarse y arrancar. Un ``wait_for_port`` que sólo conecta da por listo un
     contenedor que todavía está haciendo ``apk add``, y la medición sale vacía
@@ -216,7 +216,8 @@ def proftpd_target():
     servidor FTP, un vsftpd cuyo saludo (``220 (vsFTPd 3.0.5)``) es justo el
     formato que el parser sabía leer. Ese 1,00 no medía la calidad del
     dissector, medía la coincidencia entre el dissector y el contenedor
-    elegido — la misma trampa que la Fase 0 documentó en #269 y #270.
+    elegido — la misma trampa de medir contra un doble hecho a la medida del
+    código que se mide.
 
     ProFTPD es el otro servidor FTP extendido y saluda de otra forma; en su
     configuración por defecto de Debian, además, **omite la versión**. Con él
@@ -227,7 +228,7 @@ def proftpd_target():
     # original venía de Debian, cuyo paquete la crea en su postinstalación, y
     # se ejecutaba sobre Alpine, donde no tiene por qué existir: ProFTPD aborta
     # con un fatal si el usuario que nombra su configuración no está, y el
-    # contenedor moría en el segundo uno (#455). Los dos ``||`` la hacen
+    # contenedor moría en el segundo uno. Los dos ``||`` la hacen
     # idempotente, para que la receta siga valiendo el día que el paquete sí
     # traiga la cuenta.
     #

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -57,7 +57,7 @@ def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
     """``wait_for_port`` con el cliente Docker ya puesto.
 
     Sin él, un contenedor que muere al arrancar se comunica como un puerto
-    que no contestó, que es el síntoma y nunca la causa (#455).
+    que no contestó, que es el síntoma y nunca la causa.
     """
     wait_for_port(host, port, timeout, docker_path=_DOCKER)
 
@@ -426,7 +426,7 @@ def test_missing_security_headers_detected_against_real_container(app, admin_use
     headers = {f.check_id for f in findings if f.category == "security_header"}
     # La familia esperada sale del feed, no de una lista escrita aquí. La lista
     # estuvo escrita, con tres identificadores, y se quedó atrás en cuanto el
-    # feed creció (#455).
+    # feed creció.
     assert headers == always_missing_header_checks()
     assert all(f.confirmed and f.qod == 99 for f in findings if f.category == "security_header")
 
@@ -456,7 +456,7 @@ def test_tls_expired_cert_detected_against_real_container(app, admin_user, tls_e
 
 # ------------------------------------------- familia network contra servidores reales
 #
-# Los cuatro casos que cierran #265. Hasta aquí, los dos únicos checks no-web
+# Por qué existen estos cuatro casos: hasta aquí, los dos únicos checks no-web
 # del motor sólo se habían ejercitado contra dobles, y por eso nadie vio que el
 # transporte leía una forma de respuesta que ni FTP ni Redis producen: el
 # escaneo terminaba en verde y el FTP anónimo seguía ahí. Un positivo y un

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -24,7 +24,7 @@ verlo.
 **Los señuelos son la mitad del banco a propósito.** ``nginx-endurecido`` manda
 la familia entera de cabeceras —la que declare el feed en cada momento, no una
 lista fija: se quedó en tres cuando el feed pasó a seis y dejó de ser un control
-negativo (#455)— y no debe producir ni un hallazgo de esa familia;
+negativo— y no debe producir ni un hallazgo de esa familia;
 ``nginx-senuelos`` sirve un 200 en las rutas que los checks de ``exposed_path``
 piden, pero con un cuerpo que no es lo que el check busca — un ``.git/config``
 que no es un config de Git, un ``backup.sql`` que no es un volcado. Un check que
@@ -74,11 +74,11 @@ _HTTP_PORT = 8080
 _TLS_PORT = 8443
 
 # La familia de cabeceras se **deriva del feed**, no se escribe aquí. Estuvo
-# escrita a mano, con tres identificadores, y cuando el feed creció (#296) nadie
+# escrita a mano, con tres identificadores, y cuando el feed creció nadie
 # la actualizó: los tres checks nuevos —CSP, Referrer-Policy y
 # Permissions-Policy— pasaron a contarse como falsos positivos en los diecisiete
-# objetivos HTTP del catálogo y tumbaron la precisión de la Fase R a 0,557
-# (#455). Ver ``_security_headers.py`` para la derivación y su única excepción.
+# objetivos HTTP del catálogo y tumbaron la precisión del banco a 0,557.
+# Ver ``_security_headers.py`` para la derivación y su única excepción.
 _HEADERS = always_missing_header_checks()
 
 
@@ -126,7 +126,7 @@ def _tls_serve(files: dict) -> str:
 # hallazgo. Manda la familia **entera** de cabeceras, no sólo las tres con
 # las que se escribió: en cuanto el feed creció, un «endurecido» al que le
 # faltaban tres cabeceras dejó de ser un control negativo y pasó a aportar
-# tres falsos positivos él solo (#455).
+# tres falsos positivos él solo.
 _HARDENED_CONF = (
     "printf '%s' 'server { listen 80; "
     'add_header Strict-Transport-Security "max-age=31536000" always; '
@@ -175,15 +175,15 @@ _REAL_EXPOSURES = {
 # Un volcado de base de datos expuesto dispara **dos** checks del feed, no uno.
 # ``sql-backup-exposure`` (CRITICAL) pide /backup.sql con un cuerpo que contenga
 # INSERT INTO o CREATE TABLE; ``sql-dump-exposure`` (HIGH), añadido cuando el
-# feed creció (#296), pide una lista de nombres en la que /backup.sql también
+# feed creció, pide una lista de nombres en la que /backup.sql también
 # está. El mismo fichero satisface a los dos.
 #
 # El catálogo los etiqueta como pareja porque, tal y como está hoy el feed, los
 # dos hallazgos son ciertos: contarlos como uno solo haría del segundo un falso
 # positivo que no lo es. Pero el solapamiento **sí es un defecto del feed**, no
 # del banco —en producción produce dos hallazgos con severidades distintas para
-# el mismo fichero— y se sigue en #456. Cuando ahí se decida deduplicarlos, esta
-# pareja vuelve a ser un solo identificador.
+# el mismo fichero— y sigue sin resolverse en el feed. El día que se
+# deduplique, esta pareja vuelve a ser un solo identificador.
 _SQL_DUMP_CHECKS = {
     "lybra:sql-backup-exposure@1",
     "lybra:sql-dump-exposure@1",
@@ -347,7 +347,7 @@ _CATALOGUE = (
         # Las mismas siete rutas, pero servidas por HTTPS. Hasta ahora ningún
         # check de ``exposed_path`` se ejercitaba nunca sobre TLS, que es como
         # sirve la mayoría de los sitios reales — y es justo el camino donde la
-        # detección de esquema por observación (#268) decide si la sonda habla
+        # detección de esquema por observación decide si la sonda habla
         # en claro o cifrado.
         command=_tls_serve(_REAL_EXPOSURES),
         expected=_HEADERS | _ALL_EXPOSURE_CHECKS | {"lybra:tls-self-signed-cert@1"},
@@ -445,7 +445,7 @@ def _wait_until_serving(port: int, tls: bool, label: str = "", timeout: float = 
     sonda TLS, nginx ya estaba en pie y el check de certificado sí funcionaba.
     El banco reportaba tres falsos negativos por objetivo TLS y ningún fallo.
 
-    Es la tercera vez que esta carrera muerde en este paquete (#265, L49), y
+    Es la tercera vez que esta carrera muerde en este paquete, y
     siempre con la misma cara: se lee como "el motor no detectó".
 
     La comprobación es deliberadamente **cruda** —un socket y una línea de
@@ -499,7 +499,7 @@ def _running(target: Target) -> Iterator[int]:
     # Un contenedor que muere al arrancar —una configuración de nginx que no
     # parsea, sin ir más lejos— produce cero hallazgos, y cero hallazgos es
     # indistinguible de "el motor no detectó nada" en el agregado. Registrarlo
-    # es lo que hace que el log diga cuál de las dos cosas pasó (#455).
+    # es lo que hace que el log diga cuál de las dos cosas pasó.
     remember_container(port, name)
     try:
         wait_for_port("127.0.0.1", port, docker_path=_DOCKER)

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -90,7 +90,7 @@ def test_an_external_target_is_scanned_directly():
 def test_the_oracle_container_is_told_how_to_reach_the_host():
     """Traducir el objetivo a ``host.docker.internal`` no sirve de nada si el
     contenedor no sabe resolver ese nombre, que es lo que pasa en Docker sobre
-    Linux — y por tanto en el runner del banco nocturno (#455). La bandera que
+    Linux — y por tanto en el runner del banco nocturno. La bandera que
     lo mapea contra la puerta de enlace del host tiene que ir en el ``docker
     run``, y antes de la imagen: lo que va después son argumentos de Nmap."""
     arguments = _docker_args("/usr/bin/docker")
@@ -136,7 +136,7 @@ def test_an_unreachable_target_stops_the_bench_instead_of_scoring_zero():
 
 
 # --------------------------------------------------------------------------
-# Un contenedor caído no puede leerse como un fallo del motor (#455)
+# Un contenedor caído no puede leerse como un fallo del motor
 # --------------------------------------------------------------------------
 #
 # Puras también: sólo comprueban qué hace el registro cuando no sabe nada del
@@ -175,7 +175,7 @@ def _forget_container(port: int) -> None:
 
 
 # --------------------------------------------------------------------------
-# La familia de cabeceras del banco no puede quedarse atrás del feed (#455)
+# La familia de cabeceras del banco no puede quedarse atrás del feed
 # --------------------------------------------------------------------------
 #
 # Éste es el test que faltaba. Los bancos que miden la familia necesitan Docker

--- a/API/tests/postgres/test_migrations.py
+++ b/API/tests/postgres/test_migrations.py
@@ -77,7 +77,7 @@ def alembic_config(migrations_url):
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Bug preexistente destapado por esta matriz (#356): la revisión "
+        "Bug preexistente destapado por esta matriz: la revisión "
         "b2c3d4e5f6a7 inserta en PlanLimit diez migraciones antes de que "
         "f2b3c4d5e6f7 cree la tabla, así que `alembic upgrade head` sobre una "
         "base vacía falla. No se nota en producción porque el primer "
@@ -105,7 +105,7 @@ def test_the_whole_chain_applies_to_an_empty_database(alembic_config, migrations
     strict=True,
     reason=(
         "Depende de que `upgrade head` funcione sobre una base vacía, que hoy "
-        "no lo hace (#356). Se quita junto con el marcador del test anterior."
+        "no lo hace. Se quita junto con el marcador del test anterior."
     ),
 )
 def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_config,

--- a/API/tests/unit/test_config_view_paths.py
+++ b/API/tests/unit/test_config_view_paths.py
@@ -1,5 +1,4 @@
-"""Las rutas de configuración que codifica el SPA tienen que existir de verdad
-(A11 en ``plans/deuda-tecnica-y-calidad.md``).
+"""Las rutas de configuración que codifica el SPA tienen que existir de verdad.
 
 ``web/app/src/views/ConfigView.vue`` enlaza cada control del formulario con
 ``store.configFlat['ruta.con.puntos']``. Ese ``configFlat`` es el aplanado de

--- a/API/tests/unit/test_hygeia_inventory_adapter.py
+++ b/API/tests/unit/test_hygeia_inventory_adapter.py
@@ -130,8 +130,8 @@ def test_the_stripped_version_matches_an_nvd_range():
     Este test afirmaba también lo contrario para la versión **sin** recortar
     (``version_compare(raw, "2.39") < 0``), porque entonces era cierto: el
     comparador partía la cadena en tramos de dígitos y de letras, y el sufijo
-    de empaquetado dejaba la instalada por debajo del inicio del rango. Desde
-    #267 ya no lo es — el comparador reconoce y separa la revisión de
+    de empaquetado dejaba la instalada por debajo del inicio del rango. Ya no
+    lo es — el comparador reconoce y separa la revisión de
     distribución él mismo, así que las dos formas comparan igual. Afirmar aquí
     el fallo antiguo sería congelarlo.
 

--- a/API/tests/unit/test_iris_fp_regression.py
+++ b/API/tests/unit/test_iris_fp_regression.py
@@ -1,7 +1,6 @@
 """Corpus de regresión de falsos positivos.
 
-Prerrequisito bloqueante de la recalibración de pesos
-(``plans/feature/iris/iris-rule-weight-recalibration.md``, sección 7.1): sin
+Prerrequisito bloqueante de la recalibración de pesos de las reglas: sin
 un corpus que de verdad estrese los contaminantes identificados por el
 consejo (saludo genérico, urgencia media, tracking de imágenes, cadena
 Received interna, destinatarios ocultos, coexistiendo en el mismo correo,

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -1,8 +1,7 @@
 """Tests unitarios de los conectores de buzón (Gmail / Microsoft Graph).
 
 Todo el HTTP está mockeado (``unittest.mock.patch`` sobre ``requests.get``/
-``requests.post``) -- sin red real, sin credenciales OAuth reales. Ver
-plans/feature/iris/iris-mailbox-connector.md Fase 4.
+``requests.post``) -- sin red real, sin credenciales OAuth reales.
 """
 
 from __future__ import annotations

--- a/API/tests/unit/test_iris_recalibration_rules.py
+++ b/API/tests/unit/test_iris_recalibration_rules.py
@@ -1,5 +1,4 @@
-"""Tests de las reglas/gates nuevos de la recalibración de pesos
-(``plans/feature/iris/iris-rule-weight-recalibration.md``, secciones 3 y 5):
+"""Tests de las reglas/gates nuevos de la recalibración de pesos de Iris:
 
 - Auth Results Provenance (G-A): authserv-id ↔ último `by` del Received.
 - Recipient Domain Lookalike (G-B): lookalike del dominio del destinatario.

--- a/API/tests/unit/test_lybra_cascade.py
+++ b/API/tests/unit/test_lybra_cascade.py
@@ -236,8 +236,8 @@ def test_a_blind_probe_that_raises_does_not_stop_the_next_one():
 
 def test_the_cascade_is_derived_from_the_registry_not_a_parallel_list():
     """La razón de que `banner_readers` y `blind_probers` se calculen y no se
-    escriban: una lista paralela es exactamente lo que se queda atrás. #272
-    documenta el caso — un mapa a mano con dos entradas mientras el módulo ya
+    escriban: una lista paralela es exactamente lo que se queda atrás. Ya
+    pasó: un mapa a mano con dos entradas mientras el módulo ya
     definía once predicados."""
     dissectors = default_dissectors()
     readers = {dissector.label for dissector in banner_readers(dissectors)}

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -629,7 +629,7 @@ def test_a_tls_service_on_an_arbitrary_port_still_misses_the_hygiene_checks():
     El esquema ya se observa, así que un TLS en 7777 se sondea bien y recibe
     los checks de cabeceras. Lo que no recibe son los de higiene de
     certificado: su candidatura sigue decidiéndose por número de puerto.
-    Hacerla observada del todo es #283.
+    Hacerla observada del todo está pendiente.
     """
     from src.modules.features.themis.lybra import is_tls_service
 

--- a/API/tests/unit/test_lybra_correlation.py
+++ b/API/tests/unit/test_lybra_correlation.py
@@ -167,7 +167,7 @@ def test_a_partial_scan_still_states_what_it_did_see():
     ({"cvss_score": 5.0, "epss_score": 0.6}, "public", "HIGH"),     # high EPSS escalates
     ({"cvss_score": 0.0, "confirmed": True}, "public", "MEDIUM"),   # confirmed w/o CVSS floors
     ({"cvss_score": 0.0}, "public", "INFO"),
-    # required_os (#118): an unconfirmed, platform-gated CVSS 9.8 match cannot
+    # required_os: an unconfirmed, platform-gated CVSS 9.8 match cannot
     # be verified without OS-detection, so it is capped at MEDIUM instead of
     # reading as CRITICAL.
     ({"cvss_score": 9.8, "required_os": "windows_10"}, "public", "MEDIUM"),

--- a/API/tests/unit/test_lybra_dsl_chaining.py
+++ b/API/tests/unit/test_lybra_dsl_chaining.py
@@ -216,7 +216,7 @@ def test_the_first_matching_payload_wins_as_a_single_finding():
     assert len(tried) == 1                                # paró en el primero
 
 
-# =============================================== validación de forma (CI, #275)
+# ===================================================== validación de forma (CI)
 
 
 def test_the_shipped_feed_including_the_payload_check_is_well_formed():

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -295,7 +295,7 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["confirmed"] is True
 
 
-# ------------------------------------------- marca de reproducibilidad (#270)
+# -------------------------------------------------- marca de reproducibilidad
 #
 # Cada hallazgo lleva una marca que dice contra qué se resolvió. Para los checks
 # activos era cierta (sube cada vez que cambia el feed); para la detección por
@@ -369,7 +369,7 @@ def test_the_mark_fits_in_the_column_that_stores_it():
 
 
 def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
-    """El criterio de cierre de #267, extremo a extremo dentro del motor.
+    """El comparador de versiones de distribución, extremo a extremo en el motor.
 
     El inventario de un agente entrega versiones de paquete de distribución
     (`1:7.4-1ubuntu1`), y NVD sólo publica rangos sobre versiones de

--- a/API/tests/unit/test_lybra_feed_shape.py
+++ b/API/tests/unit/test_lybra_feed_shape.py
@@ -104,8 +104,8 @@ def test_a_script_without_plugin_is_reported(feed):
 
 
 def test_a_network_service_without_predicate_is_reported(feed):
-    """El caso de #272: un check ``network`` para un protocolo que ningún
-    predicado reconoce. Aquel arreglo lo hizo fallar al cargar; esta validación
+    """Un check ``network`` para un protocolo que ningún predicado reconoce.
+    Cargar el feed ya falla en ese caso; esta validación
     lo encuentra además sobre un feed externo, que no pasa por ese camino."""
     # El nombre tiene que ser uno que ningún `is_*_service` reconozca. Aquí
     # estuvo "postgres" hasta que L12 le dio su predicado, que es justo la

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -329,7 +329,7 @@ def test_the_longest_possible_v4_vector_fits_in_the_column():
     assert len(peor_caso) <= CveEntry.__table__.c.cvss_vector.type.length
 
 
-# ------------------------------------------------- platform-gated CVEs (#118)
+# -------------------------------------------------------- platform-gated CVEs
 
 def _and_node_item(platform_cpe: str) -> dict:
     """One CVE whose only applicability node ANDs an Apache match with a
@@ -352,7 +352,7 @@ def test_ingest_nvd_cve_and_node_tags_software_match_with_platform():
     """NVD's 'product AND platform' node shape must gate the software row
     with the platform's product token — the mechanism behind CVE-2024-38472-
     style ("...on Windows") false positives reported against non-Windows
-    hosts (Issue #118)."""
+    hosts."""
     item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
     _cve, matches = ingest_nvd_cve(item)
     assert len(matches) == 1  # the platform-only cpeMatch produces no row of its own

--- a/API/tests/unit/test_lybra_package_invariants.py
+++ b/API/tests/unit/test_lybra_package_invariants.py
@@ -1,5 +1,4 @@
-"""Invariantes estructurales del motor Lybra (D1 en
-plans/deuda-tecnica-y-calidad.md, y L52).
+"""Invariantes estructurales del motor Lybra.
 
 Son dos, y protegen cosas distintas: que la capa pura ``themis/lybra/`` no
 toque el ORM, y que la capa con efectos ``themis/managers/lybra/`` no dependa

--- a/API/tests/unit/test_nuclei_adapter.py
+++ b/API/tests/unit/test_nuclei_adapter.py
@@ -170,7 +170,7 @@ def test_cpe_and_cvss_vector_read_from_classification():
     assert f["cvss_vector"] == "CVSS:3.1/x"
 
 
-# ------------------------------------------------------- finding_to_json (#118)
+# -------------------------------------------------------------- finding_to_json
 
 def test_finding_to_json_exposes_required_os_and_feeds_the_cap_into_priority():
     """An unconfirmed, platform-gated CVSS 9.8 finding must serialize its

--- a/API/tests/unit/test_scan_deadline_closes_the_row.py
+++ b/API/tests/unit/test_scan_deadline_closes_the_row.py
@@ -1,7 +1,7 @@
 """Un escaneo que agota su plazo cierra su fila en vez de quedarse «escaneando».
 
 La cola mata un trabajo que se pasa de tiempo lanzándole ``JobDeadlineExceeded``
-desde fuera. Esa excepción hereda de ``BaseException`` a propósito (#395), para
+desde fuera. Esa excepción hereda de ``BaseException`` a propósito, para
 que ningún ``except Exception`` del código de negocio la confunda con un fallo
 de red y se la trague.
 
@@ -78,7 +78,7 @@ def test_an_external_scanner_out_of_time_is_failed_with_its_reason(monkeypatch):
 
 def test_the_deadline_keeps_climbing_after_the_row_is_closed(monkeypatch):
     """Si se capturara sin volver a lanzarla, la fila diría «falló» y la cola
-    diría «terminado con éxito» — la contradicción de #395 otra vez, del revés.
+    diría «terminado con éxito» — la misma contradicción, del revés.
 
     Además el temporizador dispara una sola vez: un plazo tragado deja al
     trabajo corriendo sin ningún límite a partir de ese momento.

--- a/API/tests/unit/test_scheduling_semantics.py
+++ b/API/tests/unit/test_scheduling_semantics.py
@@ -1,5 +1,4 @@
-"""``calculate_next_run`` y ``_build_trigger`` no pueden divergir en silencio
-(A12 en plans/deuda-tecnica-y-calidad.md).
+"""``calculate_next_run`` y ``_build_trigger`` no pueden divergir en silencio.
 
 ``ThemisScheduler`` calcula "cuándo dispara" por dos caminos independientes:
 

--- a/API/tests/unit/test_scribe_generator.py
+++ b/API/tests/unit/test_scribe_generator.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Scribe payload-size guardrail (Issue #118).
+"""Unit tests for the Scribe payload-size guardrail.
 
 Covers the heuristic token estimate (``estimate_tokens`` / ``AIInput.estimated_tokens``)
 and ``AIGenerator``'s pre-flight check: an oversized prompt must be rejected

--- a/API/tests/unit/test_themis_ai_analysis_error_message.py
+++ b/API/tests/unit/test_themis_ai_analysis_error_message.py
@@ -1,4 +1,4 @@
-"""Unit tests for how the PDF report reacts when the AI writer fails (#118).
+"""Unit tests for how the PDF report reacts when the AI writer fails.
 
 ``PrintingStrategy._append_ai_analysis`` used to catch every exception the
 same way, rendering a generic "No se pudo generar análisis IA" paragraph

--- a/API/tests/unit/test_themis_ai_writer.py
+++ b/API/tests/unit/test_themis_ai_writer.py
@@ -214,7 +214,7 @@ def test_rollup_de_servicios_se_recorta_al_tope_priorizando_severidad(monkeypatc
     assert servicios[0]["producto"] == "product-critico 1.0"
 
 
-# ------------------------------------------------------- NmapAIWriter (#118)
+# -------------------------------------------------------------- NmapAIWriter
 
 _FAKE_NMAP_PROMPTS = {
     "nmap": {

--- a/web/app/src/components/config/ScannerCard.vue
+++ b/web/app/src/components/config/ScannerCard.vue
@@ -34,7 +34,7 @@ const props = defineProps({
   prefix: { type: String, required: true },
   flat: { type: Object, required: true },
   // Colapsada por defecto para que las cuatro tarjetas de Themis empiecen a la
-  // misma altura (issue #451): expandir una no debe descolocar a las demás,
+  // misma altura: expandir una no debe descolocar a las demás,
   // así que cada tarjeta abre de forma independiente, no en modo acordeón.
   defaultOpen: { type: Boolean, default: false },
 })

--- a/web/app/src/components/iris/IrisDocumentsModal.vue
+++ b/web/app/src/components/iris/IrisDocumentsModal.vue
@@ -112,7 +112,7 @@ function verdictClass(v) {
 <style scoped>
 /* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
    (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
-   se borra (#131). */
+   se borra. */
 .modal {
   position: fixed;
   inset: 0;

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -248,7 +248,7 @@ function onFile(event) {
      static) — que no hace scroll — dejando el input clavado en un punto fijo
      mientras .panel-content (el que sí scrollea, y queda por medio) se movía
      por su cuenta. Al enfocarlo el navegador lo llevaba a su posición real
-     (desincronizada), desplazando toda la página. Refs #135. */
+     (desincronizada), desplazando toda la página. */
   position: relative;
   display: inline-flex; align-items: center; justify-content: center;
   padding: 0.4rem 0.75rem; border-radius: 7px; cursor: pointer;

--- a/web/app/src/components/themis/ScanPreviewModal.vue
+++ b/web/app/src/components/themis/ScanPreviewModal.vue
@@ -129,7 +129,7 @@ function fmtDate(iso) { if (!iso) return ''; return new Date(iso).toLocaleDateSt
 <style scoped>
 /* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
    (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
-   se borra (#131). */
+   se borra. */
 .modal {
   position: fixed;
   inset: 0;

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -670,8 +670,8 @@ function handleSave() { store.saveConfig() }
 .collapsible + .collapsible { margin-top: 0.5rem; }
 /* `align-items: start` evita que Grid estire cada tarjeta a la altura de la más
    alta de su fila (Lybra, con varias subsecciones, frente a Nmap/Nikto casi
-   sin opciones propias) — ese estirado era el hueco vacío que denunciaba el
-   issue #451, no un exceso de contenido de Lybra. */
+   sin opciones propias) — ese estirado era el hueco vacío que se veía, no
+   un exceso de contenido de Lybra. */
 .scanner-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.85rem; margin-top: 0.85rem; align-items: start; }
 .form-group { display: flex; flex-direction: column; gap: 0.25rem; }
 .form-group label { font-size: var(--fs-md); font-weight: 600; color: var(--text-dim); }

--- a/web/app/src/views/LandingView.vue
+++ b/web/app/src/views/LandingView.vue
@@ -627,7 +627,7 @@ onUnmounted(() => {
    (`.scene { overflow: hidden }`), así que este `overflow` no protegía nada
    del fondo — solo recortaba, sin querer, cualquier desplegable de la
    cabecera (AccountMenu, Herramientas, Documentación) que no cupiera en los
-   100vh del hero (issue #140). */
+   100vh del hero. */
 .vista {
   position: relative;
   height: 100vh;


### PR DESCRIPTION
## Resumen

Muchos comentarios y docstrings del código justificaban una decisión con un número de issue o con una ruta a un documento de la carpeta `plans/`. Por ejemplo: `(#118)`, `ver #455`, `D5 en plans/deuda-tecnica-y-calidad.md` o `Fase 4 del plan plans/feature/iris/...`. A quien lee el código eso no le explica nada: tiene que salir a buscar el issue o el documento, y esos documentos están vivos, así que cambian, se reorganizan o desaparecen. Uno de los que se citaban, el plan del conector de buzón de Iris, ya no existe en el repositorio.

La norma de `CLAUDE.md` ya prohíbe estas referencias en el código; este PR limpia las que quedaban. Es el primero de varios. Este cubre los **números de issue y PR** y las **rutas a `plans/`**. Los **códigos de apartado** de esos planes que aparecen sueltos (`B08`, `M08`, `§16.2`, `Fase R`…) son varios cientos y se reescribirán en PRs aparte, uno por módulo, para que cada uno se pueda revisar con calma.

## Qué se ha hecho

Unas 120 referencias en 77 ficheros de `API/src`, `API/tests` y `web/app/src`. Hay dos tipos de caso.

- **La referencia era un añadido** a una explicación que ya estaba escrita al lado, como `Tope de puertos detallados que viajan al prompt (#118): un host con cientos de puertos…`. Aquí basta con quitarla, porque el comentario ya se entendía solo. Es la gran mayoría.
- **La referencia era la explicación.** En estos casos se escribe lo que decía el issue o el documento:
  - `iris/model.py` decía «ver el plan del conector para saber por qué el token no puede vivir en Acheron». Ahora explica el motivo. Acheron es la bóveda cifrada de contraseñas, y sus campos solo se descifran en el cliente. El sync del buzón corre en segundo plano, sin el usuario delante, y necesita que el servidor use el token por su cuenta. Por eso el token se guarda aquí, cifrado en reposo con una clave del servidor.
  - `lybra/fingerprinting/tls.py` decía que la decisión de no implementar JARM, y lo que haría falta para reabrirla, estaba en el roadmap. JARM es una técnica de identificación de servidores TLS. El docstring ahora dice directamente qué haría falta para reabrirla: un laboratorio con al menos cuatro pilas TLS distintas contra el que validar el hash, y alguien que de verdad vaya a consumirlo.
  - `system/taskqueue/outbox.py` tenía un párrafo sobre el alcance de la *primera* versión de la outbox, que citaba el issue que la pidió. La outbox transaccional es el mecanismo que guarda la intención de encolar un trabajo en la misma transacción que la entidad que lo origina. Aquel párrafo ya no era cierto, y ahora dice dónde se aplica hoy.
  - `test_lybra_precision_bench.py` decía que el solapamiento de dos checks que detectan el mismo volcado SQL «se sigue en #456». Ese issue se cerró etiquetando la pareja en el banco de medición, no deduplicándolos en el feed. El comentario ahora dice lo que es verdad: el solapamiento sigue en el feed.
  - Unos pocos casos más en tests del motor Lybra: «el criterio de cierre de #267» o «el caso de #272» pasan a describir el caso con palabras propias.

Se han dejado a propósito los identificadores que parecen referencias pero no lo son:
- colores CSS como `#333`;
- la versión de un kernel (`#98-Ubuntu`) en un fixture de SNMP;
- los números de análisis del corpus de regresión de Iris (`análisis #34`), que identifican muestras de correo y no issues.

Tampoco se tocan las referencias a estándares externos como `RFC 1001 §4.1`.

## Validación

- Una búsqueda de números de issue/PR y rutas a `plans/` sobre `API/src`, `API/tests` y `web/app/src` no devuelve nada fuera de las excepciones de arriba.
- Suite completa de `pytest` (sin cobertura): **3033 aprobados, 52 omitidos**, sin fallos.
- En el SPA solo cambian comentarios dentro de bloques `<style>` y un comentario de JavaScript; los delimitadores quedan intactos (lo comprueban también las suites del SPA en CI).
- Ninguna línea añadida pasa de 100 caracteres.

## Notas

- Sin cambios de comportamiento: solo comentarios, docstrings y dos cadenas `reason` de `xfail` en `tests/postgres/test_migrations.py`.
- Siguiente paso: los PRs por módulo con los códigos de apartado (Themis, Iris, Hygeia y el resto junto con el SPA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
