### PR TITLE
Iris: quitar de los comentarios los códigos de apartado del roadmap

### DIFF
--- a/API/src/modules/accounts/__init__.py
+++ b/API/src/modules/accounts/__init__.py
@@ -3,8 +3,6 @@ Capa comercial de Ellysia: planes, cuotas y organizaciones.
 
 Módulo transversal, no una herramienta: por eso no lleva nombre de deidad y
 vive junto a ``users``, ``system``, ``shared`` e ``infrastructure``.
-
-Diseño completo en ``plans/feature/general/planes-y-organizaciones.md``.
 """
 
 from .model import (

--- a/API/src/modules/accounts/model.py
+++ b/API/src/modules/accounts/model.py
@@ -1,8 +1,7 @@
 """
 Modelos de la capa comercial: catálogo de planes, suscripciones y organizaciones.
 
-Diseño completo en ``plans/feature/general/planes-y-organizaciones.md``. Tres
-grupos de tablas:
+Tres grupos de tablas:
 
 - **Catálogo**: ``Plan`` y ``PlanLimit`` — qué se vende y cuánto incluye.
 - **Titularidad**: ``Subscription`` — quién tiene qué y hasta cuándo.

--- a/API/src/modules/features/aegis/managers/__init__.py
+++ b/API/src/modules/features/aegis/managers/__init__.py
@@ -6,7 +6,7 @@ Managers del módulo Aegis (concienciación en ciberseguridad).
 - ``CampaignManager`` (``campaigns.py``): listas de distribución, campañas
   y el quiz público.
 
-D3 en ``plans/deuda-tecnica-y-calidad.md``: este paquete sustituye al
+Este paquete sustituye al
 antiguo ``managers.py`` de 42 KB, cuyo docstring justificaba tener los tres
 "en este único fichero por convención" — pero la convención del proyecto,
 desde que Themis pasó a paquete, es la contraria. Las tres

--- a/API/src/modules/features/aegis/managers/campaigns.py
+++ b/API/src/modules/features/aegis/managers/campaigns.py
@@ -1,6 +1,5 @@
 """
-CampaignManager — campañas de concienciación (D3 en
-plans/deuda-tecnica-y-calidad.md).
+CampaignManager — campañas de concienciación.
 
 CRUD de listas de distribución y sus destinatarios, y el ciclo de vida de
 una campaña: creación (draft), lanzamiento (snapshot del quiz + tokens
@@ -225,7 +224,7 @@ class CampaignManager(TaskTrackingMixin):
             repo = CampaignRepository(uow)
             repo.launch_campaign(campaign_id, questions_snapshot, campaign_recipients)
             # La intención de encolar va en la MISMA transacción que el
-            # lanzamiento (#551). Antes el submit caía fuera, y si Redis fallaba
+            # lanzamiento. Antes el submit caía fuera, y si Redis fallaba
             # justo ahí la campaña quedaba lanzada —snapshot congelado, tokens
             # acuñados, cuota cobrada— pero sin un solo correo enviado y sin
             # nada que lo reintentase: no hay reconciliación de campañas.

--- a/API/src/modules/features/aegis/managers/org_profile.py
+++ b/API/src/modules/features/aegis/managers/org_profile.py
@@ -1,6 +1,5 @@
 """
-AegisOrgProfileManager — perfil de organización (D3 en
-plans/deuda-tecnica-y-calidad.md).
+AegisOrgProfileManager — perfil de organización.
 
 Los valores estables de generación (empresa, contacto, tono, tamaño,
 jurisdicción, productos vigilados): devolverlos con defaults si el usuario

--- a/API/src/modules/features/aegis/managers/pills.py
+++ b/API/src/modules/features/aegis/managers/pills.py
@@ -1,6 +1,5 @@
 """
-AegisManager — generación de píldoras de concienciación (D3 en
-plans/deuda-tecnica-y-calidad.md).
+AegisManager — generación de píldoras de concienciación.
 
 Crea documentos pendientes y lanza el workflow de generación en la
 TaskQueue, persiste el contenido (tips en AegisTip, avisos en
@@ -661,7 +660,7 @@ class AegisManager(TaskTrackingMixin):
     def _create_pending_document_and_dispatch(self, topic_id: int, tweaks: dict) -> tuple[int, int]:
         """Crea el ``AegisDocument`` 'pending' y su intención de encolado, juntos.
 
-        Las dos filas viajan en la misma transacción (#551). Antes el documento
+        Las dos filas viajan en la misma transacción. Antes el documento
         se confirmaba aquí y el ``submit()`` caía fuera, sin ningún try/except:
         si Redis fallaba justo ahí, la píldora se quedaba en ``pending`` para
         siempre —un "Generando..." que nunca termina— con las dos cuotas ya

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -147,7 +147,7 @@ def get_capabilities():
 @handle_exceptions(logger=logger)
 def get_retention_policy():
     """Política de retención de Iris y cuántos de tus análisis la reflejan
-    ya (M09/B17): cuántos conservan el raw todavía y cuántos ya lo perdieron."""
+    ya: cuántos conservan el raw todavía y cuántos ya lo perdieron."""
     user = get_current_user()
     report = IrisManager.get_retention_report(user.id)
     return {
@@ -188,7 +188,7 @@ def get_analysis_status(args: dict):
         "status": status,
         "totalScore": analysis.total_score if analysis else None,
         "verdict": analysis.verdict if analysis else None,
-        # B03: el motivo solo tiene sentido cuando el análisis murió. Enviarlo
+        # El motivo solo tiene sentido cuando el análisis murió. Enviarlo
         # siempre dejaría un `failureReason` colgando de un análisis que
         # terminó bien tras un reintento y confundiría a quien lea el estado.
         "failureCode": analysis.failure_code if analysis else None,
@@ -300,7 +300,7 @@ def get_analysis_iocs(analysis_id: int):
 @handle_exceptions(default_exception=IrisAnalysisNotFoundError, logger=logger)
 def export_analysis(analysis_id: int):
     """Exportar el análisis completo (resultado, reglas, raw si sigue
-    disponible, Received-path e IOCs) como fichero JSON descargable (B19) --
+    disponible, Received-path e IOCs) como fichero JSON descargable --
     pensado para guardar una copia antes de que la retención purgue el raw."""
     user = get_current_user()
     manager = IrisManager()
@@ -472,7 +472,7 @@ def get_document_status(args):
     analysis_id = args.get("analysisId")
 
     doc_mgr = IrisReportManager()
-    # E4: lookup dual (por documentId o, si no, el último documento del
+    # Lookup dual (por documentId o, si no, el último documento del
     # análisis) + verificación de ownership viven en el manager, no aquí.
     document = doc_mgr.get_document_status(document_id, analysis_id, user.id)
 
@@ -497,7 +497,7 @@ def get_document_status(args):
 @limiter.limit("300 per hour; 2000 per day")
 @handle_exceptions(default_exception=DocumentError, logger=logger)
 def get_all_documents(args):
-    """Documentos del usuario, paginados (B17: antes devolvía la lista
+    """Documentos del usuario, paginados (antes devolvía la lista
     completa sin límite)."""
     user = get_current_user()
 
@@ -576,7 +576,7 @@ def download_document(document_id: int):
         document.filename,
         mimetype="application/pdf",
         as_attachment=True,
-        # B11: el nombre descargable identifica el documento, no solo el
+        # El nombre descargable identifica el documento, no solo el
         # análisis. Dos informes del mismo análisis llegaban al navegador con
         # el mismo nombre y el segundo sobrescribía al primero en la carpeta
         # de descargas.
@@ -606,7 +606,7 @@ def delete_document(document_id: int):
 
 
 # =============================================================================
-# Mailbox connector (Fase 4) — Gmail / Microsoft Graph
+# Mailbox connector — Gmail / Microsoft Graph
 # =============================================================================
 
 def _serialize_connection(connection) -> dict:
@@ -777,7 +777,7 @@ def list_mailbox_connection_folders(connection_id: int):
 @limiter.limit("60 per hour; 300 per day")
 @handle_exceptions(default_exception=IrisMailboxConnectionNotFoundError, logger=logger)
 def get_mailbox_connection_health(connection_id: int):
-    """Estado observable de una conexión de buzón (M10).
+    """Estado observable de una conexión de buzón.
 
     Distingue "no hay correo nuevo" de "Iris está atascado" sin tener que
     leer los logs del servidor: expone contadores de mensajes descubiertos/
@@ -856,7 +856,7 @@ def _serialize_notification_preference(preference) -> dict:
 @require_oauth_token
 @require_attributes(at_least_one=[AttributeType.IRIS_READ])
 def get_notification_preferences():
-    """Preferencias de notificación del usuario actual (M08).
+    """Preferencias de notificación del usuario actual.
 
     Si nunca las ha tocado, devuelve los valores por defecto sin crear una
     fila -- ver ``IrisNotificationPreferenceManager.get_or_default``.
@@ -875,7 +875,7 @@ def get_notification_preferences():
 @require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
 @limiter.limit("60 per hour; 300 per day")
 def update_notification_preferences(data):
-    """Actualizar las preferencias de notificación del usuario actual (M08).
+    """Actualizar las preferencias de notificación del usuario actual.
 
     Actualización parcial: solo se tocan los campos presentes en el cuerpo
     (ver ``IrisNotificationPreferenceUpdateRequestSchema``). No exige

--- a/API/src/modules/features/iris/exceptions.py
+++ b/API/src/modules/features/iris/exceptions.py
@@ -41,7 +41,7 @@ class IrisAnalysisNotReadyError(IrisError):
 
 class IrisRawMessagePurgedError(IrisError):
     """El raw de este análisis ya no existe -- lo purgó la política de
-    retención (M09/B17/B19), que conserva el resultado analítico
+    retención, que conserva el resultado analítico
     (score/veredicto/reglas) pero no el contenido del correo indefinidamente.
 
     410 Gone y no 404: el análisis existe de verdad y su resultado sigue
@@ -114,7 +114,7 @@ class IrisMailboxOAuthStateError(IrisError):
 
 class IrisMailboxInvalidFolderError(IrisError):
     """Raised when ``folder`` doesn't match any real folder/label the
-    provider returns for this account (B16) — wrong id, typo, or a value
+    provider returns for this account — wrong id, typo, or a value
     that belongs to another provider."""
     default_code = ErrorCode.VALIDATION_ERROR
     default_status_code = 400

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -13,7 +13,7 @@ Managers del módulo Iris (análisis de correo).
 - ``IrisNotificationPreferenceManager`` (``notifications.py``): lectura y
   escritura de las preferencias de notificación de un usuario (M08).
 
-D4 en ``plans/deuda-tecnica-y-calidad.md``: Iris era el único módulo con
+Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el
 segundo fichero más grande del repositorio) y ``mailbox_managers.py``,
 este último además suelto mientras el resto del conector de buzón vivía

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -11,7 +11,7 @@ Managers del módulo Iris (análisis de correo).
 - ``IrisPhishingNotifyManager`` (``notifications.py``): correo de alerta
   cuando la ingesta automática de buzón clasifica un correo como Phishing.
 - ``IrisNotificationPreferenceManager`` (``notifications.py``): lectura y
-  escritura de las preferencias de notificación de un usuario (M08).
+  escritura de las preferencias de notificación de un usuario.
 
 Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -74,7 +74,7 @@ _VERDICT_SEVERITY = {v: i for i, v in enumerate(_VERDICT_ORDER)}
 # from Gmail used to net *positive* despite a -23 risk payload underneath.
 _CEILING = 100.0
 
-# Recalibración de pesos (§18): techos de familia. Varias reglas dentro del
+# Recalibración de pesos: techos de familia. Varias reglas dentro del
 # mismo cluster suelen corroborar el mismo hecho subyacente (p.ej. SPF+DKIM+
 # DMARC+Domain Alignment todas fallando describen UN fallo de autenticación,
 # no cuatro independientes) -- sin techo, sumarlas todas exagera la
@@ -110,7 +110,7 @@ class IrisManager(TaskTrackingMixin):
     TASK_CATEGORY = "iris.analyze"
     _TOP_SIGNALS_LIMIT = 5
 
-    # __init__ (task_queue inyectable) lo aporta TaskTrackingMixin (A10).
+    # __init__ (task_queue inyectable) lo aporta TaskTrackingMixin.
 
     # =========================================================================
     # PUBLIC API
@@ -135,18 +135,18 @@ class IrisManager(TaskTrackingMixin):
 
         Args:
             raw_headers: Bloque de solo cabeceras como texto plano (entrada
-                original, previa a Fase 2).
+                original, anterior al soporte de mensaje completo).
             user_id: Primary key del usuario que solicita el análisis.
             title: Etiqueta opcional definida por el usuario para
                 identificarlo rápido en el histórico. Por defecto ``None``.
-            raw_message: Mensaje ``.eml`` crudo completo como texto plano
-                (Fase 2). Tiene prioridad sobre ``raw_headers`` cuando se dan
+            raw_message: Mensaje ``.eml`` crudo completo como texto plano.
+                Tiene prioridad sobre ``raw_headers`` cuando se dan
                 los dos, porque es un superconjunto de los datos de
                 cabecera. Las reglas que necesitan cuerpo/enlaces/adjuntos
                 solo los ven cuando se proporciona este campo. Por defecto
                 ``None``.
             connection_id: IrisMailboxConnection por la que se ingirió este
-                mensaje (Fase 3-4). ``None`` para envíos manuales -- el
+                mensaje (ingesta automática de buzón). ``None`` para envíos manuales -- el
                 flujo original, que sigue siendo el que no requiere
                 conexión. Por defecto ``None``.
             source_message_uid: Id del mensaje específico del proveedor,
@@ -154,7 +154,7 @@ class IrisManager(TaskTrackingMixin):
                 ``(connection_id, source_message_uid)`` es UNIQUE a nivel de
                 base de datos. Un reintento de sync de buzón que reenvía el
                 mismo mensaje nunca duplica el análisis ni cobra cuota dos
-                veces (B09) -- ver la comprobación de idempotencia más abajo.
+                veces -- ver la comprobación de idempotencia más abajo.
                 Por defecto ``None``.
 
         Returns:
@@ -178,10 +178,10 @@ class IrisManager(TaskTrackingMixin):
 
         self._validate_headers_pre(raw_input)
 
-        # B09: comprobar idempotencia ANTES de cobrar cuota -- un reintento
+        # Comprobar idempotencia ANTES de cobrar cuota -- un reintento
         # de sync de buzón (Gmail/Graph pueden repetir un mensaje) para algo
         # ya aceptado no debe volver a cobrar ni crear un segundo análisis.
-        # El propio checkpoint de mailbox (B01) ya evita llegar hasta aquí
+        # El propio checkpoint de mailbox ya evita llegar hasta aquí
         # en el caso común; esto cubre además la llamada directa.
         if connection_id is not None and source_message_uid is not None:
             existing = build_repository(IrisAnalysisRepository).get_by_source(
@@ -211,7 +211,7 @@ class IrisManager(TaskTrackingMixin):
             with UnitOfWork() as uow:
                 IrisAnalysisRepository(uow).save(analysis)
                 analysis_id = analysis.id
-                # B08: la intención de publicar se guarda en la MISMA
+                # La intención de publicar se guarda en la MISMA
                 # transacción que el análisis -- si la API muere o Redis
                 # falla justo después del commit, el barrido periódico de
                 # la outbox (o la reconciliación de arranque) publica el
@@ -255,7 +255,7 @@ class IrisManager(TaskTrackingMixin):
 
     @staticmethod
     def get_capabilities() -> Dict[str, Any]:
-        """Límites y modos de análisis que la interfaz necesita conocer (B13).
+        """Límites y modos de análisis que la interfaz necesita conocer.
 
         El backend rechazaba mensajes por encima de un tamaño que la UI no
         tenía forma de saber: el usuario elegía un fichero que la interfaz
@@ -283,7 +283,7 @@ class IrisManager(TaskTrackingMixin):
     @staticmethod
     def get_retention_report(user_id: int) -> Dict[str, Any]:
         """Política de retención vigente más el estado real de los análisis
-        de este usuario frente a ella (M09/B17): cierra el criterio de
+        de este usuario frente a ella: cierra el criterio de
         "existe una política visible" con datos concretos, no solo los
         valores de configuración -- un usuario puede ver cuántos de sus
         análisis conservan todavía el raw y cuántos ya lo perdieron por
@@ -450,7 +450,7 @@ class IrisManager(TaskTrackingMixin):
 
         Raises:
             IrisRawMessagePurgedError: La retención ya purgó el raw de este
-                análisis (M09/B17/B19) -- sin él no hay nada que reanalizar.
+                análisis -- sin él no hay nada que reanalizar.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
         if analysis.raw_headers is None:
@@ -468,7 +468,7 @@ class IrisManager(TaskTrackingMixin):
 
         Raises:
             IrisRawMessagePurgedError: La retención ya purgó el raw de este
-                análisis (M09/B17/B19) -- distinto de "sin cuerpo completo":
+                análisis -- distinto de "sin cuerpo completo":
                 aquí no hay ningún raw que parsear, ni cabeceras.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
@@ -502,7 +502,7 @@ class IrisManager(TaskTrackingMixin):
 
         Raises:
             IrisRawMessagePurgedError: La retención ya purgó el raw de este
-                análisis (M09/B17/B19).
+                análisis.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
         if analysis.raw_headers is None:
@@ -552,12 +552,12 @@ class IrisManager(TaskTrackingMixin):
         }
 
     def export_analysis(self, analysis_id: int, user_id: int) -> Dict[str, Any]:
-        """Exportación completa de un análisis (B19): resultado, reglas,
+        """Exportación completa de un análisis: resultado, reglas,
         raw (si no se ha purgado ya) y las dos vistas que se derivan de él
         (Received-chain path, IOCs).
 
         Pensada para que el usuario se lleve una copia completa **antes**
-        de que la retención (M09/B17) purgue el raw -- una vez purgado,
+        de que la retención purgue el raw -- una vez purgado,
         ``receivedPath``/``iocs`` dejan de estar disponibles (ver
         ``get_analysis_path``/``get_analysis_iocs``) y esta exportación ya
         no puede recuperarlos; salen como ``None`` en vez de hacer fallar
@@ -599,7 +599,7 @@ class IrisManager(TaskTrackingMixin):
         Fire-and-forget: encola y vuelve. El llamante relee
         ``get_analysis_results`` (``aiSummary``) para ver el resultado.
 
-        `B10`: la operación es **idempotente por análisis**. Antes consumía
+        La operación es **idempotente por análisis**. Antes consumía
         cuota y encolaba sin mirar si ya había un resumen o un trabajo en
         curso, así que dos peticiones seguidas —dos clics, un reintento del
         navegador— cobraban dos veces y lanzaban dos generaciones del mismo
@@ -640,7 +640,7 @@ class IrisManager(TaskTrackingMixin):
             return "running"
 
         # La concreta y el techo agregado de IA, en ese orden, para que el 402
-        # nombre lo que el usuario estaba pidiendo. consume_many() (B09) las
+        # nombre lo que el usuario estaba pidiendo. consume_many() las
         # cobra como una sola operación: si AI_REQUESTS no tiene cupo tras
         # haber cobrado IRIS_AI_SUMMARIES, la reembolsa antes de relanzar --
         # antes se quedaba cobrada sin nada que la explicara.
@@ -728,7 +728,7 @@ class IrisManager(TaskTrackingMixin):
         and leaves ``ai_summary`` as ``NULL`` rather than failing the
         already-finished analysis it's attached to.
 
-        `B10`: además deja el estado en terminal y, si no hubo resumen,
+        Además deja el estado en terminal y, si no hubo resumen,
         devuelve la cuota. Cobrar antes de trabajar es correcto —cobrar
         después permitiría lanzar N generaciones concurrentes con cupo para
         una— pero obliga a devolver el dinero cuando el trabajo no se hace.
@@ -767,7 +767,7 @@ class IrisManager(TaskTrackingMixin):
         ``_task_queue.cancel()`` lea "sigue en marcha" y que este método
         escriba en la base de datos no son un único paso atómico: el worker
         puede llamar a ``_persist_analysis_results()`` y confirmar
-        ``finished`` justo en ese hueco. B07: la escritura real de
+        ``finished`` justo en ese hueco. La escritura real de
         ``status`` pasa por ``IrisAnalysisRepository.transition_if_state()``,
         un ``UPDATE ... WHERE status IN (...)`` condicionado que solo uno de
         los dos escritores en competencia puede ganar, así que una
@@ -967,7 +967,7 @@ class IrisManager(TaskTrackingMixin):
         1. Marks the analysis as ``running``.
         2. Parses the raw text into both a flat headers dict (legacy
            rules) and a full ``MessageContext`` (body/links/attachments
-           — Fase 2 rules). ``raw_input`` may be a headers-only block or
+           — full-message rules). ``raw_input`` may be a headers-only block or
            a full ``.eml`` message; the context degrades gracefully to
            empty body/links/attachments in the former case.
         3. Runs every registered rule against the message (N1: against
@@ -989,7 +989,7 @@ class IrisManager(TaskTrackingMixin):
                 self._fail_analysis(analysis_id, classify_failure(e))
                 return
 
-            # B03: parseo, validación y evaluación comparten manejador con la
+            # Parseo, validación y evaluación comparten manejador con la
             # persistencia. Estaban fuera de todo `try`, así que un parser roto
             # o un `.eml` que no lo era dejaban la fila en `running` para
             # siempre: RQ marcaba el job como fallido, pero nadie tocaba la
@@ -1034,7 +1034,7 @@ class IrisManager(TaskTrackingMixin):
         """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
 
         Extraído de :meth:`_run_analysis` al envolver esa función en un único
-        manejador de ciclo de vida (`B03`): el bucle es la parte larga, y
+        manejador de ciclo de vida: el bucle es la parte larga, y
         dejarlo en línea dentro del ``try`` habría escondido qué se está
         protegiendo exactamente.
 
@@ -1044,14 +1044,14 @@ class IrisManager(TaskTrackingMixin):
             (que no es un fallo: no se persiste nada y la cancelación ya dejó
             su propio estado terminal).
         """
-        # N1: a "report phishing" forward is safe to unwrap unconditionally
+        # A "report phishing" forward is safe to unwrap unconditionally
         # for a human-submitted analysis, but the same message/rfc822
         # mechanism lets an attacker send their own phishing as the outer
         # message and staple a benign .eml on as an attachment — analyzing
         # only the unwrapped inner message would then score the wrong
         # mail entirely. Evaluate both when a wrapper exists and keep the
         # worse verdict; this matters most for unattended ingestion
-        # (Fase 3+), where there is no human eyeballing the wrapper first.
+        # (mailbox ingestion), where there is no human eyeballing the wrapper first.
         contexts_to_evaluate = [context]
         if context.wrapper_context is not None:
             contexts_to_evaluate.append(context.wrapper_context)
@@ -1098,7 +1098,7 @@ class IrisManager(TaskTrackingMixin):
             base_verdict = self._determine_verdict(total_score)
             verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
 
-            # B05: una regla que revienta no aborta el análisis, pero tampoco
+            # Una regla que revienta no aborta el análisis, pero tampoco
             # puede desaparecer sin dejar rastro. La política conservadora se
             # aplica aquí, junto al resto de gates, para que la degradación se
             # lea entre los demás motivos del veredicto y no en un rincón
@@ -1128,11 +1128,11 @@ class IrisManager(TaskTrackingMixin):
         Antes cada regla abría (y confirmaba) su propio ``UnitOfWork`` --
         unos 40 commits por análisis, y una cancelación a mitad de bucle
         dejaba huérfanas las filas ya confirmadas de un análisis
-        ``cancelled`` (C2/C3). Una sola transacción para todo el lote
+        ``cancelled``. Una sola transacción para todo el lote
         arregla las dos cosas: es atómica, y un ``return`` antes de este
         punto (cancelación) ya no deja nada confirmado.
 
-        B07: la escritura final de ``status="finished"`` (junto con los
+        La escritura final de ``status="finished"`` (junto con los
         campos de score/veredicto que la acompañan) pasa por
         ``IrisAnalysisRepository.transition_if_state()``, que solo la
         aplica si la fila sigue ``running``. Sin esa condición, una
@@ -1180,7 +1180,7 @@ class IrisManager(TaskTrackingMixin):
         *negative* part of each rule's score (``min(0, score)``), so passing
         a rule never inflates the total. Clamped to ``[0, _CEILING]``.
 
-        Recalibración de pesos (§18): before summing, each rule's penalty is
+        Recalibración de pesos: before summing, each rule's penalty is
         attributed to its ``family`` (if any) and the family's total is
         floored at ``_FAMILY_SCORE_FLOORS[family]`` — a cluster of rules
         corroborating the same underlying fact can't out-vote its own cap.
@@ -1246,7 +1246,7 @@ class IrisManager(TaskTrackingMixin):
         # (the chain itself declares a prior hop broken) is its own gate,
         # see D7 in ROADMAP.md.
         #
-        # B06: la supresión exige además que la cadena la haya validado un
+        # La supresión exige además que la cadena la haya validado un
         # verificador de confianza (`details["verified"]`). Un `cv=pass` a
         # secas es una afirmación del propio mensaje sobre sí mismo, y como
         # Iris no verifica firmas, bastaba escribirlo para desactivar los tres
@@ -1261,7 +1261,7 @@ class IrisManager(TaskTrackingMixin):
         dmarc_fail = verdict_is("DMARC", "fail") and not arc_pass
         align_fail = verdict_is("Domain Alignment", "fail") and not arc_pass
 
-        # G-A (forense, recalibración de pesos): un authserv-id que reclama
+        # Auth Results Provenance (forense, recalibración de pesos): un authserv-id que reclama
         # "pass" pero no aparece en ningún salto de la propia cadena
         # Received del mensaje es una línea forjada por el remitente --
         # cierra el bypass de confiar ciegamente en Authentication-Results
@@ -1334,13 +1334,14 @@ class IrisManager(TaskTrackingMixin):
             and any(finding.get("type") == "brand_in_subdomain" for finding in (subdomain.details.get("findings") or []))
         )
 
-        # G-B (red team, máxima prioridad): lookalike del dominio del
+        # Recipient Domain Lookalike (red team, máxima prioridad): lookalike del dominio del
         # DESTINATARIO, no de una marca -- el vector BEC nº1, hoy invisible
         # porque Lookalike Sender Domain solo compara contra
         # `canonical_brands`.
         recipient_lookalike = verdict_is("Recipient Domain Lookalike", "fail")
 
-        # G-C (red team): el display name ES una dirección de otro dominio
+        # Display Name Foreign Address (red team): el display name ES una
+        # dirección de otro dominio
         # (`"ceo@acme.com" <attacker@evil.com>`). Escala a Phishing solo
         # cuando esa dirección falsa suplanta la propia organización
         # destinataria o una marca conocida -- si no, queda en Suspicious.
@@ -1350,17 +1351,17 @@ class IrisManager(TaskTrackingMixin):
             display_foreign_fail and bool(display_foreign.details.get("impersonates_target"))
         )
 
-        # G-D (red team): TOAD/callback -- teléfono + lenguaje de pago sin
+        # TOAD Callback Pattern (red team): teléfono + lenguaje de pago sin
         # enlaces/adjuntos/hilo previo, una clase de ataque hoy invisible.
         toad_callback = verdict_is("TOAD Callback Pattern", "fail")
 
-        # G-E (red team): urgencia fuerte combinada con un enlace del cuerpo
+        # External Login Link (red team): urgencia fuerte combinada con un enlace del cuerpo
         # a un dominio ajeno al remitente -- aproxima el "primo autenticado"
         # (dominio propio, auth limpia, marca fuera de la lista) sin
         # depender de `canonical_brands`.
         external_login_link = verdict_is("External Login Link", "fail")
 
-        # Comprobación forense adicional (§5): aproximación offline de
+        # Comprobación forense adicional: aproximación offline de
         # coherencia HELO -- ruidosa en solitario (nombres de host varían
         # mucho de forma legítima), solo se combina con un fallo de auth.
         origin_helo_mismatch = verdict_is("Origin HELO Coherence", "fail")
@@ -1566,7 +1567,7 @@ class IrisManager(TaskTrackingMixin):
         tarea viva en TaskQueue que lo actualice tras reiniciar, y el registro
         se queda así para siempre. Se llama una vez al arrancar la API.
 
-        `B04`: antes se conservaba el análisis **solo** si su tarea estaba
+        Antes se conservaba el análisis **solo** si su tarea estaba
         exactamente en ``pending``. Un job ``running`` puede estar avanzando en
         otro proceso —los workers son procesos aparte, y reiniciar la API no
         los para—, así que ese criterio marcaba como fallidos análisis que
@@ -1606,7 +1607,7 @@ class IrisManager(TaskTrackingMixin):
         ``failure`` es opcional solo para no romper a un llamador que ya no
         tenga la excepción a mano; en la práctica todos los caminos de
         ``_run_analysis`` la traen, porque un ``failed`` sin motivo es
-        justamente lo que `B03` venía a quitar de en medio.
+        justamente lo que el manejo de fallos vino a quitar de en medio.
 
         No se propaga ninguna excepción desde aquí: esto es el último
         recurso de la tarea, y un fallo escribiendo el fallo solo puede

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -8,8 +8,8 @@ Coordinates the analysis lifecycle:
    determines a verdict, and persists results.
 4. Provides status queries and cancellation support.
 
-D4 en ``plans/deuda-tecnica-y-calidad.md``: extraído del ``managers.py``
-de 64 KB que reunía este manager y el de informes.
+Extraído del antiguo ``managers.py`` de 64 KB, que reunía este manager y el
+de informes.
 """
 
 from __future__ import annotations
@@ -666,7 +666,7 @@ class IrisManager(TaskTrackingMixin):
             # ni la reserva ni el cobro tienen sentido.
             #
             # Es la razón por la que este sitio se quedó fuera de la outbox
-            # transaccional al auditarlo en #551: la compensación ya existe y
+            # transaccional: la compensación ya existe y
             # es completa -- el análisis no se queda en `running` y el usuario
             # recupera su cuota, así que puede reintentar. Lo único que la
             # outbox añadiría es ejecutar el resumen solo en vez de que el

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -1,7 +1,6 @@
 """
 IrisMailboxManager — OAuth connect/callback, connection CRUD, and background
-mailbox sync for the Iris mailbox connector (Fase 4 del plan
-plans/feature/iris/iris-mailbox-connector.md).
+mailbox sync for the Iris mailbox connector.
 
 Fichero separado de ``managers.py`` (que ya tiene 1080+ líneas con
 IrisManager + IrisReportManager) siguiendo el precedente de módulos grandes
@@ -457,7 +456,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         antes del ``submit()``, así que no hay huérfano que prevenir, y un
         encolado perdido se repara solo en la siguiente pasada del
         ``IrisMailboxScheduler``, que sondea periódicamente todas las
-        conexiones. Se revisó con los demás en #551 y se dejó así.
+        conexiones.
         """
         self._task_queue.submit(
             func=IrisMailboxManager.execute_sync_connection,

--- a/API/src/modules/features/iris/managers/mailbox.py
+++ b/API/src/modules/features/iris/managers/mailbox.py
@@ -73,7 +73,7 @@ def _duration_ms(started_at: Optional[datetime]) -> Optional[int]:
 
     Returns:
         Optional[int]: Milisegundos transcurridos, o ``None`` si
-            ``started_at`` es ``None`` (M10: sin esto, un sync sin duración
+            ``started_at`` es ``None`` (sin esto, un sync sin duración
             conocida se vería como "0 ms", que parece salud perfecta en vez
             de un dato ausente).
     """
@@ -112,7 +112,7 @@ class IrisMailboxManager(TaskTrackingMixin):
     #: no esté aquí se añade al final, alfabéticamente.
     _PROVIDER_DISPLAY_ORDER = ("microsoft", "gmail")
 
-    # __init__ (task_queue inyectable) lo aporta TaskTrackingMixin (A10). Ya
+    # __init__ (task_queue inyectable) lo aporta TaskTrackingMixin. Ya
     # declaraba TASK_CATEGORY/EXTERNAL_ID_PREFIX sin heredar del mixin —
     # ahora hereda también external_id_for/find_task/task_status_of.
 
@@ -237,7 +237,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         connector = get_connector(provider, self._redirect_uri(), folder=folder)
         token_set = connector.exchange_code(code)
 
-        # B16: recién canjeado el code tenemos un access_token fresco -- es
+        # Recién canjeado el code tenemos un access_token fresco -- es
         # el único momento del flujo de conexión en que se puede comprobar
         # la carpeta contra la cuenta real antes de guardarla.
         folder_metadata = (
@@ -298,7 +298,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         if status is not None and status not in _VALID_UPDATE_STATUSES:
             raise ValueError(f"status debe ser uno de {_VALID_UPDATE_STATUSES}")
 
-        # B16: cambiar de carpeta exige un access_token vivo para comprobarla
+        # Cambiar de carpeta exige un access_token vivo para comprobarla
         # contra la cuenta real -- lo mismo que list_folders().
         folder_display_name = None
         folder_type = None
@@ -328,7 +328,7 @@ class IrisMailboxManager(TaskTrackingMixin):
 
     def list_folders(self, connection_id: int, user_id: int) -> list[MailboxFolder]:
         """Carpetas/etiquetas reales de la cuenta -- únicos valores válidos
-        para ``folder`` en ``update_connection()`` (B16)."""
+        para ``folder`` en ``update_connection()``."""
         connection = self.assert_connection_ownership(connection_id, user_id)
         try:
             access_token, connector = self._ensure_access_token(connection)
@@ -339,7 +339,7 @@ class IrisMailboxManager(TaskTrackingMixin):
 
     def get_connection_health(self, connection_id: int, user_id: int) -> dict:
         """Estado observable de una conexión, sin tener que leer los logs
-        del servidor (M10).
+        del servidor.
 
         Reúne columnas de la propia conexión con recuentos en vivo de
         ``IrisMailboxInbox`` (pendientes/reintentando/``dead``) y de
@@ -477,7 +477,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         if connection is None or connection.status != "active":
             return
 
-        # B02: serializa los syncs de una misma conexión. El job_id
+        # Serializa los syncs de una misma conexión. El job_id
         # determinista de TaskQueue ya evita reencolar mientras el anterior
         # sigue "started", pero ese estado no se autorrecupera si el worker
         # muere a mitad de sync -- este lock sí, por TTL.
@@ -510,7 +510,7 @@ class IrisMailboxManager(TaskTrackingMixin):
                 self._record_sync_error(connection_id, str(e))
                 return
 
-            # B01: el mensaje entra en la cola de checkpoint antes de intentar
+            # El mensaje entra en la cola de checkpoint antes de intentar
             # ingerirlo -- así una cuota agotada o un fallo a mitad de lote no
             # lo pierden, sino que lo dejan pendiente para el próximo sondeo.
             self._enqueue_pending(connection_id, refs)
@@ -571,7 +571,7 @@ class IrisMailboxManager(TaskTrackingMixin):
                 ))
 
             if new_refs:
-                # M10: contador acumulado -- la fila de checkpoint de un
+                # Contador acumulado -- la fila de checkpoint de un
                 # mensaje aceptado se borra al resolverse, así que sin esto
                 # "cuántos ha descubierto esta conexión en total" se perdería
                 # con ella. Incremento atómico dentro del propio UPDATE, no
@@ -598,7 +598,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         analysis_repo = build_repository(IrisAnalysisRepository)
 
         for entry in inbox_repo.get_pending(connection_id):
-            # B02: un lote grande puede tardar más que el TTL inicial del
+            # Un lote grande puede tardar más que el TTL inicial del
             # lock -- renovarlo en cada mensaje evita que otro sync lo dé
             # por huérfano mientras éste sigue trabajando de verdad.
             lock.renew()
@@ -727,11 +727,11 @@ class IrisMailboxManager(TaskTrackingMixin):
                 return
             if advance_cursor:
                 fresh.sync_cursor = new_cursor
-                # M10: solo cuando la cola de checkpoint queda vacía se puede
+                # Solo cuando la cola de checkpoint queda vacía se puede
                 # decir de verdad "todo al día" -- last_sync_at por sí solo no
                 # distingue eso de un sync que dejó mensajes atascados.
                 fresh.last_success_at = utcnow_naive()
-                # M08: un sync limpio resuelve cualquier atasco anterior --
+                # Un sync limpio resuelve cualquier atasco anterior --
                 # se limpia aquí, no solo cuando se envía el aviso, para que
                 # una recaída futura genere un aviso nuevo en vez de quedar
                 # silenciada para siempre por la primera.
@@ -760,7 +760,7 @@ class IrisMailboxManager(TaskTrackingMixin):
         reintentar en bucle contra su API (mismo patrón degradado que
         ``execute_ai_summary_generation``).
 
-        Avisa al dueño de la conexión (M08), pero solo en la transición
+        Avisa al dueño de la conexión, pero solo en la transición
         hacia este estado: los tres puntos que llaman a este método pueden
         volver a invocarlo mientras la conexión sigue sin reautorizar (un
         segundo intento de cambiar de carpeta, por ejemplo), y sin esta

--- a/API/src/modules/features/iris/managers/notifications.py
+++ b/API/src/modules/features/iris/managers/notifications.py
@@ -2,7 +2,7 @@
 Notificaciones de Iris: aviso por correo de un veredicto Phishing en la
 ingesta automática de buzón (``IrisPhishingNotifyManager``), del digest
 diario que agrupa los que no eran de alta confianza (``IrisDigestNotifyManager``),
-y de los dos avisos operativos de M08 -- conexión que necesita
+y de los dos avisos operativos -- conexión que necesita
 reautorización (``IrisReauthNotifyManager``) y conexión activa atascada sin
 un sync limpio (``IrisStuckSyncNotifyManager``).
 
@@ -64,7 +64,7 @@ _UNSET = object()
 
 class IrisNotificationPreferenceManager:
     """Lectura y escritura de las preferencias de notificación de un
-    usuario (M08) -- una fila por usuario, creada perezosamente en el
+    usuario -- una fila por usuario, creada perezosamente en el
     primer ``update()``."""
 
     @staticmethod
@@ -177,7 +177,7 @@ class IrisPhishingNotifyManager:
     @staticmethod
     def _run_notify(analysis_id: int) -> None:
         """Envía el correo de aviso al dueño del análisis, salvo que las
-        preferencias de M08 digan que debe esperar al digest o que el
+        preferencias de notificación digan que debe esperar al digest o que el
         usuario lo tiene silenciado.
 
         Re-comprueba veredicto y origen aquí dentro (un job encolado por
@@ -188,8 +188,7 @@ class IrisPhishingNotifyManager:
 
         Un veredicto de alta confianza (``total_score`` en o por debajo de
         ``iris.criticalPhishingScoreThreshold``) ignora tanto el silenciado
-        como el digest -- el criterio de cierre de M08 exige que nunca se
-        pierda una incidencia crítica.
+        como el digest: una incidencia crítica nunca debe perderse.
         """
         from src.modules.users.managers import UserManager
 
@@ -252,7 +251,7 @@ class IrisPhishingNotifyManager:
 
 class IrisDigestNotifyManager:
     """Envía el resumen diario de veredictos Phishing no críticos que
-    quedaron diferidos por ``digest_enabled`` (M08, categoría ``iris.notify``)."""
+    quedaron diferidos por ``digest_enabled`` (categoría ``iris.notify``)."""
 
     TASK_CATEGORY = "iris.notify"
     EXTERNAL_ID_PREFIX = "iris-digest-notify:"
@@ -342,7 +341,7 @@ class IrisDigestNotifyManager:
 
 class IrisReauthNotifyManager:
     """Avisa por correo cuando una conexión de buzón pasa a necesitar
-    reautorización (M08, categoría ``iris.notify``)."""
+    reautorización (categoría ``iris.notify``)."""
 
     TASK_CATEGORY = "iris.notify"
     EXTERNAL_ID_PREFIX = "iris-reauth-notify:"
@@ -436,7 +435,7 @@ class IrisReauthNotifyManager:
 
 class IrisStuckSyncNotifyManager:
     """Avisa por correo cuando una conexión activa lleva atascada sin un
-    sync limpio (M08, categoría ``iris.notify``)."""
+    sync limpio (categoría ``iris.notify``)."""
 
     TASK_CATEGORY = "iris.notify"
     EXTERNAL_ID_PREFIX = "iris-stuck-sync-notify:"

--- a/API/src/modules/features/iris/managers/reports.py
+++ b/API/src/modules/features/iris/managers/reports.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class IrisReportManager(DocumentManager):
     """Manager for IrisDocument lifecycle and async PDF report generation.
 
-    CRUD/ownership are shared with Themis via ``DocumentManager`` (A3); this
+    CRUD/ownership are shared with Themis via ``DocumentManager``; this
     class keeps only what is really Iris-specific: creating an
     ``IrisDocument`` and rendering its PDF via :class:`IrisPDFCreator`.
     """
@@ -63,7 +63,7 @@ class IrisReportManager(DocumentManager):
             uow.commit_for_handoff()
         return document.id  # type: ignore
 
-    # get_documents_by_parent: usa el default de DocumentManager (A9).
+    # get_documents_by_parent: usa el default de DocumentManager.
 
     def generate_report(self, analysis_id: int, user_id: int) -> int:
         """Create an IrisDocument and start async PDF generation.

--- a/API/src/modules/features/iris/managers/reports.py
+++ b/API/src/modules/features/iris/managers/reports.py
@@ -1,9 +1,9 @@
 """
 IrisReportManager — ciclo de vida de IrisDocument y generación asíncrona
-del informe PDF (D4 en ``plans/deuda-tecnica-y-calidad.md``).
+del informe PDF.
 
 El CRUD y la comprobación de propiedad los comparte con Themis vía
-``DocumentManager`` (A3); aquí queda solo lo propio de Iris: crear el
+``DocumentManager``; aquí queda solo lo propio de Iris: crear el
 ``IrisDocument`` y renderizar su PDF con :class:`IrisPDFCreator`.
 """
 

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -35,7 +35,7 @@ class IrisAnalysis(Base):
                  vive cifrado en la fila ``IrisRawMessage`` asociada
                  (``raw_message``, 1:1) para poder purgarlo de forma
                  independiente sin borrar el resultado analítico ya
-                 calculado (M09/B19). Se lee y se escribe exactamente igual
+                 calculado. Se lee y se escribe exactamente igual
                  que antes de esa separación -- ``analysis.raw_headers`` y
                  ``IrisAnalysis(raw_headers=...)`` siguen funcionando sin
                  cambios en el resto del código. ``None`` cuando la política
@@ -90,7 +90,7 @@ class IrisAnalysis(Base):
                  el worker -- es la traza de la intención del usuario, no del
                  resultado, así que no se borra ni se sobreescribe aunque el
                  worker termine primero y el análisis acabe ``finished`` en
-                 vez de ``cancelled`` (B07).
+                 vez de ``cancelled``.
         user_id: Foreign key to the owning User.
         user: SQLAlchemy relationship to User.
         rule_results: Ordered list of IrisRuleResult (per-rule outcomes).
@@ -163,7 +163,7 @@ class IrisAnalysis(Base):
         """Contenido raw (cabeceras o ``.eml`` completo) de este análisis.
 
         Delega en ``raw_message.content`` -- ver el docstring de esta clase
-        (M09/B19) sobre por qué el raw vive en su propia fila en vez de en
+        sobre por qué el raw vive en su propia fila en vez de en
         una columna de ``IrisAnalysis``. ``None`` si la retención ya lo
         purgó.
         """
@@ -181,11 +181,11 @@ class IrisAnalysis(Base):
 
 class IrisRawMessage(Base):
     """Contenido raw (cabeceras o ``.eml`` completo) de un ``IrisAnalysis``,
-    en su propia fila -- separado del resultado analítico (M09/B19).
+    en su propia fila -- separado del resultado analítico.
 
     Antes vivía en ``IrisAnalysis.raw_headers``, una columna en la misma
     fila que el score, el veredicto y el resumen de IA: purgar el raw
-    después de un plazo (política de retención, B17) obligaba a elegir entre
+    después de un plazo (política de retención) obligaba a elegir entre
     borrar el análisis entero -- perdiendo el resultado, que sí tiene valor
     a largo plazo -- o dejarlo indefinidamente, que es justo lo que la
     retención existe para evitar. Con el raw en su propia fila,
@@ -260,20 +260,20 @@ class IrisMailboxConnection(Base):
         folder: Provider-specific folder/label id to watch; NULL = default
                  inbox. Es el ``provider_id`` opaco que ``MailboxConnector``
                  usa para filtrar ``list_new`` -- nunca texto libre: solo se
-                 guarda tras validarse contra ``MailboxConnector.list_folders()``
-                 (B16), así que un valor no vacío siempre corresponde a una
+                 guarda tras validarse contra ``MailboxConnector.list_folders()``,
+                así que un valor no vacío siempre corresponde a una
                  carpeta real de esta cuenta en el momento en que se guardó.
         folder_display_name: Nombre legible de ``folder`` (p.ej. "Facturas",
                  "Trabajo/Clientes"); NULL junto con ``folder`` cuando se
-                 vigila la bandeja de entrada por defecto (B16).
+                 vigila la bandeja de entrada por defecto.
         folder_type: "system" (Inbox, Sent, Trash... del propio proveedor) |
                  "user" (etiqueta/carpeta creada por la cuenta); NULL junto
-                 con ``folder`` (B16).
+                 con ``folder``.
         full_message_mode: If True, fetch the complete raw message
                  (attachments/body included) instead of headers only. Off
                  by default — the user must opt in explicitly per
-                 connection (see Fase 5 frontend design: this is a
-                 deliberate, not a hidden, choice).
+                 connection (this is a deliberate, not a hidden,
+                 choice).
         sync_cursor: Opaque provider cursor (Gmail historyId / Graph
                  deltaLink) marking how far ingestion has progressed. NULL
                  until the first bootstrap sync runs (see
@@ -295,21 +295,21 @@ class IrisMailboxConnection(Base):
                  cuando no hay ninguno. Se limpia al terminar (éxito o
                  error) -- no confundir con ``last_sync_at``, que registra el
                  último intento *terminado*. Existe para que la UI sepa que
-                 hay un sync en marcha sin tener que adivinarlo (B02).
+                 hay un sync en marcha sin tener que adivinarlo.
         sync_job_id: Id del job de TaskQueue que sostiene el lock de sync
-                 actual; NULL cuando no hay ninguno en curso (B02).
+                 actual; NULL cuando no hay ninguno en curso.
         last_success_at: Cuándo terminó el último sync que dejó la cola de
                  checkpoint (``IrisMailboxInbox``) completamente vacía -- es
                  decir, sin ningún mensaje descubierto pendiente de aceptar.
                  A diferencia de ``last_sync_at`` (que se actualiza aunque
                  queden mensajes atascados por cuota o por un fallo), esto
                  es lo que distingue "no hay correo nuevo" de "Iris está
-                 atascado" sin mirar los logs del servidor (M10). NULL si
+                 atascado" sin mirar los logs del servidor. NULL si
                  nunca ha terminado un sync sin dejar nada pendiente.
         last_sync_duration_ms: Cuánto tardó el último intento de sync
                  (terminara en éxito o en error), en milisegundos. NULL si
                  nunca ha habido un intento con ``sync_started_at`` registrado
-                 (M10) -- una latencia que crece sync a sync es la señal de
+                 -- una latencia que crece sync a sync es la señal de
                  que el proveedor se está degradando antes de que llegue a
                  fallar del todo.
         messages_discovered_total: Cuántos mensajes ha descubierto esta
@@ -319,10 +319,10 @@ class IrisMailboxConnection(Base):
                  "aceptados" (la tabla ``IrisAnalysis``) o "pendientes"/
                  "fallidos" (la tabla ``IrisMailboxInbox``), la fila de
                  checkpoint de un mensaje aceptado se borra al resolverse, así
-                 que sin este contador ese dato desaparecería con ella (M10).
+                 que sin este contador ese dato desaparecería con ella.
         stuck_alert_sent_at: Cuándo se avisó por última vez de que esta
-                 conexión lleva atascada más de ``iris.stuckSyncAfterMinutes``
-                 (M08). Se limpia en cuanto un sync vuelve a dejar la cola de
+                 conexión lleva atascada más de ``iris.stuckSyncAfterMinutes``.
+                Se limpia en cuanto un sync vuelve a dejar la cola de
                  checkpoint vacía (mismo punto que actualiza
                  ``last_success_at``), así que un problema que se resuelve y
                  vuelve a aparecer más tarde genera un aviso nuevo en vez de
@@ -331,7 +331,7 @@ class IrisMailboxConnection(Base):
         user: SQLAlchemy relationship to User.
         analyses: Analyses ingested through this connection.
         inbox_entries: Cola de checkpoint de mensajes descubiertos y aún no
-                 resueltos (ver ``IrisMailboxInbox`` / B01).
+                 resueltos (ver ``IrisMailboxInbox``).
     """
     __tablename__ = "IrisMailboxConnection"
 
@@ -386,7 +386,7 @@ class IrisMailboxInbox(Base):
     proveedor tanto si el lote se ingería entero como si no: una cuota
     agotada o un fallo a mitad de lote perdían en silencio los mensajes que
     quedaban sin procesar, porque el proveedor nunca los vuelve a devolver
-    una vez el cursor avanza (B01). Cada mensaje que devuelve ``list_new``
+    una vez el cursor avanza. Cada mensaje que devuelve ``list_new``
     se encola aquí antes de intentar ingerirlo, y el cursor del proveedor
     solo avanza cuando la cola de la conexión queda vacía.
 
@@ -507,7 +507,7 @@ class IrisDocument(Document):
 
 class IrisNotificationPreference(Base):
     """Preferencias de notificación de un usuario para las alertas
-    automáticas de Iris (M08): una fila por usuario, creada perezosamente
+    automáticas de Iris: una fila por usuario, creada perezosamente
     la primera vez que la modifica (ver ``IrisNotificationPreferenceManager``).
 
     Deliberadamente por usuario y no por conexión: hoy Iris solo tiene un
@@ -539,7 +539,7 @@ class IrisNotificationPreference(Base):
                  Por defecto ``True``.
         notify_sync_stuck: Si se avisa quando una conexión activa lleva más
                  de ``iris.stuckSyncAfterMinutes`` sin completar un sync
-                 limpio (ver ``IrisMailboxConnection.last_success_at``, M10).
+                 limpio (ver ``IrisMailboxConnection.last_success_at``).
                  Por defecto ``True``.
         digest_last_sent_at: Cuándo se envió el último digest a este usuario;
                  ``None`` si nunca se ha enviado uno. El scheduler lo usa

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -229,9 +229,12 @@ class IrisMailboxConnection(Base):
     automatic Iris ingestion.
 
     Stores the minimum needed to re-request access later — never the
-    mailbox content itself. See ``plans/feature/iris/iris-mailbox-connector.md``
-    Fase 2/3 for the full design rationale (why this can't live in Acheron,
-    why the refresh token is encrypted at rest instead).
+    mailbox content itself.
+
+    The refresh token cannot live in an Acheron vault: vault fields are only
+    ever decrypted on the client, and the background sync needs the server
+    to use the token on its own, with no user present. So it is stored here
+    instead, encrypted at rest with a server-side key.
 
     Attributes:
         id: Primary key, auto-incrementing integer.

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -119,9 +119,9 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         """El análisis ya aceptado para este (connection_id, source_message_uid),
         si existe.
 
-        Usado tanto por la cola de checkpoint del sync de buzón (B01, que
+        Usado tanto por la cola de checkpoint del sync de buzón (que
         solo necesita saber si existe) como por ``IrisManager.analyze()``
-        (B09, que necesita el id para devolverlo sin cobrar cuota de nuevo)
+        (que necesita el id para devolverlo sin cobrar cuota de nuevo)
         -- reconocer un mensaje ya aceptado en un intento anterior, p.ej.
         tras un fallo entre el commit de ``IrisAnalysis`` y el borrado de su
         entrada en ``IrisMailboxInbox``, de forma que un reintento nunca
@@ -141,11 +141,11 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         return self.get_by_source(connection_id, source_message_uid) is not None
 
     def count_by_connection(self, connection_id: int) -> int:
-        """Cuántos análisis ha aceptado en total esta conexión (M10).
+        """Cuántos análisis ha aceptado en total esta conexión.
 
         Es la cuenta real de "mensajes aceptados" -- no hace falta un
         contador aparte, porque cada mensaje aceptado por el checkpoint de
-        buzón (B01) deja exactamente una fila ``IrisAnalysis`` con este
+        buzón deja exactamente una fila ``IrisAnalysis`` con este
         ``connection_id`` y nunca se borra al resolverse (a diferencia de su
         entrada en ``IrisMailboxInbox``, que sí desaparece).
         """
@@ -159,7 +159,7 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         self, user_id: int, since: datetime, critical_threshold: float,
     ) -> List[IrisAnalysis]:
         """Veredictos Phishing de buzón que el digest diario todavía no ha
-        resumido (M08).
+        resumido.
 
         Solo entran los que ``_enqueue_phishing_notification`` ya habría
         notificado si no fuera por el digest -- ``connection_id`` no nulo
@@ -196,12 +196,12 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
 
     def count_by_user(self, user_id: int) -> int:
         """Cuántos análisis tiene este usuario en total -- para el informe
-        de retención (M09/B17), que necesita el denominador."""
+        de retención, que necesita el denominador."""
         return self._session.query(IrisAnalysis.id).filter(IrisAnalysis.user_id == user_id).count()
 
     def count_with_raw_retained_by_user(self, user_id: int) -> int:
         """De los análisis de este usuario, cuántos conservan todavía su
-        raw (M09/B17) -- el complemento de cuántos ya se purgaron."""
+        raw -- el complemento de cuántos ya se purgaron."""
         return (
             self._session.query(IrisAnalysis.id)
             .join(IrisRawMessage, IrisRawMessage.analysis_id == IrisAnalysis.id)
@@ -211,7 +211,7 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
 
     def purge_raw_messages_older_than(self, cutoff: datetime) -> int:
         """Purga (borra) el ``IrisRawMessage`` de cada análisis creado antes
-        de ``cutoff``, conservando el análisis y sus resultados (M09/B17/B19).
+        de ``cutoff``, conservando el análisis y sus resultados.
 
         DELETE masivo en vez de cargar cada fila por el ORM: ``IrisRawMessage``
         no tiene ninguna tabla que dependa de ella (a diferencia de borrar un
@@ -231,15 +231,14 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
 
     def get_analyses_older_than(self, cutoff: datetime) -> List[IrisAnalysis]:
         """Análisis creados antes de ``cutoff`` -- candidatos a borrado
-        completo cuando ``iris.analysisRetentionDays`` está activo (B17).
+        completo cuando ``iris.analysisRetentionDays`` está activo.
 
         Devuelve instancias ORM (no un ``DELETE`` masivo): borrarlas una a
         una vía ``BaseRepository.delete`` es lo que dispara el cascade real
         hacia ``IrisRuleResult`` (``cascade="all, delete-orphan"`` es un
         mecanismo del ORM, no de la base de datos -- un ``DELETE`` en SQL
-        directo sobre ``IrisAnalysis`` dejaría esas filas huérfanas). El
-        criterio de cierre de B17 exige explícitamente que la retención no
-        deje huérfanos.
+        directo sobre ``IrisAnalysis`` dejaría esas filas huérfanas), y la
+        retención no puede dejar huérfanos.
         """
         return (
             self._session.query(IrisAnalysis)
@@ -250,7 +249,7 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
     def transition_if_state(self, analysis_id: int, from_states: list[str], **fields: Any) -> bool:
         """Aplica ``fields`` sobre un análisis solo si su ``status`` actual
         está en ``from_states`` -- transición SQL condicionada, no un
-        leer-decidir-escribir (B07).
+        leer-decidir-escribir.
 
         El caso real: el usuario cancela un análisis a la vez que el worker
         termina de procesarlo. Sin esta condición dentro del propio UPDATE,
@@ -262,7 +261,7 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         ``rowcount`` es 1); el segundo no cambia nada (``rowcount`` 0), y
         quien lo invoque sabe por el valor de retorno que perdió la carrera
         y no debe fiarse de que su transición se aplicó. Mismo patrón que
-        ``_claim_ai_summary()`` (B10), generalizado a cualquier conjunto de
+        ``_claim_ai_summary()``, generalizado a cualquier conjunto de
         campos en vez de una sola columna.
 
         Args:
@@ -347,7 +346,7 @@ class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):
 
     def get_newly_stuck_connections(self, stuck_after_minutes: int) -> List[IrisMailboxConnection]:
         """Conexiones activas que siguen intentando sincronizar pero llevan
-        atascadas sin un sync limpio, y todavía no se ha avisado de ello (M08).
+        atascadas sin un sync limpio, y todavía no se ha avisado de ello.
 
         "Sigue intentando" (``last_sync_at`` no nulo) las distingue de una
         conexión recién creada que aún no ha tenido su primer sondeo -- esa
@@ -382,7 +381,7 @@ class IrisMailboxConnectionRepository(BaseRepository[IrisMailboxConnection]):
 
 class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
     """Data-access layer for IrisMailboxInbox -- la cola de checkpoint por
-    mensaje que B01 introduce delante del cursor del proveedor."""
+    mensaje que va delante del cursor del proveedor."""
 
     _MODEL = IrisMailboxInbox
 
@@ -404,7 +403,7 @@ class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
         """Si quedan referencias sin resolver.
 
         Mientras esto sea True, ``_finish_sync`` no puede confirmar el
-        cursor del proveedor (B01) -- avanzarlo perdería esas referencias
+        cursor del proveedor -- avanzarlo perdería esas referencias
         para siempre, porque el proveedor no las vuelve a listar.
         """
         return (
@@ -433,7 +432,7 @@ class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
         return {row[0] for row in rows}
 
     def count_pending(self, connection_id: int) -> int:
-        """Cuántas referencias siguen sin resolver ahora mismo (M10) --
+        """Cuántas referencias siguen sin resolver ahora mismo --
         contadas en vivo sobre la tabla real, no un contador aparte que
         pudiera desincronizarse de ella."""
         return (
@@ -447,7 +446,7 @@ class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
 
     def count_retrying(self, connection_id: int) -> int:
         """Cuántas referencias pendientes ya han fallado al menos una vez
-        (M10) -- distingue "recién descubierto, primer intento" de "se le
+        -- distingue "recién descubierto, primer intento" de "se le
         está costando, va por el segundo o más"."""
         return (
             self._session.query(IrisMailboxInbox.id)
@@ -461,7 +460,7 @@ class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
 
     def count_dead(self, connection_id: int) -> int:
         """Cuántas referencias agotaron ``iris.maxInboxAttempts`` y quedaron
-        ``dead`` (B01/M10) -- mensajes que Iris ha dejado de intentar
+        ``dead`` -- mensajes que Iris ha dejado de intentar
         procesar, visibles pero ya sin bloquear el cursor."""
         return (
             self._session.query(IrisMailboxInbox.id)
@@ -474,7 +473,7 @@ class IrisMailboxInboxRepository(BaseRepository[IrisMailboxInbox]):
 
     def oldest_pending_created_at(self, connection_id: int) -> Optional[datetime]:
         """Cuándo se encoló la referencia pendiente más antigua de esta
-        conexión, o ``None`` si no queda ninguna (M10).
+        conexión, o ``None`` si no queda ninguna.
 
         La edad de esa fecha es la señal de "cuánto lleva atascado el
         mensaje más viejo" -- más útil para un administrador que un simple
@@ -514,7 +513,7 @@ class IrisRuleResultRepository(BaseRepository[IrisRuleResult]):
 
 
 class IrisNotificationPreferenceRepository(BaseRepository[IrisNotificationPreference]):
-    """Data-access layer for IrisNotificationPreference (M08) -- una fila
+    """Data-access layer for IrisNotificationPreference -- una fila
     por usuario, ver ``IrisNotificationPreference`` en ``model.py``."""
 
     _MODEL = IrisNotificationPreference
@@ -530,7 +529,7 @@ class IrisNotificationPreferenceRepository(BaseRepository[IrisNotificationPrefer
         )
 
     def get_due_for_digest(self, interval_hours: int) -> List[IrisNotificationPreference]:
-        """Usuarios con el digest activo a los que toca enviarles uno (M08):
+        """Usuarios con el digest activo a los que toca enviarles uno:
         nunca se les ha enviado, o el último fue hace más de
         ``iris.digestIntervalHours``."""
         cutoff = utcnow_naive() - timedelta(hours=interval_hours)
@@ -548,7 +547,7 @@ class IrisNotificationPreferenceRepository(BaseRepository[IrisNotificationPrefer
 class IrisReportRepository(DocumentRepository[IrisDocument]):
     """Data-access layer for IrisDocument records (generated PDF reports).
 
-    Las tres consultas de documentos las aporta ``DocumentRepository`` (A9).
+    Las tres consultas de documentos las aporta ``DocumentRepository``.
     """
 
     _MODEL = IrisDocument

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -15,7 +15,7 @@ class AnalyzeRequestSchema(Schema):
     """Request body for ``POST /iris/analyze``.
 
     Accepts either ``headers`` (a headers-only block, original behaviour)
-    or ``message`` (a full raw ``.eml`` message — Fase 2). At least one of
+    or ``message`` (a full raw ``.eml`` message). At least one of
     the two is required; if both are present, ``message`` takes priority
     since it is a superset of the header information.
     """
@@ -33,7 +33,7 @@ class AnalyzeRequestSchema(Schema):
 
     @validates_schema
     def validate_max_size(self, data, **kwargs):
-        """C4: sin tope superior, un .eml de decenas de MB (adjuntos incluidos)
+        """Sin tope superior, un .eml de decenas de MB (adjuntos incluidos)
         entraba entero a una columna Text y se re-parseaba completo (incluida
         la decodificación base64) en cada lectura posterior. Leído con CR en
         cada validación, no horneado al importar el módulo, para que un
@@ -130,7 +130,7 @@ class RuleResultSchema(Schema):
 
 
 class TopSignalSchema(Schema):
-    """One of the highest-penalty rules for a finished analysis (S2)."""
+    """One of the highest-penalty rules for a finished analysis."""
     ruleName = fields.String()
     category = fields.String(load_default=None)
     score = fields.Float()
@@ -146,7 +146,7 @@ class AiSummarySchema(Schema):
 
 
 class FailedRuleSchema(Schema):
-    """Regla que no se pudo **ejecutar** durante un análisis (B05).
+    """Regla que no se pudo **ejecutar** durante un análisis.
 
     No confundir con una regla que detectó algo: esas van en ``rules`` con su
     puntuación negativa. Estas son las que lanzaron una excepción, así que su
@@ -370,7 +370,7 @@ class IrisDocumentItemSchema(Schema):
 
 
 class IrisDocumentsQuerySchema(Schema):
-    """Query parameters for ``GET /iris/documents`` (B17): antes devolvía
+    """Query parameters for ``GET /iris/documents``: antes devolvía
     todos los documentos del usuario de golpe, sin límite -- misma
     convención página/tamaño que ``ResultsQuerySchema`` para el listado de
     análisis."""
@@ -379,7 +379,7 @@ class IrisDocumentsQuerySchema(Schema):
 
 
 class IrisDocumentListResponseSchema(Schema):
-    """Página de los IrisDocument del usuario actual (B17)."""
+    """Página de los IrisDocument del usuario actual."""
     documents = fields.List(fields.Nested(IrisDocumentItemSchema))
     total = fields.Integer()
     page = fields.Integer()
@@ -400,7 +400,7 @@ class IrisDocumentDeleteResponseSchema(Schema):
 
 
 # =============================================================================
-# Mailbox connector (Fase 4) — Gmail / Microsoft Graph
+# Mailbox connector — Gmail / Microsoft Graph
 # =============================================================================
 
 class IrisMailboxProvidersResponseSchema(Schema):
@@ -412,7 +412,7 @@ class IrisMailboxConnectRequestSchema(Schema):
     """Request body for ``POST /iris/mailbox/connect``."""
     provider = fields.String(required=True)
     fullMessageMode = fields.Boolean(load_default=False)
-    # B16: la validación real (existe, pertenece a esta cuenta/proveedor) es
+    # La validación real (existe, pertenece a esta cuenta/proveedor) es
     # de red y solo se puede hacer con un access_token en la mano -- ver
     # IrisMailboxManager._validate_folder(), llamada desde handle_callback().
     # Aquí solo se descarta lo evidentemente inválido antes de firmar el
@@ -455,7 +455,7 @@ class IrisMailboxUpdateConnectionRequestSchema(Schema):
 
 
 class IrisMailboxFolderSchema(Schema):
-    """Una carpeta/etiqueta real de la cuenta conectada (B16)."""
+    """Una carpeta/etiqueta real de la cuenta conectada."""
     providerId = fields.String()
     displayName = fields.String()
     folderType = fields.String()
@@ -469,7 +469,7 @@ class IrisMailboxFoldersResponseSchema(Schema):
 
 class IrisMailboxHealthResponseSchema(Schema):
     """Estado observable de una conexión de buzón, sin tener que leer los
-    logs del servidor (M10)."""
+    logs del servidor."""
     status = fields.String()
     lastSyncAt = UTCDateTime(allow_none=True)
     lastSuccessAt = UTCDateTime(allow_none=True)
@@ -513,7 +513,7 @@ class IrisMailboxCallbackQuerySchema(Schema):
 
 class IrisRetentionReportResponseSchema(Schema):
     """Política de retención vigente y estado real de los análisis del
-    usuario frente a ella (M09/B17)."""
+    usuario frente a ella."""
     rawMessageRetentionDays = fields.Integer()
     analysisRetentionDays = fields.Integer(allow_none=True)
     totalAnalyses = fields.Integer()
@@ -522,7 +522,7 @@ class IrisRetentionReportResponseSchema(Schema):
 
 
 class IrisNotificationPreferenceResponseSchema(Schema):
-    """Preferencias de notificación del usuario actual (M08)."""
+    """Preferencias de notificación del usuario actual."""
     digestEnabled = fields.Boolean()
     mutedUntil = UTCDateTime(allow_none=True)
     notifyReauthRequired = fields.Boolean()

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -90,13 +90,13 @@ class IrisAIWriter:
 
     @staticmethod
     def _degradation_note(report: Dict[str, Any]) -> str:
-        """Aviso que se añade al prompt cuando el análisis fue degradado (B05).
+        """Aviso que se añade al prompt cuando el análisis fue degradado.
 
         Va anexado al final del prompt en vez de como marcador de la plantilla
         porque las plantillas viven en ``SecOpsConfig.json``: un marcador nuevo
         obligaría a editar la configuración desplegada para que este aviso
         apareciera, y un despliegue con la plantilla vieja se quedaría
-        silenciosamente sin él — justo el fallo silencioso que B05 corrige.
+        silenciosamente sin él — justo el fallo silencioso que se quiere evitar.
 
         Sin esto, el modelo redacta un resumen ejecutivo seguro sobre un
         análisis que no lo es: no tiene forma de saber que faltan reglas,

--- a/API/src/modules/features/iris/services/auth_trust.py
+++ b/API/src/modules/features/iris/services/auth_trust.py
@@ -44,7 +44,7 @@ frontera). Es el caso normal del correo legítimo."""
 
 TRUST_BELOW_BOUNDARY = "below_boundary"
 """El ``authserv-id`` solo aparece en saltos que el remitente pudo fabricar.
-Es el bypass que cierra `B06`: la cabecera existe y "cuadra" con la cadena,
+Es el bypass que esta frontera cierra: la cabecera existe y "cuadra" con la cadena,
 pero cuadra con la parte de la cadena que escribió el atacante."""
 
 TRUST_ABSENT = "absent"

--- a/API/src/modules/features/iris/services/failures.py
+++ b/API/src/modules/features/iris/services/failures.py
@@ -72,7 +72,7 @@ def classify_failure(error: BaseException) -> AnalysisFailure:
     ``IrisInvalidInputError`` es la única excepción cuyo mensaje se propaga
     tal cual: lo construye este módulo a partir de un recuento de cabeceras,
     nunca del contenido del correo. Cualquier otra excepción —incluido un
-    parser roto, que es el caso que motiva `B03`— se colapsa en un mensaje
+    parser roto, que es el caso que motiva esta clasificación— se colapsa en un mensaje
     genérico: el ``str(error)`` de una librería de terceros puede arrastrar
     el fragmento de entrada que la hizo reventar.
     """

--- a/API/src/modules/features/iris/services/mailbox/__init__.py
+++ b/API/src/modules/features/iris/services/mailbox/__init__.py
@@ -2,7 +2,7 @@ from .base import MailboxConnector, MailboxFolder, MessageRef, TokenSet
 from .registry import MAILBOX_CONNECTORS, get_connector
 
 # Importados por su efecto secundario: cada uno se da de alta en
-# MAILBOX_CONNECTORS vía @register_connector al importarse (B5). El
+# MAILBOX_CONNECTORS vía @register_connector al importarse. El
 # paquete es el único punto que debe dispararlo — ver el docstring de
 # registry.py sobre por qué éste no los importa directamente.
 from . import gmail as _gmail  # noqa: F401

--- a/API/src/modules/features/iris/services/mailbox/base.py
+++ b/API/src/modules/features/iris/services/mailbox/base.py
@@ -1,6 +1,6 @@
 """
 MailboxConnector — interfaz común para los conectores de buzón externo
-(Gmail, Microsoft Graph), Fase 4 del plan mailbox-connector.
+(Gmail, Microsoft Graph).
 
 Mismo espíritu que ``tools/herald``/``tools/scribe`` (interfaz +
 implementaciones intercambiables), con una diferencia deliberada en cómo se
@@ -45,7 +45,7 @@ class MessageRef:
 
 @dataclass
 class MailboxFolder:
-    """Una carpeta/etiqueta real del proveedor que Iris puede vigilar (B16).
+    """Una carpeta/etiqueta real del proveedor que Iris puede vigilar.
 
     ``provider_id`` es el valor opaco que ``IrisMailboxConnection.folder``
     guarda y que los conectores usan para filtrar ``list_new`` -- nunca se
@@ -104,7 +104,7 @@ class MailboxConnector(ABC):
 
     @abstractmethod
     def list_folders(self, access_token: str) -> list[MailboxFolder]:
-        """Carpetas/etiquetas reales de la cuenta conectada (B16).
+        """Carpetas/etiquetas reales de la cuenta conectada.
 
         Única fuente de verdad para validar ``IrisMailboxConnection.folder``:
         un valor que no aparece aquí no es una carpeta que este proveedor y

--- a/API/src/modules/features/iris/services/mailbox/locks.py
+++ b/API/src/modules/features/iris/services/mailbox/locks.py
@@ -1,5 +1,5 @@
 """
-Lock distribuido por conexión para el sync de buzón de Iris (B02).
+Lock distribuido por conexión para el sync de buzón de Iris.
 
 ``IrisMailboxManager.submit_sync()`` ya evita reencolar un job mientras el
 anterior sigue "started" (mismo ``job_id`` determinista, ver

--- a/API/src/modules/features/iris/services/mailbox/microsoft.py
+++ b/API/src/modules/features/iris/services/mailbox/microsoft.py
@@ -187,8 +187,8 @@ class GraphConnector(MailboxConnector):
         # diferencia de Google) -- solo el propio usuario
         # (myaccount.microsoft.com) o un admin de Entra ID pueden hacerlo.
         # Documentado explícitamente en vez de fingir una llamada que no
-        # existe: borrar la fila localmente sigue siendo correcto (Fase 3:
-        # "guardar lo mínimo"), el token simplemente sigue siendo válido en
+        # existe: borrar la fila localmente sigue siendo correcto (el
+        # conector guarda lo mínimo), el token simplemente sigue siendo válido en
         # el lado de Microsoft hasta que expire o el usuario lo revoque allí.
         logger.warning(
             "Microsoft Graph no soporta revocación de refresh_token por la "

--- a/API/src/modules/features/iris/services/mailbox/scheduling.py
+++ b/API/src/modules/features/iris/services/mailbox/scheduling.py
@@ -1,9 +1,9 @@
 """
 IrisMailboxScheduler — sondea las conexiones de buzón activas cada
 ``iris.pollIntervalMinutes`` y encola un job de sync por conexión vencida.
-También registra el chequeo periódico de notificaciones de M08 (digests
-diarios pendientes y avisos de conexión atascada) y el job de retención de
-M09/B17/B19 (purgar raw vencido, borrar análisis enteros si hay un límite
+También registra el chequeo periódico de notificaciones (digests
+diarios pendientes y avisos de conexión atascada) y el job de retención
+(purgar raw vencido, borrar análisis enteros si hay un límite
 duro configurado) -- ver los docstrings de ``services/notifications/
 scheduling.py`` y ``services/retention.py`` sobre por qué comparten este
 scheduler en vez de tener uno propio cada uno.
@@ -109,7 +109,7 @@ class IrisMailboxScheduler:
                 manager.submit_sync(connection.id)
                 queued += 1
             except Exception as e:
-                # B02: una conexión que no se puede encolar (p.ej. ya hay un
+                # Una conexión que no se puede encolar (p.ej. ya hay un
                 # job "started" con el mismo job_id determinista) no debe
                 # tumbar el resto del sondeo -- cada conexión es
                 # independiente de sus vecinas en la lista de vencidas.
@@ -120,13 +120,13 @@ class IrisMailboxScheduler:
     @staticmethod
     @scheduler_job(logger, "Error revisando notificaciones de Iris")
     def _run_notifications() -> None:
-        """Entry point del job de notificaciones de M08 (aislamiento de
+        """Entry point del job de notificaciones (aislamiento de
         errores y cierre de sesión vía ``scheduler_job``)."""
         check_and_notify()
 
     @staticmethod
     @scheduler_job(logger, "Error en la retención de Iris")
     def _run_retention() -> None:
-        """Entry point del job de retención de M09/B17/B19 (aislamiento de
+        """Entry point del job de retención (aislamiento de
         errores y cierre de sesión vía ``scheduler_job``)."""
         run_retention()

--- a/API/src/modules/features/iris/services/notifications/scheduling.py
+++ b/API/src/modules/features/iris/services/notifications/scheduling.py
@@ -1,5 +1,5 @@
 """
-Job periódico de notificaciones de Iris (M08): digests diarios pendientes
+Job periódico de notificaciones de Iris: digests diarios pendientes
 de enviar y avisos de conexión atascada sin un sync limpio.
 
 No es un scheduler propio (no hay una clase con su propia instancia de

--- a/API/src/modules/features/iris/services/parsers.py
+++ b/API/src/modules/features/iris/services/parsers.py
@@ -58,7 +58,7 @@ def parse_raw_headers(raw: str) -> Dict[str, str]:
         forging their own ``Authentication-Results`` line in the message
         they send), attacker-injected. Keeping "last occurrence wins"
         here handed a one-line spoofing bypass to every rule that reads
-        ``Authentication-Results``/``ARC-Seal`` from this dict (A1, N5).
+        ``Authentication-Results``/``ARC-Seal`` from this dict.
     """
     headers: Dict[str, str] = {}
     current_key: str | None = None
@@ -180,14 +180,14 @@ class MessageContext:
     and the ``wrapper_*`` fields preserve just enough of the outer
     message's identity for the report to say so, and ``wrapper_context``
     carries the *full* parsed wrapper so the caller can run the rule
-    engine on it too (N1): a real "report phishing" forward is benign to
+    engine on it too: a real "report phishing" forward is benign to
     unwrap, but an attacker can just as easily send their own phishing as
     the outer message and staple a benign ``.eml`` on as a
     ``message/rfc822`` attachment — unwrapping unconditionally then
     means the 40 rules never see the phishing the victim actually
     received. Analyzing only the unwrapped inner message is what a
     forward-unaware submission always wants; the ingestion pipeline
-    (Fase 3+) is exactly the "automatic, no human forwarding" case where
+    (mailbox ingestion) is exactly the "automatic, no human forwarding" case where
     that assumption stops holding, so it must evaluate both and keep the
     worse verdict.
     """
@@ -336,7 +336,7 @@ def parse_raw_message(raw: str) -> MessageContext:
         envelope. ``unwrapped_from_forward`` is set, ``wrapper_from``/
         ``wrapper_subject`` retain the forwarding envelope's identity for
         the report to reference, and ``wrapper_context`` carries the full
-        parsed wrapper (N1) so the caller can run the rule engine on it
+        parsed wrapper so the caller can run the rule engine on it
         too and keep the worse of the two verdicts — see
         ``MessageContext`` for why analyzing only the unwrapped inner
         message is unsafe once submissions are no longer human-forwarded.

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -3,7 +3,7 @@ Calidad de un análisis: qué se pudo inspeccionar de verdad y qué no.
 
 Una regla que revienta no aborta el análisis —eso sería peor: un solo fallo
 tiraría un informe entero por 47 reglas que sí funcionaron—, pero tampoco
-puede desaparecer sin dejar rastro. Hasta `B05`, una excepción de regla se
+puede desaparecer sin dejar rastro. Antes, una excepción de regla se
 convertía en un ``RuleResult(score=0, verdict="error")`` y ahí se acababa
 todo: el análisis podía terminar como ``Legitimate`` sin ninguna advertencia,
 aunque la regla que faltó fuera la que decide si el mensaje está autenticado.

--- a/API/src/modules/features/iris/services/redaction.py
+++ b/API/src/modules/features/iris/services/redaction.py
@@ -1,6 +1,6 @@
 """
 services/redaction.py — redacción de PII en las vistas de Iris que pueden
-salir del panel autenticado (M09).
+salir del panel autenticado.
 
 Hoy la única de esas vistas es el PDF exportable de un análisis
 (``services/reports.py::IrisPDFCreator.append_raw_headers``), que hasta

--- a/API/src/modules/features/iris/services/registry.py
+++ b/API/src/modules/features/iris/services/registry.py
@@ -48,7 +48,7 @@ class RuleRegistry:
         # Instance attribute, not class attribute: the latter is shared
         # across every RuleRegistry (in practice just the ``iris_rules``
         # singleton, but ``clear()`` — used in tests — mutated it as
-        # global state regardless, making test order matter (C6).
+        # global state regardless, making test order matter.
         self._rules: List[Dict] = []
 
     def register(self, name: str, category: str = "general",
@@ -64,7 +64,7 @@ class RuleRegistry:
                 ``services.parsers.MessageContext`` (headers + body
                 + links + attachments) instead of the plain ``headers``
                 dict. Used by rules that inspect the full message body.
-            family: Recalibración de pesos -- techo de familia (§18): agrupa
+            family: Recalibración de pesos -- techo de familia: agrupa
                 reglas que corroboran el mismo hecho subyacente (p.ej. "auth",
                 "identity") para que ``_aggregate_score`` limite la suma de
                 penalizaciones de la familia y no cuente el mismo hecho varias

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -457,7 +457,7 @@ class IrisPDFCreator:
         elements.append(Spacer(1, 0.22 * inch))
 
     def append_quality_warning(self, elements: list, theme: IrisReportTheme) -> None:
-        """Aviso de análisis degradado (B05), justo debajo del veredicto.
+        """Aviso de análisis degradado, justo debajo del veredicto.
 
         Va aquí y no entre las señales de más abajo porque contradice
         parcialmente lo que el lector acaba de leer: el veredicto grande de la
@@ -494,7 +494,7 @@ class IrisPDFCreator:
         elements.append(Spacer(1, 0.22 * inch))
 
     def append_gate_reasons(self, elements: list, theme: IrisReportTheme) -> None:
-        """Señales de alta confianza que fijaron el veredicto (S1).
+        """Señales de alta confianza que fijaron el veredicto.
 
         Solo aparece cuando algún gate se disparó — explica el "por qué"
         del veredicto más allá de la puntuación numérica.
@@ -662,7 +662,7 @@ class IrisPDFCreator:
     def append_raw_headers(self, elements: list, theme: IrisReportTheme) -> None:
         """Vuelca el raw completo del correo -- la única vista de Iris que
         sale del panel autenticado tal cual una vez descargado el PDF, así
-        que es la que se redacta (M09, ``iris.redactPiiInReports``): no se
+        que es la que se redacta (``iris.redactPiiInReports``): no se
         toca el remitente/destinatario/responder-a/return-path, que son la
         evidencia del informe (ya mostrados en "Vista Previa del Correo"),
         pero sí cualquier otra dirección, teléfono o número con forma de
@@ -739,7 +739,7 @@ class IrisPDFCreator:
         elements.append(Paragraph(f"Informe generado automáticamente | {timestamp}", theme.footer))
 
     def _output_path(self) -> str:
-        """Ruta del PDF, única por **documento** y no por análisis (B11).
+        """Ruta del PDF, única por **documento** y no por análisis.
 
         El modelo permite N ``IrisDocument`` por análisis, pero el nombre solo
         dependía del ``analysis_id``, así que todos escribían el mismo fichero:

--- a/API/src/modules/features/iris/services/retention.py
+++ b/API/src/modules/features/iris/services/retention.py
@@ -1,15 +1,15 @@
 """
-services/retention.py — política de retención de Iris (M09/B17/B19).
+services/retention.py — política de retención de Iris.
 
 Job idempotente, invocado periódicamente por ``IrisMailboxScheduler``
 (``services/mailbox/scheduling.py``, sin ``add_job`` propio para no sumar
 un scheduler más al módulo -- mismo criterio que el chequeo de
-notificaciones de M08). Dos pasos independientes:
+notificaciones). Dos pasos independientes:
 
 1. **Purgar el raw vencido** (``iris.rawMessageRetentionDays``, por defecto
    90 días): borra ``IrisRawMessage`` de cada análisis lo bastante viejo,
    conservando el análisis y sus resultados -- "el resultado puede
-   conservarse sin el raw" (B19) es el comportamiento por defecto, no una
+   conservarse sin el raw" es el comportamiento por defecto, no una
    opción.
 2. **Borrar análisis enteros** solo si ``iris.analysisRetentionDays`` está
    activo (``> 0``; ``0`` lo desactiva). Con cascada real hacia

--- a/API/src/modules/features/iris/services/rules/auth_rules.py
+++ b/API/src/modules/features/iris/services/rules/auth_rules.py
@@ -49,7 +49,7 @@ from ..text import extract_domain, registrable_domain
 def _dmarc_is_conclusive(auth_lower: str) -> bool:
     """True cuando DMARC ya dio un veredicto explícito (pass o fail).
 
-    Recalibración de pesos (§2): SPF y DKIM son subordinados de DMARC (RFC
+    Recalibración de pesos: SPF y DKIM son subordinados de DMARC (RFC
     7489 ya los integra) -- cuando DMARC es concluyente, el hecho "no
     autenticado" ya lo pesó DMARC en solitario y SPF/DKIM solo aportan un
     matiz menor. Con DMARC ausente (o solo `none`/`bestguesspass`/policy sin
@@ -70,7 +70,7 @@ def check_spf(headers: dict) -> RuleResult:
         - ``pass`` (score +5) when SPF passes. A passing result only proves
           the sending server is authorised — it is weak positive evidence,
           not proof of legitimacy, so the credit is intentionally small.
-          NOTE (C1): under the subtractive model every rule's score is
+          NOTE: under the subtractive model every rule's score is
           clamped to <= 0 when the analysis aggregates its total (see
           ``IrisManager._run_analysis``), so this +5 never actually raises
           the total — it exists only so a caller/test inspecting this
@@ -410,7 +410,7 @@ def check_arc_chain(context) -> RuleResult:
     chain *declares* — it does not re-verify the ARC cryptographic
     signatures itself (same accepted limitation as SPF/DKIM/DMARC above).
 
-    `B06`: ``cv=pass`` por sí solo ya **no** ablanda ningún gate. Esa
+    ``cv=pass`` por sí solo ya **no** ablanda ningún gate. Esa
     afirmación la hace el propio mensaje sobre sí mismo, y Iris no verifica
     firmas criptográficas, así que un atacante podía escribir un ``ARC-Seal:
     cv=pass`` inventado y con eso suprimir los gates de SPF, DMARC y
@@ -511,7 +511,7 @@ _AUTHSERV_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\.[a-z]{2,}$")
     needs_context=True,
 )
 def check_auth_results_provenance(context) -> RuleResult:
-    """Recalibración de pesos, gate G-A (forense): SPF/DKIM/DMARC/Alignment
+    """Recalibración de pesos, gate forense: SPF/DKIM/DMARC/Alignment
     solo leen el *contenido* de Authentication-Results, nunca verifican
     quién lo escribió -- un atacante puede añadir su propia línea
     ``spf=pass; dkim=pass; dmarc=pass`` al correo que él mismo envía, y las
@@ -520,7 +520,7 @@ def check_auth_results_provenance(context) -> RuleResult:
     del mensaje. Si el authserv-id que reclama "pass" no aparece como host
     `by` de ningún salto, la línea es forjada.
 
-    `B06`: aparecer en la cadena tampoco basta. Los saltos de abajo los aporta
+    Aparecer en la cadena tampoco basta. Los saltos de abajo los aporta
     quien envía el mensaje, así que un atacante podía inyectar a la vez su
     propio `Received` y su propio `Authentication-Results` y hacer que se
     corroboraran entre sí — los dos elementos contrastados eran suyos. La

--- a/API/src/modules/features/iris/services/rules/body_links_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_links_rules.py
@@ -252,7 +252,7 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
     description=(
         "Señal informativa (score 0): ¿hay algún enlace del cuerpo cuyo "
         "dominio registrable difiere del From y no es un ESP conocido? Se "
-        "combina con Alarming Keywords fuerte (G-E) para aproximar el "
+        "combina con Alarming Keywords fuerte para aproximar el "
         "'primo autenticado' -- dominio propio, auth limpia, marca fuera de "
         "`canonical_brands` -- sin depender de esa lista."
     ),

--- a/API/src/modules/features/iris/services/rules/reply_path_rules.py
+++ b/API/src/modules/features/iris/services/rules/reply_path_rules.py
@@ -31,7 +31,7 @@ from ..text import extract_domain, is_free_provider, registrable_domain
 
 
 def _is_esp_domain(domain: str | None) -> bool:
-    """True when *domain* is a known ESP infrastructure domain (B3).
+    """True when *domain* is a known ESP infrastructure domain.
 
     A newsletter sent via Mailchimp/SendGrid legitimately has three
     distinct registrable domains across From/Reply-To/Return-Path — that
@@ -286,7 +286,7 @@ def check_triangulation(headers: dict) -> RuleResult:
     present = [domain for domain in (from_dom, reply_dom, return_dom) if domain]
     distinct = set(present)
 
-    # B3: a Reply-To/Return-Path on a known ESP domain is exactly what
+    # A Reply-To/Return-Path on a known ESP domain is exactly what
     # legitimate bulk mail looks like (From=company.com, Reply-To on the
     # ESP's reply infra, Return-Path on the ESP's bounce infra) — three
     # distinct domains by design, not a triangulation attack.

--- a/API/src/modules/features/iris/services/rules/sender_identity_rules.py
+++ b/API/src/modules/features/iris/services/rules/sender_identity_rules.py
@@ -553,7 +553,7 @@ def check_suspicious_tld(headers: dict) -> RuleResult:
             recommendation=None,
         )
 
-    # Dedupe by domain before scoring (B4): the same domain in From,
+    # Dedupe by domain before scoring: the same domain in From,
     # Reply-To *and* Return-Path is one suspicious fact, not three — the
     # loop above appends one entry per header it appears in, so a single
     # domain could otherwise cost -15 instead of -5.
@@ -666,7 +666,7 @@ def check_recipient_domain_lookalike(headers: dict) -> RuleResult:
 
 
 # Cualquier cosa con forma de dirección de correo, para detectar un display
-# name que ES una dirección en vez de un nombre (G-C).
+# name que ES una dirección en vez de un nombre.
 _EMAIL_LIKE_RE = re.compile(r"[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}")
 
 

--- a/API/src/modules/features/iris/services/text.py
+++ b/API/src/modules/features/iris/services/text.py
@@ -93,7 +93,7 @@ def url_host(url: str) -> Optional[str]:
     """Hostname (lowercase, sin credenciales ni puerto) de una URL, o None.
 
     Soporta netloc IPv6 entre corchetes (``[::1]:8080``) — un ``.split(":")``
-    ingenuo lo destroza y deja solo ``"["`` (N4).
+    ingenuo lo destroza y deja solo ``"["``.
     """
     try:
         parsed = urlparse(url)
@@ -115,7 +115,7 @@ _HEX_IP_HOST_RE = re.compile(r"^0x[0-9a-f]{1,8}$", re.IGNORECASE)
 
 
 def is_obfuscated_ip_host(host: str) -> bool:
-    """True cuando *host* es un literal IPv4 disfrazado de decimal u hex (N4).
+    """True cuando *host* es un literal IPv4 disfrazado de decimal u hex.
 
     ``_URL_IP_HOST_RE`` (dotted-quad) no detecta estas formas — un enlace de
     phishing puede usarlas para evadir el chequeo de "IP literal" a simple vista.
@@ -403,7 +403,7 @@ def analyze_url(href: str, sender_domain: Optional[str] = None,
     # normal on a company's own site. An insecure (http) page asking for
     # credentials on top of that is the textbook harvesting-page pattern.
     #
-    # N3: that "known brand's domain" carve-out is also what let a
+    # That "known brand's domain" carve-out is also what let a
     # credential-harvest form hosted on ``docs.google.com`` or
     # ``sharepoint.com`` through with zero findings — those are
     # multi-tenant hosting services where the path/subdomain is

--- a/API/src/modules/features/iris/services/text.py
+++ b/API/src/modules/features/iris/services/text.py
@@ -1,7 +1,6 @@
 """
-Utilidades de texto/dominio compartidas entre las reglas de Iris (D6 en
-plans/deuda-tecnica-y-calidad.md — antes mezclado con wordlists.py en un
-único shared.py de 957 líneas).
+Utilidades de texto/dominio compartidas entre las reglas de Iris (antes
+mezcladas con wordlists.py en un único shared.py de 957 líneas).
 
 Extracción de dominios/hosts, distancia de edición, homóglifos, y el
 análisis de URL completo (``analyze_url``) que usan tanto Body Links (sobre

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -387,7 +387,7 @@ _DEFAULTS: dict[str, Any] = {
     # de la marca (google.com, sharepoint.com...) pero el path/subdominio
     # es de un usuario cualquiera, así que una página de cosecha de
     # credenciales alojada ahí hoy se salta el chequeo pensado solo para
-    # "es la propia web de la marca" (N3).
+    # "es la propia web de la marca".
     "multitenant_hosting_domains": [
         "docs.google.com", "forms.gle", "forms.office.com", "drive.google.com",
         "sites.google.com", "sharepoint.com", "onedrive.live.com",
@@ -398,7 +398,7 @@ _DEFAULTS: dict[str, Any] = {
 
     # Lenguaje de pago/facturación/suscripción/soporte combinable con un
     # número de teléfono para el patrón TOAD (Telephone-Oriented Attack
-    # Delivery, G-D): "su suscripción se renovó, llame para cancelar" -- sin
+    # Delivery): "su suscripción se renovó, llame para cancelar" -- sin
     # enlaces ni adjuntos, invisible al resto de reglas.
     "toad_phrases": [
         "subscription", "auto-renewal", "auto renewal", "renewal", "renewed",
@@ -427,7 +427,7 @@ def _data(key: str) -> Any:
     return value if value is not None else _DEFAULTS[key]
 
 
-# B18: las cachés se indexan por (versión de configuración, nombre del
+# Las cachés se indexan por (versión de configuración, nombre del
 # dataset), no solo por el nombre.
 #
 # Antes la clave era el nombre a secas y eran permanentes, así que recargar la
@@ -566,7 +566,7 @@ def brand_trusted_domains() -> tuple[tuple[tuple[str, ...], tuple[str, ...]], ..
 
 
 # =============================================================================
-# MATCHING DE FRASES CON LÍMITES DE PALABRA (B1)
+# MATCHING DE FRASES CON LÍMITES DE PALABRA
 # =============================================================================
 #
 # Los datasets de frases (bec_phrases, credential_phrases, high/low_signal_

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -1,7 +1,7 @@
 """
 Datasets de detección (marcas, dominios, keywords, extensiones…) compartidos
-entre las reglas de Iris (D6 en plans/deuda-tecnica-y-calidad.md — antes
-mezclado con text.py en un único shared.py de 957 líneas).
+entre las reglas de Iris (antes mezclados con text.py en un único shared.py
+de 957 líneas).
 
 Los datasets se leen de ``SecOpsConfig.json`` (bloque ``features.iris.data.*``)
 a través de ``config_reading.get_iris_data``. Cada dataset tiene un default

--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -485,7 +485,7 @@ def get_false_positives():
     Cada uno es una muestra etiquetada gratis: dice contra qué check y contra
     qué producto se equivoca el motor. Es la entrada que convierte el marcado
     de falsos positivos en un bucle de mejora en vez de una casilla de
-    interfaz — el banco de medición (#278) y el ranking de qué familias fallan
+    interfaz — el banco de falsos positivos y el ranking de qué familias fallan
     más se alimentan de aquí.
     """
     user = get_current_user()

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -96,8 +96,8 @@ _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
 # checks de higiene de certificado, no cómo se habla con ellos. La lista es una
 # red de seguridad barata, no una verdad: un TLS en un puerto que no esté aquí
 # se sondea igual de bien (el esquema se observa), pero no recibe los checks de
-# certificado. Ampliarla es gratis; hacerla innecesaria es #283, que ataca la
-# misma enfermedad —decidir por número de puerto— desde el otro lado.
+# certificado. Ampliarla es gratis; lo que la haría innecesaria es decidir la
+# candidatura observando el servicio en vez de mirar su número de puerto.
 _TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986, 636, 3269}
 
 # APIs de administración que hablan HTTP y publican su versión en un JSON sin

--- a/API/src/modules/features/themis/lybra/distro.py
+++ b/API/src/modules/features/themis/lybra/distro.py
@@ -24,8 +24,8 @@ y su ``confirmed=false``. Callar es la respuesta correcta cuando no se sabe.
 La señal más fuerte no es el banner sino la **revisión del propio paquete**:
 ``1:2.4.49-1ubuntu1`` sólo lo escribe Ubuntu, ``2.4.49-1~deb11u1`` sólo Debian
 (y dice hasta la versión), ``2.4.49-r0`` sólo Alpine, ``2.4.49-1.el8`` sólo la
-familia de Red Hat. Eso ya lo extrae :func:`~.kb.split_distro_version` desde
-#267 — aquí sólo se lee.
+familia de Red Hat. Eso ya lo extrae :func:`~.kb.split_distro_version`; aquí
+sólo se lee.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
@@ -35,8 +35,9 @@ que la ruta rápida de los servicios en su puerto de siempre no paga nada:
 
 La lista de intentos es **dato derivado del registro**, no una lista paralela:
 un dissector nuevo entra en la cascada por declarar sus dos capacidades, sin
-que este módulo cambie. Ése es justamente el error que #272 documentó — un mapa
-escrito a mano que se quedó con dos entradas mientras el módulo definía once.
+que este módulo cambie. Una lista paralela es justo lo que se queda atrás: hubo
+un mapa escrito a mano que se quedó con dos entradas mientras el módulo definía
+once.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/tls.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/tls.py
@@ -3,7 +3,7 @@
 Reads the negotiated protocol version and the self-signed/expiry status of the
 certificate.
 
-**JARM: archivado, no pendiente** (L24, 2026-09-02). Este módulo hace **un**
+**JARM: archivado, no pendiente** (2026-09-02). Este módulo hace **un**
 handshake, y de ahí salen la versión de protocolo, el autofirmado y la
 caducidad. JARM haría diez saludos deliberadamente distintos y hashearía el
 conjunto para identificar la *pila* TLS, no el producto.
@@ -15,14 +15,16 @@ puede buscar en ningún catálogo. Y comprobar esa coincidencia exige un
 laboratorio con varias pilas TLS distintas (OpenSSL, BoringSSL, Schannel,
 JSSE), que no existe aquí.
 
-A eso se suma que no es requisito de ninguna definición de hecho —la Fase F se
-cierra con la concordancia frente a Nmap, no con JARM—, que su prioridad medida
-es la más baja del backlog, y que diez saludos por servicio TLS es la sonda más
-cara del catálogo a cambio de un dato que nadie consultaría.
+A eso se suma que nada del fingerprinting depende de él —su medida de éxito es
+la concordancia frente a Nmap, no JARM—, que es de lo menos prioritario que hay
+pendiente, y que diez saludos por servicio TLS es la sonda más cara del
+catálogo a cambio de un dato que nadie consultaría.
 
-La decisión está escrita, con qué haría falta para reabrirla, en la sección
-Fase F de ``plans/feature/themis/lybra-engine-roadmap.md``. No es un "todavía
-no": es un "no, y por esto".
+Qué haría falta para reabrirlo: un laboratorio con al menos cuatro pilas TLS
+distintas contra el que comprobar que el hash coincide con el de la
+implementación de referencia, y alguien que de verdad vaya a consumir el hash
+—un catálogo de JARMs conocidos, o la necesidad de reconocer infraestructura
+que no dice nada de sí misma—. No es un "todavía no": es un "no, y por esto".
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -223,7 +223,7 @@ def kb_feed_version(state: Dict[str, Optional[datetime]]) -> str:
     Spelled out rather than hashed on purpose: the point is that someone
     reading a finding a year from now can tell what it was resolved against,
     and a hash only says "not the same as that other one" — it needs a lookup
-    table that does not exist yet (#302). A source with no date reports
+    table that does not exist. A source with no date reports
     ``none``, which is honest: an empty knowledge source is exactly the thing
     this mark exists to make visible.
 

--- a/API/src/modules/features/themis/managers/lybra/__init__.py
+++ b/API/src/modules/features/themis/managers/lybra/__init__.py
@@ -1,4 +1,4 @@
-"""Piezas de Lybra que sí necesitan el ORM (D1 en plans/deuda-tecnica-y-calidad.md).
+"""Piezas de Lybra que sí necesitan el ORM.
 
 ``LybraEngineManager`` (``engine.py``) y ``ServiceSource``/``DiscoveryProbes``
 (``sources.py``) vivían sueltos en ``managers/`` con nombres con prefijo

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -213,7 +213,7 @@ class LybraEngineManager(ScanManager):
 
         ``services`` acepta tanto ``Service`` como el dict equivalente, y por el
         mismo motivo de compatibilidad: desde que ``run_scan`` encola por la
-        outbox (#551) los argumentos se guardan en JSONB, así que llegan como
+        outbox transaccional los argumentos se guardan en JSONB, así que llegan como
         dicts. Un job pickleado por RQ antes de ese cambio sigue trayendo
         dataclasses, y esos se dejan pasar tal cual.
         """
@@ -245,8 +245,9 @@ class LybraEngineManager(ScanManager):
             services: Lista de servicios tal como viajó en el job, o ``None``
                 si el escaneo es de autodescubrimiento (Lybra descubre los
                 puertos él mismo y no recibe payload). Cada elemento puede ser
-                un dict —lo normal desde #551— o ya un ``Service``, que es como
-                viaja un job pickleado por RQ antes de ese cambio o una llamada
+                un dict —lo normal desde que se encola por la outbox— o ya un
+                ``Service``, que es como viaja un job pickleado por RQ antes de
+                ese cambio o una llamada
                 directa desde un test.
 
         Returns:
@@ -519,7 +520,7 @@ class LybraEngineManager(ScanManager):
             self.update_scan_status(scan_id, ScanStatus.FAILED, scan_failure.reason)
         # La sentencia de muerte de la cola. Hereda de ``BaseException`` para
         # que ningún ``except Exception`` la confunda con un fallo de red
-        # (#395), y el efecto colateral era que tampoco la veía el único sitio
+        # y se la trague, y el efecto colateral era que tampoco la veía el único sitio
         # que sabe qué fila hay que cerrar: la fila se quedaba en `running`
         # para siempre y el panel decía «escaneando» un día después. Se captura
         # explícitamente, se cierra la fila y **se vuelve a lanzar**, para que
@@ -1191,7 +1192,7 @@ class LybraEngineManager(ScanManager):
         Cada uno es **una muestra etiquetada gratis**, que es lo que convierte
         esta necesidad de una casilla de interfaz en un bucle de mejora: dicen
         contra qué check y contra qué producto se equivoca el motor, que es
-        exactamente la entrada que el banco de falsos positivos (#278) tiene
+        exactamente la entrada que el banco de falsos positivos tiene
         que aprender a consumir y lo que permite rankear qué familia falla más.
 
         Hasta L35 esa señal no existía: el usuario sólo podía decir "acepto el

--- a/API/src/modules/features/themis/managers/nikto.py
+++ b/API/src/modules/features/themis/managers/nikto.py
@@ -1,5 +1,5 @@
-"""NiktoScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: ver el docstring de nmap.py para el porqué)."""
+"""NiktoScanManager — extraído del antiguo thirdparty_scans_managers.py (ver el
+docstring de nmap.py para el porqué)."""
 
 import logging
 from typing import Optional

--- a/API/src/modules/features/themis/managers/nmap.py
+++ b/API/src/modules/features/themis/managers/nmap.py
@@ -1,8 +1,10 @@
-"""NmapScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: el fichero unificaba Nmap/Nikto/Nuclei
-"porque cada uno era pequeño y compartía la misma forma"; con A4 (base
-_create_scan_record) y A6 (base _previous_findings_map) ya no comparten
-apenas cuerpo, así que la unificación dejó de pagarse sola)."""
+"""NmapScanManager — extraído del antiguo thirdparty_scans_managers.py.
+
+Aquel fichero unificaba Nmap/Nikto/Nuclei "porque cada uno era pequeño y
+compartía la misma forma"; desde que la creación del registro
+(``_create_scan_record``) y el mapa de hallazgos previos
+(``_previous_findings_map``) viven en la clase base, ya no comparten apenas
+cuerpo, así que la unificación dejó de pagarse sola."""
 
 import logging
 from typing import Optional

--- a/API/src/modules/features/themis/managers/nuclei.py
+++ b/API/src/modules/features/themis/managers/nuclei.py
@@ -1,5 +1,5 @@
-"""NucleiScanManager — extraido de thirdparty_scans_managers.py (D2 en
-plans/deuda-tecnica-y-calidad.md: ver el docstring de nmap.py para el porqué)."""
+"""NucleiScanManager — extraído del antiguo thirdparty_scans_managers.py (ver el
+docstring de nmap.py para el porqué)."""
 
 import logging
 from typing import Callable, Optional

--- a/API/src/modules/features/themis/managers/scan.py
+++ b/API/src/modules/features/themis/managers/scan.py
@@ -442,8 +442,8 @@ class ScanManager(TaskTrackingMixin, ABC):
         la clave ``rq:worker:<name>`` sobrevive con su TTL completo a una
         muerte abrupta, así que su mera existencia no prueba nada.
 
-        Mismo arreglo que Iris hizo en su reconciliación (#208); el defecto era
-        literalmente el mismo porque este método fue el espejo del que se copió.
+        Mismo arreglo que ya tenía la reconciliación de Iris; el defecto era
+        literalmente el mismo porque aquélla se copió de este método.
 
         Returns:
             Número de escaneos marcados como FAILED.
@@ -563,7 +563,7 @@ class ScanManager(TaskTrackingMixin, ABC):
 
         # El mismo plazo agotado que recoge ``LybraEngineManager._run_lybra``,
         # aquí para los tres escáneres que sí lanzan un subproceso. Hereda de
-        # ``BaseException`` (#395) para que no lo capture ningún ``except
+        # ``BaseException`` para que no lo capture ningún ``except
         # Exception``, y el precio era que la fila se quedaba en `running`
         # eternamente cuando la cola mataba el trabajo. Se cierra la fila y se
         # vuelve a lanzar, para que RQ siga viendo un trabajo fallido.

--- a/API/src/modules/features/themis/managers/traceroute.py
+++ b/API/src/modules/features/themis/managers/traceroute.py
@@ -98,7 +98,7 @@ class TracerouteManager(TaskTrackingMixin):
         así que no existe el huérfano que la outbox previene. Un fallo de
         encolado deja simplemente un fallo de caché — el cliente sigue
         sondeando, no encuentra resultado fresco y la siguiente petición vuelve
-        a encolar. Se revisó con los demás en #551 y se decidió dejarlo así.
+        a encolar.
         """
         key = self._trace_key(user_id, target)
         timeout = int(CR.traceroute_config().timeout) + 30

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -901,7 +901,7 @@ class Finding(Base):
     # Quality / provenance
     source       = Column(String(32), index=True)
     check_id     = Column(String(128))
-    # 64 y no 32: desde #270 la marca de la detección por versión describe el
+    # 64 y no 32: la marca de la detección por versión describe el
     # estado de la base de conocimiento ("lybra-kb:nvd=2026-08-29,kev=...,
     # epss=..."), que ocupa hasta 54 caracteres. Se escribe entera en vez de
     # resumirla en un hash para que un hallazgo guardado siga diciendo, por sí

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -1257,8 +1257,7 @@ class KbRepository(BaseRepository[CveEntry]):
         tell those two apart after the fact.
 
         Read from the data itself rather than from a sync log, because there is
-        no sync log — recording when each source was last synchronised is
-        #302. These dates are the closest honest proxy: not "when did we last
+        no sync log. These dates are the closest honest proxy: not "when did we last
         ask NVD", but "how recent is the newest thing we know". A source with
         no rows, or whose rows carry no date, reports ``None``, which is
         information too and must not be dressed up as a date.

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -50,7 +50,7 @@ class NmapAIWriter:
         _generator: scribe AIGenerator used for model calling.
     """
 
-    # Tope de puertos detallados que viajan al prompt (#118): un host con
+    # Tope de puertos detallados que viajan al prompt: un host con
     # cientos de puertos abiertos (mala configuración, o un rango escaneado
     # como si fuera un solo host) podía generar un 'ports_json' sin límite.
     # '{{total_ports}}' sigue reportando el recuento real (no el recortado),
@@ -527,12 +527,12 @@ class LybraAIWriter:
     # completo (confirmados + KEV + cola), no solo a la cola: un scan con más
     # de _MAX_HIGHLIGHTED_FINDINGS hallazgos confirmados/KEV podía generar un
     # payload sin límite real pese a este tope, porque antes solo recortaba
-    # "rest" (Issue #118). El rollup por servicio cubre igualmente los que no
+    # "rest". El rollup por servicio cubre igualmente los que no
     # entran, así que un host con cientos de CVEs sigue describiéndose entero.
     _MAX_HIGHLIGHTED_FINDINGS = 25
     _MAX_DESCRIPTION_CHARS = 300
 
-    # Tope de grupos del rollup por servicio (#118): un objetivo con muchos
+    # Tope de grupos del rollup por servicio: un objetivo con muchos
     # productos/puertos distintos (un rango de red, no un solo host) podía
     # generar un 'services_json' sin límite pese a que ya es una compresión
     # de los hallazgos. Ordenado por severidad (ver _build_service_rollup),
@@ -611,7 +611,7 @@ class LybraAIWriter:
         # repositorio) para que, al recortar, sobrevivan los más graves —
         # y se recortan igual que la cola: antes solo _rest_ tenía tope, así
         # que un scan con más de _MAX_HIGHLIGHTED_FINDINGS confirmados/KEV
-        # generaba un payload sin límite real pese a la constante (#118).
+        # generaba un payload sin límite real pese a la constante.
         priority = list({id(finding): finding for finding in findings
                           if finding.get("confirmed") or finding.get("in_kev")}.values())
         priority.sort(key=self._sort_key)

--- a/API/src/modules/features/themis/services/reports/__init__.py
+++ b/API/src/modules/features/themis/services/reports/__init__.py
@@ -12,13 +12,13 @@ Generación de informes PDF de Themis.
     lybra.py     LybraPrintingStrategy
     nuclei.py    NucleiPrintingStrategy
 
-D5 en ``plans/deuda-tecnica-y-calidad.md``: este paquete sustituye al
+Este paquete sustituye al
 ``reports.py`` de 85 KB, el fichero más grande del repositorio. Su
 estructura interna ya era buena —el registro ``@PrintingStrategy.register``
 estaba bien hecho— y el problema era puramente de tamaño: tocar la paleta
 de un escáner obligaba a abrir un fichero de 2.000 líneas, y dos cambios en
 escáneres distintos colisionaban siempre en el mismo sitio. Es la misma
-Fase 3 que ya se aplicó a ``themis/managers.py``.
+partición que ya se aplicó a ``themis/managers.py``.
 
 Las cuatro estrategias se importan aquí por su **efecto secundario**: cada
 una se da de alta en ``PrintingStrategy._registry`` con su decorador al

--- a/API/src/modules/features/themis/services/reports/base.py
+++ b/API/src/modules/features/themis/services/reports/base.py
@@ -4,8 +4,6 @@
 Cada tipo de escaneo se da de alta con ``@PrintingStrategy.register(...)``
 junto a su propia clase; ``resolve_printing_strategy`` despacha por ese
 registro, así que añadir un tipo nuevo no toca este fichero.
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import logging

--- a/API/src/modules/features/themis/services/reports/creator.py
+++ b/API/src/modules/features/themis/services/reports/creator.py
@@ -1,7 +1,5 @@
 """
 ``PDFCreator``: arma el documento PDF a partir de la estrategia del escaneo.
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import os

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -1,8 +1,6 @@
 """
 ``FindingsPrintingStrategy``: base compartida por los tipos de escaneo que
 viven enteramente en ``Finding`` (Lybra y Nuclei).
-
-D5 en ``plans/deuda-tecnica-y-calidad.md``.
 """
 
 import logging

--- a/API/src/modules/infrastructure/document_repository.py
+++ b/API/src/modules/infrastructure/document_repository.py
@@ -1,6 +1,5 @@
 """
-Repositorio base para las entidades ``Document`` (A9 en
-plans/deuda-tecnica-y-calidad.md).
+Repositorio base para las entidades ``Document``.
 
 Los tres repositorios de documentos del proyecto —Themis (informes PDF de
 escaneo), Iris (informes PDF de análisis) y Aegis (píldoras de

--- a/API/src/modules/shared/_documents.py
+++ b/API/src/modules/shared/_documents.py
@@ -83,7 +83,7 @@ def submit_report_generation(task_queue, document_id: int, repo_cls: Type, **sub
     devolviendo el mismo error al cliente.
 
     Este manejo es la razón por la que los informes de Themis e Iris se
-    quedaron **fuera** de la outbox transaccional al auditarlos en #551, aunque
+    quedaron **fuera** de la outbox transaccional, aunque
     siguen el mismo patrón create-then-enqueue que Themis y Aegis sí migraron:
     un encolado fallido no deja el documento colgado en ``running`` para
     siempre, lo marca ``error``, y el usuario ve el fallo y puede volver a
@@ -148,7 +148,7 @@ class DocumentManager(TaskTrackingMixin):
     """CRUD y ownership compartidos por el ciclo de vida de un documento.
 
     ``ThemisReportManager`` e ``IrisReportManager`` eran el mismo manager con
-    los nombres cambiados (A3 en ``plans/deuda-tecnica-y-calidad.md``): esta
+    los nombres cambiados: esta
     base concentra lo que de verdad era idéntico. La generación en sí
     (``generate_report``/``_generate_pdf_async``/``execute_report_generation``)
     se queda en cada subclase porque el ``render`` y el disparador difieren

--- a/API/src/modules/shared/report_theme.py
+++ b/API/src/modules/shared/report_theme.py
@@ -1,8 +1,8 @@
 """
 Tema visual de los informes PDF: paleta y estilos.
 
-Nació en Themis (D5 en ``plans/deuda-tecnica-y-calidad.md``, extraído del
-``reports.py`` de 85 KB, el fichero más grande del repositorio) y vive aquí
+Nació en Themis (extraído del antiguo ``reports.py`` de 85 KB, el fichero más
+grande del repositorio) y vive aquí
 desde que Hygeia también imprime. No sabe nada de escaneos ni de activos: solo
 importa ``reportlab``, así que cualquier módulo que genere un PDF puede
 heredarlo y salir con la misma cara que el resto del producto.

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -615,8 +615,7 @@ class ScribeConfig(_StrategySelection):
 
     max_input_tokens: int = 24000
     """Tope de tokens estimados del prompt (system + examples + user) que
-    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia (Issue
-    #118).
+    ``AIGenerator.digest`` deja pasar antes de invocar la estrategia.
 
     Sin esto, un writer de dominio (p.ej. ``LybraAIWriter`` con un scan de
     muchos hallazgos) podía generar un payload que OpenAI rechazaba con un

--- a/API/src/modules/system/taskqueue/outbox.py
+++ b/API/src/modules/system/taskqueue/outbox.py
@@ -46,11 +46,11 @@ recalculan y sobrescriben por ``analysis_id`` en vez de crear filas nuevas,
 así que una repetición ahí es trabajo de más, no un dato duplicado -- pero
 quien añada un nuevo consumidor de outbox debe poder decir lo mismo del suyo.
 
-**Alcance de esta primera aplicación (B08).** El propio issue #240 pide
-aplicarlo primero a análisis e ingesta y dejar para después el PDF, el
-resumen de IA y las notificaciones -- todos siguen el mismo patrón
-create-then-enqueue y son candidatos igual de válidos, pero mezclarlos aquí
-habría triplicado el tamaño de este cambio sin necesidad.
+**Dónde se aplica.** Donde una fila confirmada antes de encolar puede quedarse
+huérfana o, peor, ser el guardia que impide volver a intentarlo: los escaneos
+de Themis, las campañas y píldoras de Aegis, el análisis de Iris y los avisos
+con guardia anti-duplicado de Iris y Hygeia. Los sitios que siguen llamando a
+``submit()`` directamente explican por qué junto a esa llamada.
 
 **Por qué el dispatcher vive en un fichero aparte** (``dispatcher.py``): este
 módulo es la base (modelo + (de)serialización) que ``outbox_repository.py``

--- a/API/src/modules/tools/scribe/exceptions.py
+++ b/API/src/modules/tools/scribe/exceptions.py
@@ -46,7 +46,7 @@ class AIResponseError(EllysiaException):
 
 
 class AIPayloadTooLargeError(EllysiaException):
-    """El prompt estimado supera el tope de tokens configurado (Issue #118).
+    """El prompt estimado supera el tope de tokens configurado.
 
     Se lanza *antes* de invocar la estrategia — nunca es transitorio (el mismo
     prompt sobredimensionado fallaría igual en cada reintento), así que

--- a/API/src/modules/tools/scribe/generator.py
+++ b/API/src/modules/tools/scribe/generator.py
@@ -85,7 +85,7 @@ class AIGenerator:
             self._failures += 1
             self._last_failure_time = time.time()
 
-    # ── Guardarraíl de tamaño (Issue #118) ──────────────────────────────────
+    # ── Guardarraíl de tamaño ───────────────────────────────────────────────
 
     @staticmethod
     def _check_payload_size(ai_input: AIInput) -> None:
@@ -131,7 +131,7 @@ class AIGenerator:
             CircuitBreakerOpenError: Si el breaker del backend está abierto.
             AIPayloadTooLargeError: Si el prompt estimado supera el tope
                 configurado — se comprueba antes de llamar a la estrategia y
-                no se reintenta (Issue #118): un prompt sobredimensionado
+                no se reintenta: un prompt sobredimensionado
                 falla igual en cada intento, así que reintentarlo solo
                 desperdicia llamadas y tiempo.
             AIFallbackExhaustedError: Si se agotan los reintentos.

--- a/API/src/modules/tools/scribe/inputs.py
+++ b/API/src/modules/tools/scribe/inputs.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # tiktoken, que además tokeniza distinto por modelo/backend). ~4 es la cifra
 # que la propia documentación de OpenAI da como regla general para texto en
 # inglés/español; de sobra para un guardarraín de "no mandes un payload
-# disparatado" — no hace falta precisión exacta para eso (Issue #118).
+# disparatado" — no hace falta precisión exacta para eso.
 _CHARS_PER_TOKEN = 4
 
 
@@ -95,7 +95,7 @@ class AIInput:
         return messages
 
     def estimated_tokens(self) -> int:
-        """Estimación heurística del tamaño del prompt completo (Issue #118).
+        """Estimación heurística del tamaño del prompt completo.
 
         Suma sobre todos los mensajes que ``to_messages`` enviaría — no solo
         el último — porque es el total lo que un backend factura contra su

--- a/API/tests/integration/test_aegis_outbox.py
+++ b/API/tests/integration/test_aegis_outbox.py
@@ -219,7 +219,7 @@ def test_generating_a_pill_with_redis_down_leaves_a_recoverable_dispatch(
 ):
     """La píldora se crea en ``pending`` y su generación queda en la outbox.
 
-    Antes de #551 este era el peor de los dos casos de Aegis: sin outbox, sin
+    Antes era el peor de los dos casos de Aegis: sin outbox, sin
     try/except y sin reconciliación, el documento se quedaba en ``pending`` para
     siempre con las dos cuotas de IA ya cobradas.
     """

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -62,13 +62,13 @@ def test_delete_requires_delete_attribute(client, stripped_user, auth_headers):
 
 
 def test_analyze_rejects_request_without_headers_or_message(client, root_headers):
-    # Fase 2: 'headers' ya no es obligatorio si se envía 'message', pero al
+    # 'headers' ya no es obligatorio si se envía 'message', pero al
     # menos uno de los dos debe estar presente (validado en el schema).
     resp = client.post("/iris/analyze", headers=root_headers, json={"title": "x"})
     assert resp.status_code == 422
 
 
-# --------------------------------------------------------------- B13: capacidades
+# --------------------------------------------------------------- capacidades
 
 def test_capabilities_requires_authentication(client):
     assert client.get("/iris/capabilities").status_code == 401
@@ -81,7 +81,7 @@ def test_capabilities_requires_read_attribute(client, stripped_user, auth_header
 
 def test_capabilities_publishes_the_limit_the_api_actually_enforces(client, regular_user,
                                                                    auth_headers):
-    """B13: el frontend tenía su propio tope, y había derivado a 2× del real.
+    """El frontend tenía su propio tope, y había derivado a 2× del real.
 
     La única defensa contra que vuelva a derivar es que el número que publica
     este endpoint sea el mismo que aplica la validación, leído del mismo sitio.

--- a/API/tests/integration/test_iris_ai_summary.py
+++ b/API/tests/integration/test_iris_ai_summary.py
@@ -1,4 +1,4 @@
-"""B10: el resumen ejecutivo de IA se pide una vez y se cobra una vez.
+"""El resumen ejecutivo de IA se pide una vez y se cobra una vez.
 
 Antes, `generate_ai_summary` consumía cuota y encolaba sin mirar si ya había
 un resumen o un trabajo en curso. Dos peticiones seguidas —dos clics, un
@@ -71,7 +71,7 @@ class _CountingQuota:
         type(self).consumed.append(key.db_name)
 
     def consume_many(self, user_id, keys, amount=1):
-        # Mismo comportamiento que el QuotaManager real (B09): si alguna
+        # Mismo comportamiento que el QuotaManager real: si alguna
         # clave falla, reembolsa las que esta llamada ya cobró.
         consumed = []
         try:

--- a/API/tests/integration/test_iris_analysis_failures.py
+++ b/API/tests/integration/test_iris_analysis_failures.py
@@ -1,4 +1,4 @@
-"""B03: un análisis que se rompe acaba en un estado terminal con motivo.
+"""Un análisis que se rompe acaba en un estado terminal con motivo.
 
 Antes, el parseo y la validación del mensaje vivían **fuera** de todo bloque
 ``try`` de ``IrisManager._run_analysis``. Una excepción ahí —un parser que

--- a/API/tests/integration/test_iris_cancellation.py
+++ b/API/tests/integration/test_iris_cancellation.py
@@ -1,4 +1,4 @@
-"""B07: transiciones de estado atómicas frente a cancelación concurrente.
+"""Transiciones de estado atómicas frente a cancelación concurrente.
 
 ``cancel_analysis()`` señaliza TaskQueue y ``_persist_analysis_results()``
 (el worker, al terminar de evaluar las reglas) escriben el ``status`` final

--- a/API/tests/integration/test_iris_degraded_analysis.py
+++ b/API/tests/integration/test_iris_degraded_analysis.py
@@ -1,4 +1,4 @@
-"""B05: una regla rota no puede pasar inadvertida en el informe.
+"""Una regla rota no puede pasar inadvertida en el informe.
 
 El criterio de cierre del issue pide las tres familias de regla fallida —
 autenticación, adjuntos y contenido— con comportamiento conservador. Estos

--- a/API/tests/integration/test_iris_documents.py
+++ b/API/tests/integration/test_iris_documents.py
@@ -180,7 +180,7 @@ def test_list_all_documents_for_user(client, app, root_user, root_headers, fake_
 
 
 def test_documents_are_paginated(client, app, root_user, root_headers, fake_queue):
-    """B17: antes devolvía todos los documentos del usuario sin límite."""
+    """Antes devolvía todos los documentos del usuario sin límite."""
     for _ in range(3):
         analysis_id = _seed_analysis(app, root_user.id)
         client.post(f"/iris/results/{analysis_id}/document", headers=root_headers)
@@ -220,11 +220,11 @@ def test_delete_document(client, app, root_user, root_headers, fake_queue):
     assert after.status_code == 404
 
 
-# --------------------------------------------------------------- B11: PDFs independientes
+# --------------------------------------------------------------- PDFs independientes
 
 def test_two_documents_of_the_same_analysis_are_independent(client, app, root_user,
                                                             root_headers, fake_queue):
-    """B11 de punta a punta.
+    """Dos documentos del mismo análisis no se pisan, de punta a punta.
 
     El modelo permite N ``IrisDocument`` por análisis (relación ``documents``
     con ``cascade="all, delete-orphan"``), pero el PDF se llamaba

--- a/API/tests/integration/test_iris_mailbox_endpoints.py
+++ b/API/tests/integration/test_iris_mailbox_endpoints.py
@@ -170,7 +170,7 @@ def test_sync_queues_and_returns_202(client, admin_user, auth_headers, app):
     submit_sync.assert_called_once_with(connection_id)
 
 
-# --------------------------------------------------------------- B16: folder
+# --------------------------------------------------------------- folder
 
 def test_update_connection_folder_too_long_returns_422(client, admin_user, auth_headers, app):
     connection_id = _save_connection(app, admin_user.id)

--- a/API/tests/integration/test_iris_mailbox_health.py
+++ b/API/tests/integration/test_iris_mailbox_health.py
@@ -1,4 +1,4 @@
-"""M10: salud y observabilidad de una conexión de buzón.
+"""Salud y observabilidad de una conexión de buzón.
 
 Antes, ``last_sync_at`` se actualizaba igual tanto si el sync no encontraba
 nada nuevo como si dejaba mensajes atascados por una cuota agotada o un
@@ -36,7 +36,7 @@ pytestmark = pytest.mark.integration
 
 class _FakeLockRedis:
     """Doble en memoria de RedisConnectionFactory.decoded() para
-    MailboxSyncLock (B02): SET NX EX más el script Lua de liberación
+    MailboxSyncLock: SET NX EX más el script Lua de liberación
     condicionada al token del titular -- ver test_iris_mailbox_manager.py,
     de donde se copia este doble, ya que _sync_connection adquiere el lock
     siempre."""
@@ -308,7 +308,7 @@ def test_a_dead_lettered_message_shows_up_as_dead_not_pending(app, regular_user,
     assert health["messages_pending"] == 0
     assert health["messages_dead"] == 1
     # Con la cola sin pendientes (el dead-letter ya no bloquea), el cursor sí
-    # se confirma y el sync cuenta como "limpio" -- ver B01.
+    # se confirma y el sync cuenta como "limpio".
     assert health["last_success_at"] is not None
 
 

--- a/API/tests/integration/test_iris_mailbox_manager.py
+++ b/API/tests/integration/test_iris_mailbox_manager.py
@@ -73,7 +73,7 @@ def _fake_state_redis():
 
 class _FakeLockRedis:
     """Doble en memoria de RedisConnectionFactory.decoded() para
-    MailboxSyncLock (B02): SET NX EX más los dos scripts Lua de
+    MailboxSyncLock: SET NX EX más los dos scripts Lua de
     renovación/liberación condicionados al token del titular."""
 
     def __init__(self):
@@ -107,7 +107,7 @@ class _FakeLockRedisFactory:
 
 @pytest.fixture(autouse=True)
 def _fake_lock_redis():
-    """``MailboxSyncLock`` (B02) importa su propio ``RedisConnectionFactory``
+    """``MailboxSyncLock`` importa su propio ``RedisConnectionFactory``
     en el namespace de ``locks.py`` -- se dobla aquí para todos los tests de
     este fichero, ya que ``_sync_connection`` adquiere el lock siempre."""
     factory = _FakeLockRedisFactory()
@@ -130,7 +130,7 @@ class _FakeConnector:
         self.revoked_tokens = []
         self._revoke_raises = revoke_raises
         self._refresh_raises_reauth = refresh_raises_reauth
-        # B16: por defecto expone "INBOX" -- suficiente para los tests que
+        # Por defecto expone "INBOX" -- suficiente para los tests que
         # no ejercitan folder explícitamente pero sí pasan por
         # _ensure_access_token en algún camino que valide.
         self._folders = folders if folders is not None else [
@@ -180,7 +180,7 @@ class _FakeConnector:
 
 
 class _QueueTestConnector(_FakeConnector):
-    """Doble para los tests de checkpoint (B01): lista un lote fijo de
+    """Doble para los tests de checkpoint: lista un lote fijo de
     mensajes y puede fallar la ingesta de ids concretos un número de veces
     controlado antes de empezar a tener éxito -- simula un fallo transitorio
     (el mensaje se recupera) o uno permanente (nunca se agota el contador)."""
@@ -349,7 +349,7 @@ def test_handle_callback_rejects_replayed_state(app, regular_user):
                 IrisMailboxManager().handle_callback(state, "auth-code")
 
 
-# --------------------------------------------------------------- B16: folder
+# --------------------------------------------------------------- folder
 
 def test_handle_callback_validates_folder_against_the_provider(app, regular_user):
     with app.app_context():
@@ -572,7 +572,7 @@ def test_sync_connection_stops_at_daily_quota(app, regular_user, monkeypatch):
         with UnitOfWork() as uow:
             assert IrisAnalysisRepository(uow).get_by_user(regular_user.id) == []
 
-            # B01: la cuota agotada deja el mensaje en cola para el próximo
+            # La cuota agotada deja el mensaje en cola para el próximo
             # sondeo -- confirmar el cursor ahora lo perdería para siempre.
             conn = IrisMailboxConnectionRepository(uow).get_by_id(connection_id)
             assert conn.sync_cursor == "cursor-0"
@@ -581,7 +581,7 @@ def test_sync_connection_stops_at_daily_quota(app, regular_user, monkeypatch):
             assert pending[0].attempts == 0
 
 
-# --------------------------------------------------------- B01: checkpoint por mensaje
+# --------------------------------------------------------- checkpoint por mensaje
 
 def test_sync_connection_defers_cursor_and_pending_message_when_quota_is_hit(app, regular_user, monkeypatch):
     with app.app_context():
@@ -776,7 +776,7 @@ def test_trigger_sync_submits_task_with_correct_category(app, regular_user):
     assert fake_queue.submitted[0]["args"] == (connection_id,)
 
 
-# --------------------------------------------------------- B02: lock de sync
+# --------------------------------------------------------- lock de sync
 
 def test_sync_connection_is_a_no_op_when_lock_already_held(app, regular_user, _fake_lock_redis):
     with app.app_context():

--- a/API/tests/integration/test_iris_mailbox_model.py
+++ b/API/tests/integration/test_iris_mailbox_model.py
@@ -102,10 +102,10 @@ def test_analysis_source_message_uid_unique_per_connection(app, regular_user):
             repo.save(IrisAnalysis(raw_headers="From: c@d.com", user_id=regular_user.id))
 
 
-# --------------------------------------------------------------- B12: cursor opaco
+# --------------------------------------------------------------- cursor opaco
 
 def test_sync_cursor_column_has_no_length_limit():
-    """B12: la columna era ``String(255)``, pero el ``@odata.deltaLink`` de
+    """La columna era ``String(255)``, pero el ``@odata.deltaLink`` de
     Microsoft Graph es una URL con un token de estado dentro que la rebasa.
 
     Esta comprobación mira el **tipo declarado**, no un round-trip, a
@@ -150,7 +150,7 @@ def test_a_long_opaque_cursor_survives_a_round_trip(app, regular_user):
             assert len(fetched.sync_cursor) > 255
 
 
-# --------------------------------------------------------------- B01: IrisMailboxInbox
+# --------------------------------------------------------------- IrisMailboxInbox
 
 def test_create_and_fetch_inbox_entry(app, regular_user):
     with app.app_context():

--- a/API/tests/integration/test_iris_mailbox_scheduling.py
+++ b/API/tests/integration/test_iris_mailbox_scheduling.py
@@ -1,5 +1,5 @@
 """Tests de integración de IrisMailboxScheduler -- sondeo periódico de
-conexiones de buzón y (M08) chequeo periódico de notificaciones."""
+conexiones de buzón y chequeo periódico de notificaciones."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ def _connection(user_id: int, account_email: str) -> IrisMailboxConnection:
 
 
 def test_poll_connections_continues_after_one_connection_fails_to_enqueue(app, regular_user, admin_user):
-    """B02: ``submit_sync()`` puede levantar (p.ej. ya hay un job "started"
+    """``submit_sync()`` puede levantar (p.ej. ya hay un job "started"
     con el mismo job_id determinista para esa conexión) -- eso no debe
     impedir que el resto de conexiones vencidas se encolen en el mismo
     sondeo. Antes de este fix, una excepción a mitad del bucle abortaba el
@@ -54,7 +54,7 @@ def test_poll_connections_continues_after_one_connection_fails_to_enqueue(app, r
 
 
 def test_run_notifications_delegates_to_check_and_notify(app):
-    """El job de notificaciones (M08) es una costura fina -- toda la lógica
+    """El job de notificaciones es una costura fina -- toda la lógica
     vive en ``services/notifications/scheduling.check_and_notify``; aquí
     solo se comprueba que el scheduler la invoca."""
     with app.app_context():
@@ -65,7 +65,7 @@ def test_run_notifications_delegates_to_check_and_notify(app):
 
 
 def test_run_retention_delegates_to_run_retention(app):
-    """El job de retención (M09/B17/B19) es igual de fino -- toda la lógica
+    """El job de retención es igual de fino -- toda la lógica
     vive en ``services/retention.run_retention``."""
     with app.app_context():
         with mock.patch.object(scheduling_mod, "run_retention") as fake_retention:

--- a/API/tests/integration/test_iris_notification_preferences_endpoints.py
+++ b/API/tests/integration/test_iris_notification_preferences_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests de integración de ``GET/PUT /iris/notification-preferences`` (M08).
+"""Tests de integración de ``GET/PUT /iris/notification-preferences``.
 
 La matriz de atributos (IRIS_READ / IRIS_UPDATE) ya está cubierta por
 ``test_iris_permissions.py``; aquí se verifica el contrato HTTP: valores por

--- a/API/tests/integration/test_iris_notification_scheduling.py
+++ b/API/tests/integration/test_iris_notification_scheduling.py
@@ -1,5 +1,5 @@
-"""Tests de integración del chequeo periódico de notificaciones de Iris
-(M08): digests diarios pendientes y avisos de conexión atascada.
+"""Tests de integración del chequeo periódico de notificaciones de Iris:
+digests diarios pendientes y avisos de conexión atascada.
 
 Cubre las dos consultas nuevas de ``repositories.py`` (``get_due_for_digest``,
 ``get_newly_stuck_connections``) y ``services/notifications/scheduling.py``,

--- a/API/tests/integration/test_iris_notifications.py
+++ b/API/tests/integration/test_iris_notifications.py
@@ -2,14 +2,14 @@
 cuando la ingesta automática de buzón clasifica un correo como Phishing
 (``IrisPhishingNotifyManager``), el digest diario que agrupa los que no
 eran de alta confianza (``IrisDigestNotifyManager``), y los dos avisos
-operativos de M08 -- reautenticación (``IrisReauthNotifyManager``) y
+operativos -- reautenticación (``IrisReauthNotifyManager``) y
 conexión atascada (``IrisStuckSyncNotifyManager``).
 
 Cubre el contrato del aviso de phishing: solo análisis de buzón con
 veredicto Phishing notifican (los manuales los pidió el propio usuario, que
 ya ve el informe), el correo va al dueño del análisis y su contenido incluye
 el asunto -- el mismo que ahora se usa como título del análisis. Y el de
-M08: un veredicto de alta confianza (``total_score`` en o por debajo de
+las preferencias: un veredicto de alta confianza (``total_score`` en o por debajo de
 ``iris.criticalPhishingScoreThreshold``, 20 por defecto) siempre notifica al
 momento; uno por encima de ese umbral respeta el silenciado temporal y el
 digest diario del usuario.
@@ -220,7 +220,7 @@ def test_phishing_trigger_never_raises_when_queue_is_down(app, regular_user):
             assert analysis.status == "finished"
 
 
-# ===================================================================== M08
+# =====================================================================
 # Preferencias de notificación: silenciado, digest y los dos avisos operativos.
 
 # ------------------------------------------- IrisNotificationPreferenceManager
@@ -276,7 +276,7 @@ def test_muted_for_minutes_zero_clears_an_active_mute(app, regular_user):
     assert _reload_preference(app, regular_user.id).muted_until is None
 
 
-# --------------------------------- IrisPhishingNotifyManager respeta M08
+# ------------------------- IrisPhishingNotifyManager respeta las preferencias
 
 def test_critical_phishing_ignores_an_active_mute(app, regular_user):
     """total_score=10 está por debajo del umbral de alta confianza (20) --
@@ -354,7 +354,7 @@ def test_non_critical_phishing_is_deferred_to_the_digest(app, regular_user):
 
 def test_non_critical_phishing_sends_normally_without_preferences(app, regular_user):
     """Sin fila de preferencias (usuario que nunca las ha tocado), un
-    Phishing no crítico se comporta como antes de M08: se notifica."""
+    Phishing no crítico se comporta como si no hubiera preferencias: se notifica."""
     connection_id = _save_connection(app, regular_user.id)
     analysis_id = _save_analysis(app, regular_user.id, verdict="Phishing",
                                  connection_id=connection_id, total_score=35.0)

--- a/API/tests/integration/test_iris_permissions.py
+++ b/API/tests/integration/test_iris_permissions.py
@@ -1,4 +1,4 @@
-"""B14: la matriz ABAC de Iris, atada a un test.
+"""La matriz ABAC de Iris, atada a un test.
 
 El `README.md` documentaba `IRIS_UPDATE` para reanálisis, resumen de IA y
 generación de PDF, mientras el código exigía `IRIS_CREATE`. Un cliente que

--- a/API/tests/integration/test_iris_quota_idempotency.py
+++ b/API/tests/integration/test_iris_quota_idempotency.py
@@ -1,9 +1,9 @@
-"""B09: IrisManager.analyze() cobra cuota exactamente por los análisis que de
+"""IrisManager.analyze() cobra cuota exactamente por los análisis que de
 verdad se crean -- ni por un reintento de Gmail/Graph que reenvía el mismo
 mensaje, ni por una carrera perdida contra la UniqueConstraint de
 idempotencia.
 
-``QuotaManager.consume_many()`` (el otro artefacto de B09, la generación de
+``QuotaManager.consume_many()`` (la otra pieza del cobro exacto, para la generación de
 IA que cobra dos claves) tiene su propia cobertura en test_quotas.py.
 """
 

--- a/API/tests/integration/test_iris_raw_message.py
+++ b/API/tests/integration/test_iris_raw_message.py
@@ -1,4 +1,4 @@
-"""Tests de integración de la separación raw/resultado de Iris (M09/B19):
+"""Tests de integración de la separación raw/resultado de Iris:
 ``IrisAnalysis.raw_headers`` es ahora una property respaldada por
 ``IrisRawMessage`` (fila 1:1, cifrada), no una columna.
 
@@ -73,7 +73,7 @@ def test_deleting_the_analysis_cascades_to_its_raw_message(app, regular_user):
 
 
 def test_deleting_the_analysis_cascades_to_its_rule_results(app, regular_user):
-    """B17: el criterio de cierre exige que la retención no deje huérfanos
+    """El criterio de cierre exige que la retención no deje huérfanos
     -- comprobado aquí sobre el borrado normal (no solo el de retención),
     ya que ambos pasan por el mismo cascade del ORM."""
     analysis_id = _save_analysis(app, regular_user.id)

--- a/API/tests/integration/test_iris_raw_purge_endpoints.py
+++ b/API/tests/integration/test_iris_raw_purge_endpoints.py
@@ -1,9 +1,9 @@
 """Tests de integración de lo que pasa en la superficie HTTP de Iris una vez
-la retención purga el raw de un análisis (M09/B17/B19): ``/path`` e
+la retención purga el raw de un análisis: ``/path`` e
 ``/iocs`` (derivados del raw) pasan a devolver 410, ``/reanalyze`` también
 (no hay nada que reanalizar), pero el resultado principal, la exportación y
 el informe de retención siguen funcionando -- "el resultado puede
-conservarse sin el raw" es el criterio de cierre de B19.
+conservarse sin el raw" es justo lo que se comprueba.
 """
 
 from __future__ import annotations

--- a/API/tests/integration/test_iris_reconciliation.py
+++ b/API/tests/integration/test_iris_reconciliation.py
@@ -1,11 +1,11 @@
-"""C1/B04: reconciliación de análisis Iris huérfanos tras un apagado abrupto.
+"""Reconciliación de análisis Iris huérfanos tras un apagado abrupto.
 
 Espejo de la reconciliación que ya existía para Themis (ScanManager.
 reconcile_orphaned_scans) — sin esto, un análisis que queda en pending/running
 cuando el proceso muere se queda así para siempre, porque no hay ninguna tarea
 viva en TaskQueue que lo actualice tras reiniciar.
 
-`B04` cambió el criterio. Antes se conservaba el análisis solo si su tarea
+El criterio cambió. Antes se conservaba el análisis solo si su tarea
 estaba exactamente en ``pending``, y eso se comía trabajo vivo: los workers son
 procesos aparte, reiniciar la API no los para, y un job ``running`` puede estar
 avanzando ahora mismo en otro proceso. La pregunta correcta no es "¿en qué
@@ -120,7 +120,7 @@ def test_reconcile_leaves_still_queued_analysis_alone(app, regular_user):
 
 
 def test_reconcile_leaves_a_running_analysis_alone(app, regular_user):
-    """El caso que motiva B04.
+    """El caso que motivó cambiar el criterio.
 
     El worker está analizando ahora mismo en otro proceso. Con el criterio
     viejo —conservar solo si el estado es exactamente ``pending``— este

--- a/API/tests/integration/test_iris_retention.py
+++ b/API/tests/integration/test_iris_retention.py
@@ -1,11 +1,11 @@
-"""Tests de integración de la retención de Iris (M09/B17/B19):
+"""Tests de integración de la retención de Iris:
 ``services/retention.py`` y las dos consultas de ``IrisAnalysisRepository``
 en las que se apoya.
 
 Cubre las dos mitades del job (purgar solo el raw vencido, borrar el
 análisis entero cuando hay un límite duro configurado), que ninguna de las
 dos deja huérfanos (``IrisRuleResult``), y que volver a ejecutar el job sin
-datos nuevos no hace nada (idempotencia -- el criterio de cierre de M09).
+datos nuevos no hace nada (idempotencia).
 """
 
 from __future__ import annotations
@@ -101,7 +101,7 @@ def test_get_analyses_older_than_finds_only_old_rows(app, regular_user):
 
 
 def test_deleting_old_analyses_via_repository_leaves_no_orphaned_rule_results(app, regular_user):
-    """B17: el criterio de cierre exige explícitamente que la retención no
+    """El criterio de cierre exige explícitamente que la retención no
     deje huérfanos."""
     old_id = _save_analysis(app, regular_user.id, created_at=utcnow_naive() - timedelta(days=400))
     with app.app_context():
@@ -126,7 +126,7 @@ def test_deleting_old_analyses_via_repository_leaves_no_orphaned_rule_results(ap
 
 def test_run_retention_purges_raw_but_keeps_the_analysis_by_default(app, regular_user):
     """analysisRetentionDays=0 (el default) desactiva el borrado completo --
-    "el resultado puede conservarse sin el raw" (B19) es el comportamiento
+    "el resultado puede conservarse sin el raw" es el comportamiento
     por defecto."""
     old_id = _save_analysis(app, regular_user.id, created_at=utcnow_naive() - timedelta(days=100))
 

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -699,7 +699,8 @@ def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, 
     Lo que se sustituye es el **socket**, no la sesión: el ``NetworkSession``
     real hace su trabajo, saludo incluido. Un doble por encima de la sesión
     entrega respuestas que el transporte real no produce, y eso fue justo lo
-    que ocultó el bug de #265 (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
+    que ocultó que los dos checks ``network`` no podían dispararse contra un
+    servidor real (ver la nota de ``tests/unit/test_lybra_checks.py``)."""
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.lybra import checks as checks_mod
 
@@ -823,7 +824,7 @@ class _FrozenClock:
 def test_a_scan_that_runs_out_of_clock_stops_probing_and_finishes_partial(app, admin_user, monkeypatch):
     """El plazo del panel acota el escaneo entero, no sólo su primera fase.
 
-    El descubrimiento de puertos tenía presupuesto de reloj desde #395, pero las
+    El descubrimiento de puertos ya tenía presupuesto de reloj, pero las
     fases siguientes no tenían ninguno: un «plazo por operación» limita lo que
     tarda cada sonda, no cuántas sondas se hacen, y cuántas se hacen lo decide
     cuántos puertos abiertos tenga el objetivo. Con un rango ancho el

--- a/API/tests/integration/test_themis_reconciliation.py
+++ b/API/tests/integration/test_themis_reconciliation.py
@@ -14,7 +14,7 @@ Lo que veía el usuario era una contradicción: el escaneo aparecía como fallid
 y, minutos más tarde, el worker terminaba y escribía ``finished`` encima de esa
 misma fila.
 
-Es el mismo defecto que Iris arregló en #208, y no por casualidad: esta
+Es el mismo defecto que Iris ya arregló en la suya, y no por casualidad: esta
 reconciliación fue el original del que aquélla se copió. Estos tests son el
 espejo de ``test_iris_reconciliation.py``, con la diferencia de que aquí el
 método es un ``classmethod`` sobre una clase abstracta que barre los escaneos de

--- a/API/tests/integration/test_themis_scan_outbox.py
+++ b/API/tests/integration/test_themis_scan_outbox.py
@@ -184,7 +184,7 @@ class TestLybraServicesSurviveJsonb:
         assert LybraEngineManager._rehydrate_services(payload) == [original]
 
     def test_rehydrate_passes_through_dataclasses_and_none(self):
-        """Compatibilidad: un job pickleado por RQ antes de #551 trae ``Service``
+        """Compatibilidad: un job pickleado por RQ antes de la outbox trae ``Service``
         ya construidos, y el modo autodescubrimiento no trae ninguno."""
         original = Service(port=22, protocol="tcp", name="ssh")
 

--- a/API/tests/oracle/_docker_helpers.py
+++ b/API/tests/oracle/_docker_helpers.py
@@ -90,7 +90,7 @@ def remember_container(port: int, name: str) -> None:
 
     Sin este apunte, los esperadores de este módulo sólo pueden informar de que
     un puerto no contestó, que es el síntoma y nunca la causa. Con él pueden
-    mirar si el contenedor sigue vivo y adjuntar su log. Ver #455: el objetivo
+    mirar si el contenedor sigue vivo y adjuntar su log. Ya pasó: el objetivo
     de ProFTPD moría al arrancar y el banco lo comunicaba como un timeout de
     cuatro minutos contra un puerto, sin una sola línea sobre el contenedor.
     """

--- a/API/tests/oracle/_nmap_oracle.py
+++ b/API/tests/oracle/_nmap_oracle.py
@@ -79,7 +79,7 @@ def _docker_args(docker_path: str) -> List[str]:
     host dentro y **termina con código 0**. Nada lanzaba, el banco leía «Nmap
     no identificó nada» y lo apuntaba como desacuerdo de fingerprint. Tres
     tests de concordancia fallaban cada noche por una discrepancia que no
-    existía (#455).
+    existía.
 
     En Docker Desktop la bandera es redundante pero inocua: mapea a la misma
     puerta de enlace que ya estaba puesta.
@@ -143,7 +143,7 @@ def assert_target_was_scanned(document: str, error_output: str, target: str) -> 
     """Comprobar que el oráculo llegó a mirar el objetivo, y no a otra cosa.
 
     Hay dos formas muy distintas de que ``run_nmap_sv`` devuelva un mapa vacío,
-    y confundirlas es lo que tuvo el banco nocturno en rojo tres noches (#455):
+    y confundirlas es lo que tuvo el banco nocturno en rojo tres noches:
 
     - **El puerto no está abierto.** Es un resultado legítimo, y el que la
       documentación de :func:`parse_nmap_xml` describe: Nmap habló con el

--- a/API/tests/oracle/_security_headers.py
+++ b/API/tests/oracle/_security_headers.py
@@ -4,13 +4,13 @@ Los bancos necesitan saber qué es un acierto y qué es un falso positivo, y par
 la familia de cabeceras esa lista estaba escrita a mano **dos veces**: una en
 ``test_lybra_precision_bench.py`` y otra en ``test_lybra_oracle_bench.py``, las
 dos con los mismos tres identificadores. Cuando el feed creció de 28 a 55 checks
-(#296) y aparecieron CSP, ``Referrer-Policy`` y ``Permissions-Policy``, ninguna
+y aparecieron CSP, ``Referrer-Policy`` y ``Permissions-Policy``, ninguna
 de las dos se enteró. Los tres checks nuevos son detecciones **correctas** —un
 nginx recién sacado de la caja no manda ninguna de esas cabeceras— pero como el
 catálogo no los listaba como esperados, se contaron como falsos positivos en los
-diecisiete objetivos HTTP del banco y hundieron la precisión de la Fase R a
+diecisiete objetivos HTTP del banco y hundieron la precisión del banco a
 0,557 frente a un umbral de 0,90. El banco nocturno llevaba tres noches en rojo
-por eso (#455).
+por eso.
 
 La lección es la del repositorio de siempre: una lista que hay que acordarse de
 actualizar a mano se desincroniza, y lo hace en silencio. Así que aquí no se

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -39,7 +39,7 @@ SNMP). Los cuatro fallos están documentados uno a uno más abajo con
 arregle su test pasará a XPASS y habrá que quitarle el marcador — la convención
 del repositorio para un bug documentado.
 
-Requiere Docker. Marcado ``oracle``, fuera del run por defecto de CI (#280).
+Requiere Docker. Marcado ``oracle``, fuera del run por defecto de CI.
 """
 
 from __future__ import annotations
@@ -136,8 +136,8 @@ def _wait_for_http(port: int, timeout: float = 240.0) -> None:
 def _wait_for_greeting(port: int, expect: bytes, timeout: float = 240.0) -> None:
     """Esperar a que el servidor emita **su** saludo, no a que el puerto acepte.
 
-    Es la lección que dejó #265 en la Fase 0 y aquí vuelve a hacer falta: el
-    proxy de Docker acepta la conexión TCP en cuanto existe el espacio de red
+    Es una lección que ya dejaron los checks ``network`` y que aquí vuelve a
+    hacer falta: el proxy de Docker acepta la conexión TCP en cuanto existe el espacio de red
     del contenedor, mucho antes de que el servidor de dentro haya terminado de
     instalarse y arrancar. Un ``wait_for_port`` que sólo conecta da por listo un
     contenedor que todavía está haciendo ``apk add``, y la medición sale vacía
@@ -216,7 +216,8 @@ def proftpd_target():
     servidor FTP, un vsftpd cuyo saludo (``220 (vsFTPd 3.0.5)``) es justo el
     formato que el parser sabía leer. Ese 1,00 no medía la calidad del
     dissector, medía la coincidencia entre el dissector y el contenedor
-    elegido — la misma trampa que la Fase 0 documentó en #269 y #270.
+    elegido — la misma trampa de medir contra un doble hecho a la medida del
+    código que se mide.
 
     ProFTPD es el otro servidor FTP extendido y saluda de otra forma; en su
     configuración por defecto de Debian, además, **omite la versión**. Con él
@@ -227,7 +228,7 @@ def proftpd_target():
     # original venía de Debian, cuyo paquete la crea en su postinstalación, y
     # se ejecutaba sobre Alpine, donde no tiene por qué existir: ProFTPD aborta
     # con un fatal si el usuario que nombra su configuración no está, y el
-    # contenedor moría en el segundo uno (#455). Los dos ``||`` la hacen
+    # contenedor moría en el segundo uno. Los dos ``||`` la hacen
     # idempotente, para que la receta siga valiendo el día que el paquete sí
     # traiga la cuenta.
     #

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -57,7 +57,7 @@ def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
     """``wait_for_port`` con el cliente Docker ya puesto.
 
     Sin él, un contenedor que muere al arrancar se comunica como un puerto
-    que no contestó, que es el síntoma y nunca la causa (#455).
+    que no contestó, que es el síntoma y nunca la causa.
     """
     wait_for_port(host, port, timeout, docker_path=_DOCKER)
 
@@ -426,7 +426,7 @@ def test_missing_security_headers_detected_against_real_container(app, admin_use
     headers = {f.check_id for f in findings if f.category == "security_header"}
     # La familia esperada sale del feed, no de una lista escrita aquí. La lista
     # estuvo escrita, con tres identificadores, y se quedó atrás en cuanto el
-    # feed creció (#455).
+    # feed creció.
     assert headers == always_missing_header_checks()
     assert all(f.confirmed and f.qod == 99 for f in findings if f.category == "security_header")
 
@@ -456,7 +456,7 @@ def test_tls_expired_cert_detected_against_real_container(app, admin_user, tls_e
 
 # ------------------------------------------- familia network contra servidores reales
 #
-# Los cuatro casos que cierran #265. Hasta aquí, los dos únicos checks no-web
+# Por qué existen estos cuatro casos: hasta aquí, los dos únicos checks no-web
 # del motor sólo se habían ejercitado contra dobles, y por eso nadie vio que el
 # transporte leía una forma de respuesta que ni FTP ni Redis producen: el
 # escaneo terminaba en verde y el FTP anónimo seguía ahí. Un positivo y un

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -24,7 +24,7 @@ verlo.
 **Los señuelos son la mitad del banco a propósito.** ``nginx-endurecido`` manda
 la familia entera de cabeceras —la que declare el feed en cada momento, no una
 lista fija: se quedó en tres cuando el feed pasó a seis y dejó de ser un control
-negativo (#455)— y no debe producir ni un hallazgo de esa familia;
+negativo— y no debe producir ni un hallazgo de esa familia;
 ``nginx-senuelos`` sirve un 200 en las rutas que los checks de ``exposed_path``
 piden, pero con un cuerpo que no es lo que el check busca — un ``.git/config``
 que no es un config de Git, un ``backup.sql`` que no es un volcado. Un check que
@@ -74,11 +74,11 @@ _HTTP_PORT = 8080
 _TLS_PORT = 8443
 
 # La familia de cabeceras se **deriva del feed**, no se escribe aquí. Estuvo
-# escrita a mano, con tres identificadores, y cuando el feed creció (#296) nadie
+# escrita a mano, con tres identificadores, y cuando el feed creció nadie
 # la actualizó: los tres checks nuevos —CSP, Referrer-Policy y
 # Permissions-Policy— pasaron a contarse como falsos positivos en los diecisiete
-# objetivos HTTP del catálogo y tumbaron la precisión de la Fase R a 0,557
-# (#455). Ver ``_security_headers.py`` para la derivación y su única excepción.
+# objetivos HTTP del catálogo y tumbaron la precisión del banco a 0,557.
+# Ver ``_security_headers.py`` para la derivación y su única excepción.
 _HEADERS = always_missing_header_checks()
 
 
@@ -126,7 +126,7 @@ def _tls_serve(files: dict) -> str:
 # hallazgo. Manda la familia **entera** de cabeceras, no sólo las tres con
 # las que se escribió: en cuanto el feed creció, un «endurecido» al que le
 # faltaban tres cabeceras dejó de ser un control negativo y pasó a aportar
-# tres falsos positivos él solo (#455).
+# tres falsos positivos él solo.
 _HARDENED_CONF = (
     "printf '%s' 'server { listen 80; "
     'add_header Strict-Transport-Security "max-age=31536000" always; '
@@ -175,15 +175,15 @@ _REAL_EXPOSURES = {
 # Un volcado de base de datos expuesto dispara **dos** checks del feed, no uno.
 # ``sql-backup-exposure`` (CRITICAL) pide /backup.sql con un cuerpo que contenga
 # INSERT INTO o CREATE TABLE; ``sql-dump-exposure`` (HIGH), añadido cuando el
-# feed creció (#296), pide una lista de nombres en la que /backup.sql también
+# feed creció, pide una lista de nombres en la que /backup.sql también
 # está. El mismo fichero satisface a los dos.
 #
 # El catálogo los etiqueta como pareja porque, tal y como está hoy el feed, los
 # dos hallazgos son ciertos: contarlos como uno solo haría del segundo un falso
 # positivo que no lo es. Pero el solapamiento **sí es un defecto del feed**, no
 # del banco —en producción produce dos hallazgos con severidades distintas para
-# el mismo fichero— y se sigue en #456. Cuando ahí se decida deduplicarlos, esta
-# pareja vuelve a ser un solo identificador.
+# el mismo fichero— y sigue sin resolverse en el feed. El día que se
+# deduplique, esta pareja vuelve a ser un solo identificador.
 _SQL_DUMP_CHECKS = {
     "lybra:sql-backup-exposure@1",
     "lybra:sql-dump-exposure@1",
@@ -347,7 +347,7 @@ _CATALOGUE = (
         # Las mismas siete rutas, pero servidas por HTTPS. Hasta ahora ningún
         # check de ``exposed_path`` se ejercitaba nunca sobre TLS, que es como
         # sirve la mayoría de los sitios reales — y es justo el camino donde la
-        # detección de esquema por observación (#268) decide si la sonda habla
+        # detección de esquema por observación decide si la sonda habla
         # en claro o cifrado.
         command=_tls_serve(_REAL_EXPOSURES),
         expected=_HEADERS | _ALL_EXPOSURE_CHECKS | {"lybra:tls-self-signed-cert@1"},
@@ -445,7 +445,7 @@ def _wait_until_serving(port: int, tls: bool, label: str = "", timeout: float = 
     sonda TLS, nginx ya estaba en pie y el check de certificado sí funcionaba.
     El banco reportaba tres falsos negativos por objetivo TLS y ningún fallo.
 
-    Es la tercera vez que esta carrera muerde en este paquete (#265, L49), y
+    Es la tercera vez que esta carrera muerde en este paquete, y
     siempre con la misma cara: se lee como "el motor no detectó".
 
     La comprobación es deliberadamente **cruda** —un socket y una línea de
@@ -499,7 +499,7 @@ def _running(target: Target) -> Iterator[int]:
     # Un contenedor que muere al arrancar —una configuración de nginx que no
     # parsea, sin ir más lejos— produce cero hallazgos, y cero hallazgos es
     # indistinguible de "el motor no detectó nada" en el agregado. Registrarlo
-    # es lo que hace que el log diga cuál de las dos cosas pasó (#455).
+    # es lo que hace que el log diga cuál de las dos cosas pasó.
     remember_container(port, name)
     try:
         wait_for_port("127.0.0.1", port, docker_path=_DOCKER)

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -90,7 +90,7 @@ def test_an_external_target_is_scanned_directly():
 def test_the_oracle_container_is_told_how_to_reach_the_host():
     """Traducir el objetivo a ``host.docker.internal`` no sirve de nada si el
     contenedor no sabe resolver ese nombre, que es lo que pasa en Docker sobre
-    Linux — y por tanto en el runner del banco nocturno (#455). La bandera que
+    Linux — y por tanto en el runner del banco nocturno. La bandera que
     lo mapea contra la puerta de enlace del host tiene que ir en el ``docker
     run``, y antes de la imagen: lo que va después son argumentos de Nmap."""
     arguments = _docker_args("/usr/bin/docker")
@@ -136,7 +136,7 @@ def test_an_unreachable_target_stops_the_bench_instead_of_scoring_zero():
 
 
 # --------------------------------------------------------------------------
-# Un contenedor caído no puede leerse como un fallo del motor (#455)
+# Un contenedor caído no puede leerse como un fallo del motor
 # --------------------------------------------------------------------------
 #
 # Puras también: sólo comprueban qué hace el registro cuando no sabe nada del
@@ -175,7 +175,7 @@ def _forget_container(port: int) -> None:
 
 
 # --------------------------------------------------------------------------
-# La familia de cabeceras del banco no puede quedarse atrás del feed (#455)
+# La familia de cabeceras del banco no puede quedarse atrás del feed
 # --------------------------------------------------------------------------
 #
 # Éste es el test que faltaba. Los bancos que miden la familia necesitan Docker

--- a/API/tests/postgres/test_migrations.py
+++ b/API/tests/postgres/test_migrations.py
@@ -77,7 +77,7 @@ def alembic_config(migrations_url):
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Bug preexistente destapado por esta matriz (#356): la revisión "
+        "Bug preexistente destapado por esta matriz: la revisión "
         "b2c3d4e5f6a7 inserta en PlanLimit diez migraciones antes de que "
         "f2b3c4d5e6f7 cree la tabla, así que `alembic upgrade head` sobre una "
         "base vacía falla. No se nota en producción porque el primer "
@@ -105,7 +105,7 @@ def test_the_whole_chain_applies_to_an_empty_database(alembic_config, migrations
     strict=True,
     reason=(
         "Depende de que `upgrade head` funcione sobre una base vacía, que hoy "
-        "no lo hace (#356). Se quita junto con el marcador del test anterior."
+        "no lo hace. Se quita junto con el marcador del test anterior."
     ),
 )
 def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_config,

--- a/API/tests/unit/test_config_view_paths.py
+++ b/API/tests/unit/test_config_view_paths.py
@@ -1,5 +1,4 @@
-"""Las rutas de configuración que codifica el SPA tienen que existir de verdad
-(A11 en ``plans/deuda-tecnica-y-calidad.md``).
+"""Las rutas de configuración que codifica el SPA tienen que existir de verdad.
 
 ``web/app/src/views/ConfigView.vue`` enlaza cada control del formulario con
 ``store.configFlat['ruta.con.puntos']``. Ese ``configFlat`` es el aplanado de

--- a/API/tests/unit/test_hygeia_inventory_adapter.py
+++ b/API/tests/unit/test_hygeia_inventory_adapter.py
@@ -130,8 +130,8 @@ def test_the_stripped_version_matches_an_nvd_range():
     Este test afirmaba también lo contrario para la versión **sin** recortar
     (``version_compare(raw, "2.39") < 0``), porque entonces era cierto: el
     comparador partía la cadena en tramos de dígitos y de letras, y el sufijo
-    de empaquetado dejaba la instalada por debajo del inicio del rango. Desde
-    #267 ya no lo es — el comparador reconoce y separa la revisión de
+    de empaquetado dejaba la instalada por debajo del inicio del rango. Ya no
+    lo es — el comparador reconoce y separa la revisión de
     distribución él mismo, así que las dos formas comparan igual. Afirmar aquí
     el fallo antiguo sería congelarlo.
 

--- a/API/tests/unit/test_iris_auth_trust.py
+++ b/API/tests/unit/test_iris_auth_trust.py
@@ -1,4 +1,4 @@
-"""B06: frontera de confianza de la cadena ``Received``.
+"""Frontera de confianza de la cadena ``Received``.
 
 El corpus de ataque que pide el criterio de cierre del issue: **ningún
 ``Authentication-Results`` aportado por el atacante convierte por sí solo un
@@ -87,7 +87,7 @@ def test_boundary_stops_at_the_first_foreign_organisation():
 
 
 # ---------------------------------------------------------------------------
-# El ataque que cierra B06
+# El ataque que cierra la frontera de confianza
 # ---------------------------------------------------------------------------
 
 def test_injected_received_plus_auth_results_no_longer_passes():
@@ -132,7 +132,7 @@ def test_the_same_header_from_the_real_delivering_server_still_passes():
 
 
 def test_an_authserv_id_that_never_touched_the_message_still_fails():
-    """El caso que ya se detectaba antes de B06 sigue detectándose."""
+    """El caso que ya se detectaba antes de la frontera de confianza sigue detectándose."""
     context = MessageContext(
         headers={
             "authentication-results": "inventado.example; spf=pass; dkim=pass; dmarc=pass",

--- a/API/tests/unit/test_iris_dataset_cache.py
+++ b/API/tests/unit/test_iris_dataset_cache.py
@@ -1,4 +1,4 @@
-"""B18: un cambio de configuración llega al siguiente análisis.
+"""Un cambio de configuración llega al siguiente análisis.
 
 Los datasets de detección de Iris —marcas, proveedores gratuitos, keywords,
 TLDs sospechosos, tabla de homóglifos— se cachean, y con razón: se consultan

--- a/API/tests/unit/test_iris_failures.py
+++ b/API/tests/unit/test_iris_failures.py
@@ -1,4 +1,4 @@
-"""B03: clasificación del motivo por el que un análisis de Iris muere.
+"""Clasificación del motivo por el que un análisis de Iris muere.
 
 Un ``failed`` sin motivo no es accionable: quien lo mira no sabe si el
 problema era su fichero o el motor. ``classify_failure`` es la costura que
@@ -32,7 +32,7 @@ def test_invalid_input_keeps_its_own_message():
 
 
 def test_unexpected_error_never_leaks_the_exception_text():
-    """El caso que motiva B03: un parser que revienta y arrastra en su
+    """El caso que motiva esta clasificación: un parser que revienta y arrastra en su
     ``str()`` el fragmento de entrada que no supo digerir."""
     leaked = "b'From: victima@banco.example\\r\\nAuthorization: Bearer s3cr3t'"
     failure = classify_failure(ValueError(f"cannot decode {leaked}"))

--- a/API/tests/unit/test_iris_fp_regression.py
+++ b/API/tests/unit/test_iris_fp_regression.py
@@ -1,7 +1,6 @@
 """Corpus de regresión de falsos positivos.
 
-Prerrequisito bloqueante de la recalibración de pesos
-(``plans/feature/iris/iris-rule-weight-recalibration.md``, sección 7.1): sin
+Prerrequisito bloqueante de la recalibración de pesos de las reglas: sin
 un corpus que de verdad estrese los contaminantes identificados por el
 consejo (saludo genérico, urgencia media, tracking de imágenes, cadena
 Received interna, destinatarios ocultos, coexistiendo en el mismo correo,

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -1,8 +1,7 @@
 """Tests unitarios de los conectores de buzón (Gmail / Microsoft Graph).
 
 Todo el HTTP está mockeado (``unittest.mock.patch`` sobre ``requests.get``/
-``requests.post``) -- sin red real, sin credenciales OAuth reales. Ver
-plans/feature/iris/iris-mailbox-connector.md Fase 4.
+``requests.post``) -- sin red real, sin credenciales OAuth reales.
 """
 
 from __future__ import annotations

--- a/API/tests/unit/test_iris_mailbox_connectors.py
+++ b/API/tests/unit/test_iris_mailbox_connectors.py
@@ -239,7 +239,7 @@ def test_graph_list_new_with_cursor_caches_headers_from_delta_response():
     assert raw == "From: a@b.com\r\n"
 
 
-# B12: el deltaLink de Graph es un token opaco que puede rebasar los 255
+# El deltaLink de Graph es un token opaco que puede rebasar los 255
 # caracteres que la columna `sync_cursor` permitía. Estos tests fijan que el
 # conector lo devuelve intacto — cualquier recorte lo invalida, y un cursor
 # inválido tira la sincronización incremental al bootstrap.

--- a/API/tests/unit/test_iris_message_parser.py
+++ b/API/tests/unit/test_iris_message_parser.py
@@ -1,4 +1,4 @@
-"""Tests unitarios de Fase 2: parser de mensaje completo y reglas que
+"""Tests unitarios del parser de mensaje completo y de las reglas que
 dependen del cuerpo/enlaces/adjuntos (``needs_context=True``).
 """
 
@@ -59,7 +59,7 @@ def test_parse_multipart_message_extracts_html_links_and_attachment():
     assert ctx.attachments[0].filename == "invoice.exe"
 
 
-# ------------------------------------------------- Nested message/rfc822 forward (I2)
+# ------------------------------------------------- Nested message/rfc822 forward
 
 def _forward_with_nested_original(inner_from="PayPal Support <support@paypal-security.tk>",
                                    inner_subject="Urgent Verify Account") -> str:
@@ -172,7 +172,7 @@ def test_subject_title_uses_inner_subject_of_report_phishing_forward():
     assert build_subject_title(raw) == "Tu factura caduca hoy"
 
 
-# --------------------------------------------------------------- Received chain (C3/C8)
+# --------------------------------------------------------------- Received chain
 
 def test_received_chain_neutral_when_absent():
     ctx = MessageContext(headers={})
@@ -238,7 +238,7 @@ def test_received_chain_passes_when_consistent():
     assert result.verdict == "pass"
 
 
-# --------------------------------------------------------------- Body links (C10)
+# --------------------------------------------------------------- Body links
 
 def test_body_links_neutral_when_no_links():
     ctx = MessageContext(headers={})
@@ -354,7 +354,7 @@ def test_body_links_passes_when_clean():
     assert result.verdict == "pass"
 
 
-# ------------------------------------------------------- Body links deep URL heuristics (D2)
+# ------------------------------------------------------- Body links deep URL heuristics
 
 def test_body_links_flags_userinfo_credential_lure():
     # http://paypal.com@evil.io/ — everything before '@' is attacker text;
@@ -449,7 +449,7 @@ def test_body_links_does_not_flag_login_on_known_brand_domain():
     assert result.verdict == "pass"
 
 
-# --------------------------------------------------------------- Body content (C12)
+# --------------------------------------------------------------- Body content
 
 def test_body_content_neutral_when_empty():
     ctx = MessageContext(headers={})
@@ -543,7 +543,7 @@ def test_body_content_ignores_responsive_css_in_style_block():
     assert result.score == 0
 
 
-# --------------------------------------------------------------- Suspicious attachments (C11)
+# --------------------------------------------------------------- Suspicious attachments
 
 def test_attachments_falls_back_to_headers_when_no_parts():
     ctx = MessageContext(headers={
@@ -598,7 +598,7 @@ def test_attachments_passes_on_benign_pdf():
 
 
 def test_attachments_includes_sha256_and_md5_when_content_present():
-    # D8: flagged attachments carry hashes so they're pivotable as IOCs.
+    # Flagged attachments carry hashes so they're pivotable as IOCs.
     import hashlib
     content = b"MZ\x00\x00fake-exe-content"
     ctx = MessageContext(headers={}, attachments=[

--- a/API/tests/unit/test_iris_new_rules.py
+++ b/API/tests/unit/test_iris_new_rules.py
@@ -1,4 +1,4 @@
-"""Tests unitarios de las 10 reglas añadidas en Fase 1.
+"""Tests unitarios de diez reglas forenses de Iris.
 
 Cubre señales forenses observables en el correo:
 - Display name vs. email local aleatorio

--- a/API/tests/unit/test_iris_quality.py
+++ b/API/tests/unit/test_iris_quality.py
@@ -1,4 +1,4 @@
-"""B05: calidad del análisis — qué se inspeccionó de verdad y qué no.
+"""Calidad del análisis — qué se inspeccionó de verdad y qué no.
 
 Una regla que revienta se convertía en un ``RuleResult(verdict="error")`` y
 ahí se acababa todo: el análisis podía terminar como ``Legitimate`` sin

--- a/API/tests/unit/test_iris_recalibration_rules.py
+++ b/API/tests/unit/test_iris_recalibration_rules.py
@@ -1,5 +1,4 @@
-"""Tests de las reglas/gates nuevos de la recalibración de pesos
-(``plans/feature/iris/iris-rule-weight-recalibration.md``, secciones 3 y 5):
+"""Tests de las reglas/gates nuevos de la recalibración de pesos de Iris:
 
 - Auth Results Provenance (G-A): authserv-id ↔ último `by` del Received.
 - Recipient Domain Lookalike (G-B): lookalike del dominio del destinatario.

--- a/API/tests/unit/test_iris_recalibration_rules.py
+++ b/API/tests/unit/test_iris_recalibration_rules.py
@@ -1,12 +1,12 @@
 """Tests de las reglas/gates nuevos de la recalibración de pesos de Iris:
 
-- Auth Results Provenance (G-A): authserv-id ↔ último `by` del Received.
-- Recipient Domain Lookalike (G-B): lookalike del dominio del destinatario.
-- Display Name Foreign Address (G-C): display name que ES una dirección
+- Auth Results Provenance: authserv-id ↔ último `by` del Received.
+- Recipient Domain Lookalike: lookalike del dominio del destinatario.
+- Display Name Foreign Address: display name que ES una dirección
   de otro dominio.
-- TOAD Callback Pattern (G-D): teléfono + lenguaje de pago sin
+- TOAD Callback Pattern: teléfono + lenguaje de pago sin
   enlaces/adjuntos/hilo previo.
-- External Login Link (G-E): señal informativa para el combo con
+- External Login Link: señal informativa para el combo con
   Alarming Keywords.
 
 Cada regla se prueba en aislamiento (igual que ``test_iris_message_parser.py``)
@@ -38,7 +38,7 @@ def _gated(base_verdict, named):
     return verdict, reasons
 
 
-# --------------------------------------------------------------- G-A: Auth Results Provenance
+# --------------------------------------------------------------- Auth Results Provenance
 
 def test_auth_provenance_flags_authserv_absent_from_received_chain():
     ctx = MessageContext(
@@ -120,7 +120,7 @@ def test_gate_auth_forged_escalates_to_phishing():
     assert reasons
 
 
-# --------------------------------------------------------------- G-B: Recipient Domain Lookalike
+# --------------------------------------------------------------- Recipient Domain Lookalike
 
 def test_recipient_lookalike_flags_typo_of_recipient_domain():
     headers = {
@@ -150,7 +150,7 @@ def test_gate_recipient_lookalike_escalates_to_phishing():
     assert verdict == "Phishing"
 
 
-# --------------------------------------------------------------- G-C: Display Name Foreign Address
+# --------------------------------------------------------------- Display Name Foreign Address
 
 def test_display_name_foreign_address_flags_email_in_display_name():
     headers = {"from": '"ceo@acme.com" <attacker@evil.com>'}
@@ -192,7 +192,7 @@ def test_gate_display_foreign_without_impersonation_only_suspicious():
     assert verdict == "Suspicious"
 
 
-# --------------------------------------------------------------- G-D: TOAD Callback Pattern
+# --------------------------------------------------------------- TOAD Callback Pattern
 
 def test_toad_callback_flags_phone_and_billing_language_without_links():
     ctx = MessageContext(
@@ -235,7 +235,7 @@ def test_toad_callback_passes_without_billing_keywords():
     assert result.verdict == "pass"
 
 
-# --------------------------------------------------------------- G-E: External Login Link
+# --------------------------------------------------------------- External Login Link
 
 def test_external_login_link_flags_non_esp_foreign_host():
     ctx = MessageContext(

--- a/API/tests/unit/test_iris_redaction.py
+++ b/API/tests/unit/test_iris_redaction.py
@@ -1,4 +1,4 @@
-"""Tests unitarios de ``services/redaction.py`` (M09): puro, sin BD."""
+"""Tests unitarios de ``services/redaction.py``: puro, sin BD."""
 
 from __future__ import annotations
 

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -61,7 +61,7 @@ def test_print_pdf_creates_a_file():
 
 
 def test_two_documents_of_the_same_analysis_do_not_collide():
-    """B11: el modelo permite N documentos por análisis, pero el nombre del
+    """El modelo permite N documentos por análisis, pero el nombre del
     fichero solo dependía del análisis, así que todos escribían el mismo PDF."""
     first = IrisPDFCreator(report=_sample_report(), document_id=1).print_pdf()
     second = IrisPDFCreator(report=_sample_report(), document_id=2).print_pdf()
@@ -163,7 +163,7 @@ def test_print_pdf_with_legitimate_verdict():
     assert os.path.exists(path)
 
 
-# ------------------------------------------------ M09: redacción del raw dump
+# ------------------------------------------------ redacción del raw dump
 
 def _theme() -> IrisReportTheme:
     return IrisReportTheme(getSampleStyleSheet(), PALETTE)

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -126,12 +126,12 @@ def test_dmarc_missing_is_neutral():
     assert result.score == 0
 
 
-# -------------------------------------------------------------------- ARC (D7)
+# -------------------------------------------------------------------- ARC
 
 class _ArcContext:
     """Contexto mínimo para ``check_arc_chain``.
 
-    B06 pasó la regla a ``needs_context=True``: ya no le basta con las
+    La frontera de confianza pasó la regla a ``needs_context=True``: ya no le basta con las
     cabeceras, necesita la cadena Received para saber si quien dice haber
     validado la cadena ARC está por encima de la frontera de confianza.
     """
@@ -155,7 +155,7 @@ def test_arc_cv_pass_is_positive():
 
 
 def test_arc_cv_pass_alone_is_not_verified():
-    """B06: `cv=pass` es lo que el mensaje dice de sí mismo.
+    """`cv=pass` es lo que el mensaje dice de sí mismo.
 
     Iris no verifica firmas criptográficas, así que esa declaración no puede
     valer como prueba — cualquiera puede escribirla. La regla sigue
@@ -435,7 +435,7 @@ def test_missing_list_unsubscribe_is_neutral():
     assert result.score == 0
 
 
-# ------------------------------------------------- RFC 2047 encoded-subject bypass (B5)
+# ------------------------------------------------- RFC 2047 encoded-subject bypass
 
 def test_encoded_subject_does_not_bypass_keyword_scan():
     # "Account Suspended - Verify Now" Base64-encoded as an RFC 2047 word.
@@ -446,7 +446,7 @@ def test_encoded_subject_does_not_bypass_keyword_scan():
     assert result.verdict.startswith("alarming_")
 
 
-# ----------------------------------------------------------------- Verdict gating (B3)
+# ----------------------------------------------------------------- Verdict gating
 
 def _rr(verdict, **details):
     return RuleResult(score=0, verdict=verdict, details=details)
@@ -480,12 +480,12 @@ def test_gating_caps_at_suspicious_on_domain_misalignment():
 
 
 def test_gating_verified_arc_pass_softens_spf_dmarc_alignment_gates():
-    # D7: a legitimate forward validated by ARC (cv=pass) must not trip
+    # A legitimate forward validated by ARC (cv=pass) must not trip
     # the SPF/DMARC/alignment gates that exist to catch spoofing --
     # mailing lists/forwarders routinely break raw SPF/alignment as a
     # side effect of legitimate relaying.
     #
-    # B06 añade la condición que faltaba: la validación tiene que venir
+    # La frontera de confianza añade la condición que faltaba: la validación tiene que venir
     # confirmada por un verificador de confianza (`verified`), no del propio
     # sello del mensaje.
     named = {
@@ -498,7 +498,7 @@ def test_gating_verified_arc_pass_softens_spf_dmarc_alignment_gates():
 
 
 def test_gating_unverified_arc_pass_no_longer_softens_the_gates():
-    """B06, el bypass que se cierra.
+    """El bypass que cierra la frontera de confianza.
 
     Antes bastaba con escribir `ARC-Seal: cv=pass` en el propio correo para
     desactivar de golpe los tres gates que cazan suplantación. Ahora un ARC sin
@@ -586,7 +586,7 @@ def test_gating_forces_phishing_on_link_brand_impersonation():
 
 
 def test_gating_forces_phishing_on_suspicious_qr_code():
-    # D1: a QR code decoding to a suspicious URL is a strong evasion
+    # A QR code decoding to a suspicious URL is a strong evasion
     # signal on its own -- it never appears as text/link anywhere.
     named = {
         "QR Code Links": _rr("fail"),
@@ -596,7 +596,7 @@ def test_gating_forces_phishing_on_suspicious_qr_code():
 
 
 def test_gating_returns_human_readable_reasons():
-    # S1: the reasons that fired must be surfaced (not just logged) so the
+    # The reasons that fired must be surfaced (not just logged) so the
     # report can explain WHY the verdict was gated.
     named = {"Lookalike Sender Domain": _rr("fail")}
     verdict, reasons = IrisManager._apply_verdict_gates("Legitimate", named)
@@ -611,7 +611,7 @@ def test_gating_returns_empty_reasons_when_clean():
     assert reasons == []
 
 
-# --------------------------------------------------------------- Top signals (S2)
+# --------------------------------------------------------------- Top signals
 
 def _rd(rule_name, score, category="header_analysis"):
     return {"ruleName": rule_name, "category": category, "score": score,
@@ -649,7 +649,7 @@ def test_top_signals_caps_at_limit_and_keeps_original_index():
 
 def _unfamilied_defs(count: int) -> list[dict]:
     # No `family` key -> passes through _aggregate_score's family-cap logic
-    # untouched, matching these tests' original (pre-§18) intent.
+    # untouched, matching these tests' original intent, from before family caps existed.
     return [{"name": f"Rule{i}", "family": ""} for i in range(count)]
 
 
@@ -735,7 +735,7 @@ def test_iocs_empty_lists_when_headers_only_and_clean(monkeypatch):
 
 
 def test_iocs_includes_attachment_sha256(monkeypatch):
-    # D8: every attachment's hash is surfaced as an IOC, not just ones a
+    # Every attachment's hash is surfaced as an IOC, not just ones a
     # rule flagged as suspicious.
     import base64
     import hashlib
@@ -827,7 +827,7 @@ def test_generate_ai_summary_rejects_unfinished_analysis(monkeypatch):
 
 
 def test_generate_ai_summary_submits_task_for_finished_analysis(monkeypatch):
-    """B10 añadió dos pasos con estado a esta función —reclamar la fila y
+    """El cobro idempotente añadió dos pasos con estado a esta función —reclamar la fila y
     cobrar cuota— que un test sin base de datos no puede ejercitar.
 
     Aquí se sustituyen los dos por dobles para que el test siga siendo lo que

--- a/API/tests/unit/test_lybra_cascade.py
+++ b/API/tests/unit/test_lybra_cascade.py
@@ -236,8 +236,8 @@ def test_a_blind_probe_that_raises_does_not_stop_the_next_one():
 
 def test_the_cascade_is_derived_from_the_registry_not_a_parallel_list():
     """La razón de que `banner_readers` y `blind_probers` se calculen y no se
-    escriban: una lista paralela es exactamente lo que se queda atrás. #272
-    documenta el caso — un mapa a mano con dos entradas mientras el módulo ya
+    escriban: una lista paralela es exactamente lo que se queda atrás. Ya
+    pasó: un mapa a mano con dos entradas mientras el módulo ya
     definía once predicados."""
     dissectors = default_dissectors()
     readers = {dissector.label for dissector in banner_readers(dissectors)}

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -629,7 +629,7 @@ def test_a_tls_service_on_an_arbitrary_port_still_misses_the_hygiene_checks():
     El esquema ya se observa, así que un TLS en 7777 se sondea bien y recibe
     los checks de cabeceras. Lo que no recibe son los de higiene de
     certificado: su candidatura sigue decidiéndose por número de puerto.
-    Hacerla observada del todo es #283.
+    Hacerla observada del todo está pendiente.
     """
     from src.modules.features.themis.lybra import is_tls_service
 

--- a/API/tests/unit/test_lybra_correlation.py
+++ b/API/tests/unit/test_lybra_correlation.py
@@ -167,7 +167,7 @@ def test_a_partial_scan_still_states_what_it_did_see():
     ({"cvss_score": 5.0, "epss_score": 0.6}, "public", "HIGH"),     # high EPSS escalates
     ({"cvss_score": 0.0, "confirmed": True}, "public", "MEDIUM"),   # confirmed w/o CVSS floors
     ({"cvss_score": 0.0}, "public", "INFO"),
-    # required_os (#118): an unconfirmed, platform-gated CVSS 9.8 match cannot
+    # required_os: an unconfirmed, platform-gated CVSS 9.8 match cannot
     # be verified without OS-detection, so it is capped at MEDIUM instead of
     # reading as CRITICAL.
     ({"cvss_score": 9.8, "required_os": "windows_10"}, "public", "MEDIUM"),

--- a/API/tests/unit/test_lybra_dsl_chaining.py
+++ b/API/tests/unit/test_lybra_dsl_chaining.py
@@ -216,7 +216,7 @@ def test_the_first_matching_payload_wins_as_a_single_finding():
     assert len(tried) == 1                                # paró en el primero
 
 
-# =============================================== validación de forma (CI, #275)
+# ===================================================== validación de forma (CI)
 
 
 def test_the_shipped_feed_including_the_payload_check_is_well_formed():

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -295,7 +295,7 @@ def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     assert vuln["confirmed"] is True
 
 
-# ------------------------------------------- marca de reproducibilidad (#270)
+# -------------------------------------------------- marca de reproducibilidad
 #
 # Cada hallazgo lleva una marca que dice contra qué se resolvió. Para los checks
 # activos era cierta (sube cada vez que cambia el feed); para la detección por
@@ -369,7 +369,7 @@ def test_the_mark_fits_in_the_column_that_stores_it():
 
 
 def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
-    """El criterio de cierre de #267, extremo a extremo dentro del motor.
+    """El comparador de versiones de distribución, extremo a extremo en el motor.
 
     El inventario de un agente entrega versiones de paquete de distribución
     (`1:7.4-1ubuntu1`), y NVD sólo publica rangos sobre versiones de

--- a/API/tests/unit/test_lybra_feed_shape.py
+++ b/API/tests/unit/test_lybra_feed_shape.py
@@ -104,8 +104,8 @@ def test_a_script_without_plugin_is_reported(feed):
 
 
 def test_a_network_service_without_predicate_is_reported(feed):
-    """El caso de #272: un check ``network`` para un protocolo que ningún
-    predicado reconoce. Aquel arreglo lo hizo fallar al cargar; esta validación
+    """Un check ``network`` para un protocolo que ningún predicado reconoce.
+    Cargar el feed ya falla en ese caso; esta validación
     lo encuentra además sobre un feed externo, que no pasa por ese camino."""
     # El nombre tiene que ser uno que ningún `is_*_service` reconozca. Aquí
     # estuvo "postgres" hasta que L12 le dio su predicado, que es justo la

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -329,7 +329,7 @@ def test_the_longest_possible_v4_vector_fits_in_the_column():
     assert len(peor_caso) <= CveEntry.__table__.c.cvss_vector.type.length
 
 
-# ------------------------------------------------- platform-gated CVEs (#118)
+# -------------------------------------------------------- platform-gated CVEs
 
 def _and_node_item(platform_cpe: str) -> dict:
     """One CVE whose only applicability node ANDs an Apache match with a
@@ -352,7 +352,7 @@ def test_ingest_nvd_cve_and_node_tags_software_match_with_platform():
     """NVD's 'product AND platform' node shape must gate the software row
     with the platform's product token — the mechanism behind CVE-2024-38472-
     style ("...on Windows") false positives reported against non-Windows
-    hosts (Issue #118)."""
+    hosts."""
     item = _and_node_item("cpe:2.3:o:microsoft:windows_10:*:*:*:*:*:*:*:*")
     _cve, matches = ingest_nvd_cve(item)
     assert len(matches) == 1  # the platform-only cpeMatch produces no row of its own

--- a/API/tests/unit/test_lybra_package_invariants.py
+++ b/API/tests/unit/test_lybra_package_invariants.py
@@ -1,5 +1,4 @@
-"""Invariantes estructurales del motor Lybra (D1 en
-plans/deuda-tecnica-y-calidad.md, y L52).
+"""Invariantes estructurales del motor Lybra.
 
 Son dos, y protegen cosas distintas: que la capa pura ``themis/lybra/`` no
 toque el ORM, y que la capa con efectos ``themis/managers/lybra/`` no dependa

--- a/API/tests/unit/test_nuclei_adapter.py
+++ b/API/tests/unit/test_nuclei_adapter.py
@@ -170,7 +170,7 @@ def test_cpe_and_cvss_vector_read_from_classification():
     assert f["cvss_vector"] == "CVSS:3.1/x"
 
 
-# ------------------------------------------------------- finding_to_json (#118)
+# -------------------------------------------------------------- finding_to_json
 
 def test_finding_to_json_exposes_required_os_and_feeds_the_cap_into_priority():
     """An unconfirmed, platform-gated CVSS 9.8 finding must serialize its

--- a/API/tests/unit/test_scan_deadline_closes_the_row.py
+++ b/API/tests/unit/test_scan_deadline_closes_the_row.py
@@ -1,7 +1,7 @@
 """Un escaneo que agota su plazo cierra su fila en vez de quedarse «escaneando».
 
 La cola mata un trabajo que se pasa de tiempo lanzándole ``JobDeadlineExceeded``
-desde fuera. Esa excepción hereda de ``BaseException`` a propósito (#395), para
+desde fuera. Esa excepción hereda de ``BaseException`` a propósito, para
 que ningún ``except Exception`` del código de negocio la confunda con un fallo
 de red y se la trague.
 
@@ -78,7 +78,7 @@ def test_an_external_scanner_out_of_time_is_failed_with_its_reason(monkeypatch):
 
 def test_the_deadline_keeps_climbing_after_the_row_is_closed(monkeypatch):
     """Si se capturara sin volver a lanzarla, la fila diría «falló» y la cola
-    diría «terminado con éxito» — la contradicción de #395 otra vez, del revés.
+    diría «terminado con éxito» — la misma contradicción, del revés.
 
     Además el temporizador dispara una sola vez: un plazo tragado deja al
     trabajo corriendo sin ningún límite a partir de ese momento.

--- a/API/tests/unit/test_scheduling_semantics.py
+++ b/API/tests/unit/test_scheduling_semantics.py
@@ -1,5 +1,4 @@
-"""``calculate_next_run`` y ``_build_trigger`` no pueden divergir en silencio
-(A12 en plans/deuda-tecnica-y-calidad.md).
+"""``calculate_next_run`` y ``_build_trigger`` no pueden divergir en silencio.
 
 ``ThemisScheduler`` calcula "cuándo dispara" por dos caminos independientes:
 

--- a/API/tests/unit/test_scribe_generator.py
+++ b/API/tests/unit/test_scribe_generator.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Scribe payload-size guardrail (Issue #118).
+"""Unit tests for the Scribe payload-size guardrail.
 
 Covers the heuristic token estimate (``estimate_tokens`` / ``AIInput.estimated_tokens``)
 and ``AIGenerator``'s pre-flight check: an oversized prompt must be rejected

--- a/API/tests/unit/test_themis_ai_analysis_error_message.py
+++ b/API/tests/unit/test_themis_ai_analysis_error_message.py
@@ -1,4 +1,4 @@
-"""Unit tests for how the PDF report reacts when the AI writer fails (#118).
+"""Unit tests for how the PDF report reacts when the AI writer fails.
 
 ``PrintingStrategy._append_ai_analysis`` used to catch every exception the
 same way, rendering a generic "No se pudo generar análisis IA" paragraph

--- a/API/tests/unit/test_themis_ai_writer.py
+++ b/API/tests/unit/test_themis_ai_writer.py
@@ -214,7 +214,7 @@ def test_rollup_de_servicios_se_recorta_al_tope_priorizando_severidad(monkeypatc
     assert servicios[0]["producto"] == "product-critico 1.0"
 
 
-# ------------------------------------------------------- NmapAIWriter (#118)
+# -------------------------------------------------------------- NmapAIWriter
 
 _FAKE_NMAP_PROMPTS = {
     "nmap": {

--- a/web/app/src/components/config/ScannerCard.vue
+++ b/web/app/src/components/config/ScannerCard.vue
@@ -34,7 +34,7 @@ const props = defineProps({
   prefix: { type: String, required: true },
   flat: { type: Object, required: true },
   // Colapsada por defecto para que las cuatro tarjetas de Themis empiecen a la
-  // misma altura (issue #451): expandir una no debe descolocar a las demás,
+  // misma altura: expandir una no debe descolocar a las demás,
   // así que cada tarjeta abre de forma independiente, no en modo acordeón.
   defaultOpen: { type: Boolean, default: false },
 })

--- a/web/app/src/components/iris/IrisDocumentsModal.vue
+++ b/web/app/src/components/iris/IrisDocumentsModal.vue
@@ -112,7 +112,7 @@ function verdictClass(v) {
 <style scoped>
 /* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
    (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
-   se borra (#131). */
+   se borra. */
 .modal {
   position: fixed;
   inset: 0;

--- a/web/app/src/components/iris/IrisForm.vue
+++ b/web/app/src/components/iris/IrisForm.vue
@@ -57,7 +57,7 @@ const props = defineProps({
 
 const headers = ref(props.prefill?.headers ?? '')
 const title = ref(props.prefill?.title ?? '')
-// Mensaje .eml completo (Fase 2), si el archivo arrastrado se cargó entero.
+// Mensaje .eml completo, si el archivo arrastrado se cargó entero.
 const message = ref(props.prefill?.message ?? null)
 // Cabeceras tal como llegaron del prefill: si el usuario las edita, ya no
 // podemos garantizar que sigan correspondiendo al mensaje completo cargado,

--- a/web/app/src/components/iris/IrisIocsPanel.vue
+++ b/web/app/src/components/iris/IrisIocsPanel.vue
@@ -19,7 +19,7 @@
 
 <script setup>
 /**
- * Contenido "con datos" del panel de IOCs de IrisReportViewer (A3).
+ * Contenido "con datos" del panel de IOCs de IrisReportViewer.
  *
  * El padre conserva el chrome colapsable (botón + Transition) y los estados
  * de carga/vacío: usan clases (.rv-path-loading, .spinner, .rv-path-empty)

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -87,7 +87,7 @@
       <!-- Score + Verdict hero -->
       <IrisVerdictHero :score="reportData.totalScore" :verdict="reportData.verdict" />
 
-      <!-- Análisis degradado (B05): alguna regla no llegó a ejecutarse, así que
+      <!-- Análisis degradado: alguna regla no llegó a ejecutarse, así que
            una parte del mensaje no se ha inspeccionado. Va inmediatamente
            debajo del veredicto porque lo matiza: quien lea el número grande
            tiene que saber que se calculó sin parte del examen. -->
@@ -325,7 +325,7 @@ const rulesWithIndex = computed(() =>
 )
 const flaggedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict !== 'pass'))
 
-// Análisis degradado (B05): alguna regla lanzó una excepción y no llegó a
+// Análisis degradado: alguna regla lanzó una excepción y no llegó a
 // ejecutarse. No es lo mismo que una regla que encontró algo malo —esas
 // aparecen en flaggedRules con su puntuación— sino una parte del mensaje que
 // nadie miró, y por eso el aviso va arriba y no entre los hallazgos.
@@ -350,7 +350,7 @@ async function jumpToRule(i) {
   ruleCardEls[i]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
 }
 
-// A3: valor ya resuelto desde la API pública del store — antes se leían
+// Valor ya resuelto desde la API pública del store — antes se leían
 // pathCache/currentPath (cachés internos de la estrategia de carga bajo
 // demanda) directamente desde el componente.
 const pathData = computed(() => irisStore.resolvedPathFor(props.reportId))

--- a/web/app/src/components/iris/IrisVerdictHero.vue
+++ b/web/app/src/components/iris/IrisVerdictHero.vue
@@ -13,7 +13,7 @@
 
 <script setup>
 /**
- * Score + veredicto de IrisReportViewer (A3). Bloque autónomo: sus clases
+ * Score + veredicto de IrisReportViewer. Bloque autónomo: sus clases
  * (.rv-hero*, .score-*, .verdict-*) no se comparten con ninguna otra
  * sección del informe, así que no hace falta duplicar nada en el padre.
  */

--- a/web/app/src/components/iris/intake.js
+++ b/web/app/src/components/iris/intake.js
@@ -5,7 +5,7 @@
  * son funciones puras sin DOM, igual que `components/hygeia/format.js`, así
  * que corren con `node` a secas (ver `test/iris.intake.test.mjs`).
  *
- * El segundo es el que motiva B13. El tope de tamaño estaba escrito a mano en
+ * El segundo es la razón de ser de este módulo. El tope de tamaño estaba escrito a mano en
  * la vista (`20 * 1024 * 1024`) mientras el backend aplicaba otro
  * (`iris.maxMessageBytes`, 10 MiB): el usuario elegía un fichero que la
  * interfaz daba por bueno, esperaba a que se cargara entero en memoria y

--- a/web/app/src/components/shared/WhiteLabelFields.vue
+++ b/web/app/src/components/shared/WhiteLabelFields.vue
@@ -248,7 +248,7 @@ function onFile(event) {
      static) — que no hace scroll — dejando el input clavado en un punto fijo
      mientras .panel-content (el que sí scrollea, y queda por medio) se movía
      por su cuenta. Al enfocarlo el navegador lo llevaba a su posición real
-     (desincronizada), desplazando toda la página. Refs #135. */
+     (desincronizada), desplazando toda la página. */
   position: relative;
   display: inline-flex; align-items: center; justify-content: center;
   padding: 0.4rem 0.75rem; border-radius: 7px; cursor: pointer;

--- a/web/app/src/components/themis/ScanPreviewModal.vue
+++ b/web/app/src/components/themis/ScanPreviewModal.vue
@@ -129,7 +129,7 @@ function fmtDate(iso) { if (!iso) return ''; return new Date(iso).toLocaleDateSt
 <style scoped>
 /* Antes heredado de la regla global `.modal`/`.modal.visible` de shared.css
    (legacy pre-Vue): posición, capa y centrado propios, ahora que ese bloque
-   se borra (#131). */
+   se borra. */
 .modal {
   position: fixed;
   inset: 0;

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -27,7 +27,7 @@ export const useIrisStore = defineStore('iris', () => {
   // hardcodee. Los valores por defecto solo se usan hasta el primer fetch.
   const thresholds = reactive({ legitimate: 80, suspicious: 55 })
 
-  // B13: límites que aplica el servidor (`GET /iris/capabilities`). La vista
+  // Límites que aplica el servidor (`GET /iris/capabilities`). La vista
   // los necesita para decidir igual que el API en vez de replicar constantes:
   // el tope de tamaño estaba escrito a mano allí y había derivado al doble
   // del real, así que el usuario cargaba en memoria ficheros que el backend
@@ -46,13 +46,13 @@ export const useIrisStore = defineStore('iris', () => {
 
   const documents = ref([])
   const documentsLoading = ref(false)
-  // Map de documentId -> poller de usePolling (E8). No reactive: nadie
+  // Map de documentId -> poller de usePolling. No reactive: nadie
   // renderiza a partir de él, solo se arranca y se para.
   const documentPollers = new Map()
 
   let statusPoller = null
 
-  // Fase 2: si hay un mensaje completo (.eml arrastrado) se envía en
+  // Si hay un mensaje completo (.eml arrastrado) se envía en
   // "message" para que el backend analice cuerpo, enlaces y adjuntos
   // reales; "headers" se mantiene como respaldo cuando solo se pegaron
   // cabeceras a mano.
@@ -285,7 +285,7 @@ export const useIrisStore = defineStore('iris', () => {
     }
   }
 
-  // A3: getters de valor ya resuelto — antes IrisReportViewer.vue leía
+  // Getters de valor ya resuelto — antes IrisReportViewer.vue leía
   // pathCache/currentPath/iocsCache/currentIocs directamente (cachés
   // internos de la estrategia de carga bajo demanda, no la API pública del
   // store). El componente ahora solo conoce estos cuatro getters.
@@ -326,7 +326,7 @@ export const useIrisStore = defineStore('iris', () => {
     statusPoller.start()
   }
 
-  // B10/E8: el re-encadenado y la invalidación de ciclos en vuelo los aporta
+  // El re-encadenado y la invalidación de ciclos en vuelo los aporta
   // ahora `usePolling`; aquí solo queda qué pedir y cuándo parar. Devolver
   // `false` es la condición terminal.
   async function _pollStatus(id) {
@@ -508,8 +508,8 @@ export const useIrisStore = defineStore('iris', () => {
 
   /** Sondea el estado de un documento en generación hasta que termine.
    *
-   * E8: usaba `setInterval`, el idioma que este mismo fichero documenta como
-   * incorrecto unas líneas más arriba (B10) — con la petición tardando más
+   * Usaba `setInterval`, el idioma que este mismo fichero documenta como
+   * incorrecto unas líneas más arriba — con la petición tardando más
    * de 2 s se solapaban varias. `usePolling` re-encadena. */
   function pollDocumentStatus(documentId, analysisId) {
     if (documentPollers.has(documentId)) return

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -670,8 +670,8 @@ function handleSave() { store.saveConfig() }
 .collapsible + .collapsible { margin-top: 0.5rem; }
 /* `align-items: start` evita que Grid estire cada tarjeta a la altura de la más
    alta de su fila (Lybra, con varias subsecciones, frente a Nmap/Nikto casi
-   sin opciones propias) — ese estirado era el hueco vacío que denunciaba el
-   issue #451, no un exceso de contenido de Lybra. */
+   sin opciones propias) — ese estirado era el hueco vacío que se veía, no
+   un exceso de contenido de Lybra. */
 .scanner-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.85rem; margin-top: 0.85rem; align-items: start; }
 .form-group { display: flex; flex-direction: column; gap: 0.25rem; }
 .form-group label { font-size: var(--fs-md); font-weight: 600; color: var(--text-dim); }

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -109,10 +109,10 @@ const archiveOpen = ref(false)
 // Relleno automático del formulario a partir de un .eml arrastrado.
 const prefill = ref(null)
 
-// Fase 2: enviamos el .eml completo (cuerpo, enlaces, adjuntos) para que las
+// Enviamos el .eml completo (cuerpo, enlaces, adjuntos) para que las
 // reglas de contenido puedan analizarlo.
 //
-// B13: el tope ya no se escribe aquí. Era `20 * 1024 * 1024` mientras el
+// El tope ya no se escribe aquí. Era `20 * 1024 * 1024` mientras el
 // backend aplicaba 10 MiB, así que la vista aceptaba ficheros que el API iba
 // a rechazar — después de haberlos leído enteros en memoria. Ahora sale de
 // `GET /iris/capabilities` y la decisión vive en `intake.js`, que es puro y
@@ -181,7 +181,7 @@ async function onDrop(e) {
       return
     }
     // Conservamos el mensaje completo (cuerpo, enlaces, adjuntos) para que
-    // Iris pueda aplicar las reglas de Fase 2; si el archivo se truncó por
+    // Iris pueda aplicar las reglas de contenido; si el archivo se truncó por
     // tamaño, solo enviamos las cabeceras extraídas como respaldo.
     prefill.value = {
       headers: rawHeaders,

--- a/web/app/src/views/LandingView.vue
+++ b/web/app/src/views/LandingView.vue
@@ -627,7 +627,7 @@ onUnmounted(() => {
    (`.scene { overflow: hidden }`), así que este `overflow` no protegía nada
    del fondo — solo recortaba, sin querer, cualquier desplegable de la
    cabecera (AccountMenu, Herramientas, Documentación) que no cupiera en los
-   100vh del hero (issue #140). */
+   100vh del hero. */
 .vista {
   position: relative;
   height: 100vh;


### PR DESCRIPTION
## Resumen

Los comentarios, docstrings y tests de Iris citaban por código los apartados de un roadmap: `B09: comprobar idempotencia…`, `(M09/B17/B19)`, `# --- B16: folder`, `El caso que motiva B04`, `G-C (red team)`, `Fase 2`… Para quien lee el código son etiquetas opacas: `B06` no dice nada si no se abre el documento y se busca el apartado. Además, ese documento está vivo, así que la etiqueta puede quedarse sin nada detrás.

Este PR es el tercero de la limpieza que empezó en #565. Quita esos códigos de todo lo que es de Iris: backend, tests y SPA.

## Qué se ha hecho

Unas 280 líneas en 74 ficheros, en dos pasadas.

**Una pasada mecánica** para las tres formas que no necesitan reescritura, porque la explicación ya estaba escrita:
- sufijos entre paréntesis que solo contienen códigos (`… del servidor (M10).` pasa a `… del servidor.`);
- prefijos delante de la explicación (`# B02: serializa los syncs…` pasa a `# Serializa los syncs…`);
- rótulos de sección de los tests (`# --- B16: folder` pasa a `# --- folder`).

Esta pasada solo actúa sobre comentarios y docstrings, nunca sobre código. Cuando el paréntesis abría la línea, el signo que quedaba suelto sube a la línea anterior para no dejar una línea empezando por coma.

**Una pasada manual** para los casos en que el código formaba parte de la frase. Por ejemplo:
- Los cinco gates de la recalibración de pesos (`G-A` … `G-E`) pasan a llamarse por el nombre de su regla: *Auth Results Provenance*, *Recipient Domain Lookalike*, *Display Name Foreign Address*, *TOAD Callback Pattern* y *External Login Link*.
- «Fase 2» era el soporte de **mensaje `.eml` completo** (cuerpo, enlaces y adjuntos), y «Fase 3-4» la **ingesta automática de buzón**. Ahora se dice así.
- «El caso que motiva B04», «el bypass que cierra B06», «el criterio de cierre de B17»… se reescriben describiendo el caso: el cambio de criterio de la reconciliación, la frontera de confianza de la cadena `Received`, que la retención no deje filas huérfanas.
- «las preferencias de M08» pasan a ser las **preferencias de notificación**.

Se dejan a propósito las referencias a estándares externos, como `RFC 8617 §5.2`: son documentos públicos y estables, no planes internos.

## Validación

- Una búsqueda de códigos (`BNN`, `MNN`, `G-X`, `§N` fuera de RFC, `Fase N`) sobre los ficheros de Iris no devuelve nada.
- Ninguna línea modificada pasa de 100 caracteres, y ninguna empieza por un signo suelto.
- Tests de Iris (`tests/integration/test_iris*.py` y `tests/unit/test_iris*.py`): **607 aprobados**, sin fallos.
- Test de intake del SPA (`node test/iris.intake.test.mjs`): **23 aprobados**.
- Los `.vue` modificados compilan con `@vue/compiler-sfc` (plantilla, script y estilos). El `npm run build` local no sirve de comprobación: falla antes, en `AcheronView.vue`, por una dependencia privada (`@projectellysia/acheron-core-web`) que no está instalada en esta máquina y que nada tiene que ver con este cambio.

## Notas

- Sin cambios de comportamiento: solo comentarios y docstrings, más una cadena de descripción de regla en `body_links_rules.py` que ya no menciona el código `G-E`.
- La rama sale del commit de #565, así que hasta que ese PR se mergee el diff incluye también sus cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
