### PR TITLE
chore(themis): quitar códigos de plan del motor Lybra

### DIFF
--- a/API/src/modules/features/themis/lybra/__init__.py
+++ b/API/src/modules/features/themis/lybra/__init__.py
@@ -9,28 +9,27 @@ A scan flows down through the engine's layers, and each module here owns one of
 them:
 
 ``transport``
-    Discovers which ports are open (the L0 layer) — an unprivileged asyncio
-    connect scan.
+    Discovers which ports are open — an unprivileged asyncio connect scan.
 
 ``fingerprinting``
-    Identifies what is running on a port (L1) — one dissector module per
+    Identifies what is running on a port — one dissector module per
     protocol (HTTP, SSH, TLS, FTP, SMTP/IMAP/POP3, SMB, MySQL, Redis, VNC...),
     calibrated against Nmap where an oracle bench exists.
 
 ``engine``
-    The detection core (L2): turns discovered services into findings, including
+    The detection core: turns discovered services into findings, including
     version-based CVE matches.
 
 ``checks``
-    The active-detection runtime (also L2): runs declarative checks to *confirm*
-    a vulnerability rather than merely infer it.
+    The active-detection runtime: runs declarative checks to *confirm* a
+    vulnerability rather than merely infer it.
 
 ``kb``
-    The local knowledge base (L3): a mirror of NVD/KEV/EPSS plus the version and
+    The local knowledge base: a mirror of NVD/KEV/EPSS plus the version and
     CPE logic the matcher relies on.
 
 ``correlation``
-    Deduplication, lifecycle and contextual scoring (L3): turns per-scan findings
+    Deduplication, lifecycle and contextual scoring: turns per-scan findings
     into vulnerability state on an asset over time.
 
 ``adapters``

--- a/API/src/modules/features/themis/lybra/adapters.py
+++ b/API/src/modules/features/themis/lybra/adapters.py
@@ -14,7 +14,7 @@ ruled out because its report/chart code has no test coverage and could not
 be rewritten safely in a single pass.
 
 OpenVAS had the same adapter (``openvas_result_to_finding``) until the
-scanner was removed (roadmap §7/§6.3, Ronda 2 — E2). Its historical
+scanner was removed. Its historical
 ``Finding`` rows — ``source="openvas"``, ``check_id`` prefixed
 ``"openvas:"`` — are unaffected: they live in the source-agnostic Finding
 table this module writes into, not in anything this file owns.
@@ -117,7 +117,7 @@ def nuclei_result_to_finding(result: dict, feed_version: str = "nuclei-templates
     Nuclei's output maps almost 1:1 onto ``Finding`` — unlike Nikto's
     ``osvdb_id``, a matched template can carry a real CVE, CVSS and EPSS score
     straight from its ``info.classification`` block. That is what lets a Nuclei
-    scan enter the multi-source deduplication (Fase 5) for free.
+    scan enter the multi-source deduplication for free.
 
     Args:
         result: One decoded JSONL line, as produced by ``NucleiResultProcessor``.
@@ -210,7 +210,7 @@ def _stable_hash(*parts: str) -> str:
 
 
 def finding_to_json(f: dict, exposure: str) -> dict:
-    """Serialize one ``Finding`` snapshot dict to the API JSON shape (A5).
+    """Serialize one ``Finding`` snapshot dict to the API JSON shape.
 
     Shared by ``LybraEngineManager.format_scan`` and
     ``NucleiScanManager.format_scan`` — both hand-wrote the same fifteen-key

--- a/API/src/modules/features/themis/lybra/backports.py
+++ b/API/src/modules/features/themis/lybra/backports.py
@@ -1,9 +1,9 @@
-"""Preguntarle al proveedor si esa vulnerabilidad ya está corregida (Fase O).
+"""Preguntarle al proveedor si esa vulnerabilidad ya está corregida.
 
 Un *backport* es una distribución arreglando un fallo sin subir el número de
 versión visible: Debian parchea ``apache2``, el banner sigue diciendo
 ``2.4.49``, y el motor emite una CVE que ya no existe. Es la causa número uno
-de falsos positivos de toda la detección por versión — la Fase 1 la midió en
+de falsos positivos de toda la detección por versión — se ha medido en
 **0,42**: cuatro de cada diez CVEs reportados contra un Debian o un Ubuntu ya
 estaban corregidos.
 
@@ -135,9 +135,9 @@ def _package_name(finding: dict) -> Optional[str]:
     coinciden, la consulta no encuentra nada y el hallazgo se queda como
     estaba, que es el comportamiento seguro.
 
-    ponytail: una tabla de equivalencias paquete-distro ↔ producto-NVD es el
-    siguiente paso natural, y tiene ya dónde apoyarse — el ranking de nombres
-    sin resolver de L37 mide exactamente esta clase de desajuste.
+    Pendiente: una tabla de equivalencias paquete-distro ↔ producto-NVD
+    resolvería este desajuste de nombres de forma sistemática en vez de
+    depender de que coincidan por casualidad.
     """
     package = finding.get("_package_name") or finding.get("service") or ""
     return package.strip().lower() or None

--- a/API/src/modules/features/themis/lybra/checks.py
+++ b/API/src/modules/features/themis/lybra/checks.py
@@ -11,14 +11,14 @@ deliberately mirrors the shape of Nuclei's own templates. JSON is still
 accepted by the loader — the two are the same object graph, and an external
 feed may arrive as either — but the first-party feed is YAML.
 
-The scope of this layer covers the three highest-value, lowest-cost families the
-roadmap names first: exposed paths (like ``/.git/config``), missing security
+The scope of this layer covers the three highest-value, lowest-cost families:
+exposed paths (like ``/.git/config``), missing security
 headers, and TLS/certificate hygiene (self-signed, expired, deprecated
 protocol — a ``type: "tls"`` check, evaluated against a handshake instead of an
 HTTP request/response), plus the raw protocol probes of ``type: "network"``
-(Fase N) and the first-party plugins of ``type: "script"`` (Fase R) for what no
+and the first-party plugins of ``type: "script"`` for what no
 text matcher can express — a binary protocol, a multi-step negotiation. An
-``http`` check can also **chain** requests (L30): an ``extractors`` block pulls
+``http`` check can also **chain** requests: an ``extractors`` block pulls
 a variable out of one response — a session cookie, a CSRF token, a version
 string — and later requests in the same check reference it as ``{{name}}`` in
 their path, body or headers. **Payloads** (``payloads: {name: [v1, v2, ...]}``)
@@ -30,7 +30,7 @@ The runtime is pure given an injected ``fetch`` callable, so it can be
 unit-tested with hand-crafted responses and never touches the network in tests.
 In production the manager wires the real :class:`HttpProbe`, and only when an
 opt-in config flag is set — active checks reach out and touch the target, and so
-must wait on the authorized-targets register the roadmap calls for.
+must wait on the authorized-targets register.
 """
 
 from __future__ import annotations
@@ -75,8 +75,8 @@ QOD_CONFIRMED = 99
 
 # The feed shipped in the package's feeds/ directory, alongside every other
 # Lybra feed (tech_signatures.json for the HTTP dissector, ...). YAML rather
-# than JSON since Fase R: it is Nuclei's own format — which this schema aims to
-# stay reasonably compatible with — and it takes comments, which in a feed of
+# than JSON: it is Nuclei's own format — which this schema aims to stay
+# reasonably compatible with — and it takes comments, which in a feed of
 # detection rules is the difference between being able to explain why a check
 # exists and not.
 _BUNDLED_FEED = Path(__file__).parent / "feeds" / "checks_feed.yaml"
@@ -101,7 +101,7 @@ _HTTP_SERVICE_NAMES = {"http", "https", "http-proxy", "https-alt", "http-alt"}
 _TLS_HYGIENE_PORTS = {443, 8443, 9443, 10443, 4443, 7443, 8834, 9091, 5986, 636, 3269}
 
 # APIs de administración que hablan HTTP y publican su versión en un JSON sin
-# autenticar (L17). Cada familia tiene su propio predicado —y no uno común—
+# autenticar. Cada familia tiene su propio predicado —y no uno común—
 # porque el runtime de checks selecciona los servicios por ese nombre: con un
 # único ``admin_api``, el check de Docker se ejecutaría también contra el 9200
 # de Elasticsearch, seis peticiones donde basta una.
@@ -130,12 +130,12 @@ _ADMIN_API_PORTS = (
 # habría servido de nada. Y los de las APIs de administración: hablan HTTP, y
 # excluirlos dejaba fuera tanto los checks de exposición como los de higiene de
 # certificado sobre servicios que son de los más graves que se pueden encontrar
-# expuestos (L17).
+# expuestos.
 _HTTP_PORTS = {80, 8080, 8000, 8888, 8008} | _TLS_HYGIENE_PORTS | _ADMIN_API_PORTS
-# Service names and ports for FTP — Fase N's first ``type: "network"`` family.
+# Service names and ports for FTP, the first ``type: "network"`` family.
 _FTP_SERVICE_NAMES = {"ftp"}
 _FTP_PORTS = {21}
-# Fase N's remaining priority-1/2 protocols — same "name or well-known port"
+# The remaining priority-1/2 protocols — same "name or well-known port"
 # applicability shape as HTTP/FTP above.
 _SMTP_SERVICE_NAMES = {"smtp", "submission", "smtps"}
 _SMTP_PORTS = {25, 465, 587}
@@ -169,15 +169,15 @@ _VNC_SERVICE_NAMES = {"vnc"}
 _VNC_PORTS = {5900}
 _TELNET_SERVICE_NAMES = {"telnet"}
 _TELNET_PORTS = {23}
-# SNMP — el primer protocolo de esta tabla que habla UDP (Fase N/Ronda 1,
-# roadmap §6.3). 161 también aparece en WELL_KNOWN_PORTS como TCP, así que
-# is_snmp_service (más abajo) es el único predicado de este módulo que mira
-# service.protocol: sin esa guarda, un 161/tcp abierto arrastraría al
-# dissector y al check a un datagrama que ese servicio nunca contestará.
+# SNMP — el primer protocolo de esta tabla que habla UDP. 161 también aparece
+# en WELL_KNOWN_PORTS como TCP, así que is_snmp_service (más abajo) es el
+# único predicado de este módulo que mira service.protocol: sin esa guarda,
+# un 161/tcp abierto arrastraría al dissector y al check a un datagrama que
+# ese servicio nunca contestará.
 _SNMP_SERVICE_NAMES = {"snmp"}
 _SNMP_PORTS = {161}
 
-# El resto de la superficie UDP (L22). Todos comparten con SNMP la guarda de
+# El resto de la superficie UDP. Todos comparten con SNMP la guarda de
 # protocolo por el mismo motivo: 53, 123, 137 y 1434 existen también como
 # puertos TCP, y mandarle un datagrama a un servicio TCP es tiempo perdido y
 # un hallazgo duplicado con la misma ``dedup_key``.
@@ -468,9 +468,9 @@ class Check:  # pylint: disable=too-many-instance-attributes
             has already *proposed* that CVE for the service — never "just in
             case" — and, when it fires, promotes that hypothesis from
             ``confirmed=false, qod=70`` to ``confirmed=true, qod=99`` by merging
-            on the shared ``dedup_key`` (both carry the same ``cve_ids``). It is
-            the encadenamiento versión→confirmador the roadmap names as the
-            runtime's reason to exist. A confirmer never exploits: it checks the
+            on the shared ``dedup_key`` (both carry the same ``cve_ids``). This
+            version-to-confirmer chaining is the runtime's reason to exist. A
+            confirmer never exploits: it checks the
             condition without running anything on the target, or it is not
             written.
         tags: Free-form labels (Nuclei's ``info.tags``, plus vendor/product
@@ -519,7 +519,7 @@ class Check:  # pylint: disable=too-many-instance-attributes
 def load_feed_document(path: Path) -> dict:
     """Read a feed file into its raw document, dispatching on the extension.
 
-    YAML is the feed's own format (Fase R); JSON is still accepted because the
+    YAML is the feed's own format; JSON is still accepted because the
     two shapes are the same object graph, and an externally-supplied feed may
     arrive as either. Only the deserializer differs — :func:`_parse_check` is
     given identical dicts in both cases, which is what makes the migration a
@@ -693,7 +693,7 @@ CHECK_MODES = ("safe", "aggressive")
 CHECK_CATEGORIES = (
     "exposed_path",
     # Un servicio entero alcanzable sin credenciales, no un fichero suelto que
-    # se coló bajo la raíz web (L17). La distinción no es cosmética: un
+    # se coló bajo la raíz web. La distinción no es cosmética: un
     # `exposed_path` es un descuido del despliegue, y un `exposed_service` es
     # el propio servicio ofreciéndose sin puerta — una API de Docker en claro
     # es ejecución remota de código como root sin exploit ninguno.
@@ -738,8 +738,8 @@ def validate_checks(checks: Iterable[Check]) -> List[str]:  # pylint: disable=to
     los cuatro ``_applies_*``. En los tres casos el escaneo termina en verde y
     lo único que ocurre es que una vulnerabilidad deja de detectarse.
 
-    Esta función no juzga si un check es *bueno* —eso lo miden los bancos de la
-    Fase 1—, sólo si puede llegar a ejecutarse. Devuelve los problemas en vez
+    Esta función no juzga si un check es *bueno* —eso lo miden los bancos de
+    calibración—, sólo si puede llegar a ejecutarse. Devuelve los problemas en vez
     de lanzar, para poder revisar un feed entero de una pasada en lugar de
     arreglar de uno en uno; el test que la usa afirma que la lista está vacía.
 
@@ -956,7 +956,7 @@ def is_rdp_service(service: Service) -> bool:
 
 def is_redis_service(service: Service) -> bool:
     """Return whether a service should be probed by the Redis dissector or
-    ``type: "network"`` checks (Fase N)."""
+    ``type: "network"`` checks."""
     return (service.name or "").lower() in _REDIS_SERVICE_NAMES or service.port in _REDIS_PORTS
 
 
@@ -1140,7 +1140,7 @@ _TLS_RULES: Dict[str, Callable] = {
 
 @dataclass(frozen=True)
 class ScriptContext:
-    """The restricted API a ``type: "script"`` plugin runs against (Fase R).
+    """The restricted API a ``type: "script"`` plugin runs against.
 
     A script check exists for what a declarative one cannot express: binary
     protocols, multi-step negotiations, anything needing real logic. What it
@@ -1220,8 +1220,8 @@ class _CheckFamily:
     instead: whether it wants a look at a given service at all
     (``applies_to_service``), whether one specific check within that type
     applies (``check_matches``), and how to actually run it
-    (``run_check``). Adding a fourth type (Fase R's planned ``script``) means
-    adding one more family, not a fourth loop.
+    (``run_check``). Adding a fourth type — as ``script`` did, for checks no
+    text matcher can express — means adding one more family, not a fourth loop.
     """
     applies_to_service: Callable[[Service], bool]
     check_matches: Callable[[Check, Service], bool]
@@ -1246,14 +1246,14 @@ class CheckRuntime:
             ``type: "tls"`` checks. When omitted, TLS checks are simply skipped
             — callers that never wire a TLS probe pay nothing for this family.
         network_open: An optional ``(host, port) -> NetworkSession | None``
-            callable for ``type: "network"`` checks (Fase N). One session is
+            callable for ``type: "network"`` checks. One session is
             opened per check per service and every request in that check is
             exchanged over the *same* connection, in order — this is what
             makes a login sequence like FTP's ``USER``/``PASS`` work. Omitted
             the same way ``tls_fetch`` is: callers that never wire a network
             probe pay nothing for this family.
         script_plugins: An optional ``{plugin_id: ScriptPlugin}`` registry for
-            ``type: "script"`` checks (Fase R). Injected rather than imported
+            ``type: "script"`` checks. Injected rather than imported
             so this module never has to import the fingerprinting package,
             which would close an import cycle (the dissectors import their
             applicability predicates from here). Omitted the same way the two
@@ -1280,14 +1280,14 @@ class CheckRuntime:
         self._tls_fetch = tls_fetch
         self._network_open = network_open
         self._script_plugins = dict(script_plugins or {})
-        # El tope de expansiones de un payload (L30): un check que fuzzea corta
+        # El tope de expansiones de un payload: un check que fuzzea corta
         # aquí, pase lo que pase, para que no se vuelva un barrido de fuerza
         # bruta. El manager lo inyecta desde la config; el default de 25 es el
         # que un check declarativo espera si nadie lo toca.
         self._max_payload_expansions = max(1, int(max_payload_expansions))
         # Cómo se recorren los servicios. Por defecto, el ``map`` de siempre:
-        # uno detrás de otro. El manager inyecta aquí un pool acotado por host
-        # (L23), igual que ya inyecta las sondas — este módulo no conoce la
+        # uno detrás de otro. El manager inyecta aquí un pool acotado por host,
+        # igual que ya inyecta las sondas — este módulo no conoce la
         # configuración ni monta hilos por su cuenta.
         self._mapper: Callable = mapper or map
         self._cancel_check: Optional[Callable[[], bool]] = None
@@ -1336,7 +1336,7 @@ class CheckRuntime:
         :meth:`_probe_response` for why that is a property of this loop and not
         a caching layer.
 
-        Los servicios se evalúan **a la vez** dentro de un pool acotado (L23),
+        Los servicios se evalúan **a la vez** dentro de un pool acotado,
         no en fila india: estos checks son espera de red casi entera, y un
         servicio que no contesta retrasaba a todos los que venían detrás. El
         ritmo por host lo sigue marcando el limitador, que es seguro entre
@@ -1374,7 +1374,7 @@ class CheckRuntime:
     def _run_for_service(self, service: Service) -> List[dict]:
         """Ejecuta todos los checks aplicables a **un** servicio.
 
-        Es la unidad de trabajo del pool (L23), y la razón de que el pool sea
+        Es la unidad de trabajo del pool, y la razón de que el pool sea
         seguro sin candados: las cachés de respuesta y de handshake se indexan
         por ``(host, puerto, ...)``, así que **cada hilo toca sólo las claves de
         su propio servicio**. Dos checks del mismo servicio siguen compartiendo
@@ -1493,7 +1493,7 @@ class CheckRuntime:
             return None
         last_response, last_path = fired
         finding = self._finding(check, service)
-        # Evidencia (Fase E): la respuesta que provocó el hallazgo. Sólo para
+        # Evidencia: la respuesta que provocó el hallazgo. Sólo para
         # los confirmados —los que van a un informe— y sólo si la captura está
         # activada. El payload viaja en ``_evidence`` hasta la persistencia, que
         # lo redacta y lo separa en su propia fila. La ruta es la ya sustituida
@@ -1674,7 +1674,7 @@ class CheckRuntime:
             session.close()
 
     def _run_script_check(self, check: Check, host: str, service: Service) -> Optional[dict]:
-        """Run one ``type: "script"`` check against one service (Fase R).
+        """Run one ``type: "script"`` check against one service.
 
         The plugin handles its own rate limiting through the context, since
         only it knows how many exchanges it needs — unlike the declarative
@@ -1841,7 +1841,7 @@ class HttpProbe:
         detect_scheme: An injectable ``(host, port) -> bool`` telling whether
             the service speaks TLS. Defaults to :func:`negotiates_tls`; a test
             passes a stub instead of opening a socket.
-        user_agent: The ``User-Agent`` header the probe presents (L39).
+        user_agent: The ``User-Agent`` header the probe presents.
     """
 
     def __init__(
@@ -1859,7 +1859,7 @@ class HttpProbe:
         # es sobre el servicio, no sobre la petición, y no cambia entre una y
         # otra dentro del mismo escaneo.
         self._schemes: Dict[tuple, str] = {}
-        # E7: este probe se queda deliberadamente en ``urllib`` mientras el
+        # Este probe se queda deliberadamente en ``urllib`` mientras el
         # resto del tráfico HTTP ordinario del proyecto (aegis/pills.py,
         # lybra/kb.py) usa ``requests``. Una sonda de seguridad necesita
         # control fino sobre el contexto TLS de *cada* salto, y ``requests``
@@ -1891,9 +1891,9 @@ class HttpProbe:
             port: The target port (decides http vs https).
             method: The HTTP method.
             path: The request path.
-            body: The request body (L30), or ``None`` for none. A non-GET check
+            body: The request body, or ``None`` for none. A non-GET check
                 — a login POST above all — needs this.
-            headers: Extra request headers (L30), or ``None``. The way a chained
+            headers: Extra request headers, or ``None``. The way a chained
                 check replays an extracted token: an ``Authorization`` or
                 ``Cookie`` header on the follow-up request.
 
@@ -1982,7 +1982,7 @@ class HttpProbe:
 
 
 # =========================================================================
-# NETWORK PROBE (the network edge for ``type: "network"`` checks — Fase N)
+# NETWORK PROBE (the network edge for ``type: "network"`` checks)
 # =========================================================================
 
 # How a reply ends, declared per request by the feed (``read:``). The transport

--- a/API/src/modules/features/themis/lybra/correlation.py
+++ b/API/src/modules/features/themis/lybra/correlation.py
@@ -87,25 +87,23 @@ def compute_dedup_key(finding: dict) -> str:
     material = f"{host}|{port}|{identity}"
     protocol = (finding.get("protocol") or "tcp").lower()
     if protocol != "tcp":
-        # Ronda 1 (roadmap §6.3): la sonda UDP puede abrir el mismo número de
-        # puerto que ya vigilábamos por TCP (161 es el caso real: SNMP). Sin
-        # esto, un 161/tcp y un 161/udp del mismo host colisionarían bajo la
-        # misma identidad ("check:lybra:open-port@1") y uno pisaría al otro en
-        # el merge. Condicionado a "no tcp" para que cada dedup_key ya
-        # almacenada quede intacta: hasta esta ronda todo hallazgo era TCP.
+        # La sonda UDP puede abrir el mismo número de puerto que ya
+        # vigilábamos por TCP (161 es el caso real: SNMP). Sin esto, un
+        # 161/tcp y un 161/udp del mismo host colisionarían bajo la misma
+        # identidad ("check:lybra:open-port@1") y uno pisaría al otro en el
+        # merge. Condicionado a "no tcp" para que un hallazgo TCP siga
+        # calculando la misma ``dedup_key`` que ya tiene almacenada: sólo el
+        # sufijo de protocolo cambiaría su forma, y sólo lo necesita UDP.
         material += "|" + protocol
     if port is None:
-        # A portless finding (Fase 0.9 — an inventory-origin service, e.g. an
-        # installed package with nothing listening) has no port to
-        # disambiguate different assets that happen to share the same
-        # check/category identity, or even the same CVE. ``service`` carries
-        # the product name in that case (engine.py falls back to it when
-        # there is no service name), which stays stable across a version
-        # bump — mirroring how a port's own identity already stays stable
-        # across a network service's product/version changing. Only
-        # reachable for a case that never existed before Fase 0.9 (port was
-        # always populated until now), so this cannot collide with any
-        # pre-existing dedup_key.
+        # A portless finding (an inventory-origin service, e.g. an installed
+        # package with nothing listening) has no port to disambiguate
+        # different assets that happen to share the same check/category
+        # identity, or even the same CVE. ``service`` carries the product
+        # name in that case (engine.py falls back to it when there is no
+        # service name), which stays stable across a version bump —
+        # mirroring how a port's own identity already stays stable across a
+        # network service's product/version changing.
         material += "|" + (finding.get("service") or "")
     return hashlib.sha256(material.encode()).hexdigest()[:32]
 
@@ -124,9 +122,7 @@ def merge_findings(findings: List[dict]) -> List[dict]:
     ``confirmed`` / ``in_kev`` if *any* input was, unions the CVE ids, and joins
     the distinct sources into ``source`` (e.g. ``"lybra,nuclei"``). Es el
     mecanismo de deduplicación dentro de un mismo escaneo: dos checks que
-    describen el mismo problema se cuentan una vez. También sostuvo, hasta L52,
-    la fusión en lectura de los hallazgos de los escaneos corroboradores; esa
-    fusión desapareció con ellos, la deduplicación se queda.
+    describen el mismo problema se cuentan una vez.
 
     Args:
         findings: Findings to merge. Each may already carry a ``dedup_key``; any
@@ -175,7 +171,7 @@ def _carry_decision(finding: dict, prev: dict) -> None:
 
     Sin esto, la decisión sobreviviría como estado pero perdería su
     justificación en el siguiente escaneo: un ``accepted`` sin motivo ni autor
-    es exactamente la deuda que L35 viene a quitar de en medio.
+    es una decisión que nadie puede auditar después.
     """
     for field_name in ("state_reason", "state_set_by", "state_set_at", "state_expires_at"):
         if prev.get(field_name) is not None:
@@ -185,9 +181,14 @@ def _carry_decision(finding: dict, prev: dict) -> None:
 def _decision_expired(prev: dict, moment: datetime) -> bool:
     """Si un riesgo aceptado ya ha cumplido su plazo de revisión.
 
-    Sin ``state_expires_at`` la decisión no caduca — es el caso de los
-    ``accepted`` anteriores a L35, que no tienen plazo porque nadie se lo puso.
-    Inventarles uno los reabriría todos de golpe el día del despliegue.
+    Sin ``state_expires_at`` la decisión no caduca nunca.
+
+    Warning:
+        Una fila ``accepted`` sin ``state_expires_at`` no es un error de
+        datos: significa que nadie le puso plazo, y hay que seguir
+        tratándola como una aceptación indefinida en vez de inventarle una
+        fecha, que reabriría de golpe todas las aceptaciones antiguas que
+        nunca tuvieron plazo.
     """
     expires = prev.get("state_expires_at")
     return expires is not None and expires <= moment
@@ -259,8 +260,8 @@ def apply_lifecycle(current: List[dict], previous: Dict[str, dict],
             —un barrido que se quedó sin presupuesto de reloj— porque entonces
             la ausencia no es evidencia de nada: lo que no se miró no se sabe
             si sigue ahí. Sin esta salida, un escaneo incompleto le diría al
-            usuario que sus vulnerabilidades fueron remediadas, que es el fallo
-            de L48-c por otra puerta.
+            usuario que sus vulnerabilidades fueron remediadas cuando en
+            realidad nunca se comprobaron.
 
     Returns:
         The ``current`` findings with their ``state`` set, plus one ``fixed``
@@ -348,11 +349,6 @@ def exploit_maturity(in_kev: bool, evidence: Optional[str] = None) -> str:
     una urgencia distinta de uno con una prueba de concepto en un gist, y los
     dos lo son de uno sin nada público.
 
-    La columna ``Finding.exploit_maturity`` existía desde el principio,
-    documentada como "rellenada desde la Fase 1", y nadie la escribía nunca:
-    ``NULL`` en todas las filas. Una columna que promete un dato y siempre está
-    vacía es peor que no tenerla, porque quien lee el modelo cree que existe.
-
     Args:
         in_kev: Si la CVE está en el catálogo CISA KEV. Es la evidencia más
             fuerte que hay —explotación activa confirmada— y gana siempre.
@@ -383,7 +379,7 @@ def score_finding(finding: dict, exposure: str) -> str:
       falta Metasploit o Exploit-DB, que son feeds externos nuevos), y el que
       sí se produce, ``in_the_wild``, sale de KEV, que ya sube la banda por su
       cuenta. Añadir la condición ahora sería una rama que no puede
-      dispararse, que es exactamente el pecado que L34 vino a corregir.
+      dispararse nunca, código muerto disfrazado de lógica.
     * An actively-confirmed finding with no CVSS (e.g. an exposed path) is floored
       at MEDIUM, so a confirmed issue never reads as merely informational.
     * An unconfirmed match whose CVE only applies on a specific platform

--- a/API/src/modules/features/themis/lybra/credentials.py
+++ b/API/src/modules/features/themis/lybra/credentials.py
@@ -1,16 +1,15 @@
-"""El motor de credenciales por defecto — Fase D del roadmap (L31).
+"""El motor de credenciales por defecto.
 
 Es la **única** familia de detección de Lybra que escribe en el objetivo: cada
-intento es un login real contra un servicio real. El roadmap lo dice sin
-rodeos — *"es una operación que escribe en el objetivo, que puede bloquear
-cuentas, que genera ruido en el SIEM del objetivo y que exige un control de
-tasa y un presupuesto muy distintos a un GET de .git/config"* — y por eso vive
-en su propio módulo, con sus propias guardas, en vez de ser un ``Check`` más
-del DSL declarativo de :mod:`checks`.
+intento es un login real contra un servicio real — una operación que puede
+bloquear cuentas, que genera ruido en el SIEM del objetivo y que exige un
+control de tasa y un presupuesto muy distintos a un GET de .git/config — y
+por eso vive en su propio módulo, con sus propias guardas, en vez de ser un
+``Check`` más del DSL declarativo de :mod:`checks`.
 
 **Las guardas no son opcionales, y son del llamante, no de aquí.** Este
 runtime no decide si debe correr: el manager lo invoca sólo bajo la doble
-puerta del modo agresivo (L40) — objetivo en el registro de autorización *y*
+puerta del modo agresivo — objetivo en el registro de autorización *y*
 petición explícita del usuario —, exactamente igual que cualquier otro check
 ``mode: aggressive``. Lo que sí es responsabilidad de este módulo es el
 presupuesto de intentos: **por cuenta, no por servicio** — tres contraseñas
@@ -31,9 +30,9 @@ Reutiliza deliberadamente piezas de :mod:`checks` en vez de duplicarlas: el
 mismo :class:`~.checks.Matcher` decide si una respuesta demuestra que el login
 funcionó, el mismo :class:`~.checks.Response` es lo que un matcher evalúa, y
 el ``fetch`` inyectado es la misma forma que :class:`~.checks.HttpProbe.fetch`
-ya expone desde L30 (``host, port, method, path, body, headers``) — un intento
-de credenciales *es* una petición HTTP con una cabecera ``Authorization``,
-nada más.
+ya expone (``host, port, method, path, body, headers``) — un intento de
+credenciales *es* una petición HTTP con una cabecera ``Authorization``, nada
+más.
 """
 
 from __future__ import annotations
@@ -62,7 +61,7 @@ QOD_CONFIRMED = 99
 # Servicios candidatos hoy. Sólo HTTP: es donde vive Tomcat Manager, Jenkins y
 # la mayoría de paneles de administración con credenciales de fábrica
 # conocidas, y es el único protocolo para el que ``HttpProbe.fetch`` ya sabe
-# mandar una cabecera ``Authorization`` (L30). Ampliar a FTP/SSH es straight-
+# mandar una cabecera ``Authorization``. Ampliar a FTP/SSH es straight-
 # forward por el mismo camino que las familias ``network`` de checks.py —
 # inyectar un ``attempt`` en vez de un ``fetch`` HTTP—, pero no hay ninguna
 # entrada del feed que lo necesite todavía.
@@ -237,21 +236,21 @@ def _basic_auth_headers(username: str, password: str) -> Dict[str, str]:
 
 
 class CredentialRuntime:
-    """Prueba credenciales de fábrica contra los servicios de un host (Fase D).
+    """Prueba credenciales de fábrica contra los servicios de un host.
 
     Args:
         entries: Las entradas de credenciales a probar.
         fetch: Un ``(host, port, method, path, body, headers) -> Response |
             None`` — la misma forma que :meth:`~.checks.HttpProbe.fetch`
-            expone desde L30.
+            expone.
         rate_limiter: Limitador por host opcional, aplicado antes de cada
             intento — cada login real es tráfico hacia el objetivo, y esta es
             la única familia del motor donde ese tráfico además escribe.
         max_attempts_per_account: Tope de contraseñas distintas probadas
-            contra una misma cuenta (L31) — no contra un mismo servicio. Ver
+            contra una misma cuenta — no contra un mismo servicio. Ver
             el docstring del módulo.
         capture_evidence: Si se adjunta la respuesta que demostró el acceso
-            como evidencia (Fase E) — nunca incluye la contraseña, sólo lo que
+            como evidencia — nunca incluye la contraseña, sólo lo que
             el objetivo respondió.
     """
 

--- a/API/src/modules/features/themis/lybra/distro.py
+++ b/API/src/modules/features/themis/lybra/distro.py
@@ -1,13 +1,13 @@
 """De qué distribución es este paquete, y sólo cuando se puede saber.
 
-La verificación de *backports* (Fase O) necesita saber contra qué proveedor
+La verificación de *backports* necesita saber contra qué proveedor
 preguntar: si Debian ya parcheó ``apache2`` en su ``2.4.49-1~deb11u1``, esa
 respuesta no vale para un Apache compilado a mano ni para uno de Alpine.
 
-El roadmap dejó esta pieza sin resolver y enumeró tres salidas: aplicar sólo
-cuando el inventario del agente dé la distribución, inferirla del banner cuando
-lo diga, o aplicar el descenso cuando **todas** las distribuciones candidatas
-coincidan en que está parcheado.
+Hay tres formas de resolverlo: aplicar sólo cuando el inventario del agente
+dé la distribución, inferirla del banner cuando lo diga, o aplicar el
+descenso cuando **todas** las distribuciones candidatas coincidan en que
+está parcheado.
 
 **La tercera se descarta**, y conviene decir por qué: un paquete compilado
 desde el código fuente no pertenece a ninguna distribución, así que "todas

--- a/API/src/modules/features/themis/lybra/engine.py
+++ b/API/src/modules/features/themis/lybra/engine.py
@@ -1,9 +1,9 @@
 """The detection core — turns discovered services into normalized findings.
 
-This is the L2 "detection runtime" of the roadmap. Given the services found on a
-host, the engine produces :class:`Finding`-shaped dicts: always an informational
-"this port is open" finding, and — when a CVE lookup is wired in — one finding
-per known vulnerability that affects the service's product and version.
+Given the services found on a host, the engine produces :class:`Finding`-shaped
+dicts: always an informational "this port is open" finding, and — when a CVE
+lookup is wired in — one finding per known vulnerability that affects the
+service's product and version.
 
 Two design choices keep this module easy to reason about and to test:
 
@@ -46,7 +46,7 @@ QOD_OPEN_PORT = 30
 QOD_VERSION_MATCH = 70
 
 # Quality of Detection for a version-based match built from a Service whose
-# origin is "inventory" (Fase 0.9) — a package an agent read directly off the
+# origin is "inventory" — a package an agent read directly off the
 # host, not a guess from a network banner. There is no back-port ambiguity to
 # hedge against here: the installed version *is* the version, so the match is
 # both confirmed and scored close to an actively-confirmed check (QOD_CONFIRMED
@@ -59,9 +59,9 @@ QOD_INVENTORY_MATCH = 95
 # product/version came from Nmap's own naming ("Apache httpd") or from
 # Lybra's own HTTP/SSH fingerprint reading the Server header or SSH banner
 # directly ("Apache", "OpenSSH" — see lybra.fingerprinting), or from a Hygeia
-# inventory entry's raw name. Loaded from feeds/product_aliases.json (Fase
-# I-b, paso 3) rather than hand-written here, so a new alias is one JSON
-# entry, not a code change — the same "Lybra feed" pattern checks_feed.json
+# inventory entry's raw name. Loaded from feeds/product_aliases.json rather
+# than hand-written here, so a new alias is one JSON entry, not a code
+# change — the same "Lybra feed" pattern checks_feed.json
 # and tech_signatures.json already use. Both spellings for the same product
 # are kept as separate feed entries rather than normalized, since that keeps
 # the feed a flat, auditable list. The alternative to an explicit alias —
@@ -85,10 +85,10 @@ class Service:
         product: The product name, e.g. ``"Apache httpd"``. May be empty.
         version: The product version, e.g. ``"2.4.49"``. May be empty.
         cpe: A CPE string for the service if one is known, else ``None``.
-        origin: Where this reading came from — ``"network"`` (the only value
-            that existed before Fase 0.9): inferred from a banner, a CPE Nmap
-            emitted, or Lybra's own fingerprint. Or ``"inventory"``: a fact
-            read directly off the host (e.g. a package manager), not a guess.
+        origin: Where this reading came from — ``"network"``: inferred from a
+            banner, a CPE Nmap emitted, or Lybra's own fingerprint. Or
+            ``"inventory"``: a fact read directly off the host (e.g. a
+            package manager), not a guess.
             The engine uses this to decide how much to trust a version match
             (see :data:`QOD_INVENTORY_MATCH`) — it is not network vs. local in
             the transport sense, it is inferred vs. verified.
@@ -136,7 +136,7 @@ class LybraEngine:
             EPSS exploitation-probability score.
         product_alias_lookup: A callable ``(normalized_name) -> (vendor, product)
             | None`` — the automated index derived from the KB's own
-            ``CpeMatch`` rows (Fase I-b, paso 2), consulted only when neither an
+            ``CpeMatch`` rows, consulted only when neither an
             embedded CPE nor :data:`CPE_PRODUCT_OVERRIDES` resolved the service.
             ``None`` disables this third strategy, leaving the first two.
         feed_version: The reproducibility mark stamped on every finding this
@@ -184,9 +184,8 @@ class LybraEngine:
         findings: List[dict] = []
         for service in services:
             # Resolved once and shared: the informational finding records
-            # whether resolution succeeded (Fase I-b observability), and the
-            # version-match path reuses the same result instead of resolving
-            # the CPE twice.
+            # whether resolution succeeded, and the version-match path
+            # reuses the same result instead of resolving the CPE twice.
             resolved = _resolve_cpe(service, self._product_alias_lookup,
                                     self._record_resolution)
             findings.append(self._informational_finding(service, resolved))
@@ -213,7 +212,7 @@ class LybraEngine:
     def _version_finding(self, service: Service, cve, cpe23: str) -> dict:
         """Build a single version-match finding for a service and one CVE.
 
-        An ``origin="inventory"`` service (Fase 0.9) is a verified fact, not a
+        An ``origin="inventory"`` service is a verified fact, not a
         banner guess, so it earns a higher ``qod`` and is born ``confirmed`` —
         there is no back-port ambiguity to hedge against when the version came
         straight from the package manager.
@@ -240,7 +239,7 @@ class LybraEngine:
             "cvss_vector":  cve.cvss_vector,
             "epss_score":   self._epss_lookup(cve_id) if self._epss_lookup else None,
             "in_kev":       in_kev,
-            # L34: la tercera dimensión de explotabilidad, que el modelo
+            # La tercera dimensión de explotabilidad, que el modelo
             # prometía y nadie escribía. KEV dice "se explota ahora mismo" y
             # EPSS da una probabilidad; ésta dice si existe un exploit y cuán
             # usable es, que es lo que separa una urgencia de un deber.
@@ -253,11 +252,12 @@ class LybraEngine:
             "check_id":     "lybra:version-match@1",
             "feed_version": self._feed_version,
             "qod":          QOD_INVENTORY_MATCH if is_verified else QOD_VERSION_MATCH,
-            "confirmed":    is_verified,   # a network-inferred match stays a hypothesis; Fase R confirms it actively
+            "confirmed":    is_verified,   # a network-inferred match stays a hypothesis
+                                            # until an active check confirms it
             "cpe_resolved": True,   # this finding only exists because resolution succeeded
             "state":        "open",
             # Claves de trabajo, no columnas: la verificación de backports
-            # (Fase O) necesita la versión **cruda** del paquete —con su
+            # necesita la versión **cruda** del paquete —con su
             # revisión de distribución, que es lo que nombra al proveedor— y el
             # nombre con el que esa distribución lo llama. El repositorio las
             # descarta al persistir.
@@ -294,8 +294,8 @@ class LybraEngine:
         listening anywhere), so that case gets its own phrasing and category
         instead of a nonsensical "Puerto None abierto".
 
-        ``cpe_resolved`` (Fase I-b observability) records whether ``resolved``
-        — computed once in :meth:`analyze` — found a CPE, independent of
+        ``cpe_resolved`` records whether ``resolved`` — computed once in
+        :meth:`analyze` — found a CPE, independent of
         whether the KB then had any matching CVE. Without it, "no detections"
         and "could not even identify the package" are indistinguishable in
         the data, which is exactly the ambiguity that motivated this column.
@@ -327,17 +327,16 @@ class LybraEngine:
 def services_from_payload(raw: Iterable[dict]) -> List[Service]:
     """Build engine :class:`Service` values from an externally-supplied dataset.
 
-    Fase 0.9's third input mode: a convenience for a producer whose data
-    arrives as plain dicts rather than already-built ``Service`` instances —
-    the shape a future Hygeia inventory adapter, or any other in-process
-    caller, is likely to have. A caller that already builds ``Service``
-    directly does not need this at all; ``LybraEngineManager.run_scan``
-    accepts either.
+    A third input mode alongside :func:`services_from_discovered_ports`: a
+    convenience for a producer whose data arrives as plain dicts rather than
+    already-built ``Service`` instances — the shape a future Hygeia inventory
+    adapter, or any other in-process caller, is likely to have. A caller that
+    already builds ``Service`` directly does not need this at all;
+    ``LybraEngineManager.run_scan`` accepts either.
 
     Unlike :func:`services_from_discovered_ports`, this trusts an explicit
     ``"origin"`` key if the payload sets one, defaulting to ``"network"`` so a
-    producer that predates Fase 0.9 (there are none yet) would behave exactly
-    as those two functions do.
+    producer that does not set it behaves exactly as those two functions do.
 
     Args:
         raw: An iterable of dicts with the same keys as :class:`Service`'s
@@ -386,18 +385,18 @@ def _resolve_cpe(
     1. Trust the CPE Nmap emitted, if any — falling back to the banner version
        when the CPE itself left the version as a wildcard.
     2. Normalize the product name (:func:`~.kb.normalize_product_name`) and
-       look it up in :data:`CPE_PRODUCT_OVERRIDES` (the curated alias feed,
-       Fase I-b paso 3) — an exact, hand-verified match, including cases the
-       automated index (next) correctly refuses to guess: NVD itself tags
-       "7-zip" under two different vendors (the modern ``7-zip`` and the
-       legacy ``igor_pavlov``), which paso 2's grouping sees as ambiguous and
-       discards — a human confirming which vendor NVD actually uses today is
-       exactly what this feed is for.
+       look it up in :data:`CPE_PRODUCT_OVERRIDES` (the curated alias feed)
+       — an exact, hand-verified match, including cases the automated index
+       (next) correctly refuses to guess: NVD itself tags "7-zip" under two
+       different vendors (the modern ``7-zip`` and the legacy
+       ``igor_pavlov``), which the automated index's grouping sees as
+       ambiguous and discards — a human confirming which vendor NVD actually
+       uses today is exactly what this feed is for.
     3. Look the same normalized name up in the automated index derived from
-       the KB's own ``CpeMatch`` rows (Fase I-b paso 2, ``product_alias_lookup``)
-       — reached only when the curated feed missed. This is what makes a
-       desktop inventory (Fase I) resolvable at all: neither Nmap nor a
-       hand-written table was ever going to cover it alone.
+       the KB's own ``CpeMatch`` rows (``product_alias_lookup``) — reached
+       only when the curated feed missed. This is what makes a desktop
+       inventory resolvable at all: neither Nmap nor a hand-written table was
+       ever going to cover it alone.
 
     Both 2 and 3 key off the *normalized* name, not the raw string — a
     desktop inventory entry routinely bakes the version into the name itself
@@ -416,7 +415,7 @@ def _resolve_cpe(
             detection entirely.
         record_resolution: Callback ``(nombre_normalizado, origen, resuelto)``
             para llevar la cuenta de qué nombres de producto no se consiguen
-            resolver (L37). Se invoca **sólo** cuando el nombre y la versión
+            resolver. Se invoca **sólo** cuando el nombre y la versión
             existen y aun así ninguna estrategia dio con el CPE: eso es
             exactamente "falta un alias", que es lo que el ranking tiene que
             saber. Un servicio sin versión concreta o sin nombre no falla por

--- a/API/src/modules/features/themis/lybra/evidence.py
+++ b/API/src/modules/features/themis/lybra/evidence.py
@@ -1,4 +1,4 @@
-"""La evidencia cruda de un hallazgo — capturada, redactada y con hash (Fase E).
+"""La evidencia cruda de un hallazgo — capturada, redactada y con hash.
 
 Este módulo vive en la capa pura ``lybra/``: **no toca el ORM**. El motor
 recoge la evidencia en una lista en memoria a través de un *recorder*
@@ -42,8 +42,8 @@ _SENSITIVE_HEADERS = frozenset({
 # «aquí había algo y lo quitamos» en vez de esconder que existía.
 _REDACTED = "[redacted]"
 
-# Las clases de evidencia que el modelo reconoce (MS-Fase E). Una entrada con
-# otro ``kind`` no se descarta, pero conviene que la lista viva en un sitio.
+# Las clases de evidencia que el modelo reconoce. Una entrada con otro
+# ``kind`` no se descarta, pero conviene que la lista viva en un sitio.
 EVIDENCE_KINDS = ("http_response", "ssh_banner", "tls_cert", "probe_output")
 
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/__init__.py
@@ -1,8 +1,8 @@
-"""Lybra's own service fingerprinting — the identification layer (Fase F).
+"""Lybra's own service fingerprinting — the identification layer.
 
 Instead of trusting ``nmap -sV`` blindly, this package identifies a service's
 product and version on its own terms. One module per protocol, chosen for the
-best value-for-effort in the roadmap:
+best value for the effort it costs to support:
 
 ``http_apis``
     Las APIs de administración que hablan HTTP y publican su versión en un
@@ -18,8 +18,9 @@ best value-for-effort in the roadmap:
     versión repetida en rutas de assets—, más el ``<title>``, un hash del
     favicon y el feed de firmas de tecnología al estilo Wappalyzer. Cada
     lectura registra de qué nivel salió, y ese nivel decide el ``qod`` del
-    hallazgo. Hasta L18 la única fuente era ``Server``, que es justo la que
-    cualquier despliegue fortificado suprime.
+    hallazgo. La cascada existe porque ``Server`` es justo la cabecera que
+    cualquier despliegue fortificado suprime: apoyarse solo en ella dejaría
+    ciego cualquier objetivo bien configurado.
 
 ``ssh``
     The identification banner plus **HASSH** — a fingerprint of the algorithm
@@ -29,7 +30,7 @@ best value-for-effort in the roadmap:
 ``tls``
     A single-handshake hygiene check — negotiated protocol version, self-signed
     and expiry status of the certificate. **No JARM: archivado**, con la razón
-    escrita en el docstring del módulo y en la Fase F del roadmap.
+    escrita en el docstring del módulo.
 
 ``postgres``
     La primera base de datos que **negocia** en vez de ofrecer un banner: un
@@ -60,7 +61,7 @@ best value-for-effort in the roadmap:
     contrario de un banner de texto libre. No da versión, y no se inventa una.
 
 ``ftp``, ``mail`` (SMTP/IMAP/POP3), ``mysql``, ``redis_probe``, ``vnc``
-    Fase N's non-HTTP protocols — each volunteers its identity unprompted
+    Non-HTTP protocols whose services volunteer their identity unprompted
     right after a bare TCP connect, no negotiation needed to read it.
 
 ``smb``
@@ -72,14 +73,14 @@ best value-for-effort in the roadmap:
     docstring para las simplificaciones documentadas.
 
 ``udp_services``
-    El resto de la superficie UDP (L22): DNS, NTP, NetBIOS-NS, mDNS, IKE y el
+    El resto de la superficie UDP: DNS, NTP, NetBIOS-NS, mDNS, IKE y el
     SQL Server Browser. Cada uno llega con el consumidor de su fila de
     ``UDP_PROBES``, que es la regla con la que esa tabla nació. Ahí viven los
     servicios que no aparecen en ningún escaneo TCP y los que se usan para
     amplificar ataques contra terceros.
 
 ``snmp``
-    Fase N/Ronda 1's first UDP protocol — a ``sysDescr.0`` GetRequest (the
+    The first UDP protocol here — a ``sysDescr.0`` GetRequest (the
     encoder lives in ``transport.py``, imported back here; see the module's
     own docstring for why). La versión sale de un feed de patrones **por
     fabricante** (``feeds/sysdescr_patterns.json``) y nunca de una regex
@@ -98,26 +99,25 @@ best value-for-effort in the roadmap:
     the manager.
 
 
-That said, a service found by Lybra's own transport (Fase T, no Nmap
+That said, a service found by Lybra's own transport layer (no Nmap
 involved) never had a Nmap reading to defer to in the first place — it carries
 no product/version at all. For that case, and only that case,
 ``LybraEngineManager._fingerprint_services`` uses a dissector's output to
-fill the gap: without it, the version matcher (Fase 1) would have nothing to
+fill the gap: without it, the version matcher would have nothing to
 look up and a self-discovery-only scan would never find a single CVE. The
 result still goes in at the same low-confidence, unconfirmed tier a Nmap CPE
 match would (``qod=70``) — this closes a blind spot, it does not raise
 confidence beyond what the matcher already assigns any version-based guess.
 
-**JARM está archivado, no pendiente** (L24): su valor es comparativo, y un
+**JARM está archivado, no pendiente**: su valor es comparativo, y un
 hash que no coincida bit a bit con el de la implementación de referencia no es
 una identificación peor sino ninguna — comprobar esa coincidencia exige un
 laboratorio con varias pilas TLS que no existe aquí. La decisión, con qué haría
-falta para reabrirla, está en ``tls.py`` y en la Fase F del roadmap.
+falta para reabrirla, está en ``tls.py``.
 
-El fingerprinting de sistema operativo (que el roadmap valora bajo) sigue
-aplazado, y con VNC más allá de su banner de versión y RPC sigue siendo
-territorio del oráculo —Nmap— por la valoración de prioridad-3 del propio
-roadmap.
+El fingerprinting de sistema operativo sigue aplazado por su bajo valor
+frente al esfuerzo que exige, y VNC más allá de su banner de versión, junto
+con RPC, siguen siendo territorio del oráculo —Nmap.
 """
 
 from __future__ import annotations

--- a/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/cascade.py
@@ -2,7 +2,7 @@
 
 Todos los predicados de aplicabilidad del motor deciden con la misma fórmula:
 *el nombre del servicio está en esta lista, o el puerto está en este conjunto*.
-Y cuando el descubrimiento es propio (Fase T, sin Nmap), el nombre del servicio
+Y cuando el descubrimiento es propio (sin Nmap), el nombre del servicio
 sale de ``WELL_KNOWN_PORTS``, que es **otra tabla de puertos**. Es decir: en el
 camino de autodescubrimiento, la decisión era puramente el número de puerto.
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/dispatch.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/dispatch.py
@@ -1,9 +1,9 @@
 """The dissector dispatch — replaces an if/elif chain with one entry per protocol.
 
-``LybraEngineManager._fingerprint_services`` used to ask, for every discovered
-service, "is this HTTP? SSH? FTP?" as a chain of ``if``/``elif`` branches, each
-running that protocol's own multi-step probe inline. Every new protocol Fase N
-adds meant a new branch in the manager. A :class:`Dissector` moves each
+Asking, for every discovered service, "is this HTTP? SSH? FTP?" as a chain of
+``if``/``elif`` branches would mean each branch runs that protocol's own
+multi-step probe inline, and every new protocol added means a new branch in
+the manager. A :class:`Dissector` moves each
 protocol's applicability test and probe logic into its own small object,
 registered once in :func:`~.default_dissectors`; the manager just asks each one
 in turn "does this apply, and if so, what did you find?" — adding protocol N+1
@@ -20,8 +20,7 @@ from ..engine import Service
 
 # Quality of Detection de un hallazgo de fingerprint: informativo y nada más.
 # Constata qué identificó el motor; nunca contribuye a la confianza de una
-# vulnerabilidad. Vivía en ``concordance.py`` hasta L52, cuando ese módulo se
-# fue al arnés de pruebas por medir contra Nmap dentro del producto.
+# vulnerabilidad.
 QOD_FINGERPRINT = 20
 
 
@@ -37,11 +36,11 @@ class DissectorResult:
             distinguirlo. Por defecto :data:`QOD_FINGERPRINT`, que es lo que
             todos los dissectors usaban y lo que sigue valiendo para los que
             leen una sola fuente. El de HTTP sí distingue —su versión puede
-            venir de seis sitios de calidad muy distinta— y lo aprovecha (L18).
+            venir de seis sitios de calidad muy distinta— y lo aprovecha.
         extra_layers: Las capas de servidor **adicionales** observadas en el
             mismo puerto, como tuplas ``(producto, versión, rol)``. Vacía en el
             caso normal, un elemento cuando hay un proxy inverso por delante de
-            un servidor distinto (L48-b). La primera capa no aparece aquí: ya
+            un servidor distinto. La primera capa no aparece aquí: ya
             viaja en ``product``/``version``.
     """
     product: Optional[str]
@@ -52,7 +51,7 @@ class DissectorResult:
 
 
 class Dissector:
-    """One protocol's Fase F/N identification strategy: applicability + probe.
+    """One protocol's identification strategy: applicability + probe.
 
     :meth:`probe` returns ``None`` only for a raw transport failure (connection
     refused, timeout, connection closed before anything usable arrived) — a

--- a/API/src/modules/features/themis/lybra/fingerprinting/ftp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/ftp.py
@@ -1,7 +1,7 @@
-"""The FTP dissector — Fase N's opening move into non-HTTP protocols.
+"""The FTP dissector — the simplest of the non-HTTP protocols.
 
-FTP is the cheapest possible entry into the roadmap's brecha G1 (protocols
-Lybra cannot yet identify at all): the server volunteers its whole identity
+FTP is the cheapest possible entry into protocols Lybra cannot yet identify
+at all: the server volunteers its whole identity
 unprompted, in the first line it sends after a bare TCP connect — no protocol
 negotiation, no framing, just a banner ending in ``\\r\\n``. The well-known
 ``vsftpd 2.3.4`` backdoor (CVE-2021-... no — CVE-2011-2523) is also one of the
@@ -14,7 +14,7 @@ Two banner shapes carry a version outright:
 - ``220 ProFTPD 1.3.5 Server (Debian) [...]`` — bare ``Product Version``
   tokens before any parenthetical comment (ProFTPD, and similar daemons).
 
-**Y muchos despliegues reales no llevan ninguna de las dos** (L48-a). El
+**Y muchos despliegues reales no llevan ninguna de las dos**. El
 saludo por defecto de ProFTPD en Debian es ``220 ProFTPD Server (Debian)
 [::ffff:...]``: nombra el producto y calla la versión, que es justo lo que
 recomienda cualquier guía de fortificación. Pure-FTPd hace lo mismo. Contra

--- a/API/src/modules/features/themis/lybra/fingerprinting/http.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/http.py
@@ -8,7 +8,7 @@ signature can also match a deliberately-nonexistent path's error page — some
 vendors brand their 404 more than their homepage, which is exactly how the
 SonicWall entry was found in the first place (see ``error_body`` below).
 
-**La versión no sale de una sola fuente** (L18). Salía: la cabecera
+**La versión no sale de una sola fuente**. Salía: la cabecera
 ``Server``, y nada más. Y ``server_tokens off`` en nginx, ``ServerTokens
 Prod`` en Apache y prácticamente cualquier CDN o WAF la suprimen, así que el
 caso más común en producción era justo el que dejaba al motor sin versión —
@@ -103,7 +103,7 @@ class ServiceLayer:
     podía expresarlo: se quedaba con lo que dijera la cabecera ``Server``, que
     la pone el de delante.
 
-    Eso salió caro en la medición real (L48-b): cinco servicios en tres hosts,
+    Eso salió caro en la medición real: cinco servicios en tres hosts,
     siempre el mismo patrón — Lybra decía ``nginx``, Nmap decía ``Apache
     httpd``. **Ninguno de los dos estaba equivocado**; describían capas
     distintas de la misma pila. Pero para resolver un CPE y correlacionar CVEs
@@ -273,7 +273,7 @@ def _load_matcher(matcher: dict) -> TechMatcher:
 def validate_tech_signatures(signatures: List[TechSignature]) -> List[str]:
     """Comprueba que cada firma pueda llegar a casar, y describe las que no.
 
-    Mismo criterio que ``checks.validate_checks`` (L27): el feed son datos que
+    Mismo criterio que ``checks.validate_checks``: el feed son datos que
     deciden si un producto se identifica, y su modo de fallo es el silencio —
     una firma sin matchers no casa nunca, un ``versionPattern`` sin grupo
     ``version`` casa y no aporta nada, y en los dos casos el escaneo termina en
@@ -834,14 +834,13 @@ def fingerprint_http(  # pylint: disable=too-many-locals
     )
 
 
-# ``qod`` del hallazgo de fingerprint según de dónde salió la versión. Es la
-# tabla del §10 del roadmap ("banner que coincide con un patrón específico del
-# producto: qod 80") aplicada por fin: hasta ahora todos los fingerprints
-# llevaban la misma constante, así que una versión leída de un ``Server``
-# explícito y otra deducida de una página de error valían exactamente lo
-# mismo. Sigue siendo un hallazgo informativo —no alimenta la confianza de
-# ninguna vulnerabilidad, ver ``dispatch.QOD_FINGERPRINT``—; lo que cambia es
-# que ahora dice **cuánto se fía de su propia lectura**.
+# ``qod`` del hallazgo de fingerprint según de dónde salió la versión: una
+# versión leída de un ``Server`` explícito no vale lo mismo que una deducida
+# de una página de error, así que cada fuente lleva su propia constante en
+# vez de compartir una única cifra para todos los fingerprints. Sigue siendo
+# un hallazgo informativo —no alimenta la confianza de ninguna vulnerabilidad,
+# ver ``dispatch.QOD_FINGERPRINT``—; lo que varía es **cuánto se fía de su
+# propia lectura**.
 VERSION_SOURCE_QOD: Dict[str, int] = {
     "server-header": 90,
     "powered-by-header": 85,
@@ -854,8 +853,9 @@ VERSION_SOURCE_QOD: Dict[str, int] = {
 
 @register_dissector
 class HttpDissector(Dissector):
-    """Fase F's highest-value protocol: GET /, its favicon, and a nonexistent
-    path (for error-page-only vendor signatures), combined into one fingerprint."""
+    """The highest-value protocol to fingerprint: GET /, its favicon, and a
+    nonexistent path (for error-page-only vendor signatures), combined into
+    one fingerprint."""
 
     label = "HTTP"
 
@@ -875,7 +875,7 @@ class HttpDissector(Dissector):
         response = self._probe.fetch(target, service.port, "GET", "/")
         if response is None:
             return None
-        # L20: la petición del favicon sólo se paga cuando puede pagarse a sí
+        # La petición del favicon sólo se paga cuando puede pagarse a sí
         # misma. Con el catálogo vacío no hay nada con lo que comparar el icono,
         # así que pedirlo sería una petición de red por servicio HTTP —con su
         # turno de limitador— a cambio de un dato que nadie consulta.

--- a/API/src/modules/features/themis/lybra/fingerprinting/mail.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mail.py
@@ -1,7 +1,7 @@
-"""SMTP/IMAP/POP3 dissectors — Fase N, priority-1 non-HTTP protocols.
+"""SMTP/IMAP/POP3 dissectors — high-value non-HTTP protocols.
 
 All three volunteer an identifying line unprompted, right after a bare TCP
-connect — the same shape FTP already exploits (Fase N's opening move): no
+connect — the same shape FTP already exploits: no
 negotiation, no framing, just a banner. A stopword list keeps the parser from
 mistaking a protocol's own name ("POP3", "IMAP4", "server") for a product,
 mirroring the FTP dissector's rule of never inventing an identification that

--- a/API/src/modules/features/themis/lybra/fingerprinting/mongo.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mongo.py
@@ -1,19 +1,18 @@
 """El dissector de MongoDB — y el hallazgo más famoso de la lista.
 
-MongoDB cierra el trío de bases de datos que la Fase N dejó fuera, y es el que
-tiene asociado el incidente más conocido: durante años, las instalaciones por
-defecto escuchaban en todas las interfaces **sin autenticación**, y eso produjo
-una de las mayores oleadas de fuga de datos y de ransomware de bases de datos
-que se recuerdan. Sigue apareciendo.
+MongoDB es una de las bases de datos con el incidente más conocido asociado:
+durante años, las instalaciones por defecto escuchaban en todas las
+interfaces **sin autenticación**, y eso produjo una de las mayores oleadas de
+fuga de datos y de ransomware de bases de datos que se recuerdan. Sigue
+apareciendo.
 
-**Una corrección al planteamiento original, porque cambia el diseño.** El issue
-daba por hecho que un ``hello`` sin autenticar sólo contesta si el servidor no
-exige credenciales, y que por tanto su respuesta *es* la evidencia de la
-exposición. No es así: ``hello`` (antes ``isMaster``) es el comando de
-*handshake* del protocolo y **siempre** contesta, con ``--auth`` y sin él —
-tiene que hacerlo, porque el cliente necesita saber con quién habla antes de
-poder autenticarse. Un check construido sobre esa premisa habría marcado como
-expuesto **todo** MongoDB alcanzable, incluidos los correctamente cerrados.
+**El módulo separa dos preguntas que es fácil confundir, porque no son la
+misma.** Un ``hello`` sin autenticar no sirve como evidencia de exposición:
+``hello`` (antes ``isMaster``) es el comando de *handshake* del protocolo y
+**siempre** contesta, con ``--auth`` y sin él — tiene que hacerlo, porque el
+cliente necesita saber con quién habla antes de poder autenticarse. Tratar su
+respuesta como evidencia de exposición marcaría como expuesto **todo**
+MongoDB alcanzable, incluidos los correctamente cerrados.
 
 Así que el módulo separa las dos preguntas, que resultan ser distintas:
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/mssql.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mssql.py
@@ -1,13 +1,13 @@
 """El dissector de SQL Server — el más generoso de los tres pendientes.
 
-De las tres bases de datos que la Fase N dejó fuera, SQL Server es la que más
-se identifica sola: el paquete ``PRELOGIN`` del protocolo TDS devuelve la
+De las tres bases de datos sin banner propio, SQL Server es la que más se
+identifica sola: el paquete ``PRELOGIN`` del protocolo TDS devuelve la
 versión del servidor —major, minor y build— en un campo binario de tamaño
 fijo, **sin autenticar y sin negociar nada más**.
 
 Esa versión mapea directo a un producto de NVD (``microsoft:sql_server``) con
-historial de CVEs abundante, así que es el caso limpio del apalancamiento que
-el roadmap describe: se escriben *ojos*, no checks, y la correlación de
+historial de CVEs abundante, así que es el caso limpio del apalancamiento
+que da un buen fingerprint: se escriben *ojos*, no checks, y la correlación de
 vulnerabilidades sale sola de la base de conocimiento local.
 
 El ``PRELOGIN`` dice además si el servidor **exige cifrado**, en cuatro estados

--- a/API/src/modules/features/themis/lybra/fingerprinting/postgres.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/postgres.py
@@ -1,11 +1,10 @@
 """El dissector de PostgreSQL — el primero que negocia en vez de escuchar.
 
-PostgreSQL es una de las tres bases de datos que la Fase N dejó fuera con una
-justificación honesta: *"a diferencia de MySQL/Redis, exigen un handshake
-negociado en vez de un banner ofrecido, mayor coste/riesgo que valor añadido en
-esa ronda"*. El coste sigue siendo mayor; el valor también, porque un
-PostgreSQL expuesto es un hallazgo de primer orden y hasta ahora producía un
-``open_port`` informativo y nada más.
+PostgreSQL es una de las bases de datos que, a diferencia de MySQL/Redis,
+exige un handshake negociado en vez de ofrecer un banner por su cuenta: el
+coste de identificarla es mayor, pero el valor también lo es, porque un
+PostgreSQL expuesto es un hallazgo de primer orden y sin este dissector no
+pasaría de un ``open_port`` informativo y nada más.
 
 **Conviene ser honesto sobre el techo: PostgreSQL no regala su versión antes de
 autenticar.** Ningún truco cambia eso. Lo que sí se puede observar sin
@@ -23,7 +22,7 @@ credenciales, y ya es bastante, son tres cosas:
 Los dos intercambios son lecturas del protocolo de conexión: **no se intenta
 autenticar en ningún momento**, no se manda contraseña ninguna y no se prueba
 credencial alguna. Por eso caben en modo ``safe``. Un intento de login sería
-otra cosa —Fase D— y no está aquí.
+otra cosa, y no está aquí.
 
 El formato de los mensajes viene de la documentación de PostgreSQL, "Frontend/
 Backend Protocol" §55.2.1 y §55.7. Todo se construye y se parsea a mano: traer

--- a/API/src/modules/features/themis/lybra/fingerprinting/rdp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/rdp.py
@@ -1,9 +1,9 @@
 """El dissector de RDP — el hallazgo que puede acabar en una llamada de teléfono.
 
-RDP figura en la tabla de la Fase N como prioridad 3 con coste "medio-alto".
-Por impacto real merece estar más arriba: es el vector de entrada de la mayoría
-de los incidentes de ransomware que empiezan por acceso remoto, y **BlueKeep**
-(CVE-2019-0708) sigue apareciendo en redes reales siete años después.
+Implementar RDP tiene un coste medio-alto, pero por impacto real merece
+prioridad alta: es el vector de entrada de la mayoría de los incidentes de
+ransomware que empiezan por acceso remoto, y **BlueKeep** (CVE-2019-0708)
+sigue apareciendo en redes reales siete años después.
 
 **RDP sin NLA es el hallazgo.** NLA (*Network Level Authentication*) obliga a
 autenticarse **antes** de que se cree la sesión gráfica. Sin él, cualquiera que
@@ -14,8 +14,8 @@ hallazgo que justifica un informe entero.
 
 **Cómo se observa.** Un ``X.224 Connection Request`` con un ``RDP_NEG_REQ``
 anuncia qué protocolos de seguridad soporta el cliente, y el servidor contesta
-**cuál ha elegido** — o por qué no elige ninguno. Es la sonda más compleja del
-backlog en construcción (``TPKT`` + ``X.224`` + negociación), pero su resultado
+**cuál ha elegido** — o por qué no elige ninguno. Es la sonda más compleja de
+este paquete (``TPKT`` + ``X.224`` + negociación), pero su resultado
 es binario y sin ambigüedad, que es justo lo contrario de un banner de texto
 libre: no hay nada que interpretar, el servidor dice un número.
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/redis_probe.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/redis_probe.py
@@ -1,4 +1,4 @@
-"""The Redis dissector — Fase N.
+"""The Redis dissector.
 
 Unlike FTP/SMTP/MySQL, Redis does not volunteer anything on a bare connect —
 it waits for a command. Sending ``INFO`` (a read-only, standard admin command)

--- a/API/src/modules/features/themis/lybra/fingerprinting/smb.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/smb.py
@@ -1,4 +1,4 @@
-"""The SMB dissector — Fase N's highest-value protocol by port frequency.
+"""The SMB dissector — the highest-value protocol by port frequency.
 
 Sends a minimal SMB2 NEGOTIATE request and reads the response's negotiated
 dialect and security mode — the wire format is fixed and publicly documented
@@ -22,7 +22,7 @@ surprise:
   negotiate simply yields no identification here, same as any other
   unrecognised response.
 
-**Verificado contra un Samba real** (L49, banco de concordancia): el
+**Verificado contra un Samba real** (banco de concordancia): el
 negociado funciona —el dissector habla con un ``dperson/samba`` de verdad y
 lee dialecto ``3.0.2`` y modo de seguridad, exactamente lo que los offsets
 predecían—, así que el parser deja de ser una afirmación apoyada sólo en un
@@ -37,7 +37,7 @@ responden a preguntas distintas, y la de aquí no sirve para resolver un CPE
 —que es lo que la detección por versión necesita—. Está medido y documentado
 en ``tests/oracle/test_lybra_concordance_bench.py``.
 
-**Dos intercambios más, y por qué** (L11). El NEGOTIATE de arriba dice qué
+**Dos intercambios más, y por qué**. El NEGOTIATE de arriba dice qué
 dialecto habla el servidor y si exige firma, y eso era todo. Faltaban tres
 datos que el propio protocolo ofrece sin autenticar:
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/snmp.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/snmp.py
@@ -1,5 +1,4 @@
-"""El dissector SNMP — Fase N/Ronda 1 (roadmap §6.3), sobre la sonda UDP de la
-Fase T mínima que este mismo cambio añade a ``transport.py``.
+"""El dissector SNMP — sobre la sonda UDP mínima de ``transport.py``.
 
 Lee la respuesta de un GetRequest SNMP v2c para el OID
 ``1.3.6.1.2.1.1.1.0`` (``sysDescr.0``) — el codificador del mensaje vive en
@@ -30,12 +29,12 @@ Qué NO soporta, deliberadamente:
 
 Lee un escalar y nada más.
 
-**Y desde L21 lo interpreta con un feed de patrones por fabricante.** El
-roadmap justificaba la prioridad de SNMP con una frase muy concreta —*"su
-``sysDescr`` trae producto y versión enteros en una sola lectura"*— y este
-dissector descartaba la versión a propósito, porque una regex genérica sobre
-texto libre envenenaría el matcher de CPE. La cautela era correcta; lo que
-dejaba sin cobrar es el mayor argumento de valor de SNMP.
+**La versión se interpreta con un feed de patrones por fabricante, nunca con
+una regex genérica.** El mayor argumento de valor de SNMP es que su
+``sysDescr`` trae producto y versión enteros en una sola lectura; extraer esa
+versión con una regex genérica sobre texto libre envenenaría el matcher de
+CPE, así que el dissector solo la reconoce cuando un patrón concreto de
+fabricante la confirma.
 
 ``feeds/sysdescr_patterns.json`` resuelve las dos cosas a la vez: patrones
 **por fabricante**, no un extractor general. Un formato concreto de un
@@ -44,8 +43,8 @@ SNMP es donde vive la superficie que más se le escapa a un escaneo por banner
 —switches, routers, impresoras, SAIs, cámaras—, justo los activos que un
 cliente no sabe que tiene.
 
-Las tres reglas del feed, que son las que evitan el envenenamiento que motivó
-la decisión original, están escritas en el propio fichero. La tercera es la que
+Las tres reglas del feed, que son las que evitan el envenenamiento del
+matcher de CPE, están escritas en el propio fichero. La tercera es la que
 sostiene a las otras dos: cada patrón entra con una muestra, y el test
 comprueba que casa con la suya y que **no** casa con la de ningún otro.
 """
@@ -75,9 +74,9 @@ _SYSDESCR_OID_TLV = bytes.fromhex("06082b06010201010100")
 # arriba: fingerprinting/snmp.py -> lybra/feeds/.
 _BUNDLED_SYSDESCR_PATTERNS = Path(__file__).parent.parent / "feeds" / "sysdescr_patterns.json"
 
-# El ``qod`` de una versión extraída por un patrón específico del producto: la
-# tabla del §10 del roadmap le asigna 80, por encima del 70 de un CPE genérico
-# y por debajo de una evidencia confirmada activamente.
+# El ``qod`` de una versión extraída por un patrón específico del producto: 80,
+# por encima del 70 de un CPE genérico y por debajo de una evidencia
+# confirmada activamente.
 QOD_VENDOR_PATTERN = 80
 
 
@@ -349,6 +348,6 @@ class SnmpDissector(Dissector):
             fingerprint.version,
             self.label,
             # Un patrón específico del producto vale más que la constante de
-            # fingerprint (tabla del §10); un sysDescr sin reconocer, no.
+            # fingerprint; un sysDescr sin reconocer, no.
             qod=QOD_VENDOR_PATTERN if fingerprint.matched_pattern else QOD_FINGERPRINT,
         )

--- a/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/telnet.py
@@ -1,11 +1,11 @@
 """La sonda de Telnet — porque que exista ya es el hallazgo.
 
-El roadmap descartó el *dissector* de Telnet con buen criterio: su negociación
-de opciones (IAC) no deja un texto identificable de forma fiable sin inventar
+No tiene sentido construir un *dissector* de Telnet: su negociación de
+opciones (IAC) no deja un texto identificable de forma fiable sin inventar
 patrones, así que no hay un producto/versión que leer. Pero el *check* es otra
 cosa. Telnet manda credenciales en claro por diseño; que un servicio esté ahí,
-hablando el protocolo, ya es un hallazgo de configuración de red —el que la
-Fase N prometía— sin necesidad de identificar nada.
+hablando el protocolo, ya es un hallazgo de configuración de red por sí
+mismo, sin necesidad de identificar nada.
 
 Lo que este módulo comprueba es exactamente eso y nada más: que al otro lado
 hay algo que **habla Telnet**. Un servidor Telnet abre la conversación

--- a/API/src/modules/features/themis/lybra/fingerprinting/udp_services.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/udp_services.py
@@ -1,9 +1,9 @@
-"""Los consumidores de la superficie UDP — un dissector por sonda (L22).
+"""Los consumidores de la superficie UDP — un dissector por sonda.
 
-La tabla de sondas UDP creció de una fila a siete, y la regla que la gobierna
-desde la Ronda 1 es que **cada fila llega con su consumidor**, nunca la sonda
-sola: un payload sin nadie que lea la respuesta sólo produce un ``open_port``
-informativo a cambio de construir y validar una consulta más.
+La regla que gobierna la tabla de sondas UDP es que **cada fila llega con su
+consumidor**, nunca la sonda sola: un payload sin nadie que lea la respuesta
+sólo produce un ``open_port`` informativo a cambio de construir y validar una
+consulta más.
 
 Este módulo es esa mitad. Los payloads viven en :mod:`~..udp_payloads`, por la
 misma razón de siempre — ``transport.py`` los necesita para la tabla de

--- a/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/vnc.py
@@ -1,4 +1,4 @@
-"""The VNC dissector — Fase N.
+"""The VNC dissector.
 
 The RFB protocol (RFC 6143 §7.1.1) opens with the server sending its supported
 protocol version unprompted, as a fixed 12-byte ASCII line: ``"RFB 003.008\\n"``.

--- a/API/src/modules/features/themis/lybra/ingest/__init__.py
+++ b/API/src/modules/features/themis/lybra/ingest/__init__.py
@@ -1,10 +1,10 @@
-"""Ingesta de plantillas externas al runtime propio (roadmap Fases U4 y R).
+"""Ingesta de plantillas externas al runtime propio.
 
 Tres piezas, en el orden en que actúan: el **clasificador** decide qué
-plantillas entiende el runtime (y es el mismo criterio con el que el censo de
-la Fase U4 mide), el **traductor** las convierte en ``Check`` con su procedencia
-sellada, y el **selector** reduce el resultado a lo que vale la pena lanzar
-contra un objetivo concreto.
+plantillas entiende el runtime (y es el mismo criterio que usa el censo de
+cobertura del feed para medir qué fracción es ingerible), el **traductor** las
+convierte en ``Check`` con su procedencia sellada, y el **selector** reduce el
+resultado a lo que vale la pena lanzar contra un objetivo concreto.
 """
 
 from .classifier import (

--- a/API/src/modules/features/themis/lybra/ingest/classifier.py
+++ b/API/src/modules/features/themis/lybra/ingest/classifier.py
@@ -1,14 +1,14 @@
 """
 Clasificador de plantillas de Nuclei por lo que exigen del runtime propio.
 
-Esta es la pieza que responde a la pregunta de la Fase U4 —*¿qué fracción del
-feed de Nuclei podríamos ingerir?*— y, más adelante, la que la Fase R usará para
+Esta es la pieza que responde a la pregunta de cobertura —*¿qué fracción del
+feed de Nuclei podríamos ingerir?*— y también la que la ingesta usa para
 decidir plantilla a plantilla si se traduce o se descarta.
 
-**Se escribe una sola vez a propósito.** El censo (U4) y la ingesta (R) tienen
-que estar de acuerdo sobre qué es ingerible, o el número medido no describe lo
-que la ingesta acabará haciendo. Compartiendo este módulo no pueden discrepar:
-si divergen, es un bug en un único sitio.
+**Se escribe una sola vez a propósito.** El censo de cobertura y la ingesta
+tienen que estar de acuerdo sobre qué es ingerible, o el número medido no
+describe lo que la ingesta acabará haciendo. Compartiendo este módulo no
+pueden discrepar: si divergen, es un bug en un único sitio.
 
 El criterio no es "¿entiende Nuclei esto?" sino "¿lo entiende
 :class:`~..checks.CheckRuntime`?". Hoy el runtime soporta un subconjunto
@@ -20,8 +20,8 @@ comparan texto decodificado. Todo lo demás —extractors e interpolación
 razón y a distinta distancia de poder soportarse.
 
 De ahí que la clasificación no sea binaria sino por **cubos ordenados por
-esfuerzo**: la decisión que el roadmap quiere tomar no es "¿se puede?" sino
-"¿cuánto habría que construir, y a cambio de cuántas plantillas?".
+esfuerzo**: la decisión que importa no es "¿se puede?" sino "¿cuánto habría
+que construir, y a cambio de cuántas plantillas?".
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ _NETWORK_KEYS = ("network", "tcp")
 # Protocolos que el motor no habla y no va a hablar por esta vía: o necesitan
 # una infraestructura entera (``headless`` es un navegador; ``interactsh`` es un
 # servidor fuera de banda), o son un lenguaje de scripting (``code``, ``flow``,
-# ``javascript``), que el roadmap descarta explícitamente por no poder aislarse.
+# ``javascript``), que se descartan explícitamente por no poder aislarse.
 _SCRIPTING_KEYS = ("code", "flow", "javascript")
 _OUT_OF_SCOPE_KEYS = ("dns", "file", "headless", "whois", "ssl", "websocket")
 
@@ -158,8 +158,8 @@ def _inspect_requests(requests: List[dict]) -> Set[str]:
         if request.get("extractors"):
             blockers.add("extractors")
         # El esquema binario de una sonda de red: ``inputs`` con ``type: hex``.
-        # Es justo lo que desbloquearía los checks de SMB que la Fase N no pudo
-        # construir, así que interesa contarlo por separado.
+        # Es justo lo que desbloquearía los checks de SMB, que hoy no se pueden
+        # construir con el runtime propio, así que interesa contarlo por separado.
         for entry in request.get("inputs") or []:
             if isinstance(entry, dict) and entry.get("type") == "hex":
                 blockers.add("input-hex")
@@ -241,7 +241,7 @@ def _bucket_for(blockers: Set[str]) -> Bucket:
 
 
 def is_ingestible(document: dict) -> bool:
-    """Atajo para la Fase R: si la plantilla se traduce hoy tal cual.
+    """Si la plantilla se traduce hoy tal cual, sin necesitar más soporte del runtime.
 
     Deliberadamente estricto — solo :attr:`Bucket.INGESTIBLE_NOW`. Una
     plantilla de cualquier otro cubo se descarta en la ingesta en vez de
@@ -252,7 +252,7 @@ def is_ingestible(document: dict) -> bool:
 
 
 def summarize(profiles: List[TemplateProfile]) -> Dict[str, object]:
-    """Agrega una lista de perfiles en el histograma que la Fase U4 pide.
+    """Agrega una lista de perfiles en el histograma del censo de cobertura.
 
     Args:
         profiles: Los perfiles de todas las plantillas censadas.
@@ -260,8 +260,8 @@ def summarize(profiles: List[TemplateProfile]) -> Dict[str, object]:
     Returns:
         Un diccionario con el total, el reparto por cubo (absoluto y en
         porcentaje), el reparto por protocolo, el recuento de obstáculos y el
-        dato que de verdad decide la Fase R: la fracción de las plantillas
-        **HTTP** que son ingeribles hoy tal cual.
+        dato que de verdad importa para decidir si activar la ingesta: la
+        fracción de las plantillas **HTTP** que son ingeribles hoy tal cual.
     """
     total = len(profiles)
     by_bucket: Dict[str, int] = {bucket.value: 0 for bucket in Bucket}

--- a/API/src/modules/features/themis/lybra/ingest/selector.py
+++ b/API/src/modules/features/themis/lybra/ingest/selector.py
@@ -1,4 +1,4 @@
-"""Selección de checks ingeridos antes de que el runtime los ejecute (Fase R).
+"""Selección de checks ingeridos antes de que el runtime los ejecute.
 
 **El problema que resuelve, en números.** ``CheckRuntime.run`` es
 O(servicios × checks) y ejecuta *todo* check HTTP contra *todo* servicio HTTP.
@@ -10,9 +10,9 @@ hora. Sin esta capa, activar la ingesta no sería una mejora, sería un disparo
 en el pie.
 
 **El criterio, en tres filtros de coste creciente.** Ninguno es sofisticado, y
-eso es deliberado: un índice por CPE de verdad es trabajo mayor y el número de
-la Fase U4 aún no dice si merece la pena. Lo que hay aquí es lo suficiente para
-que activar la ingesta sea seguro.
+eso es deliberado: un índice por CPE de verdad es trabajo mayor y el censo de
+cobertura del feed todavía no dice si merece la pena. Lo que hay aquí es lo
+suficiente para que activar la ingesta sea seguro.
 
 1. **Severidad mínima.** Las plantillas ``info`` de Nuclei son miles de
    detecciones de tecnología; no aportan hallazgos accionables y sí todo el

--- a/API/src/modules/features/themis/lybra/ingest/translator.py
+++ b/API/src/modules/features/themis/lybra/ingest/translator.py
@@ -1,10 +1,10 @@
-"""Traductor de plantillas de Nuclei a checks del runtime propio (Fase R).
+"""Traductor de plantillas de Nuclei a checks del runtime propio.
 
 Convierte una plantilla upstream en un :class:`~..checks.Check` **solo si el
 runtime la entiende entera**. La decisión de si la entiende no se toma aquí:
-la toma :func:`~.classifier.is_ingestible`, el mismo criterio que el censo de la
-Fase U4 usa para medir. Esa es la razón de que el clasificador sea un módulo
-aparte y no lógica embebida en cualquiera de los dos.
+la toma :func:`~.classifier.is_ingestible`, el mismo criterio que usa el censo
+de cobertura del feed para medir. Esa es la razón de que el clasificador sea
+un módulo aparte y no lógica embebida en cualquiera de los dos.
 
 **Traducir a medias no es una opción.** Una plantilla que use extractors o
 payloads podría "casi" traducirse ignorando esas partes, y el resultado sería un

--- a/API/src/modules/features/themis/lybra/kb.py
+++ b/API/src/modules/features/themis/lybra/kb.py
@@ -318,7 +318,7 @@ def version_in_range(version: str, match) -> bool:
 
 
 # =========================================================================
-# PRODUCT NAME NORMALIZATION (Fase I-b, paso 1)
+# PRODUCT NAME NORMALIZATION
 # =========================================================================
 
 # Content in brackets/parentheses is almost always packaging noise for a
@@ -359,7 +359,7 @@ _TRAILING_VERSION_RE = re.compile(r"(?:\s+\d+(?:\.\d+){1,3}[a-z0-9]*)+$")
 
 
 def normalize_product_name(name: str) -> str:
-    """Canonicalize a product name for CPE-alias matching (Fase I-b, paso 1).
+    """Canonicalize a product name for CPE-alias matching.
 
     Applied to *both* sides of a comparison — an inventory entry's ``name``
     and an NVD ``CpeMatch.product`` — so the two vocabularies can be compared
@@ -373,7 +373,7 @@ def normalize_product_name(name: str) -> str:
     normalization that is too aggressive risks *collision* — two different
     products reducing to the same key — which is a worse failure than staying
     unresolved, since :func:`~.repositories.KbRepository.rebuild_cpe_product_index`
-    already discards a colliding key rather than guessing (Fase I-b, paso 2).
+    already discards a colliding key rather than guessing.
 
     Args:
         name: A raw product name, from either side of the comparison.
@@ -481,11 +481,11 @@ def parse_cpe23(cpe: str) -> Optional[dict]:
     }
 
 
-# The curated product-name -> (vendor, product) alias feed (Fase I-b, paso 3),
+# The curated product-name -> (vendor, product) alias feed,
 # alongside every other Lybra feed (checks_feed.json, tech_signatures.json).
 # Same "Lybra feed" philosophy: a new alias is one JSON entry, not a code
 # change, added whenever a real inventory turns up a frequent unresolved
-# product the automated index (paso 2) can't reach — a marketing name too far
+# product the automated index can't reach — a marketing name too far
 # from its CPE ("Microsoft Visual C++ 2022 X64 Additional Runtime" vs
 # ``visual_c++``) rather than a spelling/formatting difference.
 _BUNDLED_PRODUCT_ALIASES = Path(__file__).parent / "feeds" / "product_aliases.json"
@@ -582,7 +582,7 @@ def _pick_cvss(metrics: dict) -> Tuple[Optional[float], Optional[str], Optional[
 
 
 # =========================================================================
-# AVISOS DE DISTRIBUCIÓN (Fase O — verificación de backports)
+# AVISOS DE DISTRIBUCIÓN
 # =========================================================================
 #
 # Un backport es una distribución arreglando una vulnerabilidad sin subir el
@@ -735,7 +735,7 @@ def fetch_oval(url: str, timeout: int = 60) -> str:
 def _has_exploit_reference(cve: dict) -> bool:
     """Si NVD enlaza al menos una referencia etiquetada como exploit.
 
-    Es la señal más barata de madurez de explotación que hay (L34): la propia
+    Es la señal más barata de madurez de explotación que hay: la propia
     NVD etiqueta sus referencias, y una marcada ``Exploit`` significa que
     alguien ha publicado algo que demuestra el fallo. No dice cuán usable es
     —puede ser una prueba de concepto en un gist o un exploit completo— así
@@ -1027,7 +1027,7 @@ def _http_get(url: str, timeout: int = 30, api_key: Optional[str] = None) -> byt
     last_error: Optional[Exception] = None
     for attempt in range(_RETRIES):
         try:
-            # ``socket_timeout`` sigue haciendo falta con ``requests`` (E7): ni
+            # ``socket_timeout`` sigue haciendo falta con ``requests``: ni
             # el timeout de urllib ni el de requests acotan la resolución DNS
             # (``getaddrinfo`` corre dentro de ``socket.create_connection``
             # *antes* de que el timeout se aplique al socket), y un resolver

--- a/API/src/modules/features/themis/lybra/script_checks.py
+++ b/API/src/modules/features/themis/lybra/script_checks.py
@@ -1,4 +1,4 @@
-"""Checks de tipo ``script`` — el cuarto tipo del runtime (Fase R).
+"""Checks de tipo ``script`` — el cuarto tipo del runtime.
 
 Un check declarativo compara texto: pide algo y mira si la respuesta contiene
 un patrón. Eso cubre el 90 % de lo web, pero deja fuera todo lo que exige
@@ -6,15 +6,12 @@ lógica: un protocolo binario, una negociación de varios pasos cuyo resultado
 hay que interpretar, o un hecho que ya se dedujo pero que ningún matcher de
 texto puede expresar. Para eso está este tipo.
 
-**Un caso concreto, que es el que motiva el módulo.** La Fase N dejó anotado que
-los checks "SMB sin firma" y "SMBv1 habilitado" *no se pudieron construir*
-porque «el runtime declarativo actual solo compara texto decodificado, y una
-respuesta SMB2 es binaria». Pero el dissector de SMB ya negocia con el servidor
-y ya lee su ``SecurityMode``: el hecho está observado, solo faltaba un vehículo
-para convertirlo en un hallazgo. Un plugin de primera parte es ese vehículo, y
-llega mucho antes que el camino alternativo (adoptar el esquema ``network`` de
-Nuclei con ``type: hex`` y un matcher ``binary``, que depende de la medición de
-U4).
+**Un caso concreto, que es el que motiva el módulo.** Los checks "SMB sin
+firma" y "SMBv1 habilitado" no se pueden expresar como un check declarativo,
+porque el runtime declarativo sólo compara texto decodificado y una respuesta
+SMB2 es binaria. Pero el dissector de SMB ya negocia con el servidor y ya lee
+su ``SecurityMode``: el hecho está observado, sólo faltaba un vehículo para
+convertirlo en un hallazgo. Un plugin de primera parte es ese vehículo.
 
 **Por qué los plugins se inyectan y no se importan.** ``checks.py`` no importa
 ``fingerprinting`` a propósito — lo dice su propio comentario en ``_TLS_RULES``:
@@ -130,8 +127,7 @@ class SmbV1EnabledPlugin(ScriptPlugin):
     **El NEGOTIATE de SMB2 no puede verlo**, y por eso este check tiene su
     propia sonda: son dos protocolos distintos con dos saludos distintos, así
     que un servidor con SMB1 activo contesta con toda normalidad al SMB2 y no
-    dice ni una palabra sobre el otro. Ésta es la comprobación que la tabla de
-    la Fase N pedía y que no se pudo construir entonces.
+    dice ni una palabra sobre el otro.
 
     La evidencia es una aceptación explícita: el servidor contesta un
     ``NEGOTIATE`` de SMB1 con estado correcto y eligiendo un dialecto. El
@@ -158,7 +154,7 @@ class SmbV1EnabledPlugin(ScriptPlugin):
 class SnmpDefaultCommunityPlugin(ScriptPlugin):
     """Detecta un servicio SNMP que acepta la comunidad por defecto ``public``.
 
-    Comparte la sonda con el dissector SNMP (Fase N/Ronda 1, roadmap §6.3) a
+    Comparte la sonda con el dissector SNMP a
     propósito: que ``sysDescr`` conteste a ``public`` ES la evidencia del
     hallazgo, no una comprobación aparte — no tiene sentido mandar el mismo
     datagrama dos veces con dos sondas distintas.

--- a/API/src/modules/features/themis/lybra/transport.py
+++ b/API/src/modules/features/themis/lybra/transport.py
@@ -1,7 +1,7 @@
 """
 Lybra's own port discovery — the transport layer.
 
-This is the always-available foundation of the roadmap's transport plan: an
+This is the always-available foundation of the transport layer: an
 unprivileged TCP ``connect`` scan built on asyncio. It lets an Lybra scan find
 open ports for itself, so a scan no longer has to be handed the ports from a
 prior Nmap run.
@@ -9,31 +9,29 @@ prior Nmap run.
 Several faster or lower-level techniques are deliberately *not* built here — a
 stateless SYN fast-path, and AIMD (loss-based) rate control. They would need
 raw-socket privileges (``CAP_NET_RAW``), cannot be exercised in this test
-environment, and the roadmap itself treats them as later optimizations to
-reach for only once measured throughput demands them. The connect scan below
-is the base that is always present; a raw path would only ever be a faster
-route to the same result, with Nmap still available as the oracle to check
-against.
+environment, and are later optimizations to reach for only once measured
+throughput demands them. The connect scan below is the base that is always
+present; a raw path would only ever be a faster route to the same result,
+with Nmap still available as the oracle to check against.
 
-**UDP is a separate, smaller story** (Fase N/Ronda 1, roadmap §6.3): a
+**UDP is a separate, smaller story**: a
 "connect scan" is meaningless over a datagram socket, so the only signal
 available without raw sockets is a curated payload/expected-reply pair per
 port — and *that* needs no ``CAP_NET_RAW`` at all, an unprivileged
 ``sendto``/``recvfrom`` (or a connected UDP socket, which is what this module
-uses) suffices. :data:`UDP_PROBES` nació con una sola fila (SNMP en el
-161) y una regla: crece una fila por protocolo que un check o un dissector
-consuma de verdad, no antes de necesitarlo. L22 la cumple — siete filas, cada
-una con su consumidor en ``fingerprinting/udp_services.py``— y con siete el
-barrido pasa a ser concurrente, porque siete plazos de dos segundos en fila
-india son medio minuto de espera contra un host que seguramente no tenga
-ninguno de esos servicios.
+uses) suffices. :data:`UDP_PROBES` crece una fila por protocolo que un check
+o un dissector consuma de verdad, no antes de necesitarlo — hoy son siete,
+cada una con su consumidor en ``fingerprinting/udp_services.py``, y con siete
+el barrido es concurrente, porque siete plazos de dos segundos en fila india
+son medio minuto de espera contra un host que seguramente no tenga ninguno de
+esos servicios.
 
 The event loop is created and torn down entirely inside :func:`scan_ports_sync`
 — the "asyncio island". It lives within a single synchronous worker call and
 never touches the Flask process or an ORM session. The connection opener is
 injectable, so the scanner can be tested without opening real sockets.
 
-**Un barrido vacío y un barrido bloqueado no son lo mismo** (L48-c). Un
+**Un barrido vacío y un barrido bloqueado no son lo mismo**. Un
 objetivo que deja de contestar a mitad de camino —él mismo, o un cortafuegos
 por delante— produce un plazo agotado en cada puerto, y sumarlos daba una
 lista vacía indistinguible de un host genuinamente limpio. Por eso el barrido
@@ -82,7 +80,7 @@ logger = logging.getLogger(__name__)
 
 
 # Maps a well-known TCP port to its conventional service name. Used to label a
-# freshly discovered port before we have a banner for it; fingerprinting (Fase F)
+# freshly discovered port before we have a banner for it; fingerprinting
 # refines the label when it is enabled.
 WELL_KNOWN_PORTS = {
     21: "ftp", 22: "ssh", 23: "telnet", 25: "smtp", 53: "domain", 80: "http",
@@ -486,8 +484,7 @@ def scan_ports_sync(
     Devuelve ``None`` —no ``[]``— cuando el barrido salió bloqueado o truncado.
     Una lista vacía significa, y sólo significa, "el objetivo contestó y no
     tiene nada abierto"; confundir las dos cosas es lo que hacía que un barrido
-    bloqueado le dijera al usuario que sus vulnerabilidades fueron remediadas
-    (L48-c).
+    bloqueado le dijera al usuario que sus vulnerabilidades fueron remediadas.
 
     Quien sí necesite los resultados parciales de un barrido truncado —el
     motor, que puede reportarlos marcando el escaneo como incompleto— debe
@@ -509,15 +506,14 @@ def services_from_discovered_ports(
 
     A connect (or UDP probe) scan only learns *that* a port answered, not what
     is behind it, so these services carry no product or version —
-    fingerprinting (Fase F/N) fills those in when it runs. Each service is
+    fingerprinting fills those in when it runs. Each service is
     labelled with its well-known name so that, for example, HTTP checks still
     select the right ports.
 
     Args:
         open_ports: The discovered open port numbers.
         protocol: The transport they were discovered over — ``"tcp"`` (the
-            default, and the only value before Fase N/Ronda 1) or ``"udp"``
-            for :func:`scan_udp_ports_sync`'s results.
+            default) or ``"udp"`` for :func:`scan_udp_ports_sync`'s results.
 
     Returns:
         One :class:`Service` per port.
@@ -600,13 +596,9 @@ def build_snmp_get_request(community: str = "public") -> bytes:
 
 
 # Tabla payload→puerto para el descubrimiento UDP. Una fila por protocolo que
-# de verdad tiene un dissector o un check consumiéndolo, que es la regla con la
-# que nació con una sola fila: DNS y NTP se evaluaron y se descartaron entonces
-# porque nada los consumía, no porque no valieran.
-#
-# L22 cumple esa regla en vez de cambiarla: cada fila nueva llega **con su
-# consumidor**, todos en ``fingerprinting/udp_services.py``. Ahí vive la
-# superficie que no aparece en ningún escaneo TCP y que se usa a diario en
+# de verdad tiene un dissector o un check consumiéndolo: cada fila nueva llega
+# **con su consumidor**, todos en ``fingerprinting/udp_services.py``. Ahí vive
+# la superficie que no aparece en ningún escaneo TCP y que se usa a diario en
 # ataques de amplificación — servicios que convierten al host del cliente en
 # arma contra terceros, que es una conversación distinta y más incómoda que
 # "tienes un puerto abierto".
@@ -667,8 +659,7 @@ def scan_udp_ports_sync(  # pylint: disable=too-many-arguments
     "cerrado" — significa "no lo sabemos", así que aquí solo se reportan
     puertos que de verdad contestaron algo.
 
-    **Concurrente desde L22, y por aritmética.** Con una tabla de un puerto un
-    escáner paralelo era andamiaje, y así se dijo. Con siete filas, un
+    **Concurrente por aritmética.** Con siete filas en :data:`UDP_PROBES`, un
     reintento y dos segundos de plazo, el peor caso secuencial son veintiocho
     segundos de espera contra un host que probablemente no tenga ninguno de
     esos servicios. Un hilo por sonda —son siete, no doscientos— lo deja en el
@@ -688,8 +679,8 @@ def scan_udp_ports_sync(  # pylint: disable=too-many-arguments
         retries: Reintentos adicionales tras un primer silencio. Un
             datagrama perdido (no un puerto cerrado) haría que el mismo
             puerto oscilara entre abierto y cerrado entre escaneos, y el
-            ciclo de vida de la Fase 5 lo leería como ``fixed``/``regressed``
-            falsos — de ahí que el valor por defecto no sea 0.
+            ciclo de vida lo leería como ``fixed``/``regressed`` falsos — de
+            ahí que el valor por defecto no sea 0.
         sender: Callable inyectable ``(host, port, payload, timeout) ->
             Optional[bytes]``, espejo del ``opener`` del escáner TCP. Por
             defecto, :func:`udp_send_recv`.

--- a/API/src/modules/features/themis/lybra/udp_payloads.py
+++ b/API/src/modules/features/themis/lybra/udp_payloads.py
@@ -5,11 +5,10 @@ que la única señal disponible sin privilegios de raw socket es **mandar algo
 que ese protocolo entienda y ver si contesta**. De ahí que la tabla de sondas
 sea payload por puerto y no una lista de números.
 
-La Ronda 1 la abrió con una sola fila —SNMP en el 161— y una regla de
-crecimiento explícita: *"crece una fila por protocolo que un check o dissector
-realmente consuma, no antes de necesitarlo"*. Este módulo es esa regla
-cumplida, no cambiada: cada payload de aquí llega junto con el consumidor que
-lo lee (:mod:`~.fingerprinting.udp_services`).
+La regla de crecimiento es explícita: *"crece una fila por protocolo que un
+check o dissector realmente consuma, no antes de necesitarlo"*. Cada payload
+de aquí llega junto con el consumidor que lo lee
+(:mod:`~.fingerprinting.udp_services`).
 
 **Por qué la superficie UDP importa.** Ahí viven servicios que no aparecen en
 ningún escaneo TCP y que se usan a diario en ataques de amplificación — es

--- a/API/src/modules/features/themis/managers/authorized_target.py
+++ b/API/src/modules/features/themis/managers/authorized_target.py
@@ -1,4 +1,4 @@
-"""AuthorizedTargetManager — el registro de objetivos autorizados (roadmap §6).
+"""AuthorizedTargetManager — el registro de objetivos autorizados.
 
 Extraído de ``lybra/engine.py``: no comparte modelo, repositorio ni lógica con
 ``LybraEngineManager`` — es un gate legal transversal, consultado también por
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class AuthorizedTargetManager:
     """CRUD y comprobación de pertenencia para el registro de objetivos autorizados.
 
-    Registro de objetivos autorizados (roadmap §6). Antes de que Lybra ejecute
+    Registro de objetivos autorizados. Antes de que Lybra ejecute
     cualquier operación que toque la red del objetivo (autodescubrimiento propio,
     fingerprinting propio, comprobaciones activas del runtime), el objetivo debe
     estar en este registro por usuario. Es un gate legal, no de red o de

--- a/API/src/modules/features/themis/managers/kb_sync.py
+++ b/API/src/modules/features/themis/managers/kb_sync.py
@@ -1,8 +1,8 @@
 """KbSyncManager y KbQueryManager — escritura y lectura de la KB local.
 
-``KbSyncManager`` se extrajo de themis/managers.py (Fase 3 del refactor de
-estructura). ``KbQueryManager`` es posterior y es el contrato de lectura que
-consumen otros módulos.
+``KbSyncManager`` sincroniza la base de conocimiento local (NVD, CISA-KEV,
+FIRST-EPSS, avisos OVAL/CSAF de distribuciones) contra sus fuentes upstream.
+``KbQueryManager`` es el contrato de lectura que consumen otros módulos.
 """
 
 import json
@@ -61,7 +61,7 @@ class KbSyncManager:
         return count
 
     def sync_oval(self, sources: dict) -> int:
-        """Espejar los avisos de las distribuciones (Fase O).
+        """Espejar los avisos de las distribuciones.
 
         ``sources`` mapea ``"<vendor>[:<release>]"`` a la URL de su feed, para
         que añadir Debian 12 o Rocky 9 sea una línea de configuración y no de
@@ -171,7 +171,7 @@ class KbSyncManager:
                 repo.upsert_cve(cve_row, cpe_matches)
 
     def rebuild_cpe_product_index(self) -> int:
-        """Rebuild the CPE product-name index (Fase I-b, paso 2). See
+        """Rebuild the CPE product-name index. See
         ``KbRepository.rebuild_cpe_product_index`` for the algorithm."""
         with UnitOfWork() as uow:
             repository = KbRepository(uow)

--- a/API/src/modules/features/themis/managers/lybra/engine.py
+++ b/API/src/modules/features/themis/managers/lybra/engine.py
@@ -1,4 +1,5 @@
-"""LybraEngineManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""LybraEngineManager — orquesta el motor de escaneo propio de Lybra: descubrimiento
+de servicios, fingerprinting, checks activos y persistencia de los hallazgos resultantes."""
 
 import logging
 import time
@@ -78,7 +79,7 @@ class LybraEngineManager(ScanManager):
     Manager for Lybra's own vulnerability engine.
 
     Unlike the other scanners it launches no external subprocess: it discovers
-    the target's services itself (Fase T) — or takes a services list the caller
+    the target's services itself — or takes a services list the caller
     already resolved — and produces normalized :class:`Finding` rows through the
     :class:`LybraEngine`. Because that work is a fast, in-memory pass (no
     network), it does not go through the base ``_execute_scan`` (built for
@@ -95,7 +96,8 @@ class LybraEngineManager(ScanManager):
     SCHEDULED_REQUIRED_ARGS = ("target",)
 
     # Categories that are point-in-time events, not persistent vulnerability
-    # state - excluded from lifecycle tracking (see Phase 2.5 in _run_lybra).
+    # state - excluded from lifecycle tracking (see the lifecycle pass in
+    # _run_lybra).
     _EVENT_CATEGORIES = {"fingerprint", "surface_change"}
 
     def __init__(self, task_queue: ITaskQueue | None = None) -> None:
@@ -103,13 +105,18 @@ class LybraEngineManager(ScanManager):
 
     @classmethod
     def scheduled_run_kwargs(cls, arguments: dict) -> dict:
-        """target obligatorio + discover_ports opcional (B1). Un escaneo
-        programado siempre es autodescubrimiento (Fase T) — nunca tiene un
+        """Construye los argumentos de ejecución para un escaneo Lybra programado.
+
+        target obligatorio + discover_ports opcional. Un escaneo
+        programado siempre es autodescubrimiento — nunca tiene un
         payload de services que programar.
 
-        Un ``ProgramedScan`` creado antes de L52 puede llevar todavía una clave
-        ``deep`` en su columna JSON ``arguments``; se ignora sin más, que es lo
-        que hace este método con cualquier argumento que no reconozca."""
+        Warning:
+            Un ``ProgramedScan`` puede llevar todavía una clave ``deep`` en su
+            columna JSON ``arguments`` (formato antiguo, ya no usado al
+            programar). Este método la ignora sin más, que es lo que hace con
+            cualquier argumento que no reconozca.
+        """
         kwargs = super().scheduled_run_kwargs(arguments)
         kwargs["discover_ports"] = arguments.get("discover_ports")
         return kwargs
@@ -136,23 +143,23 @@ class LybraEngineManager(ScanManager):
           target's network. ``target`` is still required — it is the host
           identity findings get attached to.
         - **Self-discovery** (``target``, optional ``discover_ports``): Lybra
-          discovers the open ports itself with its own connect scan (Fase T).
+          discovers the open ports itself with its own connect scan.
           The caller validates the target (reject private, etc.).
 
         Args:
             programed_scan_id: Set when launched by the scheduler (Themis
                 scheduled scans), same convention as the other scan managers.
-            asset_id: Fase I — the Hygeia asset whose inventory produced
+            asset_id: The Hygeia asset whose inventory produced
                 ``services``. Recorded on the scan row for provenance and
                 grouping; it is never an input to the analysis itself, which
                 is why it does not travel in the TaskQueue args.
-            aggressive: Explicit request for the aggressive mode (L40).
+            aggressive: Explicit request for the aggressive mode.
                 Deliberately **not** enough on its own — ``_run_lybra`` only
                 honours it when the target is *also* in the authorized-target
                 register. A registered target does not pre-authorize
                 everything that could ever be done to it; this is the second
                 half of that double gate, and it is what unblocks the
-                default-credentials engine (Fase D, L31), the only family that
+                default-credentials engine, the only family that
                 writes to the target. Never set from a scheduled scan — see
                 ``scheduled_run_kwargs``, which does not forward it.
 
@@ -206,7 +213,7 @@ class LybraEngineManager(ScanManager):
 
         ``timeout`` es opcional para que un job encolado antes de ese cambio
         —que viaja con una tupla de tres argumentos— siga ejecutándose tras el
-        despliegue en vez de fallar al deserializarse. ``aggressive`` (L40) es
+        despliegue en vez de fallar al deserializarse. ``aggressive`` es
         opcional por el mismo motivo, con el mismo default seguro: un job
         encolado antes de este cambio se ejecuta en modo ``safe``, nunca en
         agresivo por sorpresa.
@@ -285,26 +292,19 @@ class LybraEngineManager(ScanManager):
         worker.
 
         ``timeout`` es el que el usuario escribió en el panel de lanzamiento.
-        Hasta ahora sólo alimentaba el plazo de la cola —un plazo que, por cómo
-        se inyecta, un hilo bloqueado en una llamada al sistema rebasa sin
-        enterarse— y por tanto no limitaba el escaneo de verdad. Ahora abre
-        además un plazo de reloj propio, y ese plazo acota **el escaneo
-        entero**: el descubrimiento come de él como presupuesto, y las fases de
-        después lo consultan por ``should_stop`` y se cortan solas.
+        Abre un plazo de reloj propio que acota **el escaneo entero**: el
+        descubrimiento come de él como presupuesto, y las fases de después lo
+        consultan por ``should_stop`` y se cortan solas. Un plazo por
+        operación —2 s por puerto, 8 s por petición HTTP— no basta por sí
+        solo: limita cuánto tarda cada sonda, no cuántas se hacen, y cuántas
+        se hacen lo decide el objetivo (cuántos puertos abiertos tenga), no el
+        motor.
 
-        Acotar sólo el descubrimiento no bastaba, aunque lo pareciera. Un
-        «plazo por operación» —2 s por puerto, 8 s por petición HTTP— limita
-        cuánto tarda cada sonda, no cuántas se hacen, y cuántas se hacen no lo
-        decide el motor: lo decide cuántos puertos abiertos tenga el objetivo.
-        Con un rango ancho, el fingerprinting corría horas contra el ritmo
-        deliberadamente lento del ``HostRateLimiter``, y su único límite acababa
-        siendo la sentencia de muerte de la cola.
-
-        ``aggressive`` (L40) es la petición explícita del usuario; por sí sola
+        ``aggressive`` es la petición explícita del usuario; por sí sola
         no basta. El modo efectivo con el que corren los checks activos y el
-        motor de credenciales (Fase D, L31) sólo sube a ``"aggressive"``
+        motor de credenciales sólo sube a ``"aggressive"``
         cuando además ``is_target_authorized`` es verdadero — la doble puerta
-        que el roadmap exige para cualquier cosa que escriba en el objetivo.
+        que protege cualquier cosa que escriba en el objetivo.
         Un objetivo autorizado sin petición explícita se queda en ``safe``;
         una petición explícita sobre un objetivo no autorizado, también.
         """
@@ -318,12 +318,7 @@ class LybraEngineManager(ScanManager):
             Las dos cosas significan lo mismo para todo lo que viene detrás —
             vio parte del objetivo, no todo— y por eso comparten predicado: cada
             fase lo consulta y se corta sola, el escaneo se marca ``is_partial``
-            y termina bien. Antes sólo el descubrimiento TCP consumía el plazo y
-            las fases siguientes corrían sin cota ninguna, así que el único
-            límite real del fingerprinting era la sentencia de muerte de la
-            cola: un escaneo con muchos puertos abiertos la alcanzaba siempre,
-            porque cuántos servicios hay que sondear no lo decide el motor sino
-            el objetivo.
+            y termina bien.
             """
             return is_cancelled() or (deadline is not None and time.monotonic() >= deadline)
 
@@ -369,7 +364,7 @@ class LybraEngineManager(ScanManager):
                     and source_target
                     and AuthorizedTargetManager.is_authorized(user_id, source_target)
                 )
-                # La doble puerta del modo agresivo (L40): la petición
+                # La doble puerta del modo agresivo: la petición
                 # explícita del usuario por sí sola no basta, y el registro de
                 # autorización por sí solo tampoco — autorizar un objetivo no
                 # es autorizar cualquier cosa contra él. Sólo con las dos a la
@@ -381,10 +376,10 @@ class LybraEngineManager(ScanManager):
                 # Un escaneo cancelado a mitad es, a efectos del ciclo de vida,
                 # lo mismo que uno truncado por reloj: vio parte del objetivo,
                 # no todo. Comparte la bandera ``is_partial`` para no cerrar por
-                # omisión lo que no llegó a comprobar (el fallo de L48-c).
+                # omisión lo que no llegó a comprobar.
                 is_partial = resolved.is_partial or should_stop()
-                # Descubrimiento hecho: 40 % del trabajo (pesos honestos del §3
-                # del issue — descubrimiento 40, fingerprint 30, checks 20,
+                # Descubrimiento hecho: 40 % del trabajo (reparto de pesos entre
+                # las fases: descubrimiento 40, fingerprint 30, checks 20,
                 # correlación y persistencia 10).
                 report(40)
 
@@ -421,12 +416,12 @@ class LybraEngineManager(ScanManager):
                     epss_lookup=lambda cve_id: getattr(kb_repo.get_epss(cve_id), "score", None),
                     product_alias_lookup=kb_repo.resolve_product_alias,
                     feed_version=kb_feed_version(kb_repo.knowledge_state()),
-                    # L37: qué nombres de producto no logramos identificar. El
+                    # Qué nombres de producto no logramos identificar. El
                     # motor los cuenta, no los escribe — el paquete `lybra/` es
                     # libre de ORM y lo sigue siendo porque esto entra
                     # inyectado, como los demás lookups.
                     record_resolution=kb_repo.record_resolution,
-                    # L34: la madurez de explotación. Sale de lo que ya está en
+                    # La madurez de explotación. Sale de lo que ya está en
                     # casa —la referencia que la propia NVD etiqueta como
                     # exploit— y se combina con KEV dentro del motor.
                     exploit_evidence_lookup=kb_repo.exploit_evidence,
@@ -438,7 +433,7 @@ class LybraEngineManager(ScanManager):
             # Las CVEs que la detección por versión acaba de proponer. Son las
             # hipótesis (confirmed=false, qod=70) que un confirmador puede
             # ascender a hecho: el runtime sólo corre un confirmador cuya CVE
-            # esté aquí — nunca "por si acaso" (L29).
+            # esté aquí — nunca "por si acaso".
             proposed_cves = frozenset(
                 cve for finding in findings_data
                 for cve in (finding.get("cve_ids") or ()))
@@ -452,7 +447,7 @@ class LybraEngineManager(ScanManager):
                                             mode=mode))
                 is_partial = is_partial or should_stop()
 
-            # Motor de credenciales por defecto (Fase D, L31) — la única
+            # Motor de credenciales por defecto — la única
             # familia que escribe en el objetivo. ``_run_credential_checks``
             # repite por su cuenta la comprobación de ``mode`` antes de probar
             # nada; esta condición sólo evita el trabajo de construir el
@@ -478,19 +473,18 @@ class LybraEngineManager(ScanManager):
             # ausencia de un hallazgo que esta vez no se llegó a comprobar no
             # es evidencia de que se haya corregido. Sin esto, un
             # descubrimiento truncado le diría al usuario que sus
-            # vulnerabilidades fueron remediadas — el fallo de L48-c por otra
-            # puerta.
+            # vulnerabilidades fueron remediadas.
             findings_data = apply_lifecycle(
                 trackable, trackable_previous, close_missing=not is_partial) + events
 
-            # Fase O, y **después** del ciclo de vida a propósito. Un backport
-            # de la distribución corrige el fallo sin subir el número de
-            # versión visible, que es la causa número uno de falsos positivos
-            # del motor —medida en 0,42 por el banco de la Fase 1—, así que la
-            # palabra del proveedor es la última sobre si el hallazgo es real.
-            # Antes del ciclo de vida el veredicto se perdía: `apply_lifecycle`
-            # reasigna el estado de todo hallazgo presente, y un `fixed` recién
-            # puesto volvía a `open` en la misma pasada.
+            # Se aplica el backport **después** del ciclo de vida a propósito.
+            # Un backport de la distribución corrige el fallo sin subir el
+            # número de versión visible, que es la causa más común de falsos
+            # positivos del motor, así que la palabra del proveedor es la
+            # última sobre si el hallazgo es real. Si se aplicara antes,
+            # `apply_lifecycle` reasignaría el estado de todo hallazgo
+            # presente y borraría ese veredicto: un `fixed` recién puesto
+            # volvería a `open` en la misma pasada.
             with UnitOfWork() as uow:
                 apply_backport_verdicts(findings_data, KbRepository(uow).distro_package_status)
 
@@ -544,7 +538,7 @@ class LybraEngineManager(ScanManager):
         budget_seconds: Optional[float] = None,
         cancel_check: Optional[Callable[[], bool]] = None,
     ) -> Optional[PortSweep]:
-        """Discover open ports with Lybra's own connect scan (Fase T).
+        """Discover open ports with Lybra's own connect scan.
 
         Devuelve el barrido entero y no una lista porque los desenlaces son
         tres, no dos, y el llamante tiene que distinguirlos:
@@ -553,7 +547,7 @@ class LybraEngineManager(ScanManager):
         - **bloqueado** (``None``) — nada contestó de ninguna forma, así que no
           se sabe nada. Tratarlo como "todo cerrado" hacía que el ciclo de vida
           marcara como corregidos hallazgos que seguían abiertos, y le dijera
-          al usuario que sus vulnerabilidades se arreglaron solas (L48-c).
+          al usuario que sus vulnerabilidades se arreglaron solas.
         - **truncado** (``was_truncated``) — se acabó el reloj a mitad. Lo
           encontrado es cierto; lo que quedó sin mirar es desconocido. El
           escaneo sigue adelante con lo que hay y se marca como parcial, en
@@ -590,7 +584,7 @@ class LybraEngineManager(ScanManager):
         return sweep
 
     def _discover_udp_ports(self, target: str) -> list:
-        """Discover open UDP ports via the curated probe table (Fase N/Ronda 1).
+        """Discover open UDP ports via the curated probe table.
 
         Unlike :meth:`_discover_ports`, this never returns ``None``: UDP
         silence is *by definition* indistinguishable from "nothing there", so
@@ -614,14 +608,14 @@ class LybraEngineManager(ScanManager):
     def _run_active_checks(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self, target: str, services, cancel_check=None,
         proposed_cves=None, mode: str = "safe") -> list:
-        """Run the check runtime against the target's HTTP, TLS, network (Fase N)
-        and script (Fase R) services.
+        """Run the check runtime against the target's HTTP, TLS, network
+        and script services.
 
         Best-effort: a runtime failure (unreachable host, etc.) yields no active
         findings rather than failing the whole scan.
 
         ``mode`` llega ya resuelto por :meth:`_run_lybra` — esta capa no decide
-        si el agresivo procede, sólo lo aplica (L40): un ``check`` marcado
+        si el agresivo procede, sólo lo aplica: un ``check`` marcado
         ``mode: aggressive`` en el feed sigue sin correr en modo ``safe``, y
         eso lo sigue decidiendo ``CheckRuntime._applies_mode`` como siempre.
         """
@@ -654,7 +648,7 @@ class LybraEngineManager(ScanManager):
             return []
 
     def _run_credential_checks(self, target: str, services, mode: str) -> list:
-        """Probar credenciales por defecto contra los servicios del objetivo (Fase D, L31).
+        """Probar credenciales por defecto contra los servicios del objetivo.
 
         Es la única familia de detección que escribe en el objetivo, así que
         no basta con la doble puerta de quien llama (autorizado + agresivo
@@ -679,9 +673,9 @@ class LybraEngineManager(ScanManager):
                     user_agent=engine.http_user_agent,
                 ).fetch,
                 # Intervalo mayor que el de los checks de lectura: cada
-                # intento aquí es un login real, y el roadmap pide
-                # explícitamente un ritmo distinto al de un GET de
-                # ``.git/config`` para no parecer un ataque de fuerza bruta.
+                # intento aquí es un login real, y hace falta un ritmo
+                # distinto al de un GET de ``.git/config`` para no parecer un
+                # ataque de fuerza bruta.
                 rate_limiter=HostRateLimiter(min_interval=engine.rate_limit_interval * 5),
                 max_attempts_per_account=credentials.max_attempts,
                 capture_evidence=CR.lybra_evidence_config().enabled,
@@ -692,11 +686,11 @@ class LybraEngineManager(ScanManager):
             return []
 
     def _ingested_checks(self, services) -> list:
-        """Checks traducidos del árbol de plantillas de Nuclei (Fase R).
+        """Checks traducidos del árbol de plantillas de Nuclei.
 
-        Desactivado por defecto: hasta que el censo de la Fase U4 diga que la
-        ingesta merece la pena, esto devuelve una lista vacía y el motor corre
-        exactamente con su feed propio, como hasta ahora.
+        Desactivado por defecto: hasta que el censo de cobertura del feed diga
+        que la ingesta merece la pena, esto devuelve una lista vacía y el
+        motor corre exactamente con su feed propio.
 
         La selección (:func:`select_for_services`) se aplica **aquí**, antes de
         construir el runtime, y no dentro de él: el feed propio no debe pagar
@@ -734,24 +728,18 @@ class LybraEngineManager(ScanManager):
     def _fingerprint_services(self, target: str, services: list, cancel_check=None) -> tuple:
         """Run Lybra's own HTTP/SSH/FTP dissectors and identify each service.
 
-        Fase F. La identificación que sale de aquí **es** la identificación del
+        La identificación que sale de aquí **es** la identificación del
         servicio: alimenta el matcher de versiones (``LybraEngine._resolve_cpe``)
-        y deja además un hallazgo informativo con lo que se leyó.
-
-        Hasta L52 no era así. Un servicio que ya traía producto y versión de un
-        escaneo Nmap previo era intocable — la lectura propia no podía
-        sobrescribirlo, sólo emitir un veredicto de «concuerda / no concuerda
-        con Nmap». Ese modo de arranque ya no existe, y con él se fue la
-        subordinación: un motor cuyo propio análisis no puede prevalecer sobre
-        el de otra herramienta no es independiente. La comparación con Nmap
-        sigue siendo posible, pero como **medición**, desde el arnés de pruebas
-        (``tests/oracle/_concordance.py``), no dentro del producto.
+        y deja además un hallazgo informativo con lo que se leyó. El motor es
+        independiente: su propio análisis prevalece sobre el de otra
+        herramienta. La comparación con Nmap sigue siendo posible, pero como
+        **medición**, desde el arnés de pruebas (``tests/oracle/_concordance.py``),
+        no dentro del producto.
 
         Best-effort per service; a probe failure just skips that service. The
         dissector selection itself is a registry lookup
-        (:func:`~..lybra.default_dissectors`), not an if/elif chain — adding
-        protocol N+1 to Fase N never touches this method again, only that
-        registry.
+        (:func:`~..lybra.default_dissectors`), not an if/elif chain — adding a
+        new protocol never touches this method again, only that registry.
 
         Returns:
             A ``(services, findings)`` tuple: the service list with any newly
@@ -784,11 +772,11 @@ class LybraEngineManager(ScanManager):
                 except Exception:
                     logger.debug("Fingerprinting failed for %s:%s", target, service.port, exc_info=True)
             elif (service.protocol or "tcp").lower() != "udp":
-                # Ningún dissector reclama este servicio, que hasta L10 quería
-                # decir "se acabó": la aplicabilidad se decide por nombre o por
-                # número de puerto, y en el camino de autodescubrimiento el
-                # nombre sale a su vez de una tabla de puertos. Un MySQL en el
-                # 33060 o un SSH en el 2222 quedaban completamente ciegos.
+                # Ningún dissector reclama este servicio: la aplicabilidad se
+                # decide por nombre o por número de puerto, y en el camino de
+                # autodescubrimiento el nombre sale a su vez de una tabla de
+                # puertos. Sin la cascada de abajo, un MySQL en el 33060 o un
+                # SSH en el 2222 quedarían completamente ciegos.
                 #
                 # La cascada pregunta en vez de suponer (ver
                 # ``fingerprinting/cascade.py``). Sólo TCP: leer un saludo
@@ -864,14 +852,14 @@ class LybraEngineManager(ScanManager):
 
     @classmethod
     def _layer_findings(cls, service, result) -> list:
-        """Un hallazgo informativo por cada capa de servidor adicional (L48-b).
+        """Un hallazgo informativo por cada capa de servidor adicional.
 
         Un puerto HTTP no siempre lo atiende **un** programa: la topología más
         corriente que existe —un nginx de proxy inverso por delante de un
-        Apache— son dos, y hasta ahora el motor sólo podía reportar uno. La
-        medición real lo destapó: cinco servicios en tres hosts donde Lybra
-        decía ``nginx`` y Nmap decía ``Apache httpd``, sin que ninguno de los
-        dos estuviera equivocado.
+        Apache— son dos, y el motor tiene que poder reportar ambas capas: casos
+        reales muestran a Lybra diciendo ``nginx`` y a Nmap diciendo
+        ``Apache httpd`` para el mismo servicio, sin que ninguno de los dos
+        estuviera equivocado.
 
         Reportar las dos capas es la respuesta honesta. Las dos están expuestas
         y las dos tienen CVEs; elegir una en silencio produce falsos negativos
@@ -890,11 +878,9 @@ class LybraEngineManager(ScanManager):
         """Build an informational Finding stating what Lybra identified.
 
         Es una constatación, no un veredicto: dice qué vio el motor y con qué
-        dissector. Antes de L52 el título comparaba la lectura propia con la de
-        Nmap («concuerda / no concuerda con Nmap»), lo que convertía un dato
-        propio en una nota al pie sobre otra herramienta.
+        dissector, sin compararlo con lo que haya dicho otra herramienta.
 
-        El ``qod`` lo pone el dissector (L18). Era una constante para todos, de
+        El ``qod`` lo pone el dissector. Era una constante para todos, de
         modo que una versión leída de una cabecera ``Server`` explícita y otra
         deducida de una página de error valían lo mismo; ahora cada lectura
         dice cuánto se fía de sí misma. Sigue sin alimentar la confianza de
@@ -917,11 +903,11 @@ class LybraEngineManager(ScanManager):
         }
 
     def _detect_surface_changes(self, scan_repo, host_id: int, services: list[Service]) -> list:
-        """Diff this scan's services against the host's tracked surface (Fase 5).
+        """Diff this scan's services against the host's tracked surface.
 
         Emits an informational finding for a port opening for the first time,
         for a package appearing for the first time (an ``origin="inventory"``
-        service with no port, Fase 0.9), or for either kind's product/version
+        service with no port), or for either kind's product/version
         changing since it was last seen — attack-surface events in their own
         right, not vulnerability guesses. Always upserts every current service
         afterwards, so the surface stays current regardless of whether
@@ -956,7 +942,7 @@ class LybraEngineManager(ScanManager):
 
     @staticmethod
     def _new_surface_title(service, protocol: str) -> str:
-        """Title for a first-seen port or package (Fase 0.9 adds the latter)."""
+        """Title for a first-seen port or package."""
         if service.port is not None:
             return f"Nuevo puerto abierto: {service.port}/{protocol} ({service.name or 'desconocido'})"
         return f"Nuevo paquete instalado: {service.label}"
@@ -971,12 +957,12 @@ class LybraEngineManager(ScanManager):
 
     @staticmethod
     def _surface_finding(service, title: str) -> dict:
-        """Build an informational Finding for an attack-surface change (Fase 5).
+        """Build an informational Finding for an attack-surface change.
 
         ``service`` falls back to ``product`` when there is no service name —
         for a portless (inventory-origin) service this is also what
         ``compute_dedup_key`` uses to disambiguate two different packages that
-        would otherwise both hash to the same "port=None" identity (Fase 0.9).
+        would otherwise both hash to the same "port=None" identity.
         Mirrors the same fallback in ``engine.py``'s finding builders.
         """
         return {
@@ -997,7 +983,7 @@ class LybraEngineManager(ScanManager):
     def _surface_key(service_or_row) -> tuple:
         """Identity key for surface tracking: ``(port, protocol)`` for a
         networked service, or ``(None, protocol, product)`` for a portless
-        inventory service (Fase 0.9).
+        inventory service.
 
         A port already uniquely identifies a listening socket, so the product
         is deliberately excluded there — that is what lets a version bump on
@@ -1013,7 +999,7 @@ class LybraEngineManager(ScanManager):
             return (service_or_row.port, protocol, None)
         return (None, protocol, service_or_row.product or None)
 
-    # _previous_findings_map: usa el default de ScanManager (A6).
+    # _previous_findings_map: usa el default de ScanManager.
 
     @classmethod
     def _finding_view_dict(cls, finding: Finding) -> dict:
@@ -1107,8 +1093,8 @@ class LybraEngineManager(ScanManager):
                           reason: Optional[str] = None):
         """Fijar el estado de un hallazgo: asumir el riesgo, o desmentirlo.
 
-        ``accepted`` y ``false_positive`` dicen cosas opuestas y hasta L35
-        compartían casilla. Aceptar un riesgo es "esto es real, lo asumo": se
+        ``accepted`` y ``false_positive`` dicen cosas opuestas, y por eso no
+        comparten casilla. Aceptar un riesgo es "esto es real, lo asumo": se
         anota con su motivo y su autor, y **caduca**, porque un riesgo asumido
         hace un año merece volver a mirarse. Marcar un falso positivo es "esto
         no es real, el motor se equivocó": no caduca por tiempo —el motor no se
@@ -1139,7 +1125,7 @@ class LybraEngineManager(ScanManager):
             if finding is None:
                 raise FindingNotFoundError(finding_id)
             # El finding se busca por su propio id, pero la propiedad se
-            # verifica sobre el scan al que pertenece (E5): FindingNotFoundError
+            # verifica sobre el scan al que pertenece: FindingNotFoundError
             # se lanza con finding_id para no revelar el scan_id ajeno.
             assert_owned(ScanRepository, finding.scan_id, user_id,
                          lambda _scan_id: FindingNotFoundError(finding_id), uow=uow)
@@ -1168,11 +1154,11 @@ class LybraEngineManager(ScanManager):
 
         Es el documento de trabajo del feed curado de alias: cada línea es un
         alias que merece la pena escribir, ordenado por cuánto duele no
-        tenerlo. El roadmap aparcaba este ranking por falta de datos —hacía
-        falta el agente de Hygeia en más de un equipo—, pero eso vale para el
-        volumen y no para la herramienta: hay que construirlo **antes** de que
-        lleguen los datos, o cuando lleguen no habrá dónde mirarlos. Y la vía
-        de red aporta muestras desde el primer escaneo, sin agente ninguno.
+        tenerlo. El volumen de datos depende de tener el agente de Hygeia
+        desplegado en más de un equipo, pero eso vale para el volumen y no
+        para la herramienta: hay que construirla **antes** de que lleguen los
+        datos, o cuando lleguen no habrá dónde mirarlos. Y la vía de red
+        aporta muestras desde el primer escaneo, sin agente ninguno.
 
         No se acota por usuario: el feed de alias es del producto, no de quien
         escanea, y un nombre que falla lo hace para todos.
@@ -1194,9 +1180,6 @@ class LybraEngineManager(ScanManager):
         contra qué check y contra qué producto se equivoca el motor, que es
         exactamente la entrada que el banco de falsos positivos tiene
         que aprender a consumir y lo que permite rankear qué familia falla más.
-
-        Hasta L35 esa señal no existía: el usuario sólo podía decir "acepto el
-        riesgo", que es una afirmación sobre el negocio y no sobre el motor.
         """
         repo = build_repository(ScanRepository)
         return [{
@@ -1214,7 +1197,7 @@ class LybraEngineManager(ScanManager):
         } for finding in repo.get_findings_by_state(user_id, "false_positive")]
 
     def get_finding_evidence(self, finding_id: int, user_id: int) -> list:
-        """Devuelve la evidencia cruda de un hallazgo propio (Fase E).
+        """Devuelve la evidencia cruda de un hallazgo propio.
 
         Mismo criterio de propiedad que :meth:`set_finding_state`: la evidencia
         de un hallazgo de otro usuario se reporta como no encontrada, sin
@@ -1247,7 +1230,7 @@ class LybraEngineManager(ScanManager):
     ) -> LybraScan:  # pylint: disable=arguments-differ
         """Create and persist an LybraScan row.
 
-        Delegates to ``ScanManager._create_scan_record`` (A4), passing
+        Delegates to ``ScanManager._create_scan_record``, passing
         LybraScan's extra columns via ``**extra``. Antes esta clase no
         llamaba ``uow.commit_for_handoff()`` como las demás — inconsistencia
         real, no deliberada: ``run_scan()`` encola en TaskQueue justo después
@@ -1262,7 +1245,7 @@ class LybraEngineManager(ScanManager):
     def _persist_scan_results(self, uow, scan, domain_data) -> None:
         """Persist the engine's findings (``domain_data`` is a list of dicts).
 
-        Aprovecha la escritura para purgar la evidencia caducada (Fase E): cada
+        Aprovecha la escritura para purgar la evidencia caducada: cada
         escaneo que graba evidencia se lleva de paso la que ha pasado su
         retención, así la tabla no crece sin fin sin necesidad de un barredor
         aparte.
@@ -1277,7 +1260,7 @@ class LybraEngineManager(ScanManager):
         self, user_id: int, page: int = 1, per_page: int = 10,
         asset_id=ScanRepository.PANEL_SCANS,
     ):
-        """Paginated Lybra scans, split by origin (Fase I).
+        """Paginated Lybra scans, split by origin.
 
         Overrides the base implementation, which filters by ``scan_type``
         alone, so that the ordinary Lybra feed shows only what the user
@@ -1343,10 +1326,10 @@ class LybraEngineManager(ScanManager):
 
     @staticmethod
     def exposure_for(scan) -> str:
-        """Contextual exposure of a Lybra scan, for Fase 5's priority scoring.
+        """Contextual exposure of a Lybra scan, used by the priority scoring.
 
         Normally that is just ``classify_exposure(target)``. An inventory scan
-        (Fase I) is the exception: it never observed the target's network at
+        is the exception: it never observed the target's network at
         all, so its "target" is a Hygeia asset's bare hostname, not a reachable
         surface. ``classify_exposure`` recognises internal *suffixes*
         (``.local``, ``.lan``...) but not a bare ``DESKTOP-ABC``, so it would
@@ -1381,9 +1364,9 @@ class LybraEngineManager(ScanManager):
             raise ScanNotFoundError(scan_id)
 
         repo = build_repository(ScanRepository)
-        # Todos los hallazgos de un escaneo Lybra son de Lybra: hasta L52 aquí
-        # se fundían además los de los escaneos corroboradores (Nmap/Nikto/
-        # Nuclei) que el "análisis profundo" lanzaba, bajo la firma de Lybra.
+        # Todos los hallazgos de un escaneo Lybra son de Lybra: no incluyen los
+        # de los escaneos corroboradores (Nmap/Nikto/Nuclei) que el "análisis
+        # profundo" pueda lanzar aparte.
         display_findings = [self._finding_view_dict(finding) for finding in repo.get_findings_by_scan(scan_id)]
 
         exposure = self.exposure_for(scan)
@@ -1412,7 +1395,7 @@ class LybraEngineManager(ScanManager):
             # Un falso positivo no es un riesgo: el usuario ha dicho que el
             # motor se equivocó, así que no cuenta como vulnerabilidad ni
             # engorda el resumen de prioridades. Contarlo sería exactamente el
-            # informe que miente sobre la postura de seguridad (L35).
+            # informe que miente sobre la postura de seguridad.
             "vulnerableFindings": sum(
                 1 for display_finding in display_findings
                 if display_finding.get("category") == "outdated_software"

--- a/API/src/modules/features/themis/managers/lybra/sources.py
+++ b/API/src/modules/features/themis/managers/lybra/sources.py
@@ -1,4 +1,4 @@
-"""Where a Lybra scan gets its services from — los dos modos del roadmap §0.9.
+"""Where a Lybra scan gets its services from — the two modes below.
 
 Extracted out of ``lybra/engine.py`` because the manager kept re-asking the same
 question — "are we analysing an external payload, or doing our own discovery?" —
@@ -13,10 +13,10 @@ the TaskQueue itself keeps serializing the same primitive arguments it always di
 (``services`` / ``discover_ports``), and the worker rebuilds the same object with
 the same factory once it is running as ``_run_lybra``.
 
-Hubo un tercer modo, retirado en L52: analizar los servicios que un escaneo
-Nmap previo ya había descubierto. Existía porque el motor no tenía transporte
-propio; desde que la Fase T se lo dio, era la puerta de atrás de una capacidad
-que Lybra ya tiene por sí mismo, y ataba el motor a otro escáner.
+Hubo un tercer modo, retirado: analizar los servicios que un escaneo Nmap
+previo ya había descubierto. Existía porque el motor no tenía transporte
+propio; una vez que lo tuvo, ese modo se volvió la puerta de atrás de una
+capacidad que Lybra ya tiene por sí mismo, y ataba el motor a otro escáner.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 class DiscoveryProbes:
     """The three network-probing capabilities ``SelfDiscovery`` needs from
     the calling manager, passed as plain callables instead of the whole
-    manager object (E1).
+    manager object.
 
     Before, ``resolve_services`` took the full ``LybraEngineManager`` just to
     reach three of its methods — which forced this module to import that
@@ -85,9 +85,9 @@ class ServiceSource(ABC):
 
     probes_target_network: bool = True
     """
-    Whether Fase F (fingerprinting) and Fase R (active checks) may run
+    Whether fingerprinting and active checks may run
     against the target for this mode. False only for the external-payload
-    mode: that data is already a verified fact (Fase 0.9), so re-inferring
+    mode: that data is already a verified fact, so re-inferring
     it over the network would be redundant at best, and this mode exists
     precisely for hosts it might not even be able to reach.
     """
@@ -118,7 +118,7 @@ class ServiceSource(ABC):
         """Obtain this mode's services inside the caller's transaction.
 
         ``probes`` bundles the network-probing capabilities only the
-        self-discovery mode uses (E1) — the payload mode ignores it.
+        self-discovery mode uses — the payload mode ignores it.
 
         Raises ``ScanFailedError`` para un fallo irrecuperable (host
         inalcanzable, sonda reventada), con el código que dice cuál de los dos
@@ -148,7 +148,7 @@ class ServiceSource(ABC):
 
 
 class ExternalPayload(ServiceSource):
-    """Analyse a services list the caller already resolved (Fase 0.9).
+    """Analyse a services list the caller already resolved.
 
     No network discovery, fingerprinting or active checks run in this mode —
     it exists precisely for services data that came from *not* touching the
@@ -180,7 +180,7 @@ class ExternalPayload(ServiceSource):
 
 
 class SelfDiscovery(ServiceSource):
-    """Discover the target's open ports with Lybra's own connect scan (Fase T)."""
+    """Discover the target's open ports with Lybra's own connect scan."""
 
     label = "descubrimiento propio"
 
@@ -191,7 +191,7 @@ class SelfDiscovery(ServiceSource):
         if target is None:
             raise ValueError("run_scan requires services or target")
         # Self-discovery touches the target directly, unlike analysing a
-        # services payload the caller already resolved (roadmap §6).
+        # services payload the caller already resolved.
         #
         # Rechazo de IP privada aquí (no solo en el endpoint HTTP, ver
         # validate_targets en start_lybra_scan): el flujo programado
@@ -234,7 +234,7 @@ class SelfDiscovery(ServiceSource):
                 )
             discovered_ports = list(sweep.open_ports)
             is_partial = sweep.was_truncated
-            # UDP (Fase N/Ronda 1, roadmap §6.3): sonda curada aparte, nunca a
+            # UDP: sonda curada aparte, nunca a
             # partir de la lista TCP del usuario — self.ports_to_discover es una
             # lista de puertos TCP. Best-effort por diseño de
             # _discover_udp_ports: nunca aborta el descubrimiento TCP.

--- a/API/src/modules/features/themis/managers/nikto.py
+++ b/API/src/modules/features/themis/managers/nikto.py
@@ -112,8 +112,8 @@ class NiktoScanManager(ScanManager):
 
         scan_repo.persist_nikto_results(scan, host, incidents_data)
 
-        # Additive: also record each incident as a normalized Finding, so a
-        # future cross-scanner correlation pass (Fase 6) has something to fuse
+        # Additive: also record each incident as a normalized Finding, so
+        # cross-scanner correlation has something to fuse
         # against Lybra/Nuclei findings on the same host. Does not replace
         # the NiktoIncident write above — the PDF report and history charts
         # still read that (see lybra/adapters.py for why).

--- a/API/src/modules/features/themis/managers/nuclei.py
+++ b/API/src/modules/features/themis/managers/nuclei.py
@@ -32,13 +32,13 @@ logger = logging.getLogger(__name__)
 @ScanManager.register(ScanType.NUCLEI)
 class NucleiScanManager(ScanManager):
     """
-    Manager for Nuclei template-based vulnerability scans (roadmap Fase U1).
+    Manager for Nuclei template-based vulnerability scans.
 
     Unlike Nikto, Nuclei writes no result table of its own — every
     hallazgo vive directamente en ``Finding`` vía ``nuclei_result_to_finding``,
     la misma forma que ``LybraEngineManager`` ya adoptó. Eso es lo que le deja
     entrar gratis en la deduplicación multifuente, el ciclo de vida
-    ``open``/``fixed``/``regressed`` y el scoring contextual de la Fase 5.
+    ``open``/``fixed``/``regressed`` y el scoring contextual de exposición.
 
     Example:
     >>> manager = NucleiScanManager()
@@ -208,7 +208,7 @@ class NucleiScanManager(ScanManager):
         ``apply_lifecycle`` compares against this target's previous Nuclei
         scan so ``state`` is genuinely ``fixed``/``regressed``/``open`` instead
         of always ``open`` — the two things that make Nuclei "enter for free"
-        into Fase 5's correlation, per the roadmap.
+        into the multi-source correlation and exposure scoring.
         """
         results_data = domain_data
         scan_repo = ScanRepository(uow)

--- a/API/src/modules/features/themis/managers/programed.py
+++ b/API/src/modules/features/themis/managers/programed.py
@@ -1,4 +1,4 @@
-"""ProgramedScanManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Gestión de escaneos programados: alta, edición y despacho periódico de sus definiciones."""
 
 import logging
 from datetime import datetime

--- a/API/src/modules/features/themis/managers/reports.py
+++ b/API/src/modules/features/themis/managers/reports.py
@@ -1,4 +1,4 @@
-"""ThemisReportManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Gestión de documentos de Themis y generación asíncrona de sus informes PDF."""
 
 import logging
 from src.modules.accounts import LimitKey, QuotaManager

--- a/API/src/modules/features/themis/managers/scan.py
+++ b/API/src/modules/features/themis/managers/scan.py
@@ -1,4 +1,6 @@
-"""ScanManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Clase base de los managers de escaneo: ciclo de vida común (creación, despacho
+a la cola de tareas y persistencia de resultados) que cada escáner concreto
+especializa."""
 
 import logging
 from abc import ABC, abstractmethod
@@ -1024,7 +1026,7 @@ class ScanManager(TaskTrackingMixin, ABC):
                 "state": previous_finding.state or "open",
                 "snapshot": snapshot,
                 # La decisión del usuario viaja aparte del snapshot porque no
-                # describe el hallazgo sino lo que alguien dijo sobre él (L35).
+                # describe el hallazgo sino lo que alguien dijo sobre él.
                 # Sin esto sobreviviría el estado pero no su justificación, y
                 # un `accepted` sin motivo ni autor vuelve a ser deuda al día
                 # siguiente de haberlo razonado.

--- a/API/src/modules/features/themis/managers/scan_folder.py
+++ b/API/src/modules/features/themis/managers/scan_folder.py
@@ -1,4 +1,4 @@
-"""ScanFolderManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Gestión de las carpetas usadas para organizar escaneos."""
 
 import logging
 import re

--- a/API/src/modules/features/themis/managers/scan_history.py
+++ b/API/src/modules/features/themis/managers/scan_history.py
@@ -1,4 +1,4 @@
-"""ScanHistoryManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Estadísticas históricas de escaneos por host, para gráficas e informes."""
 
 import logging
 from typing import List

--- a/API/src/modules/features/themis/managers/traceroute.py
+++ b/API/src/modules/features/themis/managers/traceroute.py
@@ -1,4 +1,4 @@
-"""TracerouteManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""
+"""Traceroutes cacheados desde el servidor de Ellysia hasta los objetivos de escaneo."""
 
 import logging
 import hashlib

--- a/API/tests/integration/test_lybra.py
+++ b/API/tests/integration/test_lybra.py
@@ -1,17 +1,15 @@
 """Integration tests for the Lybra engine scan.
 
 Covers the endpoint's authorization/validation boundary and the engine pipeline
-end to end: el motor descubre los servicios por su cuenta (Fase T) o recibe una
+end to end: el motor descubre los servicios por su cuenta o recibe una
 lista ya resuelta (payload externo), persiste hallazgos y estos afloran por el
 endpoint de resultados. El cuerpo del escaneo se ejecuta directo
 (``_run_lybra``) en vez de por la cola de tareas, igual que en los tests de los
 demás escáneres, para no depender de Redis ni de un worker.
 
-Hasta L52 casi todos estos tests partían de un escaneo Nmap sembrado a mano: el
-motor tenía un modo de arranque que analizaba los servicios que otro escáner ya
-había descubierto. Ese modo se retiró junto al resto del acoplamiento con
-herramientas de terceros, así que los servicios entran ahora por los dos
-caminos que de verdad quedan.
+El motor no tiene ningún modo de arranque que analice servicios descubiertos
+por otro escáner: no hay acoplamiento con herramientas de terceros, así que
+los servicios entran por los dos caminos que de verdad existen.
 """
 
 from datetime import datetime
@@ -69,9 +67,9 @@ def _stub_self_discovery(monkeypatch, tcp_ports: list, udp_ports: list | None = 
 
 
 def _authorize_target(app, user_id: int, target: str = "10.0.0.5") -> None:
-    """Add ``target`` to the user's authorized-targets register (roadmap §6).
+    """Add ``target`` to the user's authorized-targets register.
 
-    Required before Fase F (fingerprinting) or Fase R (active checks) will run
+    Required before fingerprinting or active checks will run
     against it — see ``AuthorizedTargetManager.is_authorized``.
     """
     with app.app_context():
@@ -92,14 +90,14 @@ def test_lybra_requires_create_attribute(client, stripped_user, auth_headers):
 
 
 def test_lybra_requires_a_target(client, admin_user, auth_headers):
-    # Sin objetivo no hay escaneo: el schema lo rechaza. Antes de L52 valía
-    # también un ``sourceScanId`` (un escaneo Nmap previo) en su lugar.
+    # Sin objetivo no hay escaneo: el schema lo rechaza. No hay ningún
+    # ``sourceScanId`` (un escaneo Nmap previo) que valga en su lugar.
     resp = client.post("/themis/lybra", headers=auth_headers(admin_user), json={})
     assert resp.status_code in (400, 422)
 
 
 def test_lybra_no_longer_accepts_a_source_scan(client, app, admin_user, auth_headers):
-    """L52: lanzar Lybra desde un escaneo de otra herramienta ya no es posible.
+    """Lanzar Lybra desde un escaneo de otra herramienta ya no es posible.
 
     El schema ya no declara ``sourceScanId``, así que mandarlo sin objetivo es
     una petición sin modo válido — se rechaza en la validación, no se ignora en
@@ -111,7 +109,7 @@ def test_lybra_no_longer_accepts_a_source_scan(client, app, admin_user, auth_hea
 
 
 def test_lybra_self_discovery_requires_authorized_target(client, admin_user, auth_headers):
-    # Roadmap §6: self-discovery touches the target directly, so it must be
+    # Self-discovery touches the target directly, so it must be
     # in the caller's authorized-targets register before launch is allowed.
     resp = client.post("/themis/lybra", headers=auth_headers(admin_user),
                        json={"target": "203.0.113.9"})
@@ -152,7 +150,7 @@ def test_lybra_run_scan_self_discovery_succeeds_once_authorized(app, admin_user,
 
 def test_lybra_endpoint_threads_the_aggressive_flag_to_run_scan(
         client, admin_user, auth_headers, monkeypatch):
-    """El schema declara ``aggressive`` con ``load_default=False`` (L40): sin
+    """El schema declara ``aggressive`` con ``load_default=False``: sin
     el campo, una petición de siempre no cambia de comportamiento, y con él,
     el valor llega íntegro al manager — la mitad de la doble puerta que
     depende del usuario."""
@@ -211,7 +209,7 @@ def test_lybra_self_discovery_produces_open_port_findings(app, admin_user, monke
 
 
 def test_lybra_self_discovery_disambiguates_the_same_port_over_tcp_and_udp(app, admin_user, monkeypatch):
-    """Ronda 1 (roadmap §6.3): 161/tcp y 161/udp del mismo host son dos
+    """161/tcp y 161/udp del mismo host son dos
     servicios distintos y deben sobrevivir como dos hallazgos `open_port` con
     `dedup_key` distintas — el riesgo real que motivó la columna
     `Finding.protocol` y el arreglo de `compute_dedup_key`."""
@@ -277,7 +275,7 @@ def test_lybra_self_discovery_probe_failure_fails_without_false_fixed(app, admin
 
 
 def test_lybra_blocked_discovery_never_marks_findings_fixed(app, admin_user, monkeypatch):
-    """L48-c, la mitad que de verdad duele.
+    """El descubrimiento bloqueado a mitad de camino, la mitad que de verdad duele.
 
     Un objetivo que bloquea el barrido a mitad de camino producía una lista
     vacía indistinguible de un host limpio, y el ciclo de vida pasaba entonces
@@ -372,7 +370,7 @@ def test_lybra_self_discovery_reuses_host_created_by_nmap(app, admin_user):
         assert len(all_hosts) == 1                       # no duplicate
 
 
-# ------------------------------------------------- Fase 0.9: external payload
+# ------------------------------------------------- external payload
 
 def test_lybra_run_scan_payload_mode_requires_target(app, admin_user):
     from unittest import mock
@@ -445,7 +443,7 @@ def test_lybra_payload_mode_produces_confirmed_inventory_findings(app, admin_use
 
 def test_lybra_payload_mode_surface_tracking_distinguishes_portless_packages(app, admin_user):
     """Regression: two different installed packages both have port=None, so
-    surface tracking cannot key on (port, protocol) alone for them (Fase 0.9)
+    surface tracking cannot key on (port, protocol) alone for them
     — it must fall back to product, or the second package's upsert would
     silently overwrite the first package's tracked row."""
     with app.app_context():
@@ -509,7 +507,7 @@ def test_lybra_engine_persists_informational_findings(app, admin_user):
 
 
 def test_lybra_surface_change_detects_new_port_and_version_bump(app, admin_user):
-    """Fase 5: a host's first Lybra scan sets a silent baseline; a later scan
+    """A host's first Lybra scan sets a silent baseline; a later scan
     with an extra port and a bumped Apache version reports both as
     surface_change findings, without repeating on a third, unchanged scan."""
 
@@ -563,12 +561,12 @@ def _seed_kb_apache_cve(app):
 
 
 def test_a_scan_stamps_findings_with_the_state_of_the_knowledge_base(app, admin_user):
-    """#270: la marca de reproducibilidad sale del estado real de la KB.
+    """La marca de reproducibilidad sale del estado real de la KB.
 
-    Era la constante ``"lybra-0"`` para todos los hallazgos por versión, así que
-    un hallazgo guardado no podía decir contra qué conocimiento se resolvió.
-    Aquí se siembra la KB con fechas conocidas en las tres fuentes y se
-    comprueba que el escaneo las estampa.
+    Sin ella, ``"lybra-0"`` sería la misma constante para todos los hallazgos
+    por versión, así que un hallazgo guardado no podría decir contra qué
+    conocimiento se resolvió. Aquí se siembra la KB con fechas conocidas en las
+    tres fuentes y se comprueba que el escaneo las estampa.
     """
     from datetime import datetime
 
@@ -619,7 +617,7 @@ def _seed_kb_vsftpd_cve(app):
 
 
 def _seed_kb_mysql_cve(app):
-    """Seed the KB with a made-up CVE for mysql 8.0.34, for the Fase N MySQL
+    """Seed the KB with a made-up CVE for mysql 8.0.34, for the MySQL
     dissector's CPE-gap-filling test."""
     with app.app_context():
         with UnitOfWork() as uow:
@@ -693,7 +691,7 @@ def test_lybra_active_check_persists_confirmed_finding(app, admin_user, monkeypa
 
 
 def test_lybra_active_check_ftp_anonymous_login_persists_confirmed_finding(app, admin_user, monkeypatch):
-    """Fase N: the runtime's first ``type: "network"`` check, wired end to
+    """The runtime's first ``type: "network"`` check, wired end to
     end through the real manager (not a bare ``CheckRuntime``).
 
     Lo que se sustituye es el **socket**, no la sesión: el ``NetworkSession``
@@ -835,7 +833,7 @@ def test_a_scan_that_runs_out_of_clock_stops_probing_and_finishes_partial(app, a
     Aquí el descubrimiento se come el plazo entero. Lo que se comprueba es que
     el fingerprinting ni siquiera empieza, y que el escaneo **termina bien**
     marcado como parcial — que es lo que impide, además, que cierre por
-    omisión hallazgos que esta vez no llegó a comprobar (L48-c).
+    omisión hallazgos que esta vez no llegó a comprobar.
     """
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.managers.lybra import engine as engine_module
@@ -901,7 +899,7 @@ def test_a_scan_with_clock_to_spare_still_fingerprints(app, admin_user, monkeypa
 
 
 def test_lybra_fingerprinting_identifies_the_service_on_its_own(app, admin_user, monkeypatch):
-    """L52: el hallazgo de fingerprint constata qué identificó Lybra.
+    """El hallazgo de fingerprint constata qué identificó Lybra.
 
     Antes comparaba con el producto/versión que traía el servicio desde Nmap y
     titulaba el hallazgo con el veredicto («concuerda / no concuerda con
@@ -933,7 +931,7 @@ def test_lybra_fingerprinting_identifies_the_service_on_its_own(app, admin_user,
 
     fingerprints = [f for f in findings if f.category == "fingerprint"]
     assert len(fingerprints) == 1
-    # L18: el qod refleja de dónde salió la versión. Una cabecera `Server` con
+    # El qod refleja de dónde salió la versión. Una cabecera `Server` con
     # versión explícita es la fuente más fuerte de la cascada.
     assert fingerprints[0].qod == 90
     assert fingerprints[0].confirmed is False
@@ -942,7 +940,7 @@ def test_lybra_fingerprinting_identifies_the_service_on_its_own(app, admin_user,
 
 
 def test_lybra_identifies_a_service_on_a_non_canonical_port(app, admin_user, monkeypatch):
-    """L10: el punto ciego que multiplicaba a todos los demás.
+    """El punto ciego que multiplicaba a todos los demás.
 
     Los predicados de aplicabilidad deciden por nombre o por número de puerto,
     y en el autodescubrimiento el nombre sale a su vez de una tabla de puertos.
@@ -1009,7 +1007,7 @@ def test_lybra_leaves_a_mute_unknown_port_exactly_as_it_was(app, admin_user, mon
 
 
 def test_lybra_fingerprinting_skipped_for_unauthorized_target(app, admin_user, monkeypatch):
-    # activeChecks/fingerprintingEnabled default to True (roadmap §6): the real
+    # activeChecks/fingerprintingEnabled default to True: the real
     # gate is per-target authorization, not the config flag. No _authorize_target
     # call here on purpose.
     _stub_self_discovery(monkeypatch, [80])
@@ -1043,7 +1041,7 @@ def test_lybra_fingerprinting_config_flag_still_disables_even_if_authorized(app,
 
 def test_lybra_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user, monkeypatch):
     """El sentido de enchufar el fingerprint a la resolución de CPE: un
-    servicio descubierto por el propio motor (Fase T) tiene que poder casar con
+    servicio descubierto por el propio motor tiene que poder casar con
     un CVE a partir de su propia lectura HTTP. Sin ese cableado el matcher de
     versiones no tiene nada que buscar y un escaneo nunca encuentra un CVE.
     """
@@ -1083,8 +1081,8 @@ def test_lybra_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user, mon
 
 
 def test_lybra_ftp_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user, monkeypatch):
-    """Fase N: FTP se suma a HTTP/SSH como dissector que resuelve el CPE de un
-    servicio descubierto por el propio motor (Fase T)."""
+    """FTP se suma a HTTP/SSH como dissector que resuelve el CPE de un
+    servicio descubierto por el propio motor."""
     import src.modules.system.config_reading as CR
     from src.modules.features.themis.lybra import FtpProbe
 
@@ -1114,7 +1112,7 @@ def test_lybra_ftp_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user,
 
 
 def test_lybra_mysql_fingerprint_fills_cpe_gap_for_self_discovery(app, admin_user, monkeypatch):
-    """Fase N's dissector registry, exercised end to end through the manager:
+    """The dissector registry, exercised end to end through the manager:
     MySQL identification flows through _fingerprint_services exactly like
     HTTP/SSH/FTP do, with no special-casing anywhere above the registry."""
     import src.modules.system.config_reading as CR
@@ -1162,7 +1160,7 @@ def test_lybra_scan_surfaces_in_results_endpoint(client, app, admin_user, auth_h
     result = body["results"][0]
     assert result["scanType"] == "lybra"
     assert result["totalFindings"] == 2
-    # L52: la respuesta ya no lleva ``sourceScanId`` ni ``deep``/``deepScanIds``.
+    # La respuesta ya no lleva ``sourceScanId`` ni ``deep``/``deepScanIds``.
     assert "sourceScanId" not in result
     assert "deep" not in result
 
@@ -1431,12 +1429,12 @@ def test_the_partial_flag_reaches_the_api(client, monkeypatch, app, admin_user, 
     assert result["isPartial"] is True
 
 
-# ============================================ progreso y cancelación (L41)
+# ============================================ progreso y cancelación
 
 
 def test_a_scan_reports_progress_by_phase(monkeypatch, app, admin_user):
     """El escaneo publica progreso por fase con pesos honestos: descubrimiento
-    40, fingerprint 70, checks 90, persistencia 100 (§3 del issue)."""
+    40, fingerprint 70, checks 90, persistencia 100."""
     _authorize_target(app, admin_user.id)
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
     _stub_self_discovery(monkeypatch, [80])
@@ -1490,7 +1488,8 @@ def test_a_cancelled_scan_stops_persists_and_is_marked_partial(monkeypatch, app,
 def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, admin_user):
     """La interacción crítica con el ciclo de vida: un escaneo cancelado a mitad
     no vio todo el objetivo, así que la ausencia de un hallazgo anterior no es
-    evidencia de que se haya corregido (el fallo de L48-c por otra puerta)."""
+    evidencia de que se haya corregido (el mismo riesgo que un descubrimiento
+    intermitente produce por otra puerta)."""
     _authorize_target(app, admin_user.id)
     monkeypatch.setattr(ScanManager, "is_host_reachable", staticmethod(lambda *a, **k: True))
 
@@ -1517,7 +1516,7 @@ def test_a_cancelled_scan_does_not_close_findings_by_omission(monkeypatch, app, 
     assert fixed == []
 
 
-# ================================================= evidencia cruda (L44)
+# ================================================= evidencia cruda
 
 
 def test_a_confirmed_http_finding_stores_its_redacted_evidence(monkeypatch, app, admin_user):
@@ -1598,7 +1597,7 @@ def test_the_evidence_endpoint_returns_own_findings_and_404s_for_others(
     assert forbidden.status_code == 404
 
 
-# =============================================== confirmadores (L29)
+# =============================================== confirmadores
 
 
 def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_user):
@@ -1646,7 +1645,7 @@ def test_a_confirmer_promotes_a_hypothesis_end_to_end(monkeypatch, app, admin_us
     assert for_cve[0].qod == 99
 
 
-# =============================================== modo agresivo + credenciales (L40/L31)
+# =============================================== modo agresivo + credenciales
 
 
 def _stub_tomcat_manager(monkeypatch) -> None:
@@ -1752,7 +1751,7 @@ def test_an_authorized_and_explicit_aggressive_scan_finds_default_credentials(
     assert "s3cret" not in str(evidence[0].payload)
 
 
-# ─────────────── desmentir un hallazgo no es aceptar un riesgo (L35)
+# ─────────────── desmentir un hallazgo no es aceptar un riesgo
 #
 # Hasta ahora el esquema sólo admitía `accepted` y `open`, así que un usuario
 # que sabía que un hallazgo era falso —Debian parcheó por backport y la versión
@@ -1845,7 +1844,8 @@ def test_a_state_the_lifecycle_owns_cannot_be_set_by_hand(
 
 def test_the_manager_validates_the_state_on_its_own(app, admin_user):
     """La validación del schema protege el endpoint; el manager es la frontera
-    de verdad, y hasta L35 aceptaba cualquier cadena."""
+    de verdad y tiene que rechazar por su cuenta cualquier cadena que no sea un
+    estado válido."""
     from src.modules.shared._exceptions import ValidationError
 
     scan_id = _run_payload_scan(app, admin_user.id, target="10.0.0.25")
@@ -1911,9 +1911,8 @@ def test_false_positives_are_scoped_to_their_owner(
 
 
 def test_a_finding_carries_its_exploit_maturity(app, admin_user):
-    """`exploit_maturity` se declaraba en el modelo desde el principio,
-    documentada como "rellenada desde la Fase 1", y estaba NULL en todas las
-    filas. Ahora dice algo en cada hallazgo con CVE."""
+    """`exploit_maturity` dice algo en cada hallazgo con CVE, calculado en
+    tiempo de correlación a partir de KEV, EPSS y las referencias del CVE."""
     _seed_kb_apache_cve(app)   # siembra también KEV para esta CVE
 
     with app.app_context():
@@ -1979,7 +1978,7 @@ def test_a_cve_with_nothing_public_says_none_not_null(app, admin_user):
     assert vuln.exploit_maturity == "none"
 
 
-# ─────────────── verificación de backports de extremo a extremo (Fase O)
+# ─────────────── verificación de backports de extremo a extremo
 
 
 def _debian_services() -> list:
@@ -1992,8 +1991,8 @@ def _debian_services() -> list:
 
 
 def test_a_backported_finding_is_closed_without_touching_the_host(app, admin_user):
-    """El corazón de la Fase O: Debian ya lo parcheó sin subir el número
-    visible, así que el hallazgo por versión nunca fue real."""
+    """El corazón de la verificación de backports: Debian ya lo parcheó sin
+    subir el número visible, así que el hallazgo por versión nunca fue real."""
     _seed_kb_apache_cve(app)
     with app.app_context():
         with UnitOfWork() as uow:
@@ -2038,8 +2037,8 @@ def test_a_vendor_confirming_the_flaw_raises_the_confidence(app, admin_user):
 
 
 def test_without_a_distro_advisory_the_finding_stays_a_hypothesis(app, admin_user):
-    """El comportamiento de antes de la Fase O, que es el correcto cuando no
-    hay a quién preguntar."""
+    """El comportamiento correcto cuando no hay a quién preguntar: sin
+    veredicto de la distribución, el hallazgo se queda como hipótesis."""
     _seed_kb_apache_cve(app)
     with app.app_context():
         mgr = LybraEngineManager()

--- a/API/tests/oracle/_concordance.py
+++ b/API/tests/oracle/_concordance.py
@@ -1,9 +1,9 @@
 """Concordancia con Nmap: la vara de medir, fuera del producto.
 
-Estas tres funciones vivían dentro del paquete que se despliega
-(``lybra/fingerprinting/concordance.py`` y ``lybra/transport.py``). Se mudaron
-aquí en L52, cuando se retiró el acoplamiento de Lybra con escáneres de
-terceros, y la razón de mudarlas en vez de borrarlas merece decirse entera.
+Estas tres funciones viven aquí, fuera del paquete que se despliega
+(``lybra/fingerprinting/concordance.py`` y ``lybra/transport.py``), porque
+Lybra no tiene acoplamiento con escáneres de terceros, y la razón de que
+vivan en los tests en vez de no existir merece decirse entera.
 
 Lo que se retiró del producto es la **subordinación**: que Nmap fuera la
 autoridad en tiempo de ejecución, que un escaneo de Lybra pudiera lanzarse
@@ -15,7 +15,7 @@ Lo que no se retiró es la **medición**. Comparar el motor contra una referenci
 externa en los tests no es acoplamiento: es la única forma de demostrar que el
 motor es bueno en vez de afirmarlo. La independencia se demuestra midiéndose
 contra el mejor del mercado y empatando o ganando, no negándose a la
-comparación — y el objetivo declarado del roadmap (concordancia ≥ 0,90 en
+comparación — y el umbral que este banco exige (concordancia ≥ 0,90 en
 fingerprint, ≥ 0,95 en descubrimiento de puertos) es exactamente esa
 demostración. Aquí, en ``tests/``, la vara de medir existe y el producto no
 sabe que existe.
@@ -88,7 +88,7 @@ def agrees_with_nmap_across_layers(
 ) -> bool:
     """Decide whether **any** layer of our reading agrees with Nmap's.
 
-    Esta variante existe por un desacuerdo que resultó no serlo (L48-b). Contra
+    Esta variante existe por un desacuerdo que resultó no serlo. Contra
     objetivos reales, cinco servicios en tres hosts daban siempre el mismo
     patrón: Lybra decía ``nginx``, Nmap decía ``Apache httpd``. La lectura más
     probable —y la que el catálogo de laboratorio ahora reproduce— es un nginx

--- a/API/tests/oracle/_docker_helpers.py
+++ b/API/tests/oracle/_docker_helpers.py
@@ -1,4 +1,4 @@
-"""Shared Docker plumbing for the Lybra oracle test suite (roadmap §7).
+"""Shared Docker plumbing for the Lybra oracle test suite.
 
 Both modules in this package — the check-runtime oracle
 (``test_lybra_oracle_bench.py``) and the F/T concordance bench

--- a/API/tests/oracle/_real_kb.py
+++ b/API/tests/oracle/_real_kb.py
@@ -1,7 +1,6 @@
 """Puente de solo lectura entre el backfill NVD real y la KB del banco oráculo.
 
-**El problema que resuelve.** El roadmap (Fase U, "qué no se puede verificar en
-este equipo") ya lo había anotado como la fila que gobierna a todas las demás:
+**El problema que resuelve.** Es la fila que gobierna a todas las demás:
 *"sin KB poblada el motor no falla, devuelve vacío — que es peor, porque se lee
 como 'objetivo limpio'"*. Y eso es literalmente lo que hacía el oráculo
 diferencial: sobre sus tres objetivos reportaba `corroborated: [] · lybra_only:
@@ -26,9 +25,8 @@ productos que los contenedores del banco hablan de verdad. Los dos límites:
 clonado— se cae al subconjunto congelado que vive versionado en este mismo
 directorio (``frozen_kb.json.gz``, unos 24 KB comprimidos: 14 alias de producto,
 424 CVE y 4.085 reglas de aplicabilidad). Eso es lo que convierte estas
-mediciones en algo repetible fuera del equipo que tiene el backfill, que era
-todo el problema de L51: las cifras del roadmap iban fechadas porque eran
-instantáneas manuales.
+mediciones en algo repetible fuera del equipo que tiene el backfill: sin esto,
+las cifras publicadas irían fechadas porque serían instantáneas manuales.
 
 Se regenera con ``scripts/freeze_bench_kb.py``. Cambiarlo cambia los números que
 los bancos publican, así que conviene hacerlo en un commit propio.
@@ -54,8 +52,8 @@ from src.modules.features.themis.lybra import normalize_product_name
 from src.modules.features.themis.repositories import KbRepository
 
 #: El subconjunto congelado de la KB, versionado en el repositorio para que los
-#: bancos puedan medir en un runner de CI que no tiene ninguna base de datos
-#: (L51). Se regenera con ``scripts/freeze_bench_kb.py``.
+#: bancos puedan medir en un runner de CI que no tiene ninguna base de datos.
+#: Se regenera con ``scripts/freeze_bench_kb.py``.
 FROZEN_KB_PATH = Path(__file__).resolve().parent / "frozen_kb.json.gz"
 
 # (vendor, product) tal y como el backfill de NVD los escribe. Un producto por
@@ -114,7 +112,7 @@ def seed_from_real_backfill(products: Iterable[Tuple[str, str]] = BENCH_PRODUCTS
     engine = _real_engine()
     if engine is None:
         # Sin Postgres real se cae al subconjunto congelado, que es lo que hace
-        # que estos bancos puedan correr en un runner de CI (L51).
+        # que estos bancos puedan correr en un runner de CI.
         frozen = seed_from_frozen()
         return frozen[1] if frozen else None
 
@@ -139,7 +137,7 @@ _ALIAS_QUERY = sa.text(
 def seed_for_inventory(package_names: Iterable[str]) -> Optional[Tuple[int, int]]:
     """Copia a la KB del test lo que hace falta para analizar un inventario.
 
-    Un inventario de paquetes (Fase I) no llega con un CPE puesto, como sí hace
+    Un inventario de paquetes no llega con un CPE puesto, como sí hace
     un servicio identificado por Nmap: llega con el nombre que le da la
     distribución —``zlib1g``, ``perl-base``— y hay que resolverlo primero al
     vocabulario de NVD. Esa resolución la hace ``CpeProductAlias``, un índice

--- a/API/tests/oracle/_real_targets.py
+++ b/API/tests/oracle/_real_targets.py
@@ -23,7 +23,7 @@ import os
 import socket
 from typing import Set, Tuple
 
-#: La variable que declara el lado real de la paridad laboratorio/real (L48).
+#: La variable que declara el lado real de la paridad laboratorio/real.
 ENVIRONMENT_VARIABLE = "LYBRA_REAL_TARGETS"
 
 

--- a/API/tests/oracle/test_concordance_metrics.py
+++ b/API/tests/oracle/test_concordance_metrics.py
@@ -7,7 +7,7 @@ como cualquier test unitario — que la vara de medir esté fuera del producto n
 significa que nadie compruebe que mide bien.
 
 Estos casos venían de ``test_lybra_fingerprint.py`` y ``test_lybra_transport.py``
-y se mudaron con el código que ejercitan (L52).
+y se mudaron con el código que ejercitan.
 """
 
 import pytest

--- a/API/tests/oracle/test_lybra_concordance_bench.py
+++ b/API/tests/oracle/test_lybra_concordance_bench.py
@@ -1,14 +1,13 @@
 """Banco de concordancia no-HTTP: qué identifica Lybra frente a lo que identifica Nmap.
 
-El roadmap dice, sobre la Fase N, que *«medir la concordancia de fingerprint
-sólo sobre HTTP/SSH/TLS dejaría de ser representativo justo cuando la
-superficie se amplía»*. Y eso era exactamente lo que pasaba: los ocho
-dissectors que la Fase N añadió —FTP, SMTP, IMAP, POP3, SMB, MySQL, Redis, VNC
-y SNMP— no tenían ni un objetivo real contra el que medirse. Su única cobertura
-eran tests unitarios con sockets falsos, que verifican que el parser hace lo que
-su autor creía, no que reciba lo que un servidor de verdad emite. El criterio de
-cierre de la Fase N pide concordancia ≥ 0,90 en cuatro protocolos no-HTTP; ese
-número no existía, ni bueno ni malo.
+Medir la concordancia de fingerprint sólo sobre HTTP/SSH/TLS dejaría de ser
+representativo justo cuando la superficie se amplía. Y eso era exactamente lo
+que pasaba: los ocho dissectors no-HTTP —FTP, SMTP, IMAP, POP3, SMB, MySQL,
+Redis, VNC y SNMP— no tenían ni un objetivo real contra el que medirse. Su
+única cobertura eran tests unitarios con sockets falsos, que verifican que el
+parser hace lo que su autor creía, no que reciba lo que un servidor de verdad
+emite. El umbral de aceptación de este banco es concordancia ≥ 0,90 en cuatro
+protocolos no-HTTP; ese número no existía, ni bueno ni malo.
 
 Este módulo lo produce. Levanta un contenedor por protocolo, deja que el
 dissector real lo interrogue, y compara su lectura con la de ``nmap -sV`` sobre
@@ -16,9 +15,9 @@ el mismo servidor.
 
 ## Medir contra Nmap no es depender de Nmap
 
-Conviene decirlo porque la Fase 1 se abrió retirando justo lo contrario (L52):
-el motor ya no lanza otros escáneres, no arranca desde ellos, y su lectura
-propia no está subordinada a ninguno. Nada de eso está aquí en cuestión. Nmap
+Conviene decirlo porque el motor no lanza otros escáneres, no arranca desde
+ellos, y su lectura propia no está subordinada a ninguno. Nada de eso está
+aquí en cuestión. Nmap
 aparece en ``tests/``, nunca en el producto, y sólo como **regla graduada**: la
 independencia se demuestra midiéndose contra el mejor del mercado y empatando o
 ganando, no negándose a la comparación.
@@ -209,7 +208,7 @@ def ftp_target():
 
 @pytest.fixture(scope="module")
 def proftpd_target():
-    """El segundo servidor FTP del catálogo, y la razón de que exista (L48-a).
+    """El segundo servidor FTP del catálogo, y la razón de que exista.
 
     La familia FTP daba concordancia 1,00 en laboratorio y 0,00 contra
     objetivos reales. La explicación no era la red: el banco tenía **un solo**
@@ -254,7 +253,7 @@ def proftpd_target():
 
 @pytest.fixture(scope="module")
 def reverse_proxy_target():
-    """Un nginx de proxy inverso por delante de un Apache (L48-b).
+    """Un nginx de proxy inverso por delante de un Apache.
 
     Todos los demás objetivos HTTP del catálogo son **servidores pelados**: la
     cabecera ``Server`` y el servidor real son la misma cosa, así que leerla
@@ -287,8 +286,8 @@ def reverse_proxy_target():
 
 @pytest.fixture(scope="module")
 def smtp_target():
-    """Postfix, que da producto pero **no** versión: el caso que el roadmap
-    llama "no inventar CPE". Nmap sí extrae el producto de ese mismo saludo."""
+    """Postfix, que da producto pero **no** versión: el caso de "no inventar
+    CPE". Nmap sí extrae el producto de ese mismo saludo."""
     port, name = _PORTS["smtp"], "lybra-concordance-smtp"
     _start(name, port, 25, "alpine:latest", "sh", "-c",
            "apk add --no-cache postfix && "
@@ -537,15 +536,15 @@ def test_snmp_fingerprint_agrees_with_nmap(snmp_target):
 
 @pytest.mark.xfail(strict=True, reason=(
     "La concordancia no-HTTP medida hoy sobre los siete protocolos del catálogo "
-    "es 3/7 = 0,43, muy por debajo del 0,90 que pide el criterio de cierre de la "
-    "Fase N. Los cuatro fallos están documentados uno a uno arriba. Este test es "
-    "el número agregado: pasará a XPASS cuando se cierre el último hueco, y "
-    "entonces habrá que quitarle el marcador."
+    "es 3/7 = 0,43, muy por debajo del umbral de 0,90 que este banco exige. Los "
+    "cuatro fallos están documentados uno a uno arriba. Este test es el número "
+    "agregado: pasará a XPASS cuando se cierre el último hueco, y entonces habrá "
+    "que quitarle el marcador."
 ))
 def test_non_http_concordance_reaches_the_phase_n_threshold(
     ftp_target, smtp_target, mysql_target, smb_target, redis_target, vnc_target, snmp_target,
 ):
-    """El número que la Fase N pide y que hasta ahora no existía.
+    """El umbral de concordancia no-HTTP que este banco exige.
 
     No mide si los dissectors son *útiles* —el de SNMP lo es, y el de SMB
     también— sino si su lectura es comparable con la de la herramienta de

--- a/API/tests/oracle/test_lybra_false_positive_bench.py
+++ b/API/tests/oracle/test_lybra_false_positive_bench.py
@@ -1,7 +1,7 @@
-"""Baseline de falsos positivos de la detección por versión (L33).
+"""Baseline de falsos positivos de la detección por versión.
 
-La Fase O del roadmap se cierra con un número —*«falsos positivos del banco
-−40 % en imágenes Debian/RHEL»*— que **no se podía calcular**, porque no existía
+El objetivo declarado es un número —*«falsos positivos del banco −40 % en
+imágenes Debian/RHEL»*— que **no se podía calcular**, porque no existía
 el punto de partida del que restar ese 40 %. Peor aún: nadie sabía cuál era la
 tasa. Podía ser el 10 % o el 60 %. Y esa cifra es, literalmente, la respuesta a
 «¿me puedo fiar de esto?».
@@ -21,7 +21,7 @@ corregida**. No es un fallo del comparador: la información que distingue un cas
 del otro no está en el número de versión.
 
 Ese es el falso positivo que el escaneo de vulnerabilidades por versión produce
-a espuertas, y el que la Fase O tiene que atacar.
+a espuertas, y el que este banco tiene que atacar.
 
 ## La verdad de referencia, sin salir a la red
 
@@ -91,8 +91,8 @@ _IMAGES = (
 # La cota medida el 2026-08-31 sobre este catálogo: 8 falsos positivos
 # demostrables de 19 hallazgos por versión emitidos = 0,42.
 #
-# La aserción es un guardarraíl contra empeorar, no una meta: el objetivo de la
-# Fase O es bajar de aquí un 40 %, o sea hasta ~0,25. Cuando eso ocurra, este
+# La aserción es un guardarraíl contra empeorar, no una meta: el objetivo
+# declarado es bajar de aquí un 40 %, o sea hasta ~0,25. Cuando eso ocurra, este
 # número baja con él y el margen se estrecha.
 _BASELINE_FALSE_POSITIVE_RATE = 0.45
 
@@ -198,7 +198,7 @@ def measurement(app) -> Dict:
 
 def _print_report(seeded, per_image: Dict) -> None:
     aliases, cves = seeded
-    print(f"\n=== Baseline de falsos positivos por versión (L33) ===")
+    print(f"\n=== Baseline de falsos positivos por versión ===")
     print(f"  KB del banco: {aliases} alias de producto, {cves} CVE copiadas del backfill real")
     for image, data in per_image.items():
         emitted, false_positives = len(data["emitted"]), len(data["false_positives"])
@@ -229,7 +229,7 @@ def test_the_bench_actually_emits_something_to_judge(measurement):
 
 
 def test_version_detection_false_positive_rate_does_not_regress(measurement):
-    """La cifra que la Fase O necesita como punto de partida.
+    """La cifra que sirve de punto de partida para reducir falsos positivos.
 
     Medida el 2026-08-31: 8 falsos positivos demostrables sobre 19 hallazgos por
     versión, es decir **0,42** — y es una cota inferior, porque el oráculo sólo
@@ -264,4 +264,5 @@ def test_most_of_a_distro_inventory_never_reaches_the_knowledge_base(measurement
     packages = sum(data["packages"] for data in measurement.values())
     assert packages > 0
     # No hay aserción sobre la cobertura porque no hay umbral acordado todavía;
-    # el número sale impreso en el informe y es el que alimenta la Fase O.
+    # el número sale impreso en el informe y es el que alimenta el objetivo de
+    # reducción de falsos positivos.

--- a/API/tests/oracle/test_lybra_nuclei_differential_bench.py
+++ b/API/tests/oracle/test_lybra_nuclei_differential_bench.py
@@ -1,4 +1,4 @@
-"""Oráculo diferencial de Nuclei para Lybra (roadmap Fase U3, §8 segunda pata).
+"""Oráculo diferencial de Nuclei para Lybra.
 
 Distinto de ``test_lybra_oracle_bench.py``, que afirma "el motor debe
 encontrar la CVE tal en la imagen cual" contra objetivos con verdad conocida
@@ -10,11 +10,11 @@ porque el propio banco no los tenía anticipados.
 El método: se lanza un escaneo Lybra de autodescubrimiento real y, por
 separado, el binario real de Nuclei —ambos contra el mismo contenedor Docker,
 por la red real, nada mockeado—, y se comparan los CVE que cada uno reporta.
-El traductor ``nuclei_result_to_finding`` es el mismo que usa U1 en
-producción (roadmap: "el mismo traductor de U1, en un contenedor efímero") —
-aquí se invoca directamente sobre el JSONL, sin pasar por
-``NucleiScanManager``/TaskQueue, igual que el resto de este paquete evita
-Redis real en tests (ver conftest.py, T5).
+El traductor ``nuclei_result_to_finding`` es el mismo que se usa en
+producción — el mismo traductor, en un contenedor efímero — aquí se invoca
+directamente sobre el JSONL, sin pasar por ``NucleiScanManager``/TaskQueue,
+igual que el resto de este paquete evita Redis real en tests (ver
+conftest.py).
 
 Requiere Docker y el binario ``nuclei`` (con plantillas ya descargadas —
 ``nuclei -update-templates``, una vez, no en cada corrida). Se salta entero
@@ -56,7 +56,7 @@ pytestmark.append(pytest.mark.skipif(_NUCLEI is None, reason="Nuclei no disponib
 # httpd_2449_port, git_exposed_port y tls_healthy_port son fixtures
 # reimportadas tal cual del banco de verdad-por-etiqueta (mismo paquete): no
 # hay ninguna razón para levantar contenedores duplicados solo porque este
-# módulo mide algo distinto sobre ellos. "Sin etiqueta previa" (§8) describe
+# módulo mide algo distinto sobre ellos. "Sin etiqueta previa" describe
 # el MÉTODO —la comparación no consulta la lista de CVEs que
 # ``test_lybra_oracle_bench.py`` ya conoce, deriva su propia verdad de
 # Nuclei—, no una exigencia de que el contenedor sea uno nuevo.
@@ -106,7 +106,7 @@ def _cve_ids(findings) -> set[str]:
 
 
 def _differential_report(lybra_cves: set[str], nuclei_cves: set[str]) -> dict:
-    """Compara dos conjuntos de CVE y arma el resumen que U3 pide medir.
+    """Compara dos conjuntos de CVE y arma el resumen de este banco.
 
     - ``corroborated``: CVE que ambos motores reportan de forma independiente
       — la señal más fuerte de que la detección es real.
@@ -151,10 +151,10 @@ def real_kb(app):
 def test_differential_oracle_against_three_unlabeled_targets(
     request, app, admin_user, monkeypatch, real_kb, fixture_name, url_template,
 ):
-    """El banco diferencial de U3: por cada uno de los (al menos) tres
+    """El banco diferencial: por cada uno de los (al menos) tres
     objetivos, compara Lybra contra Nuclei y deja el desglose en el resumen
-    del test (visible con ``-s`` o en un fallo) — la definición de hecho de
-    la Fase U pide "un número", no una aserción binaria por objetivo."""
+    del test (visible con ``-s`` o en un fallo) — el criterio de este banco
+    exige "un número", no una aserción binaria por objetivo."""
     port = request.getfixturevalue(fixture_name)
 
     lybra_findings = _run_self_discovery(app, admin_user, "127.0.0.1", port, monkeypatch)

--- a/API/tests/oracle/test_lybra_oracle_bench.py
+++ b/API/tests/oracle/test_lybra_oracle_bench.py
@@ -1,22 +1,19 @@
-"""Banco de pruebas con oráculo diferencial para Lybra (roadmap §7).
+"""Banco de pruebas con oráculo diferencial para Lybra.
 
 A diferencia del resto de la suite de Lybra (``tests/integration/test_lybra.py``),
 que mockea toda la red a propósito, este módulo hace lo contrario: levanta
 contenedores Docker reales con software conocido y deja que Lybra los descubra,
-identifique y correlacione con la BC **de verdad**, por la red real. Es la pieza
-que el apartado 7 del roadmap pide y que hasta ahora no existía como artefacto
-ejecutable — solo como aspiración documentada.
+identifique y correlacione con la BC **de verdad**, por la red real. Es la
+medición ejecutable que antes sólo existía como aspiración documentada.
 
 Nmap hace de oráculo cuando aplica (concordancia de puertos/fingerprint, igual
 que ``scripts/lybra_concordance_bench.py``); para el resto, la aserción es
 directamente "el motor debe encontrar la CVE/hallazgo tal en el contenedor
-cual", tal y como describe el apartado 9 ("por dónde empezar esta misma
-semana").
+cual".
 
 Requiere Docker. Se salta entero si no está disponible — no forma parte del
-run por defecto de CI (ver ``tests.yml``, marcador ``oracle``), porque el
-propio roadmap trata "correr esta medición" como un paso operativo del
-usuario, no como una puerta de cada commit.
+run por defecto de CI (ver ``tests.yml``, marcador ``oracle``), porque correr
+esta medición es un paso operativo del usuario, no una puerta de cada commit.
 """
 
 from __future__ import annotations
@@ -217,8 +214,7 @@ def _tls_container_cmd(days: int, expired: bool) -> str:
 
 @pytest.fixture(scope="module")
 def httpd_2449_port():
-    """Un ``httpd:2.4.49`` real — el mismo ejemplo que usa el propio roadmap
-    (CVE-2021-41773) en el apartado 9."""
+    """Un ``httpd:2.4.49`` real, vulnerable a CVE-2021-41773."""
     port = _free_http_port()
     name = f"lybra-oracle-httpd-{port}"
     _docker("run", "-d", "--name", name, "-p", f"{port}:80", "httpd:2.4.49")
@@ -232,7 +228,7 @@ def httpd_2449_port():
 
 @pytest.fixture(scope="module")
 def git_exposed_port():
-    """Un nginx con ``.git/config`` expuesto — el segundo ejemplo del apartado 9.
+    """Un nginx con ``.git/config`` expuesto.
 
     El fichero se escribe dentro del propio contenedor al arrancar (sin bind
     mount): evita depender de traducción de rutas WSL↔Docker Desktop, que es
@@ -257,9 +253,9 @@ def git_exposed_port():
 @pytest.fixture
 def tls_healthy_port():
     """A self-signed cert that is otherwise healthy — valid for a year, modern
-    protocol. Closes the roadmap's Fase R gap ("la familia tls se quedó fuera
-    del banco automatizado"): a local container with a self-signed cert
-    generated at startup, avoiding both the bind-mount friction the
+    protocol. Covers the tls family in the automated bench: a local container
+    with a self-signed cert generated at startup, avoiding both the
+    bind-mount friction the
     ``.git/config`` fixture already sidesteps and the SNI/IP mismatch a real
     ``badssl.com``-style target would hit through ``AuthorizedTargetManager``
     (IP/CIDR only, no hostnames).
@@ -363,7 +359,7 @@ def _run_self_discovery(app, admin_user, target: str, port: int, monkeypatch):
     """Lanza un escaneo Lybra de autodescubrimiento real contra ``target:port``.
 
     La autorización del objetivo es idempotente a propósito: un test que barre
-    varios contenedores en un solo caso —el banco de precisión de la Fase R—
+    varios contenedores en un solo caso —el banco de precisión de familias—
     llama aquí una vez por objetivo con la misma IP y la misma BD, y el registro
     rechaza duplicados. Lo que este helper necesita es "que esté autorizado", no
     "que se acabe de añadir".
@@ -383,7 +379,7 @@ def _run_self_discovery(app, admin_user, target: str, port: int, monkeypatch):
 
 
 def test_apache_2449_self_discovery_finds_version_and_cve(app, admin_user, httpd_2449_port, monkeypatch):
-    """El motor debe encontrar CVE-2021-41773 en un httpd:2.4.49 real (roadmap §9)."""
+    """El motor debe encontrar CVE-2021-41773 en un httpd:2.4.49 real."""
     with app.app_context():
         with UnitOfWork() as uow:
             repo = KbRepository(uow)
@@ -407,7 +403,7 @@ def test_apache_2449_self_discovery_finds_version_and_cve(app, admin_user, httpd
 
 
 def test_git_config_exposure_detected_against_real_container(app, admin_user, git_exposed_port, monkeypatch):
-    """El check activo debe confirmar el .git/config expuesto (roadmap §9)."""
+    """El check activo debe confirmar el .git/config expuesto."""
     findings = _run_self_discovery(app, admin_user, "127.0.0.1", git_exposed_port, monkeypatch)
 
     exposed = [f for f in findings if f.category == "exposed_path"]
@@ -418,7 +414,7 @@ def test_git_config_exposure_detected_against_real_container(app, admin_user, gi
 
 
 def test_missing_security_headers_detected_against_real_container(app, admin_user, git_exposed_port, monkeypatch):
-    """La familia security_header (Fase R) debe confirmarse contra un nginx real
+    """La familia security_header debe confirmarse contra un nginx real
     que no manda ninguna de las tres cabeceras — vanilla nginx:alpine, sin nada
     de configuración de seguridad."""
     findings = _run_self_discovery(app, admin_user, "127.0.0.1", git_exposed_port, monkeypatch)
@@ -432,7 +428,7 @@ def test_missing_security_headers_detected_against_real_container(app, admin_use
 
 
 def test_tls_self_signed_cert_detected_against_real_container(app, admin_user, tls_healthy_port, monkeypatch):
-    """La familia tls (Fase R) debe confirmar el autofirmado contra un
+    """La familia tls debe confirmar el autofirmado contra un
     contenedor real, y no disparar en falso los otros dos checks de la misma
     familia (caducidad, protocolo obsoleto) — el control negativo que hace
     del número de precisión algo medido y no solo aspiracional."""
@@ -507,7 +503,7 @@ def test_redis_unauthenticated_access_absent_when_requirepass_is_set(app, admin_
 
 @pytest.mark.skipif(_NMAP is None, reason="nmap no disponible")
 def test_port_discovery_agrees_with_nmap_oracle(httpd_2449_port):
-    """Concordancia de puertos (Fase T) contra Nmap para un objetivo real, no mockeado."""
+    """Concordancia de puertos contra Nmap para un objetivo real, no mockeado."""
     own_ports = scan_ports_sync("127.0.0.1", [httpd_2449_port])
 
     result = subprocess.run(

--- a/API/tests/oracle/test_lybra_precision_bench.py
+++ b/API/tests/oracle/test_lybra_precision_bench.py
@@ -1,6 +1,6 @@
-"""Medición formal de precisión de las tres familias de la Fase R (roadmap §10).
+"""Medición formal de precisión de tres familias de checks.
 
-El número que la Fase R pide para darse por cerrada es explícito: *"familias de
+El número que este banco exige es explícito: *"familias de
 TLS, cabeceras y paths con precisión ≥ 0,9 medida contra el catálogo de imágenes
 etiquetadas"*. Hasta ahora ``test_lybra_oracle_bench.py`` afirmaba
 target-a-target ("en este contenedor debe salir este check"), que es una prueba
@@ -16,7 +16,7 @@ los objetivos:
     FN = estaba declarado y no disparó
     precisión = TP / (TP + FP)           recall = TP / (TP + FN)
 
-La aserción dura es solo sobre la precisión, que es lo que el roadmap fija como
+La aserción dura es solo sobre la precisión, que es lo que este banco fija como
 umbral; el recall se mide y se imprime porque un banco con precisión perfecta y
 recall ruinoso sería trivial de conseguir (no disparar nunca) y hay que poder
 verlo.
@@ -60,9 +60,9 @@ pytestmark = [pytest.mark.oracle, pytest.mark.integration]
 _DOCKER = resolve_docker()
 pytestmark.append(pytest.mark.skipif(_DOCKER is None, reason="Docker no disponible"))
 
-# Las tres familias que el número de la Fase R nombra. Todo lo demás que emita
+# Las tres familias que este banco mide. Todo lo demás que emita
 # el motor (open_port, fingerprint, outdated_software...) queda fuera del
-# cómputo: son otras fases y otros números.
+# cómputo: son otras mediciones y otros números.
 _MEASURED_CATEGORIES = {"exposed_path", "security_header", "tls"}
 
 _PRECISION_THRESHOLD = 0.9
@@ -514,7 +514,7 @@ def _measured_check_ids(findings) -> Set[str]:
 
     Los de estado ``fixed`` se excluyen, y no es un detalle: los nueve objetivos
     del catálogo comparten IP (127.0.0.1) y por tanto el mismo ``Host``, así que
-    ``apply_lifecycle`` (Fase 5) arrastra a cada escaneo un hallazgo fantasma por
+    ``apply_lifecycle`` arrastra a cada escaneo un hallazgo fantasma por
     cada uno del escaneo anterior que ya no está, precisamente para dejar
     constancia de la remediación. Contarlos como detecciones convertiría el
     ciclo de vida —que funciona— en seis falsos positivos inventados por el
@@ -527,7 +527,7 @@ def _measured_check_ids(findings) -> Set[str]:
 
 
 def test_fase_r_precision_over_labelled_catalogue(app, admin_user, monkeypatch):
-    """El número de la Fase R: precisión ≥ 0,9 sobre el catálogo etiquetado."""
+    """El umbral de este banco: precisión ≥ 0,9 sobre el catálogo etiquetado."""
     true_positives = false_positives = false_negatives = 0
     breakdown = []
 
@@ -556,7 +556,7 @@ def test_fase_r_precision_over_labelled_catalogue(app, admin_user, monkeypatch):
     recall = true_positives / (true_positives + false_negatives) if true_positives + false_negatives else 0.0
 
     report = (
-        "\n[precisión Fase R] catálogo de "
+        "\n[precisión] catálogo de "
         f"{len(_CATALOGUE)} objetivos etiquetados, familias {sorted(_MEASURED_CATEGORIES)}\n"
         + "\n".join(breakdown)
         + f"\n  TOTAL  TP={true_positives} FP={false_positives} FN={false_negatives}"
@@ -567,7 +567,7 @@ def test_fase_r_precision_over_labelled_catalogue(app, admin_user, monkeypatch):
 
     assert precision >= _PRECISION_THRESHOLD, report
 
-    # Y, por encima del umbral del roadmap, un guardarraíl contra la deriva.
+    # Y, por encima del umbral exigido, un guardarraíl contra la deriva.
     #
     # El 0,9 se fijó cuando el banco tenía 30 detecciones. Con 68 hacen falta
     # más de siete falsos positivos para bajar de ahí, así que una regresión

--- a/API/tests/oracle/test_lybra_real_parity_bench.py
+++ b/API/tests/oracle/test_lybra_real_parity_bench.py
@@ -1,8 +1,8 @@
-"""Paridad laboratorio/real: el mismo motor, contra objetivos de verdad (L48).
+"""Paridad laboratorio/real: el mismo motor, contra objetivos de verdad.
 
-El §9 del roadmap declara esta paridad **no negociable** para dar por cerradas
-las fases F (fingerprinting), T (transporte propio) y N (protocolos no-HTTP), y
-lo argumenta bien: *«eso no puede convertirse en la excusa de "el objetivo real
+Esta paridad es **no negociable** para dar por cubiertos el fingerprinting, el
+transporte propio y los protocolos no-HTTP, y el argumento es sencillo: *«eso
+no puede convertirse en la excusa de "el objetivo real
 es más difícil" cuando Nmap identifica con soltura servicios en hosts públicos
 reales. Si aparece un caso como "en localhost identificamos producto y versión,
 pero en un host público real sólo vemos puertos abiertos", no es un resultado
@@ -38,13 +38,13 @@ este ítem es el número, no un booleano.
 Lo mismo que el banco de laboratorio (``test_lybra_concordance_bench.py``), con
 las mismas funciones, para que los dos números sean comparables:
 
-- **Fase T** — concordancia de puertos: qué encuentra el connect scan propio
+- **Puertos** — concordancia de puertos: qué encuentra el connect scan propio
   frente a lo que encuentra Nmap sobre el mismo objetivo.
-- **Fases F y N** — concordancia de fingerprint: si el dissector que aplica a
+- **Fingerprint** — concordancia de fingerprint: si el dissector que aplica a
   cada servicio identifica el mismo producto que Nmap.
 
-El umbral del roadmap es 0,95 en puertos y 0,90 en fingerprint, y el criterio
-de cierre de L48 pide al menos diez objetivos variados.
+El umbral exigido es 0,95 en puertos y 0,90 en fingerprint, y el criterio
+de este banco pide al menos diez objetivos variados.
 """
 
 from __future__ import annotations
@@ -78,13 +78,13 @@ pytestmark.append(pytest.mark.skipif(
     reason="Sin LYBRA_REAL_TARGETS: el lado real de la paridad lo declara el operador",
 ))
 
-# El mínimo que pide el criterio de cierre de L48. Se comprueba en su propio
+# El mínimo que este banco exige. Se comprueba en su propio
 # test en vez de dentro de la medición: "no hay bastantes objetivos" y "los
 # objetivos que hay concuerdan poco" son dos problemas distintos y merecen dos
 # mensajes distintos.
 _MINIMUM_TARGETS = 10
 
-# Los umbrales del roadmap (§9).
+# Los umbrales exigidos.
 _PORT_THRESHOLD = 0.95
 _FINGERPRINT_THRESHOLD = 0.90
 
@@ -177,7 +177,7 @@ def _by_family(results: List[dict], measurable_only: bool = True) -> Dict[str, L
 
     La paridad se cierra **por familia**, no en promedio: un número global alto
     puede esconder que HTTP va perfecto y FTP no identifica nada, que es
-    justamente el caso que el §9 se niega a dar por bueno.
+    justamente el caso que esta medición se niega a dar por bueno.
     """
     families: Dict[str, List[Tuple]] = defaultdict(list)
     for result in results:
@@ -192,14 +192,14 @@ def _ascii(value) -> str:
     """Un banner de un servidor real puede traer cualquier byte, y la consola de
     Windows (cp1252) no codifica todo Unicode: un solo carácter raro en un
     producto hacía reventar el ``print`` del informe y con él la medición
-    entera. El informe es el entregable de L48, así que no puede caerse por un
+    entera. El informe es el entregable de este banco, así que no puede caerse por un
     acento de más — cualquier carácter fuera de ASCII se sustituye."""
     return str(value).encode("ascii", "replace").decode("ascii")
 
 
 def _print_report(results: List[dict]) -> None:
-    """Imprime la comparativa. El entregable de L48 es el número, no un OK."""
-    print("\n=== Paridad real (L48) - objetivos declarados en LYBRA_REAL_TARGETS ===")
+    """Imprime la comparativa. El entregable de este banco es el número, no un OK."""
+    print("\n=== Paridad real - objetivos declarados en LYBRA_REAL_TARGETS ===")
     for result in results:
         print(f"  {result['target']}: puertos propios={result['own_ports']} "
               f"nmap={result['nmap_ports']} concordancia={result['ports_score']:.2f}")
@@ -216,8 +216,8 @@ def _print_report(results: List[dict]) -> None:
     measurable = _fingerprint_pairs(results)
     blind = len(every_pair) - len(measurable)
     ports = [result["ports_score"] for result in results]
-    print(f"  puertos (Fase T): {sum(ports) / len(ports):.2f} sobre {len(ports)} objetivos")
-    print(f"  fingerprint (F/N): {concordance_rate(measurable):.2f} "
+    print(f"  puertos: {sum(ports) / len(ports):.2f} sobre {len(ports)} objetivos")
+    print(f"  fingerprint: {concordance_rate(measurable):.2f} "
           f"sobre {len(measurable)} servicios medibles")
     print(f"  descartados: {blind} de {len(every_pair)} servicios donde NINGUNO de los dos "
           f"identifica producto (puertos que aceptan y no contestan)")
@@ -233,7 +233,7 @@ def test_the_real_side_has_enough_targets():
     raro mueve el número medio punto.
     """
     assert len(_TARGETS) >= _MINIMUM_TARGETS, (
-        f"Sólo {len(_TARGETS)} objetivos declarados; L48 pide al menos "
+        f"Sólo {len(_TARGETS)} objetivos declarados; este banco pide al menos "
         f"{_MINIMUM_TARGETS} y variados (con y sin CDN/WAF, con y sin TLS, con "
         f"cabecera Server presente y suprimida, y alguno con servicios no-HTTP)"
     )
@@ -244,14 +244,16 @@ def test_the_real_side_has_enough_targets():
     "ejecuciones del banco con 20 minutos de diferencia dieron 0,96 y 0,58. La "
     "diferencia entera son cuatro IPs donde el descubrimiento propio devolvio "
     "lista vacia mientras Nmap encontraba sus cuatro puertos y un socket crudo "
-    "conectaba sin problema (issue L48-c). Mientras ese defecto siga abierto, la "
-    "Fase T no se puede certificar: el numero mide cuando nos bloquearon, no lo "
-    "que el transporte sabe hacer. `strict=False` a proposito — un `strict=True` "
-    "seria tan falso como la asercion, porque a veces pasa."
+    "conectaba sin problema (un fallo de descubrimiento intermitente). Mientras "
+    "ese defecto siga abierto, la concordancia de puertos no se puede certificar: "
+    "el numero mide cuando nos bloquearon, no lo que el transporte sabe hacer. "
+    "`strict=False` a proposito — un `strict=True` seria tan falso como la "
+    "asercion, porque a veces pasa."
 ))
 def test_port_discovery_matches_nmap_on_real_targets(measurements):
-    """Fase T contra objetivos reales: es donde aparecen el WAF que corta a la
-    tercera conexión y el balanceador que responde distinto en cada intento."""
+    """Concordancia de puertos contra objetivos reales: es donde aparecen el WAF
+    que corta a la tercera conexión y el balanceador que responde distinto en
+    cada intento."""
     scores = [result["ports_score"] for result in measurements]
     average = sum(scores) / len(scores)
     detail = [(result["target"], round(result["ports_score"], 2)) for result in measurements]
@@ -260,16 +262,16 @@ def test_port_discovery_matches_nmap_on_real_targets(measurements):
 
 @pytest.mark.xfail(strict=True, reason=(
     "Medido el 2026-09-01 sobre 10 objetivos reales autorizados: concordancia de "
-    "fingerprint entre 0,33 y 0,36 segun la ejecucion, frente al 0,90 que pide el "
-    "roadmap. El laboratorio daba 1,00 en las mismas familias, asi que la brecha "
-    "laboratorio/real que el §9 declara no negociable existe y esta cuantificada. "
-    "Las causas van por familia como issues de Fase 2: FTP no identifica ProFTPD "
-    "(L48-a) y HTTP lee el proxy de delante y no el servidor de detras (L48-b). El "
-    "rango en vez de una cifra unica no es imprecision: el tamano de la muestra "
-    "varia porque el descubrimiento falla de forma intermitente (L48-c)."
+    "fingerprint entre 0,33 y 0,36 segun la ejecucion, frente al umbral de 0,90 "
+    "exigido. El laboratorio daba 1,00 en las mismas familias, asi que la brecha "
+    "laboratorio/real que esta paridad declara no negociable existe y esta "
+    "cuantificada. Las causas van por familia: FTP no identifica ProFTPD y HTTP "
+    "lee el proxy de delante y no el servidor de detras. El rango en vez de una "
+    "cifra unica no es imprecision: el tamano de la muestra varia porque el "
+    "descubrimiento falla de forma intermitente."
 ))
 def test_fingerprinting_matches_nmap_on_real_targets(measurements):
-    """Fases F y N contra objetivos reales.
+    """Concordancia de fingerprint contra objetivos reales.
 
     Sólo entran los pares **medibles**: un servicio que ni la sonda propia ni
     Nmap consiguen identificar no dice nada sobre el motor, sólo sobre lo duro
@@ -286,18 +288,18 @@ def test_fingerprinting_matches_nmap_on_real_targets(measurements):
 
 @pytest.mark.xfail(strict=True, reason=(
     "Medido el 2026-09-01: FTP 0,00 y HTTP entre 0,07 y 0,25 quedan por debajo del "
-    "umbral; SSH aguanta en 0,75. La causa de FTP (L48-a) ya esta corregida —el "
+    "umbral; SSH aguanta en 0,75. La causa de FTP ya esta corregida —el "
     "parser reconocia un solo formato de saludo, el de vsftpd, y los dos hosts "
     "medidos servian ProFTPD sin version— pero el numero solo cambia cuando el "
-    "banco se vuelva a ejecutar contra objetivos reales. Queda HTTP (L48-b). Este "
+    "banco se vuelva a ejecutar contra objetivos reales. Queda HTTP. Este "
     "test pasara a XPASS cuando la ultima familia se cierre."
 ))
 def test_no_family_is_left_behind(measurements):
     """La paridad se cierra por familia, no en promedio.
 
     Un número global alto puede esconder que HTTP va perfecto y que FTP no
-    identifica nada — que es exactamente el caso que el §9 se niega a dar por
-    bueno. Una familia con un solo servicio observado no se juzga: no hay
+    identifica nada — que es exactamente el caso que esta paridad se niega a
+    dar por bueno. Una familia con un solo servicio observado no se juzga: no hay
     muestra, y suspender por ella mediría el catálogo de objetivos y no el
     motor.
     """

--- a/API/tests/oracle/test_real_targets.py
+++ b/API/tests/oracle/test_real_targets.py
@@ -1,8 +1,8 @@
-"""La lista blanca del sello de red hace exactamente lo que dice (L48).
+"""La lista blanca del sello de red hace exactamente lo que dice.
 
 El sello ``_no_outbound_sockets`` es lo que mantiene la suite en dos minutos y
 lo que garantiza que su resultado no dependa de lo que haya al otro lado de la
-red. Desde L48 tiene una excepción: las direcciones que el operador declara en
+red. Tiene una excepción: las direcciones que el operador declara en
 ``LYBRA_REAL_TARGETS`` para el banco de paridad real.
 
 Una excepción a una defensa es justo el sitio donde conviene no fiarse de la
@@ -61,7 +61,7 @@ def test_a_target_that_does_not_resolve_does_not_sink_the_rest(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# El oráculo alcanza el objetivo correcto (L48, arreglo del banco de paridad)
+# El oráculo alcanza el objetivo correcto
 # --------------------------------------------------------------------------
 #
 # Estas dos comprueban la traducción de host que el contenedor de Nmap necesita.
@@ -79,10 +79,9 @@ def test_loopback_is_reached_through_the_docker_host():
 
 
 def test_an_external_target_is_scanned_directly():
-    """El defecto que tenía el banco de paridad real: el contenedor de Nmap
-    escaneaba ``host.docker.internal`` —la máquina Docker— en vez del objetivo
-    externo, midiendo algo que no tenía nada que ver. Un host o IP que no es
-    loopback se pasa tal cual."""
+    """El contenedor de Nmap tiene que escanear el objetivo externo declarado,
+    no ``host.docker.internal`` —la máquina Docker—, que mediría algo que no
+    tiene nada que ver. Un host o IP que no es loopback se pasa tal cual."""
     assert _target_from_container("emesa.com") == "emesa.com"
     assert _target_from_container("203.0.113.9") == "203.0.113.9"
 
@@ -117,13 +116,14 @@ def test_a_closed_port_is_a_measurement_and_not_an_error():
 
 
 def test_an_unreachable_target_stops_the_bench_instead_of_scoring_zero():
-    """El fallo que estuvo tres noches disfrazado de desacuerdo de fingerprint.
+    """Un objetivo que no resuelve tiene que interrumpir el banco, no colarse
+    como un desacuerdo de fingerprint más.
 
     Cuando el nombre no resuelve, Nmap emite este XML —válido, sin ni un
-    ``<host>`` dentro— y sale con código 0. Antes eso se colaba como «Nmap no
-    identificó el servicio» y restaba en la cifra de concordancia; ahora lanza,
-    y el mensaje lleva la salida de error de Nmap para que el log de CI diga
-    por sí solo qué pasó."""
+    ``<host>`` dentro— y sale con código 0. Sin esta comprobación eso se leería
+    como «Nmap no identificó el servicio» y restaría en la cifra de
+    concordancia; en vez de eso, lanza, y el mensaje lleva la salida de error de
+    Nmap para que el log de CI diga por sí solo qué pasó."""
     with pytest.raises(RuntimeError) as failure:
         assert_target_was_scanned(
             _XML_WITHOUT_A_HOST,
@@ -246,11 +246,11 @@ def test_a_hung_docker_daemon_is_reported_as_unavailable(monkeypatch):
     al pipe hasta que alguien lo mata: el binario existe y responde, pero no hay
     demonio detrás.
 
-    Antes eso subía como ``TimeoutExpired`` desde ``resolve_docker()``, que se
-    llama al **importar** cada módulo del banco. Como los marcadores de pytest
-    se filtran después de importar, un Docker colgado producía cinco errores de
-    colección y tumbaba la suite entera — incluso con ``-m "not oracle"``, en
-    tests que ni siquiera iban a ejecutarse.
+    Sin esta comprobación, ``resolve_docker()`` propagaría ``TimeoutExpired``
+    —se llama al **importar** cada módulo del banco—, y como los marcadores de
+    pytest se filtran después de importar, un Docker colgado produciría cinco
+    errores de colección y tumbaría la suite entera — incluso con
+    ``-m "not oracle"``, en tests que ni siquiera iban a ejecutarse.
     """
     def _hangs(*args, **kwargs):
         raise subprocess.TimeoutExpired(cmd="docker version", timeout=10)

--- a/API/tests/unit/test_kb_sync_status.py
+++ b/API/tests/unit/test_kb_sync_status.py
@@ -1,4 +1,4 @@
-"""El estado de sincronización de la base de conocimiento (L36).
+"""El estado de sincronización de la base de conocimiento.
 
 Toda la detección por versión del motor depende de un espejo local de NVD, KEV
 y EPSS, y hasta ahora no había nada que registrara cuándo se refrescó cada uno.

--- a/API/tests/unit/test_lybra_admin_apis.py
+++ b/API/tests/unit/test_lybra_admin_apis.py
@@ -1,4 +1,4 @@
-"""APIs de administración expuestas sin autenticar (L17).
+"""APIs de administración expuestas sin autenticar.
 
 Docker en 2375, Elasticsearch en 9200, Kubernetes en 6443: servicios que hablan
 HTTP, publican su versión en un JSON sin credenciales, y cuya sola exposición

--- a/API/tests/unit/test_lybra_backports.py
+++ b/API/tests/unit/test_lybra_backports.py
@@ -1,8 +1,8 @@
-"""Verificación de backports contra la palabra del proveedor (Fase O, L32).
+"""Verificación de backports contra la palabra del proveedor.
 
 Un backport es una distribución corrigiendo un fallo sin subir el número de
 versión visible: Debian parchea `apache2`, el banner sigue diciendo `2.4.49`, y
-el motor emite una CVE que ya no existe. La Fase 1 midió esa tasa en **0,42**:
+el motor emite una CVE que ya no existe. La tasa medida es **0,42**:
 cuatro de cada diez CVEs reportados contra un Debian o un Ubuntu ya estaban
 corregidos.
 

--- a/API/tests/unit/test_lybra_cascade.py
+++ b/API/tests/unit/test_lybra_cascade.py
@@ -1,4 +1,4 @@
-"""La cascada de identificación para servicios fuera de su puerto canónico (L10).
+"""La cascada de identificación para servicios fuera de su puerto canónico.
 
 Los predicados de aplicabilidad deciden por nombre o por número de puerto, y en
 el camino de autodescubrimiento el nombre sale a su vez de una tabla de

--- a/API/tests/unit/test_lybra_checks.py
+++ b/API/tests/unit/test_lybra_checks.py
@@ -1,9 +1,8 @@
-"""Unit tests for the Lybra active-check runtime (Fase R).
+"""Unit tests for the Lybra active-check runtime.
 
 Pure: an injected ``fetch``/``network_open`` returns crafted responses, so no
 real network. Exercises the bundled feed, the matchers, HTTP-service
-selection, the safe/aggressive gate, and the ``type: "network"`` family Fase N
-adds.
+selection, the safe/aggressive gate, and the ``type: "network"`` family.
 
 Para la familia ``network``, el transporte se sustituye **a nivel de socket**
 (bytes) y no a nivel de sesión: la nota al principio de esa sección explica
@@ -134,7 +133,7 @@ def test_safe_mode_skips_aggressive_checks(tmp_path):
     assert len(aggressive) == 1
 
 
-# --------------------------------------------------- network checks (Fase N)
+# --------------------------------------------------- network checks
 #
 # **Dónde se sustituye el transporte, y por qué ahí.** Los tests de
 # comportamiento de protocolo de esta sección inyectan un *socket* falso y
@@ -946,7 +945,7 @@ def test_a_check_that_skipped_the_loader_with_an_unknown_service_is_logged(caplo
     assert "protocolo-de-otro-mundo" in caplog.text
 
 
-# --------------------------------------------------- ``type: "script"`` (Fase R)
+# --------------------------------------------------- ``type: "script"``
 
 class _FakeSmbProbe:
     """Stands in for SmbProbe: returns a canned (dialect, security_mode) pair.
@@ -1078,7 +1077,7 @@ def test_script_check_declares_its_plugin_in_the_bundled_feed():
     assert check.script in default_script_plugins()
 
 
-# ------------------------------------------ snmp-default-community (Ronda 1)
+# ------------------------------------------ snmp-default-community
 
 class _FakeSnmpProbe:
     """Stands in for SnmpProbe: returns a canned sysDescr string, or ``None``
@@ -1136,10 +1135,10 @@ def test_snmp_check_in_bundled_feed():
     assert check.script in default_script_plugins()
 
 
-# ------------------------------------------- feed en YAML y compatibilidad (Fase R)
+# ------------------------------------------- feed en YAML y compatibilidad
 
 def test_bundled_feed_is_yaml():
-    """El feed propio vive en YAML desde la Fase R; el JSON se retiró."""
+    """El feed propio vive en YAML; el JSON no está soportado."""
     from src.modules.features.themis.lybra.checks import _BUNDLED_FEED
     assert _BUNDLED_FEED.suffix == ".yaml"
     assert _BUNDLED_FEED.exists()

--- a/API/tests/unit/test_lybra_confirmers.py
+++ b/API/tests/unit/test_lybra_confirmers.py
@@ -1,7 +1,7 @@
-"""El encadenamiento versión → confirmador (L29).
+"""El encadenamiento versión → confirmador.
 
-Es lo más diferencial que le quedaba al motor por construir: el §11 del roadmap
-lo nombra como la razón de existir del runtime propio frente a Nuclei. Convierte
+Es lo más diferencial del motor: la razón de existir del runtime propio frente
+a Nuclei. Convierte
 una hipótesis ``confirmed=false, qod=70`` —que puede ser un falso positivo por
 backport— en un hecho verificado, que es lo que separa un informe entregable de
 uno que hay que revisar a mano.

--- a/API/tests/unit/test_lybra_correlation.py
+++ b/API/tests/unit/test_lybra_correlation.py
@@ -1,4 +1,4 @@
-"""Unit tests for Lybra correlation (Fase 5): dedup, merge, lifecycle, scoring.
+"""Unit tests for Lybra correlation: dedup, merge, lifecycle, scoring.
 
 All pure functions over finding dicts — no DB, no network.
 """
@@ -49,7 +49,7 @@ def test_dedup_key_differs_by_port_and_identity():
 
 
 # ------------------------------------------------------- dedup key: protocol
-# Ronda 1 (roadmap §6.3): un servicio puede abrir el mismo puerto por TCP y
+# Un servicio puede abrir el mismo puerto por TCP y
 # por UDP (161 es el caso real: SNMP). Estos tres tests son los más
 # importantes del cambio: fijan digests literales para que cualquier
 # modificación futura del material de hash de compute_dedup_key falle a
@@ -139,7 +139,8 @@ def test_a_partial_scan_closes_nothing():
     Un barrido que se queda sin presupuesto de reloj deja puertos sin probar.
     Si el ciclo de vida cerrara por ausencia, ese escaneo le diría al usuario
     que sus vulnerabilidades fueron remediadas cuando lo único cierto es que
-    esta vez no se comprobaron — el fallo de L48-c por otra puerta.
+    esta vez no se comprobaron — el mismo riesgo que un descubrimiento
+    intermitente puede producir por otra puerta.
     """
     cur = [{"dedup_key": "K2"}]                  # K1 estaba antes y ahora no aparece
     out = apply_lifecycle(cur, _prev("open", "K1"), close_missing=False)
@@ -182,7 +183,7 @@ def test_score_finding(finding, exposure, expected):
     assert score_finding(finding, exposure) == expected
 
 
-# ───────────────────────── falso positivo vs riesgo aceptado (L35)
+# ──────────────── falso positivo vs riesgo aceptado
 #
 # Dicen cosas opuestas y hasta ahora compartían casilla. "Acepto el riesgo" es
 # una afirmación sobre el negocio: esto es real y lo asumo. "Falso positivo" es
@@ -214,8 +215,8 @@ def test_a_false_positive_stays_refuted():
 
 def test_a_refuted_finding_carries_its_reason_and_author():
     """Sin esto la decisión sobreviviría como estado pero perdería su
-    justificación en el escaneo siguiente, que es volver a la deuda que L35
-    quita de en medio."""
+    justificación en el escaneo siguiente, y una decisión sin justificación no
+    sirve para nada."""
     cur = [{"dedup_key": "K1", "check_id": "c@1", "feed_version": "f1"}]
     out = apply_lifecycle(cur, _prev_decided("false_positive", "K1",
                                              check_id="c@1", feed_version="f1"))
@@ -275,8 +276,8 @@ def test_an_accepted_risk_holds_until_it_expires():
 
 
 def test_an_accepted_risk_without_an_expiry_does_not_expire():
-    """Los `accepted` anteriores a L35 no tienen plazo porque nadie se lo puso.
-    Inventarles uno los reabriría todos de golpe el día del despliegue."""
+    """Un `accepted` sin plazo asignado no tiene que expirar nunca por su
+    cuenta. Inventarle uno los reabriría todos de golpe el día del despliegue."""
     cur = [{"dedup_key": "K1"}]
     out = apply_lifecycle(cur, _prev_decided("accepted", "K1", expires=None),
                           now=datetime(2030, 1, 1))
@@ -295,12 +296,13 @@ def test_a_false_positive_never_expires_by_time():
     assert out[0]["state"] == "false_positive"
 
 
-# ───────────────────── madurez de explotación (L34)
+# ───────────────────── madurez de explotación
 #
-# `Finding.exploit_maturity` se declaraba en el modelo, se documentaba como
-# "rellenada desde la Fase 1" y estaba NULL en todas las filas. Una columna que
-# promete un dato y siempre está vacía es peor que no tenerla, porque quien lee
-# el modelo cree que existe.
+# `exploit_maturity` se calcula en tiempo de correlación a partir de KEV, EPSS
+# y las referencias del CVE, en vez de vivir como una columna del modelo que
+# alguien tendría que mantener rellenada: una columna que promete un dato y
+# puede quedarse vacía es peor que no tenerla, porque quien lee el modelo cree
+# que existe.
 
 from src.modules.features.themis.lybra.correlation import (   # noqa: E402
     exploit_maturity, EXPLOIT_MATURITY_LADDER,

--- a/API/tests/unit/test_lybra_credentials.py
+++ b/API/tests/unit/test_lybra_credentials.py
@@ -1,4 +1,4 @@
-"""El motor de credenciales por defecto (Fase D, L31).
+"""El motor de credenciales por defecto.
 
 Es la única familia de detección de Lybra que escribe en el objetivo, así que
 lo que estos tests protegen no es sólo "encuentra el par correcto" sino las

--- a/API/tests/unit/test_lybra_dsl_chaining.py
+++ b/API/tests/unit/test_lybra_dsl_chaining.py
@@ -1,4 +1,4 @@
-"""El DSL de checks: variables extraídas, encadenamiento y payloads (L30).
+"""El DSL de checks: variables extraídas, encadenamiento y payloads.
 
 El motor sabía hacer una petición y mirar la respuesta, y nada más. No podía
 leer un dato de una respuesta y usarlo en la siguiente (login → recurso

--- a/API/tests/unit/test_lybra_engine.py
+++ b/API/tests/unit/test_lybra_engine.py
@@ -1,8 +1,8 @@
-"""Unit tests for the Lybra engine (Fase 0) and the Nmap CPE capture refactor.
+"""Unit tests for the Lybra engine and the Nmap CPE capture refactor.
 
-Pure logic: no DB, no network. Verifies the two things Fase 0 introduces below
-the manager — the engine turning services into informational findings, and Nmap's
-``<cpe>`` surviving the parser all the way into ``ports_data``.
+Pure logic: no DB, no network. Verifies two things below the manager — the
+engine turning services into informational findings, and Nmap's ``<cpe>``
+surviving the parser all the way into ``ports_data``.
 """
 
 import types
@@ -61,11 +61,11 @@ def test_service_label_falls_back_when_product_missing():
     assert Service(port=1, protocol="tcp").label == "servicio desconocido"
 
 
-# ----------------------------------------------------- Nmap CPE capture (§2.1)
+# ----------------------------------------------------- Nmap CPE capture
 #
 # El procesador de Nmap sigue capturando el CPE de cada servicio: es de Nmap y
-# alimenta a Nmap. Lo que se retiró en L52 fue el puente por el que ese dato
-# entraba en un escaneo de Lybra.
+# alimenta a Nmap. No hay puente por el que ese dato entre en un escaneo de
+# Lybra: los dos motores son independientes.
 
 _NMAP_XML = """<?xml version="1.0"?>
 <nmaprun args="nmap -sV 10.0.0.5" version="7.94">
@@ -100,7 +100,7 @@ def test_nmap_processor_keeps_cpe_in_ports_data():
     assert by_proto["22/tcp"]["cpe"] == ""
 
 
-# ------------------------------------------------ version matcher (Fase 1)
+# ------------------------------------------------ version matcher
 
 def _fake_cve(cve_id="CVE-2021-41773", required_os=None):
     return types.SimpleNamespace(
@@ -119,7 +119,7 @@ def _lookup_for(expected_vendor_product, calls=None):
 
 
 def test_no_cve_lookup_means_informational_only():
-    # Fase 0 behaviour preserved when no lookup is wired.
+    # Behaviour when no lookup is wired: findings stay informational.
     engine = LybraEngine()
     findings = engine.analyze([Service(80, "tcp", "http", "Apache httpd", "2.4.49",
                                        "cpe:/a:apache:http_server:2.4.49")])
@@ -155,7 +155,7 @@ def test_version_finding_from_nmap_cpe():
 
 
 def test_version_finding_carries_required_os_from_the_cve_lookup():
-    """#118: a cve_lookup result flagged with a platform gate (KbRepository's
+    """A cve_lookup result flagged with a platform gate (KbRepository's
     transient CveEntry.required_os) must reach the finding dict, so
     score_finding can avoid crowning an unverifiable platform hypothesis as
     CRITICAL."""
@@ -201,7 +201,7 @@ def test_no_version_finding_without_a_concrete_version():
     assert [f["category"] for f in findings] == ["open_port"]
 
 
-# --------------------------------- Fase I-b: the automated CPE index (paso 2)
+# --------------------------------- the automated CPE index
 
 def test_version_finding_via_product_alias_lookup_when_override_misses():
     """The third strategy: a product the curated table has never heard of,
@@ -277,7 +277,7 @@ def test_embedded_version_in_the_product_name_still_resolves():
     assert findings[1]["category"] == "outdated_software"
 
 
-# ----------------------------------------------- Fase 0.9: external payload
+# ----------------------------------------------- external payload
 
 def test_version_finding_from_inventory_origin_is_confirmed_with_high_qod():
     # A service read straight off a package manager (Service.origin=="inventory")
@@ -374,7 +374,7 @@ def test_an_inventory_package_resolves_the_same_cves_as_its_upstream_version():
     El inventario de un agente entrega versiones de paquete de distribución
     (`1:7.4-1ubuntu1`), y NVD sólo publica rangos sobre versiones de
     fabricante (`7.4`). Si el paquete no cae en los mismos rangos que su
-    versión upstream, la Fase I entera —el sustituto del escaneo autenticado—
+    versión upstream, todo el sustituto del escaneo autenticado por inventario
     mide otra cosa.
 
     La búsqueda que se inyecta aquí usa `version_in_range` de verdad, no una
@@ -421,7 +421,7 @@ def test_a_plain_vendor_version_gets_no_normalization_note():
 
 
 def test_version_finding_from_network_origin_stays_a_hypothesis():
-    # Default origin ("network") behaviour is unchanged by Fase 0.9.
+    # Default origin ("network") stays an unconfirmed hypothesis.
     engine = LybraEngine(cve_lookup=_lookup_for(("openbsd", "openssh")))
     findings = engine.analyze([Service(22, "tcp", "ssh", "OpenSSH", "7.4", None)])
 
@@ -455,7 +455,7 @@ def test_informational_finding_for_inventory_service_with_a_port_is_unaffected()
     assert "22/tcp" in finding["title"]
 
 
-# --------------------------------------- cpe_resolved observability (Fase I-b)
+# --------------------------------------- cpe_resolved observability
 
 def test_informational_finding_flags_unresolved_cpe():
     # No override, no alias index wired: cannot resolve -> the informational
@@ -511,7 +511,7 @@ def test_services_from_payload_empty_returns_empty():
     assert services_from_payload([]) == []
 
 
-# ─────────────── qué nombres no se consiguen resolver (L37)
+# ─────────────── qué nombres no se consiguen resolver
 #
 # `_resolve_cpe` devuelve None sin inventar un CPE cuando ninguna estrategia
 # acierta, y esa decisión es correcta: uno fabricado que NVD no conozca no

--- a/API/tests/unit/test_lybra_engine_config.py
+++ b/API/tests/unit/test_lybra_engine_config.py
@@ -1,10 +1,10 @@
-"""El bloque de configuración del motor (L39).
+"""El bloque de configuración del motor.
 
-Hasta L39 cada timeout, cada nivel de concurrencia y cada intervalo de ritmo
-era un literal en la firma de un constructor, y el manager instanciaba las
-sondas sin argumentos. Este fichero comprueba las dos mitades del arreglo: que
-el bloque existe y está atado, y —lo que de verdad importa— que el manager
-**usa** los valores configurados en vez de los defectos del constructor.
+Cada timeout, cada nivel de concurrencia y cada intervalo de ritmo tiene que
+venir del bloque de configuración, no de un literal en la firma de un
+constructor. Este fichero comprueba las dos mitades: que el bloque existe y
+está atado, y —lo que de verdad importa— que el manager **usa** los valores
+configurados en vez de los defectos del constructor.
 """
 
 import pytest

--- a/API/tests/unit/test_lybra_evidence.py
+++ b/API/tests/unit/test_lybra_evidence.py
@@ -1,4 +1,4 @@
-"""La evidencia cruda de un hallazgo: redacción, truncado y hash (L44).
+"""La evidencia cruda de un hallazgo: redacción, truncado y hash.
 
 La parte pura, sin ORM ni red. La redacción es lo que separa «guardo lo que vi»
 de «me quedo con las llaves de casa del cliente», así que la mayoría de estos

--- a/API/tests/unit/test_lybra_favicon.py
+++ b/API/tests/unit/test_lybra_favicon.py
@@ -1,4 +1,4 @@
-"""El catálogo de favicons y su hash (L20).
+"""El catálogo de favicons y su hash.
 
 El favicon se descargaba, se hasheaba y **nadie consultaba el resultado**: una
 petición de red por servicio HTTP, con su turno de limitador, a cambio de un

--- a/API/tests/unit/test_lybra_feed_shape.py
+++ b/API/tests/unit/test_lybra_feed_shape.py
@@ -1,4 +1,4 @@
-"""El feed de checks está bien formado (L27).
+"""El feed de checks está bien formado.
 
 El feed son **datos que se ejecutan**: diecisiete reglas en YAML que deciden si
 un hallazgo de seguridad existe. Hasta ahora ningún test comprobaba que
@@ -107,10 +107,10 @@ def test_a_network_service_without_predicate_is_reported(feed):
     """Un check ``network`` para un protocolo que ningún predicado reconoce.
     Cargar el feed ya falla en ese caso; esta validación
     lo encuentra además sobre un feed externo, que no pasa por ese camino."""
-    # El nombre tiene que ser uno que ningún `is_*_service` reconozca. Aquí
-    # estuvo "postgres" hasta que L12 le dio su predicado, que es justo la
-    # forma en la que este test se mantiene honesto: el día que el protocolo
-    # inventado deja de estar inventado, hay que inventar otro.
+    # El nombre tiene que ser uno que ningún `is_*_service` reconozca. Si algún
+    # día se le da predicado a "protocolo-inventado", este test deja de ser
+    # honesto y hay que inventar otro: cada protocolo real que gane predicado
+    # deja de servir como caso negativo.
     broken = replace(_first_of_type(feed, "network"), service="protocolo-inventado")
     assert any("predicado" in problem for problem in validate_checks([broken]))
 

--- a/API/tests/unit/test_lybra_feed_web_families.py
+++ b/API/tests/unit/test_lybra_feed_web_families.py
@@ -1,4 +1,4 @@
-"""Las familias web nuevas del feed (L25): cada una con positivo y señuelo.
+"""Las familias web nuevas del feed: cada una con positivo y señuelo.
 
 La regla de oro del issue es que un check nuevo entra con su señuelo. Un check
 que sólo mira el código de estado saca falsos positivos contra un banco de
@@ -39,7 +39,7 @@ def _fired(by_path):
 
 
 def test_the_feed_reached_at_least_fifty_checks():
-    """El criterio de cierre del issue: de 17 (28 tras la Fase 2) a ≥ 50."""
+    """El umbral exigido para el feed: al menos 50 checks."""
     assert len(_CHECKS) >= 50
 
 

--- a/API/tests/unit/test_lybra_fingerprint.py
+++ b/API/tests/unit/test_lybra_fingerprint.py
@@ -1,9 +1,9 @@
-"""Unit tests for Lybra's own fingerprinting (Fase F): HTTP/SSH/FTP dissectors,
+"""Unit tests for Lybra's own fingerprinting: HTTP/SSH/FTP dissectors,
 raw SSH_MSG_KEXINIT parsing y la fórmula HASSH.
 
-La aritmética de la concordancia con Nmap ya no se prueba aquí: se fue al arnés
-de medición (``tests/oracle/test_concordance_metrics.py``) con el código que
-ejercita, en L52.
+La aritmética de la concordancia con Nmap no se prueba aquí: vive en el arnés
+de medición (``tests/oracle/test_concordance_metrics.py``), junto al código
+que ejercita.
 
 Pure logic + a fake socket for SshProbe/FtpProbe — no real network anywhere.
 """
@@ -107,7 +107,7 @@ def test_load_tech_signatures_covers_known_vendors():
 
 # =============================================== versión capturada por firma
 #
-# L19: una firma identificaba **nombres** y ahí se paraba. Sin versión no hay
+# Una firma identificaba **nombres** y ahí se paraba. Sin versión no hay
 # CPE, y sin CPE no hay ni un CVE — así que un WordPress reconocido sin
 # versión era un dato de inventario, no una detección.
 
@@ -120,7 +120,7 @@ def test_a_signature_captures_the_version_from_the_generator_meta():
     fp = fingerprint_http(Response(200, body, {}))
     assert fp.product == "WordPress"
     assert fp.version == "6.4.2"
-    # La confianza es la del nivel del que salió (L18): un `<meta generator>`
+    # La confianza es la del nivel del que salió: un `<meta generator>`
     # es evidencia explícita pero la pone la aplicación, no el servidor, así
     # que va un escalón por debajo de una cabecera `Server` completa.
     assert fp.confidence == 0.8
@@ -205,7 +205,7 @@ def test_the_signature_validator_finds_each_kind_of_breakage():
     assert len(validate_tech_signatures(duplicated)) == 1
 
 
-# ================================================ cascada de versión (L18)
+# ================================================ cascada de versión
 #
 # La versión salía de una sola fuente, la cabecera `Server`. Y `server_tokens
 # off` en nginx, `ServerTokens Prod` en Apache y cualquier CDN o WAF la
@@ -346,7 +346,7 @@ def test_every_declared_version_source_has_a_confidence_and_a_qod():
     assert set(VERSION_SOURCES) == set(VERSION_SOURCE_QOD)
 
 
-# ============================ capas de servidor: proxy y origen (L48-b)
+# ============================ capas de servidor: proxy y origen
 #
 # Contra objetivos reales, cinco servicios en tres hosts daban siempre el mismo
 # patrón: Lybra decía `nginx`, Nmap decía `Apache httpd`. Ninguno de los dos
@@ -629,7 +629,7 @@ def test_parse_ftp_banner_filezilla_two_word_product():
 
 
 def test_parse_ftp_banner_debian_proftpd_without_version():
-    """L48-a: el saludo por defecto de ProFTPD en Debian nombra el producto y
+    """El saludo por defecto de ProFTPD en Debian nombra el producto y
     calla la versión. Es el caso que se midió en real y que daba `None`
     mientras Nmap leía `ProFTPD` del mismo saludo."""
     banner = "220 ProFTPD Server (Debian) [::ffff:203.0.113.10]"
@@ -708,9 +708,9 @@ def test_ftp_probe_returns_none_on_empty_banner():
 def test_fingerprint_finding_states_what_lybra_read():
     """El título es una constatación, no un veredicto sobre otra herramienta.
 
-    Hasta L52 decía "concuerda / no concuerda con Nmap": convertía un dato
-    propio en una nota al pie sobre el escáner al que el motor estaba
-    subordinado. Ese modo de arranque ya no existe.
+    No dice "concuerda / no concuerda con Nmap": eso convertiría un dato
+    propio en una nota al pie sobre otro escáner, y el motor no está
+    subordinado a ninguno.
     """
     service = Service(port=80, protocol="tcp", name="http", product="", version="")
     result = DissectorResult("Apache", "2.4.49", "HTTP")
@@ -720,7 +720,7 @@ def test_fingerprint_finding_states_what_lybra_read():
 
 
 def test_fingerprint_finding_carries_the_qod_the_dissector_assigned():
-    """L18: el `qod` era una constante para todos los fingerprints, así que una
+    """El `qod` era una constante para todos los fingerprints, así que una
     versión leída de un `Server` explícito y otra deducida de una página de
     error valían exactamente lo mismo. Ahora cada lectura dice cuánto se fía de
     sí misma; un dissector que no distinga sigue con la constante de siempre."""

--- a/API/tests/unit/test_lybra_host_pool.py
+++ b/API/tests/unit/test_lybra_host_pool.py
@@ -1,4 +1,4 @@
-"""El pool acotado por host: fingerprinting y checks dejan la fila india (L23).
+"""El pool acotado por host: fingerprinting y checks dejan la fila india.
 
 ``_fingerprint_services`` recorría los servicios en un ``for`` y sondaba cada
 uno hasta terminar antes de pasar al siguiente. Sobre un host con veinte

--- a/API/tests/unit/test_lybra_kb.py
+++ b/API/tests/unit/test_lybra_kb.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Lybra knowledge base logic (Fase 2).
+"""Unit tests for the Lybra knowledge base logic.
 
 Pure functions only — version comparison/ranges, CPE normalization, and feed
 ingest from decoded records. The network fetchers are the thin edge and are not
@@ -462,7 +462,7 @@ def test_a_header_without_a_date_leaves_the_field_empty():
     assert list(parse_epss_rows(csv_text))[0]["scored_at"] is None
 
 
-# --------------------------------------- product name normalization (Fase I-b)
+# --------------------------------------- product name normalization
 
 @pytest.mark.parametrize("raw,expected", [
     # The real case that motivated this: a Hygeia inventory entry bakes the
@@ -513,7 +513,7 @@ def test_extract_trailing_version(raw, expected):
     assert extract_trailing_version(raw) == expected
 
 
-# ---------------------------------------------- curated alias feed (paso 3)
+# ---------------------------------------------- curated alias feed
 
 def test_load_product_aliases_covers_known_entries():
     aliases = load_product_aliases()
@@ -521,7 +521,7 @@ def test_load_product_aliases_covers_known_entries():
     assert aliases["openssh"] == ("openbsd", "openssh")
     assert aliases["nginx"] == ("nginx", "nginx")
     # A case NVD itself makes ambiguous (multiple vendors for "git") that the
-    # automated index (paso 2) correctly refuses to guess — resolved here by hand.
+    # automated index correctly refuses to guess — resolved here by hand.
     assert aliases["git"] == ("git-scm", "git")
     # Feed keys are normalized-name shaped (spaces, not hyphens) so they line
     # up with what normalize_product_name actually produces.
@@ -559,7 +559,7 @@ def test_version_scheme_mismatches_are_deliberately_not_aliased(raw_name):
     assert normalize_product_name(raw_name) not in load_product_aliases()
 
 
-# ───────────── la referencia de exploit que NVD ya etiquetaba (L34)
+# ───────────── la referencia de exploit que NVD ya etiquetaba
 
 
 def test_an_exploit_tagged_reference_is_picked_up():
@@ -594,7 +594,7 @@ def test_a_cve_with_no_references_at_all_does_not_blow_up():
     assert row["has_exploit_reference"] is False
 
 
-# ─────────────── avisos de distribución: OVAL y CSAF (Fase O, L32)
+# ─────────────── avisos de distribución: OVAL y CSAF
 
 
 _OVAL_DOC = """<?xml version="1.0"?>

--- a/API/tests/unit/test_lybra_ldap.py
+++ b/API/tests/unit/test_lybra_ldap.py
@@ -1,4 +1,4 @@
-"""El dissector de LDAP (L16).
+"""El dissector de LDAP.
 
 En una red corporativa con Active Directory el 389 está abierto siempre, y
 LDAP tiene una consulta estándar y anónima diseñada para esto: el rootDSE.

--- a/API/tests/unit/test_lybra_mongo.py
+++ b/API/tests/unit/test_lybra_mongo.py
@@ -1,8 +1,8 @@
-"""El dissector de MongoDB (L14).
+"""El dissector de MongoDB.
 
-Cierra el trío de bases de datos de la Fase N, y trae el hallazgo más famoso de
-la lista: durante años las instalaciones por defecto escuchaban en todas las
-interfaces sin autenticación.
+Completa el trío de dissectors de bases de datos, y trae el hallazgo más
+famoso de la lista: durante años las instalaciones por defecto escuchaban en
+todas las interfaces sin autenticación.
 
 El bloque que más importa aquí es el que distingue **contestar** de **dejar
 entrar**. Ver el docstring del módulo: `hello` responde siempre, así que un

--- a/API/tests/unit/test_lybra_mssql.py
+++ b/API/tests/unit/test_lybra_mssql.py
@@ -1,6 +1,6 @@
-"""El dissector de SQL Server (L13).
+"""El dissector de SQL Server.
 
-El más generoso de los tres pendientes de la Fase N: el ``PRELOGIN`` de TDS
+El más generoso de los dissectors de bases de datos: el ``PRELOGIN`` de TDS
 devuelve major, minor y build en un campo binario de tamaño fijo, sin
 autenticar y sin negociar nada más.
 

--- a/API/tests/unit/test_lybra_network_config_checks.py
+++ b/API/tests/unit/test_lybra_network_config_checks.py
@@ -1,10 +1,9 @@
-"""Los checks de configuración de red que la Fase N prometió (L26).
+"""Los checks de configuración de red.
 
-Cierran la parte de la brecha G1 que no se resuelve escribiendo ojos: una
+Cubren la parte de la superficie que no se resuelve escribiendo dissectors: una
 configuración insegura no tiene CVE y no aparece por la vía de la versión.
 
-De los catorce que el issue lista, ocho se construyeron ya en la Fase 2. Aquí
-van los cinco que faltaban: Telnet activo, VNC sin autenticación (plugins
+Aquí van cinco: Telnet activo, VNC sin autenticación (plugins
 script), y relay/STARTTLS de SMTP y FTP sin cifrado (checks network, sobre el
 ``NetworkSession`` real — la misma regla del resto del fichero: un doble por
 encima de la sesión se inventaría capacidades que el transporte real no tiene).
@@ -54,7 +53,7 @@ class _FakeNetSocket:
 
 def _fired(check_id, sock, service):
     # Sólo el check bajo prueba: los checks del mismo servicio comparten la
-    # sesión de red (la caché de sondas de L08), así que ejecutar el feed
+    # sesión de red (la caché de sondas), así que ejecutar el feed
     # entero dejaría a otro check consumiendo el socket antes que éste. Aislarlo
     # es lo que se quiere medir aquí — el comportamiento de un check, no la
     # orquestación.

--- a/API/tests/unit/test_lybra_package_invariants.py
+++ b/API/tests/unit/test_lybra_package_invariants.py
@@ -55,7 +55,7 @@ def test_lybra_package_stays_orm_free():
     )
 
 
-# ---------------------------------------------------------------- L52: sin
+# ---------------------------------------------------------------- sin
 # dependencia de otros escáneres
 
 _LYBRA_MANAGERS = (
@@ -76,7 +76,7 @@ _SIBLING_SCANNER_MANAGERS = (
 
 
 def test_lybra_manager_does_not_depend_on_other_scanners():
-    """L52: un escaneo de Lybra no lanza ningún otro escaneo.
+    """Un escaneo de Lybra no lanza ningún otro escaneo.
 
     Esta es la parte del arreglo que sobrevive al tiempo. Retirar el código fue
     lo fácil; lo que impide que vuelva a entrar dentro de seis meses —que es
@@ -98,11 +98,11 @@ def test_lybra_manager_does_not_depend_on_other_scanners():
     assert not offenders, (
         "themis/managers/lybra/ no debe importar el manager de otro escáner: "
         "Lybra es un motor independiente, no un orquestador de herramientas "
-        "ajenas (L52).\n" + "\n".join(offenders)
+        "ajenas.\n" + "\n".join(offenders)
     )
 
 
-# --------------------------------------------------- L38: una sola verdad
+# --------------------------------------------------- una sola verdad
 # sobre la exposición de un objetivo
 
 

--- a/API/tests/unit/test_lybra_postgres.py
+++ b/API/tests/unit/test_lybra_postgres.py
@@ -1,4 +1,4 @@
-"""El dissector de PostgreSQL (L12).
+"""El dissector de PostgreSQL.
 
 La primera base de datos del motor que **negocia** en vez de escuchar un banner
 ofrecido. Todo con socket falso: la sonda recibe su conector inyectado, igual

--- a/API/tests/unit/test_lybra_rdp.py
+++ b/API/tests/unit/test_lybra_rdp.py
@@ -1,4 +1,4 @@
-"""El dissector de RDP (L15).
+"""El dissector de RDP.
 
 RDP es el vector de entrada de la mayoría de los incidentes de ransomware que
 empiezan por acceso remoto, y BlueKeep (CVE-2019-0708) sigue apareciendo en

--- a/API/tests/unit/test_lybra_smb_deep.py
+++ b/API/tests/unit/test_lybra_smb_deep.py
@@ -1,4 +1,4 @@
-"""SMB más allá del NEGOTIATE: SMBv1, identidad del activo y versión (L11).
+"""SMB más allá del NEGOTIATE: SMBv1, identidad del activo y versión.
 
 El dissector de SMB leía dialecto y modo de firma, y ahí se acababa. Faltaban
 tres datos que el propio protocolo ofrece **sin autenticar**, y cada uno tiene

--- a/API/tests/unit/test_lybra_transport.py
+++ b/API/tests/unit/test_lybra_transport.py
@@ -1,4 +1,4 @@
-"""Unit tests for Lybra's own port discovery (Fase T).
+"""Unit tests for Lybra's own port discovery.
 
 The connect scanner runs on a real (test-thread) event loop but against an
 injected ``opener``, so no real sockets or privileges are involved.
@@ -78,7 +78,7 @@ def test_scan_defaults_to_curated_port_set():
 
 # --------------------------------------------- barrido bloqueado vs vacío
 #
-# L48-c: un objetivo que bloquea el barrido a mitad de camino devolvía una
+# Un objetivo que bloquea el barrido a mitad de camino devolvía una
 # lista vacía, indistinguible de un host limpio — y el ciclo de vida marcaba
 # entonces como corregidos hallazgos que seguían abiertos.
 
@@ -168,7 +168,7 @@ def test_services_from_discovered_ports_names_well_known():
     assert by_port[80].name == "http"
     assert by_port[22].name == "ssh"
     assert by_port[12345].name == ""          # unknown port -> no guessed name
-    # No product/version yet — fingerprinting (Fase F) fills those when enabled.
+    # No product/version yet — fingerprinting fills those when enabled.
     assert by_port[80].product == "" and by_port[80].version == ""
 
 
@@ -184,7 +184,7 @@ def test_services_from_discovered_ports_udp_protocol():
 
 
 # ----------------------------------------------------------------- UDP scan
-# Fase N/Ronda 1 (roadmap §6.3): a diferencia del connect scan, aquí no hay
+# A diferencia del connect scan, aquí no hay
 # "abierto/cerrado" que decidir con un solo intento — el sender devuelve
 # bytes (contestó) o None (silencio), y el escáner solo reporta lo primero.
 
@@ -270,7 +270,7 @@ def test_udp_scan_defaults_to_udp_probes_table():
 
     scan_udp_ports_sync("10.0.0.5", sender=sender)
     # retries=1 por defecto -> cada puerto de la tabla se intenta dos veces. Se
-    # compara el recuento y no la secuencia: desde L22 el barrido es
+    # compara el recuento y no la secuencia: el barrido es
     # concurrente, así que el orden en que llegan los intentos es cosa del
     # planificador y no del escáner.
     assert sorted(calls) == sorted(list(UDP_PROBES) * 2)
@@ -312,7 +312,8 @@ def test_a_truncated_sweep_is_neither_blocked_nor_clean():
 
     Y en particular no puede llegar al motor como lista de puertos: el ciclo de
     vida marcaría como corregido todo lo que estaba abierto y esta vez no dio
-    tiempo a comprobar, que es el fallo de L48-c por otra puerta.
+    tiempo a comprobar, el mismo riesgo que un descubrimiento intermitente
+    puede producir por otra puerta.
     """
     ports = list(range(1000, 1020))
     sweep = sweep_ports_sync("10.0.0.5", ports, concurrency=1,

--- a/API/tests/unit/test_lybra_udp_services.py
+++ b/API/tests/unit/test_lybra_udp_services.py
@@ -1,4 +1,4 @@
-"""La superficie UDP: seis protocolos, cada uno con su consumidor (L22).
+"""La superficie UDP: seis protocolos, cada uno con su consumidor.
 
 La tabla de sondas UDP nació con una fila y una regla —crece una fila por
 protocolo que un check o un dissector consuma de verdad, no antes—. Este


### PR DESCRIPTION
## El problema

Lybra —el motor de escaneo propio de Themis (descubrimiento de servicios, fingerprinting, checks activos, correlación)— es la parte del código con más referencias sueltas a documentos de planificación: cosas como `(Fase N)`, `(Ronda 1)`, `(§16.2)`, `(L48-c)` o `(G-A)` salpicadas en docstrings y comentarios, cada una apuntando a un apartado concreto de `plans/lybra-roadmap.md`.

El problema no es solo la etiqueta en sí: `plans/` describe intenciones y auditorías fechadas, no el estado actual (así lo dice `CLAUDE.md`), así que cualquier explicación que dependiera de "ver la Fase N" para entenderse obligaba a abrir un documento vivo, que puede haber cambiado o desaparecido, para entender código que no ha cambiado. Y varias de esas notas no solo citaban un código: contaban historia ("hasta L52 no era así", "antes el título comparaba..."), que es justo lo que la nueva norma de `CLAUDE.md` sobre docstrings prohíbe — un docstring describe el contrato de hoy, no cómo se llegó hasta él.

## Qué cambia

Cada referencia se trató según lo que hacía:

- **Etiqueta redundante** (`(Fase N)`, `(L22)`...) que no añadía nada a la frase que la rodeaba → se borra sin más.
- **Etiqueta que sí hacía trabajo** (nombrar una de dos estrategias, justificar un diseño) → se sustituye por la explicación en prosa que la etiqueta sustituía.
- **Narración histórica pura** ("hasta la Fase X esto no era así") → se elimina; esa historia vive en el mensaje de commit que la introdujo, no en el docstring.
- **Compatibilidad de datos genuina** (dos casos: un `ProgramedScan.arguments` que puede traer todavía una clave `deep` del formato antiguo; una fila `accepted` sin `state_expires_at`) → se conserva, pero movida a un bloque `Warning:` en presente, no mezclada con la descripción del comportamiento actual.

De paso, once managers hermanos de Lybra en `themis/managers/` (`nikto.py`, `nmap.py` vía `scan.py`, `nuclei.py`, `programed.py`, `reports.py`, `scan_folder.py`, `scan_history.py`, `traceroute.py`, `kb_sync.py`, `authorized_target.py`) compartían el mismo docstring puramente histórico de una sola línea (`"""XManager — extraido de themis/managers.py (Fase 3 del refactor de estructura)."""`) — no describía qué hace el manager, solo de dónde salió. Se sustituyó por una frase funcional real en cada uno.

## Qué NO cambia

Solo texto: docstrings y comentarios. Ningún nombre de función, clase, variable o fichero de test se ha tocado; ninguna lógica se ha movido ni reescrito.

## Validación

```
pytest tests/unit -k lybra                              # 1016 passed, 1 skipped
pytest tests/integration/test_lybra.py tests/unit/test_kb_sync_status.py   # 79 passed
```

Sin cambios pendientes de lint (`pylint --enable=line-too-long` no marca ninguna línea nueva por encima de 100 columnas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)