### PR TITLE
chore(themis): quitar códigos de plan del resto del módulo

### DIFF
--- a/API/src/modules/features/themis/endpoints.py
+++ b/API/src/modules/features/themis/endpoints.py
@@ -328,11 +328,11 @@ def start_nikto_scan(data):
 @require_attributes(at_least_one=[AttributeType.THEMIS_CREATE])
 @handle_exceptions(default_exception=ScanExecutionError, logger=logger)
 def start_nuclei_scan(data):
-    """Lanzar un escaneo Nuclei (roadmap Fase U1).
+    """Lanzar un escaneo Nuclei.
 
     A diferencia de Nikto, Nuclei toca el objetivo bastante más — nace sujeto
     al registro de objetivos autorizados desde el día uno, no se le añade
-    después (roadmap Fase U1, punto 3).
+    después.
     """
     target = data["target"]
     user = get_current_user()
@@ -415,7 +415,7 @@ def start_lybra_scan(data):
 @limiter.limit("60 per hour; 200 per day")
 @handle_exceptions(default_exception=DuplicateAuthorizedTargetError, logger=logger)
 def add_authorized_target(data):
-    """Añadir un objetivo (IP o CIDR) al registro de objetivos autorizados (roadmap §6)."""
+    """Añadir un objetivo (IP o CIDR) al registro de objetivos autorizados."""
     user = get_current_user()
     entry = AuthorizedTargetManager().add(user.id, data["target"], data.get("label"))
     logger.info(f"Objetivo autorizado {entry.id} ('{entry.target}') añadido por {user.username}")
@@ -619,7 +619,7 @@ def update_finding_state(data, finding_id: int):
 @limiter.limit("120 per hour; 400 per day")
 @handle_exceptions(default_exception=FindingNotFoundError, logger=logger)
 def get_finding_evidence(finding_id: int):
-    """Devolver la evidencia cruda que respalda un hallazgo (Fase E).
+    """Devolver la evidencia cruda que respalda un hallazgo.
 
     La respuesta que el objetivo dio y que provocó el hallazgo, redactada, con
     su hash y su fecha — lo que convierte «te lo digo yo» en «míralo». Sólo
@@ -650,7 +650,7 @@ def retrieve_all_scans(args):
 
     if scan_type != "all":
         manager = ScanManager.get_manager_for_type(scan_type)
-        # `assetId` solo lo entiende Lybra (Fase I): es el que separa los
+        # `assetId` solo lo entiende Lybra: es el que separa los
         # escaneos de un agente Hygeia de los lanzados desde el panel.
         if scan_type == "lybra" and args.get("assetId") is not None:
             results, total_count = manager.get_scans_paginated(user_id, page, per_page, asset_id=args["assetId"])

--- a/API/src/modules/features/themis/exceptions.py
+++ b/API/src/modules/features/themis/exceptions.py
@@ -120,7 +120,7 @@ class TargetNotAuthorizedError(ScanError):
 
     Bloquea las operaciones de Lybra que tocan la red del objetivo
     (autodescubrimiento, fingerprinting propio, comprobaciones activas) hasta
-    que el usuario lo declare explícitamente (roadmap §6).
+    que el usuario lo declare explícitamente.
     """
 
     default_code = ErrorCode.TARGET_NOT_AUTHORIZED

--- a/API/src/modules/features/themis/lybra/fingerprinting/favicon.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/favicon.py
@@ -7,11 +7,10 @@ sus instalaciones: sobrevive a ``server_tokens off``, no cambia entre versiones
 menores, y nadie se acuerda de personalizarlo. Shodan la expone como
 ``http.favicon.hash`` precisamente porque funciona.
 
-Hasta L20, este motor pagaba el coste de la técnica sin cobrar el beneficio.
-``HttpDissector.probe`` hacía una petición dedicada a ``/favicon.ico``,
-``fingerprint_http`` calculaba su SHA-256 y ``HttpFingerprint`` lo exponía como
-campo — y después **nadie lo consultaba**. Una petición de red por servicio
-HTTP, con su turno de limitador, a cambio de un dato muerto.
+``HttpDissector.probe`` pide ``/favicon.ico`` una vez por servicio HTTP,
+``fingerprint_http`` calcula su SHA-256 y ``HttpFingerprint`` lo expone como
+campo; este módulo es quien de verdad lo consulta, resolviéndolo contra el
+catálogo de abajo.
 
 Dos decisiones de diseño, ambas explícitas:
 

--- a/API/src/modules/features/themis/lybra/fingerprinting/http_apis.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/http_apis.py
@@ -15,16 +15,15 @@ puede dar**.
 - **Kubernetes en 6443**, **etcd en 2379**, **Consul en 8500** y **Kibana en
   5601** siguen el mismo patrón.
 
-Hasta L17 el motor veía ``2375/tcp abierto — docker`` (el nombre salía de
-``WELL_KNOWN_PORTS``, así que hasta lo llamaba por su nombre) y emitía un
-informativo con ``qod=30``. La información para dar un CRITICAL confirmado
-estaba a un ``GET`` de distancia y no se pedía, porque ``is_http_service``
-rechazaba esos puertos y ni el dissector HTTP ni los checks los tocaban.
+``is_http_service`` acepta estos puertos precisamente para que ``2375/tcp
+abierto — docker`` no se quede en un informativo con ``qod=30`` cuando la
+versión exacta está a un solo ``GET`` sin autenticar de distancia.
 
 **Todo lo que hay aquí son lecturas puras** (``GET``), así que caben en modo
 ``safe`` sin discusión. Y la versión extraída entra en la maquinaria de
-detección por versión que ya funciona, y produce sus CVEs sola: escribir
-*ojos*, no checks, que es el apalancamiento que el roadmap describe.
+detección por versión que ya funciona, y produce sus CVEs sola: es más
+rentable escribir *ojos* que leen una versión que checks que la persiguen uno
+a uno.
 
 **Una respuesta 401 o 403 no es un hallazgo, es lo contrario.** Significa que
 el servicio está ahí y que exige credenciales, que es exactamente como debe

--- a/API/src/modules/features/themis/lybra/fingerprinting/ldap.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/ldap.py
@@ -1,9 +1,7 @@
 """El dissector de LDAP — el servicio que más cuenta sobre una organización.
 
-LDAP estaba en la prioridad-3 de la tabla de la Fase N —*"banner y capacidades
-básicas, bajo coste cada uno, poca frecuencia"*— y esa valoración de
-**frecuencia** merecía revisarse: en una red corporativa con Active Directory,
-el 389 está abierto **siempre**.
+LDAP es bajo coste y capacidades básicas, pero no de poca frecuencia: en una
+red corporativa con Active Directory, el 389 está abierto **siempre**.
 
 Y a diferencia de casi todo lo demás, LDAP tiene una consulta estándar y
 anónima diseñada precisamente para esto: el **rootDSE**, la entrada raíz que

--- a/API/src/modules/features/themis/lybra/fingerprinting/mysql.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/mysql.py
@@ -1,4 +1,4 @@
-"""The MySQL/MariaDB dissector — Fase N.
+"""The MySQL/MariaDB dissector.
 
 MySQL's wire protocol volunteers its identity unprompted, same spirit as FTP:
 the server's very first packet after a bare TCP connect is the "Initial

--- a/API/src/modules/features/themis/lybra/fingerprinting/registry.py
+++ b/API/src/modules/features/themis/lybra/fingerprinting/registry.py
@@ -20,12 +20,11 @@ from .dispatch import Dissector
 
 _DissectorT = TypeVar("_DissectorT", bound=Type[Dissector])
 
-# Registration order follows import order (see __init__.py), which follows
-# the roadmap's own cost/value ranking — cheapest and most common protocols
-# first.
+# Registration order follows import order (see __init__.py), ranked by
+# cost/value — cheapest and most common protocols first.
 #
-# Y desde L17 el orden **importa de verdad** para un caso concreto, no sólo
-# para la legibilidad. Los predicados dejaron de ser disjuntos cuando los
+# El orden **importa de verdad** para un caso concreto, no sólo para la
+# legibilidad. Los predicados no son disjuntos: los
 # puertos de las APIs de administración (2375, 9200, 6443...) entraron en la
 # familia HTTP para que los checks de exposición y de higiene TLS los
 # alcanzaran: ahora los reclaman dos dissectors, y

--- a/API/src/modules/features/themis/managers/__init__.py
+++ b/API/src/modules/features/themis/managers/__init__.py
@@ -4,7 +4,7 @@ Managers for security scan orchestration and result persistence.
 This package provides manager classes for coordinating security scans:
 - NmapScanManager: Network exploration and security scanning.
 - NiktoScanManager: Web server vulnerability scanning.
-- NucleiScanManager: Template-based vulnerability scanning (roadmap Fase U1).
+- NucleiScanManager: Template-based vulnerability scanning.
 - LybraEngineManager: self-built detection engine (Lybra).
 
 Each manager handles the complete lifecycle of a scan:
@@ -16,9 +16,9 @@ Each manager handles the complete lifecycle of a scan:
 Database access is performed exclusively through UnitOfWork + ScanRepository.
 ScanManager no longer inherits from BaseManager.
 
-Fase 3 del refactor de estructura: este paquete sustituye al antiguo fichero
-monolítico ``managers.py`` (~2700 líneas). Cada clase vive en su propio
-módulo; este ``__init__.py`` reexporta los nombres públicos para que
+Este paquete sustituye al antiguo fichero monolítico ``managers.py``
+(~2700 líneas). Cada clase vive en su propio módulo; este ``__init__.py``
+reexporta los nombres públicos para que
 ``from src.modules.features.themis.managers import X`` (y el registro de entry
 points de la TaskQueue, que referencia estos símbolos por atributo de
 módulo) sigan funcionando sin cambios.

--- a/API/src/modules/features/themis/model.py
+++ b/API/src/modules/features/themis/model.py
@@ -138,13 +138,12 @@ class ScanType(str, Enum):
         NMAP:    Nmap network and port scanner.
         NIKTO:   Nikto web server vulnerability scanner.
         LYBRA: Lybra's own vulnerability engine (native detection).
-        NUCLEI: Nuclei template-based vulnerability scanner (Fase U1).
+        NUCLEI: Nuclei template-based vulnerability scanner.
 
-    OpenVAS was removed (roadmap §7/§6.3, Ronda 2 — E1): it was a whole
-    platform we could never add anything on top of, not a tool whose output
-    we parsed like the others (see the roadmap's §1). Historical ``Finding``
-    rows with ``source="openvas"`` are kept as provenance; nothing produces
-    new ones.
+    OpenVAS was removed: it was a whole platform we could never add anything
+    on top of, not a tool whose output we parsed like the others. Historical
+    ``Finding`` rows with ``source="openvas"`` are kept as provenance;
+    nothing produces new ones.
     """
     NMAP    = "nmap"
     NIKTO   = "nikto"
@@ -185,19 +184,20 @@ class Host(Base):
 
 
 # =========================================================================
-# HOST SERVICE (Lybra Fase 5 — the asset's attack surface, tracked over time)
+# HOST SERVICE (the asset's attack surface, tracked over time)
 # =========================================================================
 
 class HostService(Base):
     """A service Lybra has observed open on a host, tracked across scans.
 
-    Roadmap Fase 5's "cambio de sujeto": a ``Scan`` is one observation of a
-    host's attack surface at a point in time, not the surface itself. This
-    table is that surface — one row per ``(host, port, protocol)`` — so a new
-    scan can be diffed against it to notice a port opening for the first time
-    or a service's version changing, independently of whether that change
-    happens to also match a known CVE. Findings answer "is this vulnerable?";
-    this table answers "did the surface itself change?".
+    This table is a deliberate change of subject: a ``Scan`` is one
+    observation of a host's attack surface at a point in time, not the
+    surface itself. This table is that surface — one row per
+    ``(host, port, protocol)`` — so a new scan can be diffed against it to
+    notice a port opening for the first time or a service's version
+    changing, independently of whether that change happens to also match a
+    known CVE. Findings answer "is this vulnerable?"; this table answers
+    "did the surface itself change?".
 
     Populated by every Lybra scan of a target, whether its services came from
     self-discovery or from a prior Nmap scan's already-collected ports — both
@@ -208,7 +208,7 @@ class HostService(Base):
         id: Primary key.
         host_id: The asset this service belongs to.
         port: The port number, or ``None`` for a portless, ``origin="inventory"``
-            service (Fase 0.9) — an installed package has nothing listening.
+            service — an installed package has nothing listening.
         protocol: ``"tcp"`` or ``"udp"``.
         name: The service's conventional name (``"http"``, ``"ssh"``...).
         product: The identified product, or ``None`` if never resolved.
@@ -581,7 +581,7 @@ class OpenPort(Base):
             recognises the service (2.2 URI form, e.g.
             ``cpe:/a:apache:http_server:2.4.49``). Nullable: many services do
             not yield a CPE. It is the entry point the Lybra engine reads to
-            correlate versions to CVEs (see the vuln-engine roadmap).
+            correlate versions to CVEs.
 
     Relationships:
         port: Port entity.
@@ -693,10 +693,9 @@ class NiktoIncident(Base):
 
 
 # OpenVAS's three native tables (OpenVASScan, OpenVASVulnerability,
-# OpenVASScanResult) were removed here (roadmap §7/§6.3, Ronda 2 — E2+E3).
-# The development database had zero rows in any of the three (verified by
-# query before removing), so there was nothing to archive first — the
-# backfill-then-drop the roadmap originally described was unnecessary.
+# OpenVASScanResult) were removed here. The development database had zero
+# rows in any of the three (verified by query before removing), so there
+# was nothing to archive first.
 # Finding rows with source="openvas" are unaffected: they live in the
 # source-agnostic Finding table, not in these.
 
@@ -708,17 +707,12 @@ class NiktoIncident(Base):
 class LybraScan(Scan):
     """Scan produced by Lybra's own vulnerability engine.
 
-    Lybra descubre los servicios del objetivo con su propio transporte
-    (Fase T) y produce filas :class:`Finding` normalizadas.
-
-    Tuvo dos columnas más, retiradas en L52 junto al resto del acoplamiento con
-    escáneres de terceros: ``source_scan_id`` (el escaneo Nmap previo cuyos
-    servicios se analizaban) y ``deep_scan_ids`` (los ids de los escaneos
-    Nmap/Nikto/Nuclei que el "análisis profundo" lanzaba como corroboradores).
+    Lybra descubre los servicios del objetivo con su propio transporte y
+    produce filas :class:`Finding` normalizadas.
 
     Attributes:
         id: Primary key (foreign key to Scan.id).
-        asset_id: Fase I — the Hygeia MonitoredAsset whose software inventory
+        asset_id: The Hygeia MonitoredAsset whose software inventory
             originated this scan, or None when it was launched from the Themis
             panel. Deliberately a plain Integer with no ForeignKey: it is a
             soft reference that keeps Themis's *schema* independent of
@@ -756,14 +750,14 @@ class LybraScan(Scan):
 
 
 class NucleiScan(Scan):
-    """Scan launched via the Nuclei template-based scanner (roadmap Fase U1).
+    """Scan launched via the Nuclei template-based scanner.
 
     Follows the same design ``LybraScan`` already established rather than the
     Nmap/Nikto one: no result table of its own. Nuclei's JSONL output
     maps almost 1:1 onto ``Finding`` (``cve_ids``, ``cvss_score``, ``check_id``
     all come straight from the tool), so building a parallel ``NucleiFinding``
-    table would only recreate the scaffolding the roadmap's §7 dismantled
-    for OpenVAS — not something to add fresh in a brand new scan type.
+    table would only recreate the scaffolding already dismantled for
+    OpenVAS — not something to add fresh in a brand new scan type.
 
     Attributes:
         id: Primary key (foreign key to Scan.id).
@@ -780,10 +774,10 @@ class NucleiScan(Scan):
 
 class AuthorizedTarget(Base):
     """A target (IP or CIDR) a user has declared authorized for Lybra's
-    network-touching operations (roadmap §6): self-discovery (Fase T), own
-    fingerprinting (Fase F) and the active check runtime (Fase R). Analysing
-    services already known from a prior Nmap scan (Fase 1) does not need an
-    entry here, since it sends no new packets to the target.
+    network-touching operations: self-discovery, own fingerprinting and the
+    active check runtime. Analysing services already known from a prior
+    Nmap scan does not need an entry here, since it sends no new packets to
+    the target.
 
     Attributes:
         id: Primary key.
@@ -813,11 +807,11 @@ class Finding(Base):
 
     The unified finding model that lets Lybra, Nikto, Nuclei and (historically)
     OpenVAS results live in one table and be correlated (dedup by
-    ``dedup_key``). See the vuln-engine roadmap (§3.3) for the full design.
-    In Fase 0 only informational
-    "open port" findings are written (``category="open_port"``, ``qod=30``); the
-    detection columns (``cve_ids``, ``cvss_score``…) stay empty until later
-    phases fill them.
+    ``dedup_key``). A scan that only enumerates open ports without correlating
+    vulnerabilities writes informational "open port" findings
+    (``category="open_port"``, ``qod=30``); the detection columns
+    (``cve_ids``, ``cvss_score``…) stay empty until a later scan or a KB sync
+    fills them in.
 
     Attributes:
         id: Primary key.
@@ -826,14 +820,15 @@ class Finding(Base):
         title: Human-readable one-line description.
         category: Finding family ("open_port" | "outdated_software" | "tls" ...).
         port / service / cpe: The affected service.
-        protocol: Transport of the affected service ("tcp" | "udp"). Nullable —
-            every finding before Fase N's UDP probe (roadmap §6.3, Ronda 1) is
-            TCP and is never backfilled. Exists so ``compute_dedup_key`` can
-            tell a service open on 161/tcp apart from the same port on
-            161/udp; see its docstring for why the merge would otherwise
-            collide the two.
+        protocol: Transport of the affected service ("tcp" | "udp"). Nullable
+            for findings recorded before Lybra added UDP probing, which are
+            never backfilled and are all implicitly TCP. Exists so
+            ``compute_dedup_key`` can tell a service open on 161/tcp apart
+            from the same port on 161/udp; see its docstring for why the
+            merge would otherwise collide the two.
         cve_ids / cvss_score / cvss_vector / epss_score / in_kev /
-            exploit_maturity: Vulnerability correlation (filled from Fase 1 on).
+            exploit_maturity: Vulnerability correlation, filled once the
+            finding's CPE (or check) resolves against the KB.
         required_os: CPE platform token (e.g. "windows_10") this finding's CVE
             match is gated behind, or None if unconditional. Set from
             ``CpeMatch.required_os`` at correlation time; used by
@@ -847,7 +842,7 @@ class Finding(Base):
         qod: Quality of Detection 0-100.
         confirmed: Actively confirmed vs version-only deduction.
         cpe_resolved: Whether Lybra's matcher could resolve this service to a
-            CPE at all (Fase I-b observability). ``None`` for finding sources
+            CPE at all. ``None`` for finding sources
             that never attempt CPE resolution (Nikto, OpenVAS); ``True``/
             ``False`` for Lybra findings — distinguishes "checked, no CVEs"
             from "could not even identify the package" in the same data that
@@ -855,9 +850,9 @@ class Finding(Base):
         first_seen_at / last_seen_at / state: Lifecycle
             (open|fixed|regressed|accepted|false_positive).
 
-            ``accepted`` y ``false_positive`` dicen cosas **opuestas** y
-            durante mucho tiempo compartieron casilla, que es lo que L35 viene
-            a arreglar. Aceptar un riesgo es "esto es real, lo asumo": tiene
+            ``accepted`` y ``false_positive`` dicen cosas **opuestas** y por
+            eso son estados distintos en vez de compartir casilla. Aceptar un
+            riesgo es "esto es real, lo asumo": tiene
             dueño, debería caducar y volver a revisión. Marcar un falso
             positivo es "esto no es real, el motor se equivocó": no caduca,
             porque no hay nada que aceptar, y no cuenta como riesgo abierto en
@@ -889,7 +884,7 @@ class Finding(Base):
     cpe      = Column(String(255), index=True)
     protocol = Column(String(8), nullable=True)
 
-    # Vulnerability correlation (filled from Fase 1 onwards)
+    # Vulnerability correlation, filled once the finding resolves against the KB
     cve_ids          = Column(JSONB)
     cvss_score       = Column(Float)
     cvss_vector      = Column(String(255))
@@ -913,7 +908,7 @@ class Finding(Base):
     cpe_resolved = Column(Boolean, nullable=True)
 
     # Lifecycle
-    # Decisión del usuario sobre el estado (L35). Nulos mientras nadie haya
+    # Decisión del usuario sobre el estado. Nulos mientras nadie haya
     # tocado el hallazgo, que es el caso normal.
     state_reason     = Column(Text)
     state_set_by     = Column(Integer, ForeignKey("User.id"), nullable=True)
@@ -955,7 +950,7 @@ class Finding(Base):
 
 
 class FindingEvidence(Base):
-    """La respuesta cruda que provocó un hallazgo (Fase E).
+    """La respuesta cruda que provocó un hallazgo.
 
     Un hallazgo dice **qué** encontró y **con qué regla**, pero ``feed_version``
     + ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
@@ -999,7 +994,7 @@ class FindingEvidence(Base):
 class CveEntry(Base):
     """A single CVE mirrored from NVD, the core of the local knowledge base.
 
-    Stored so version→CVE correlation (Fase 1) runs against the local DB instead
+    Stored so version→CVE correlation runs against the local DB instead
     of hitting cve.circl.lu per target. ``cpe_matches`` holds the applicability
     rows (which products/version ranges the CVE affects).
     """
@@ -1016,7 +1011,7 @@ class CveEntry(Base):
     cwe_ids       = Column(JSONB)
     has_exploit_reference = Column(Boolean, nullable=False, default=False,
                                    server_default=sa_false())
-    """Si NVD enlaza al menos una referencia etiquetada como exploit (L34).
+    """Si NVD enlaza al menos una referencia etiquetada como exploit.
 
     Es la señal de madurez de explotación más barata que hay: la propia NVD
     etiqueta sus referencias, y ese dato ya viaja en cada registro que se
@@ -1074,7 +1069,7 @@ class CpeMatch(Base):
 
 class CpeProductAlias(Base):
     """A normalized product name -> (vendor, product) index, derived from
-    ``CpeMatch`` (Fase I-b, paso 2 del roadmap de Lybra).
+    ``CpeMatch``.
 
     This is deliberately *not* a mirror of NVD's full CPE Dictionary (~1.4M
     entries, expensive to keep in sync): it only indexes products that
@@ -1108,7 +1103,7 @@ class KevEntry(Base):
     """A CVE present in CISA's Known Exploited Vulnerabilities catalogue.
 
     Presence here is a strong "actively exploited in the wild" signal that
-    drives contextual prioritization (Fase 5).
+    drives contextual prioritization.
     """
     __tablename__ = "KevEntry"
 

--- a/API/src/modules/features/themis/repositories.py
+++ b/API/src/modules/features/themis/repositories.py
@@ -225,7 +225,7 @@ class ScanRepository(BaseRepository[Scan]):
             per_page: Items per page.
             asset_id: :data:`PANEL_SCANS` (the default) for the scans launched
                 from the Themis panel — those with no Hygeia asset behind them;
-                an ``int`` for one asset's inventory scans (Fase I); or ``None``
+                an ``int`` for one asset's inventory scans; or ``None``
                 for every Lybra scan regardless of origin.
 
         Returns:
@@ -268,7 +268,7 @@ class ScanRepository(BaseRepository[Scan]):
         """El escaneo más reciente por activo Hygeia, en una sola query.
 
         ``ROW_NUMBER`` sobre ``started_at`` desc particionado por activo:
-        así la rejilla de agentes de Themis (Fase I) recibe el contador de
+        así la rejilla de agentes de Themis recibe el contador de
         hallazgos de cada tarjeta sin un request por tarjeta, que es justo
         lo que ``GET /hygeia/assets`` ahorra con esto. La función de ventana
         es portable entre Postgres y el SQLite de los tests (≥ 3.25).
@@ -696,7 +696,7 @@ class ScanRepository(BaseRepository[Scan]):
         """Persist a batch of normalized Finding rows for a scan.
 
         Un finding puede traer una clave ``_evidence`` —la respuesta cruda que
-        lo provocó, que el runtime de checks adjuntó (Fase E)—. No es una
+        lo provocó, que el runtime de checks adjuntó—. No es una
         columna, así que se extrae antes de construir el ``Finding``, y se
         persiste como una fila ``FindingEvidence`` aparte, ya redactada y
         hasheada, una vez que el ``Finding`` tiene id.
@@ -825,7 +825,7 @@ class ScanRepository(BaseRepository[Scan]):
         )
 
     def get_host_services(self, host_id: int) -> List[HostService]:
-        """Return a host's currently-tracked attack surface (Fase 5)."""
+        """Return a host's currently-tracked attack surface."""
         return (
             self._session.query(HostService)
             .filter(HostService.host_id == host_id)
@@ -844,7 +844,7 @@ class ScanRepository(BaseRepository[Scan]):
         service's row always reflects its most recent observation.
 
         ``port`` is ``None`` for a portless, ``origin="inventory"`` service
-        (Fase 0.9) — an installed package with nothing listening. A port
+        — an installed package with nothing listening. A port
         already uniquely identifies which row to touch; without a port, the
         lookup keys on ``product`` too, otherwise two different packages on
         the same host would collide on the same ``(host, NULL, protocol)``
@@ -1023,7 +1023,7 @@ class KbRepository(BaseRepository[CveEntry]):
         return result
 
     def resolve_product_alias(self, normalized_name: str) -> Optional[Tuple[str, str]]:
-        """Look up a normalized product name in the automated CPE index (Fase I-b, paso 2).
+        """Look up a normalized product name in the automated CPE index.
 
         The third and last strategy ``LybraEngine._resolve_cpe`` tries, after
         an embedded CPE and the curated alias feed both miss. See
@@ -1038,7 +1038,7 @@ class KbRepository(BaseRepository[CveEntry]):
         return (row.vendor, row.product) if row else None
 
     def rebuild_cpe_product_index(self) -> int:
-        """Rebuild ``CpeProductAlias`` from the current ``CpeMatch`` table (Fase I-b, paso 2).
+        """Rebuild ``CpeProductAlias`` from the current ``CpeMatch`` table.
 
         Indexes every distinct ``(vendor, product)`` pair in ``CpeMatch`` under
         **two** normalized keys (:func:`~.lybra.kb.normalize_product_name`),
@@ -1067,7 +1067,7 @@ class KbRepository(BaseRepository[CveEntry]):
         vendors (a Jenkins plugin, a firmware component, the real Git SCM...),
         and picking one at random would risk matching CVEs against the wrong
         software. That specific, verified case is exactly what
-        ``feeds/product_aliases.json`` (paso 3) exists to override by hand.
+        ``feeds/product_aliases.json`` exists to override by hand.
 
         A full delete-and-reinsert rather than an incremental diff: this runs
         once per KB sync (nightly, at most), so the cost is a non-issue, and it
@@ -1363,7 +1363,7 @@ class KbRepository(BaseRepository[CveEntry]):
         return chosen[0].status, chosen[0].fixed_in
 
     def exploit_evidence(self, cve_id: str) -> Optional[str]:
-        """Qué madurez de explotación consta para una CVE, sin contar KEV (L34).
+        """Qué madurez de explotación consta para una CVE, sin contar KEV.
 
         Hoy sólo puede decir ``"poc"``: la señal disponible es la referencia
         que la propia NVD etiqueta como exploit, y esa etiqueta afirma que
@@ -1383,10 +1383,10 @@ class KbRepository(BaseRepository[CveEntry]):
         """Llevar la cuenta de un nombre de producto que no resuelve a un CPE.
 
         Cuando falla, suma uno a su contador; **cuando resuelve, borra la fila**.
-        Esa segunda mitad es la que cierra el bucle que pedía L37: al escribir
-        el alias que faltaba, el nombre desaparece del ranking en el siguiente
-        escaneo. Sin ella el ranking mediría el trabajo que hubo, no el que
-        queda, y no habría forma de saber si el feed está mejorando.
+        Esa segunda mitad es la que cierra el bucle: al escribir el alias que
+        faltaba, el nombre desaparece del ranking en el siguiente escaneo. Sin
+        ella el ranking mediría el trabajo que hubo, no el que queda, y no
+        habría forma de saber si el feed está mejorando.
         """
         row = (self._session.query(UnresolvedProduct)
                .filter_by(normalized_name=normalized_name, origin=origin)
@@ -1684,7 +1684,7 @@ class ProgramedScanRepository(BaseRepository[ProgramedScan]):
 
 
 class AuthorizedTargetRepository(BaseRepository[AuthorizedTarget]):
-    """Repository for the AuthorizedTarget entity (roadmap §6 register)."""
+    """Repository for the AuthorizedTarget entity."""
 
     _MODEL = AuthorizedTarget
 

--- a/API/src/modules/features/themis/schemas.py
+++ b/API/src/modules/features/themis/schemas.py
@@ -21,8 +21,8 @@ class NiktoScanRequestSchema(Schema):
 
 class NucleiScanRequestSchema(Schema):
     target = fields.String(required=True)
-    # Perfil acotado por defecto (roadmap Fase U1, punto 1): sin esto, Nuclei
-    # con el feed completo contra un solo host son miles de peticiones. "info"
+    # Perfil acotado por defecto: sin esto, Nuclei con el feed completo
+    # contra un solo host son miles de peticiones. "info"
     # queda fuera del default a propósito — son miles de plantillas de
     # tech-detect y, al ser confirmed=True sin CVSS, el suelo de
     # score_finding las subiría todas a MEDIUM.
@@ -38,17 +38,12 @@ class NucleiScanRequestSchema(Schema):
 
 class LybraScanRequestSchema(Schema):
     # Un solo modo por HTTP: Lybra descubre los puertos del objetivo con su
-    # propio transporte (Fase T). El modo de payload externo existe en el
+    # propio transporte. El modo de payload externo existe en el
     # manager, pero no se expone aquí — llega en proceso desde Hygeia.
-    #
-    # Hasta L52 había un segundo modo, ``sourceScanId``: analizar los servicios
-    # que un escaneo Nmap previo ya había descubierto. Retirado con el resto
-    # del acoplamiento con escáneres de terceros, junto al flag ``deep`` que
-    # lanzaba Nmap/Nikto/Nuclei como corroboradores.
     target = fields.String(required=True)
     ports = fields.String()
     timeout = fields.Integer(load_default=120, validate=validate.Range(min=1))
-    # La doble puerta del modo agresivo (L40): esta petición explícita del
+    # La doble puerta del modo agresivo: esta petición explícita del
     # usuario es sólo la mitad. El manager sólo la honra cuando el objetivo
     # está además en el registro de autorización — un registro no autoriza
     # cualquier cosa contra el objetivo, sólo el escaneo pasivo.
@@ -65,9 +60,10 @@ class UnresolvedProductsQuerySchema(Schema):
 
 
 class FindingStateRequestSchema(Schema):
-    # ``accepted`` y ``false_positive`` dicen cosas opuestas y hasta L35
-    # compartían casilla: aceptar un riesgo es "esto es real, lo asumo";
-    # desmentirlo es "esto no es real, el motor se equivocó". Un informe que
+    # ``accepted`` y ``false_positive`` dicen cosas opuestas y por eso son
+    # estados distintos en vez de compartir casilla: aceptar un riesgo es
+    # "esto es real, lo asumo"; desmentirlo es "esto no es real, el motor se
+    # equivocó". Un informe que
     # cuenta los segundos como riesgos aceptados miente sobre la postura de
     # seguridad. ``fixed`` y ``regressed`` no están porque los pone el ciclo de
     # vida al comparar escaneos: dejarlos escribir aquí permitiría falsear el
@@ -116,7 +112,7 @@ class ResultsQuerySchema(Schema):
     type = fields.String(load_default="all", validate=validate.OneOf([scan_type.value for scan_type in ScanType] + ["all"]))
     page = fields.Integer(load_default=1, validate=validate.Range(min=1))
     per_page = fields.Integer(load_default=10, validate=validate.Range(min=1, max=100))
-    # Fase I, solo con type=lybra: acota la lista a los escaneos originados por
+    # Solo con type=lybra: acota la lista a los escaneos originados por
     # el inventario de un activo de Hygeia. Omitirlo devuelve los escaneos
     # lanzados desde el panel de Themis (los de agente se ven por agente, no
     # mezclados en la feed general).

--- a/API/src/modules/features/themis/services/analyzers.py
+++ b/API/src/modules/features/themis/services/analyzers.py
@@ -553,7 +553,7 @@ class LybraAIWriter:
                 (``"lybra"``, ``"nuclei"``...). The writer's logic is generic
                 over the source — it only reads already-structured ``Finding``
                 rows (``cve_ids``, ``cvss``, ``epss``, ``confirmed``...) — so a
-                second tool with the same shape (Nuclei, Fase U1) reuses this
+                second tool with the same shape (Nuclei) reuses this
                 class instead of duplicating it, distinguished only by which
                 prompt pair it reads.
         """

--- a/API/src/modules/features/themis/services/history.py
+++ b/API/src/modules/features/themis/services/history.py
@@ -116,8 +116,8 @@ class NucleiMetricExtractor(MetricExtractor):
     """Metric: findings. Identity: dedup_key, or the row id for one without.
 
     Identical shape to ``LybraMetricExtractor`` — both scan types live
-    entirely in ``Finding`` (roadmap Fase U1), so there is nothing
-    Nuclei-specific to add here beyond the label.
+    entirely in ``Finding``, so there is nothing Nuclei-specific to add
+    here beyond the label.
     """
 
     metric_label = "Hallazgos"

--- a/API/src/modules/features/themis/services/nuclei_templates.py
+++ b/API/src/modules/features/themis/services/nuclei_templates.py
@@ -1,15 +1,15 @@
 """El almacén de plantillas de Nuclei — la única copia, con acceso centralizado.
 
 Themis tiene **un solo árbol de plantillas de Nuclei**, y este módulo es su
-única autoridad. La restricción no es estética: con la Fase U1 ya entregada hay
-(o habrá) tres consumidores distintos del mismo árbol, y ninguno debe clonar,
-copiar ni resolver la ruta por su cuenta.
+única autoridad. La restricción no es estética: hay (o habrá) tres
+consumidores distintos del mismo árbol, y ninguno debe clonar, copiar ni
+resolver la ruta por su cuenta.
 
-- ``NucleiScanTask`` (U1/U2) — solo necesita la ruta, para pasársela al binario
+- ``NucleiScanTask`` — solo necesita la ruta, para pasársela al binario
   por ``-templates``. Es el consumidor que ya existía.
-- La ingesta de plantillas al ``CheckRuntime`` propio (Fase R) — necesita
+- La ingesta de plantillas al ``CheckRuntime`` propio — necesita
   *leer* y parsear ese mismo árbol.
-- El censo de ingestibilidad (Fase U4) — necesita medir sobre ese mismo árbol,
+- El censo de ingestibilidad — necesita medir sobre ese mismo árbol,
   y no sobre un clon aparte del repositorio upstream: así el número medido
   corresponde a la versión que de verdad corre en producción.
 

--- a/API/src/modules/features/themis/services/reports/findings.py
+++ b/API/src/modules/features/themis/services/reports/findings.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class FindingsPrintingStrategy(PrintingStrategy):
     """Shared PDF renderer for scan types whose data lives entirely in the
     unified `Finding` table rather than a tool-specific incident/vulnerability
-    model — Lybra originally, and now Nuclei (roadmap Fase U1).
+    model — Lybra originally, and now Nuclei.
 
     Extracted from what used to be a single, Lybra-only class: Nuclei's JSONL
     output maps onto `Finding` almost as completely as Lybra's own engine does
@@ -240,7 +240,7 @@ class FindingsPrintingStrategy(PrintingStrategy):
             if finding.get("state") == "false_positive":
                 # El usuario ha desmentido este hallazgo: no es un riesgo, y un
                 # resumen que lo cuente afirma una postura de seguridad peor
-                # que la real (L35).
+                # que la real.
                 continue
             counts[finding["priority"]] = counts.get(finding["priority"], 0) + 1
 
@@ -274,16 +274,13 @@ class FindingsPrintingStrategy(PrintingStrategy):
     def _append_cpe_coverage_note(self, theme: "ReportTheme", elements: list, findings: list) -> None:
         """Advierte cuando el matcher no pudo identificar parte del inventario.
 
-        Un escaneo por inventario (Fase I) emite un hallazgo
-        ``installed_package`` por **cada** paquete, se le haya podido resolver
-        un CPE o no. Antes de la observabilidad de la Fase I-b
-        (``Finding.cpe_resolved``) esto era indistinguible de "comprobado y
-        limpio" salvo por una heurística ("cero ``outdated_software``") que
-        mezclaba dos causas sin poder nombrar cuál. Ahora el dato es exacto:
-        cuántos de los paquetes inventariados no se pudieron ni identificar
-        contra el catálogo CPE — la KB local puede seguir sin tener CVEs para
-        los que sí se resolvieron, pero eso ya no es ambiguo, es "comprobado y
-        sin hallazgos".
+        Un escaneo por inventario emite un hallazgo ``installed_package`` por
+        **cada** paquete, se le haya podido resolver un CPE o no.
+        ``Finding.cpe_resolved`` distingue exactamente cuántos de los
+        paquetes inventariados no se pudieron ni identificar contra el
+        catálogo CPE — la KB local puede seguir sin tener CVEs para los que
+        sí se resolvieron, pero eso no es ambiguo, es "comprobado y sin
+        hallazgos".
         """
         packages = sum(1 for finding in findings if finding["category"] == "installed_package")
         unresolved = sum(
@@ -405,11 +402,11 @@ class FindingsPrintingStrategy(PrintingStrategy):
         return sections
 
     def _sorted_findings(self, findings: list) -> list:
-        """Priority first (the contextual CVSS+EPSS+KEV+exposure synthesis that
-        is Lybra's whole value proposition — see roadmap §1); raw CVSS
-        only breaks ties *within* the same priority band, confirmed findings
-        before hypotheses. Es el mismo orden de antes, aplicado ahora dentro de
-        cada grupo en vez de sobre la lista entera."""
+        """Priority first (the contextual CVSS+EPSS+KEV+exposure synthesis
+        that is Lybra's whole value proposition); raw CVSS only breaks ties
+        *within* the same priority band, confirmed findings before
+        hypotheses. Este orden se aplica dentro de cada grupo, no sobre la
+        lista entera."""
         return sorted(
             findings,
             key=lambda finding: (

--- a/API/src/modules/features/themis/services/reports/lybra.py
+++ b/API/src/modules/features/themis/services/reports/lybra.py
@@ -1,4 +1,4 @@
-"""Estrategia de impresión de los informes del motor Lybra (D5)."""
+"""Estrategia de impresión de los informes del motor Lybra."""
 
 from ...model import ScanType
 from ..analyzers import LybraAIWriter
@@ -12,7 +12,7 @@ class LybraPrintingStrategy(FindingsPrintingStrategy):
 
     Color palette: Green theme, matching Lybra's own UI identity. All the
     rendering logic lives in `FindingsPrintingStrategy`; this class only fixes
-    Lybra's identity — behaviour is unchanged from before the Fase U1 extract.
+    Lybra's identity.
     """
 
     _TOOL = ScanType.LYBRA

--- a/API/src/modules/features/themis/services/reports/nuclei.py
+++ b/API/src/modules/features/themis/services/reports/nuclei.py
@@ -1,4 +1,4 @@
-"""Estrategia de impresión de los informes de Nuclei (D5, roadmap Fase U1)."""
+"""Estrategia de impresión de los informes de Nuclei."""
 
 from ...model import ScanType
 from ..analyzers import LybraAIWriter
@@ -8,14 +8,13 @@ from .findings import FindingsPrintingStrategy
 
 @PrintingStrategy.register(ScanType.NUCLEI)
 class NucleiPrintingStrategy(FindingsPrintingStrategy):
-    """Printing strategy for Nuclei scan reports (roadmap Fase U1).
+    """Printing strategy for Nuclei scan reports.
 
     Nuclei's JSONL output maps onto `Finding` almost as completely as Lybra's
     own engine (`cve_ids`, `cvss_score`, `check_id` all populated by
     `nuclei_result_to_finding`), so this reuses `FindingsPrintingStrategy`
-    wholesale — the "beneficio colateral nada menor" the roadmap's Fase U
-    called out: the PDF is the hardest part of adding a scanner, and here it
-    costs a dozen class attributes.
+    wholesale — a not-minor side benefit: the PDF is the hardest part of
+    adding a scanner, and here it costs a dozen class attributes.
 
     Color palette: Blue theme, distinct from Lybra's green so the two
     coexist without visual confusion in the tool picker.

--- a/API/src/modules/features/themis/services/tasks.py
+++ b/API/src/modules/features/themis/services/tasks.py
@@ -391,7 +391,7 @@ class NiktoScanTask(_Task):
 
 
 class NucleiScanTask(_Task):
-    """Implementación concreta para escaneos Nuclei (roadmap Fase U1).
+    """Implementación concreta para escaneos Nuclei.
 
     Modelada sobre ``NiktoScanTask``: mismo patrón de fichero de salida
     temporal + progreso vía stdout. Dos diferencias que sí importan:
@@ -439,7 +439,7 @@ class NucleiScanTask(_Task):
         self.request_timeout = request_timeout or CR.nuclei_config().request_timeout
         self._binary = CR.nuclei_config().binary_path
         # Única fuente de verdad sobre dónde vive el árbol de plantillas, la
-        # misma que usan la ingesta (Fase R) y el censo (Fase U4) para leerlo.
+        # misma que usan la ingesta y el censo de ingestibilidad para leerlo.
         # ``None`` significa "no se pudo resolver ninguno", y entonces se omite
         # ``-templates`` y decide el binario — el mismo comportamiento que había
         # cuando el valor de configuración venía vacío.

--- a/API/tests/integration/test_nuclei.py
+++ b/API/tests/integration/test_nuclei.py
@@ -1,9 +1,9 @@
-"""Integration tests for the Nuclei scan write path (roadmap Fase U1).
+"""Integration tests for the Nuclei scan write path.
 
 Verifies ``NucleiScanManager._persist_scan_results`` end to end against a real
 ``NucleiScan`` row: findings land in the shared ``Finding`` table with
 ``cve_ids``/``cvss_score``/``check_id``/``feed_version`` populated, repeated
-templates collapse within a scan, and — the Definición de Hecho of Fase U1 —
+templates collapse within a scan, and — the criterion this suite enforces —
 a Nuclei finding shares its ``dedup_key`` with a prior Lybra finding of the
 same CVE on the same host/port. No real ``nuclei`` binary involved: the JSONL
 payload is injected directly, the same pattern
@@ -112,8 +112,8 @@ def test_repeated_template_across_matched_at_collapses_to_one_finding(app, admin
 
 
 def test_nuclei_finding_shares_dedup_key_with_prior_lybra_finding_same_cve(app, admin_user, monkeypatch):
-    """The Definición de Hecho of Fase U1: a hallazgo Nuclei y uno de Lybra
-    sobre la misma CVE, host y puerto deben fundirse — mismo dedup_key."""
+    """El criterio de esta suite: un hallazgo Nuclei y uno de Lybra sobre la
+    misma CVE, host y puerto deben fundirse — mismo dedup_key."""
     monkeypatch.setattr(
         endpoints_mod, "normalize_target",
         lambda target, resolve_hostname=False: ("10.0.0.7", "10.0.0.7"),

--- a/API/tests/integration/test_scanner_finding_adapters.py
+++ b/API/tests/integration/test_scanner_finding_adapters.py
@@ -3,9 +3,6 @@
 Verifies the dual-write is genuinely additive: the legacy NiktoIncident table
 that PDF/history read is populated exactly as before, and a normalized
 Finding row now also exists for correlation.
-
-OpenVAS had the same dual-write (OpenVASScanResult) until the scanner was
-removed (roadmap §7/§6.3, Ronda 2 — E2); its test was removed with it.
 """
 
 from datetime import datetime

--- a/API/tests/integration/test_themis_scan_outbox.py
+++ b/API/tests/integration/test_themis_scan_outbox.py
@@ -1,16 +1,13 @@
-"""#551: los escáneres de Themis crean el escaneo y su encolado en una sola transacción.
+"""Los escáneres de Themis crean el escaneo y su encolado en una sola transacción.
 
-Antes, los cinco ``run_scan()`` hacían dos pasos separados:
-``_create_scan_record()`` confirmaba la fila del escaneo y, ya fuera de esa
-transacción, un ``TaskQueue.submit()`` publicaba el trabajo. Entre uno y otro
-hay una ventana real —la API se reinicia, o Redis falla en ese instante— y lo
-que quedaba era un escaneo creado que ningún worker iba a procesar nunca, con
-la cuota del usuario ya cobrada. La reconciliación de arranque acababa
-marcándolo FAILED, pero solo al reiniciar la API y sin devolver la cuota: el
-usuario pagaba por un escaneo que nunca corrió.
+Si se hicieran en dos pasos separados —confirmar la fila del escaneo y, ya
+fuera de esa transacción, publicar el trabajo con ``TaskQueue.submit()``—
+habría una ventana real entre uno y otro (la API se reinicia, o Redis falla en
+ese instante) en la que quedaría un escaneo creado que ningún worker
+procesaría nunca, con la cuota del usuario ya cobrada.
 
-Estos tests fijan el comportamiento nuevo: con Redis caído en el momento exacto
-del encolado, el escaneo existe **y** existe su fila ``TaskDispatch``
+Estos tests fijan el comportamiento correcto: con Redis caído en el momento
+exacto del encolado, el escaneo existe **y** existe su fila ``TaskDispatch``
 pendiente, así que el trabajo se recupera después en vez de perderse.
 
 ``ScanManager._create_scan_and_dispatch`` es la ayuda compartida por los cinco
@@ -135,7 +132,7 @@ class TestScanAndDispatchAreAtomic:
         set_plan_limits({LimitKey.THEMIS_LYBRA_SCANS: 5})
         with app.app_context():
             # El modo autodescubrimiento sondea el objetivo, así que exige
-            # tenerlo en el registro de objetivos autorizados (roadmap §6).
+            # tenerlo en el registro de objetivos autorizados.
             AuthorizedTargetManager().add(admin_user.id, "8.8.8.8")
             manager = LybraEngineManager()
             monkeypatch.setattr(manager, "_task_queue", _RejectingQueue())

--- a/API/tests/oracle/_nmap_oracle.py
+++ b/API/tests/oracle/_nmap_oracle.py
@@ -3,16 +3,13 @@
 Un banco de concordancia necesita una referencia externa contra la que medirse,
 y esa referencia es Nmap: la herramienta de identificación de servicios que
 todo el mundo usa, con veinte años de firmas detrás. Medirse contra ella no es
-depender de ella —el motor no la invoca nunca en producción, ver L52— es la
-única forma de convertir «nuestro fingerprinting es bueno» en un número.
+depender de ella —el motor no la invoca nunca en producción, ver la nota sobre
+objetivos externos en ``_target_from_container``— es la única forma de
+convertir «nuestro fingerprinting es bueno» en un número.
 
-**Nmap se ejecuta en un contenedor cuando no está en el sistema.** El banco
-anterior exigía un ``nmap`` instalado en la máquina y se saltaba entero cuando
-faltaba, que en la práctica significaba saltarse entero casi siempre: en un
-portátil de desarrollo con Docker pero sin Nmap —el caso normal— no había
-medición, y por tanto tampoco número. Como todo lo demás en ``tests/oracle/``
-ya necesita Docker, el oráculo pasa a ser un contenedor más
-(``instrumentisto/nmap``) y el banco deja de depender de lo que cada uno tenga
+**Nmap se ejecuta en un contenedor cuando no está en el sistema.** Como todo
+lo demás en ``tests/oracle/`` ya necesita Docker, el oráculo es un contenedor
+más (``instrumentisto/nmap``) y el banco no depende de lo que cada uno tenga
 instalado. Si hay un ``nmap`` en el PATH se usa ése, que es más rápido y evita
 el rodeo por la red del contenedor.
 
@@ -48,10 +45,11 @@ def _target_from_container(host: str) -> str:
     laboratorio, siempre en 127.0.0.1— no es alcanzable por su IP de loopback
     desde dentro de otro contenedor: hay que rebotar por ``host.docker.internal``.
 
-    Un objetivo **externo** (el banco de paridad real, L48) se alcanza por su
-    nombre o IP tal cual: sustituirlo por ``host.docker.internal`` haría que el
-    oráculo escaneara la máquina Docker en vez del objetivo, midiendo algo que
-    no tiene nada que ver. Sólo se reescribe loopback.
+    Un objetivo **externo** (el banco de paridad contra un objetivo real) se
+    alcanza por su nombre o IP tal cual: sustituirlo por
+    ``host.docker.internal`` haría que el oráculo escaneara la máquina Docker
+    en vez del objetivo, midiendo algo que no tiene nada que ver. Sólo se
+    reescribe loopback.
     """
     try:
         if ipaddress.ip_address(host).is_loopback:

--- a/API/tests/unit/test_nuclei_adapter.py
+++ b/API/tests/unit/test_nuclei_adapter.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Nuclei -> Finding adapter (roadmap Fase U1).
+"""Unit tests for the Nuclei -> Finding adapter.
 
 Pure functions over dicts (one decoded JSONL line) — no DB, no subprocess.
 """
@@ -37,7 +37,7 @@ def _result(**overrides):
 def test_cve_ids_normalized_to_uppercase():
     """compute_dedup_key hashes 'cve:' + sorted(cve_ids) — Nuclei's own
     lowercase ids would never merge with Lybra's uppercase ones
-    without this normalization (the Definición de Hecho of Fase U1)."""
+    without this normalization."""
     f = nuclei_result_to_finding(_result())
     assert f["cve_ids"] == ["CVE-2021-41773"]
 

--- a/API/tests/unit/test_nuclei_processor.py
+++ b/API/tests/unit/test_nuclei_processor.py
@@ -1,4 +1,4 @@
-"""Unit tests for NucleiResultProcessor (JSONL parsing, roadmap Fase U1)."""
+"""Unit tests for NucleiResultProcessor (JSONL parsing)."""
 
 import json
 

--- a/API/tests/unit/test_nuclei_template_classifier.py
+++ b/API/tests/unit/test_nuclei_template_classifier.py
@@ -1,13 +1,13 @@
-"""Unit tests del clasificador de ingestibilidad de plantillas (Fase U4/R).
+"""Unit tests del clasificador de ingestibilidad de plantillas.
 
 Puro: cada test construye una plantilla a mano, así que nada aquí necesita el
 feed real de Nuclei. Lo que se verifica es el *criterio* — qué cuenta como
 obstáculo y en qué cubo cae cada cosa —, no el número del censo, que solo puede
 medirse en una máquina con las plantillas instaladas.
 
-El clasificador es compartido a propósito entre el censo (U4) y la futura
-ingesta (R): si midieran con criterios distintos, el número no describiría lo
-que la ingesta acabaría haciendo.
+El clasificador es compartido a propósito entre el censo del feed instalado y
+la ingesta de plantillas: si midieran con criterios distintos, el número no
+describiría lo que la ingesta acabaría haciendo.
 """
 
 import pytest
@@ -109,8 +109,9 @@ def test_dsl_matcher_is_a_blocker():
 
 
 def test_hex_input_is_counted_separately():
-    """Es justo lo que desbloquearía los checks de SMB que la Fase N no pudo
-    construir, así que interesa poder contarlo aparte en el histograma."""
+    """Es justo lo que desbloquearía los checks de SMB que hoy no se pueden
+    construir sin entrada binaria, así que interesa poder contarlo aparte en
+    el histograma."""
     template = {
         "id": "smb-thing",
         "info": {"severity": "medium"},

--- a/API/tests/unit/test_nuclei_template_ingest.py
+++ b/API/tests/unit/test_nuclei_template_ingest.py
@@ -1,4 +1,4 @@
-"""Unit tests del traductor y el selector de plantillas ingeridas (Fase R).
+"""Unit tests del traductor y el selector de plantillas ingeridas.
 
 Puro: plantillas escritas a mano, sin feed real y sin red. Se verifica el
 *criterio* de traducción y de selección, no el comportamiento contra objetivos
@@ -65,7 +65,8 @@ def test_a_translated_check_does_not_claim_to_be_ours():
 
 
 def test_the_feed_version_of_the_tree_reaches_the_finding():
-    """Sin esto el hallazgo no sería reproducible (garantía del §9 del roadmap)."""
+    """Sin esto el hallazgo no sería reproducible: hace falta saber con qué
+    versión del feed de plantillas se generó para poder repetirlo."""
     check = translate_template(_GIT_CONFIG_TEMPLATE, _FEED_VERSION)
     fetch = lambda host, port, method, path: Response(200, "[core]", {})  # noqa: E731
     findings = CheckRuntime([check], fetch).run("h", [Service(80, "tcp", "http", "", "", None)])

--- a/API/tests/unit/test_nuclei_template_store.py
+++ b/API/tests/unit/test_nuclei_template_store.py
@@ -1,4 +1,4 @@
-"""Unit tests for the single Nuclei template store (roadmap Fases U4/R).
+"""Unit tests for the single Nuclei template store.
 
 Pure: every test builds a fake template tree under ``tmp_path``, so nothing
 here needs a real ``nuclei`` install or its multi-thousand-file feed. What is


### PR DESCRIPTION
## El problema

Continuación de [#569](https://github.com/ProjectEllysia/EllysiaServer/pull/569), que dejó libre de referencias a `plans/lybra-roadmap.md` el motor Lybra en sí. Esta PR cubre el resto de Themis: `model.py`, `schemas.py`, `endpoints.py`, `repositories.py`, los servicios de reportes/parsing/tareas, y sus tests — todo lo que aún citaba un apartado del roadmap (`Fase N`, `Ronda 1`, `§16.2`) o un número de issue (`#551`) en vez de explicar la decisión con sus propias palabras.

De paso se corrigen cinco ficheros de `themis/lybra/fingerprinting/` (`favicon.py`, `http_apis.py`, `ldap.py`, `mysql.py`, `registry.py`) que el primer pase dejó fuera de su lista por error.

## Qué cambia

Mismo criterio que en #569:

- **Etiqueta redundante** → se borra.
- **Etiqueta que sustituía una explicación real** (por qué LDAP no es de baja frecuencia, por qué `http_apis` va antes que `http` en el registro de dissectors, por qué el favicon se guarda con dos algoritmos) → se cambia por la explicación en prosa.
- **Narración histórica pura** ("hasta L17 el motor veía...", "antes...") → se elimina; esa historia vive en el commit que la introdujo.
- Ningún caso nuevo de compatibilidad de datos genuina en este lote (a diferencia de #569, que sí tuvo dos).

El cambio más grande es `model.py` — es donde vivía la mayoría de las referencias, incluida la explicación histórica de por qué se retiró OpenVAS (`ScanResult`/`OpenVASScanResult`), que se conserva en sustancia pero sin citar el apartado del roadmap del que salió.

## Qué NO cambia

Solo texto: docstrings y comentarios. Ningún nombre de función, clase, variable, fichero o test se ha tocado; ninguna lógica se ha movido ni reescrito.

## Validación

```
pytest -m unit -k themis                                              # 53 passed, 2 skipped
pytest tests/integration/test_themis.py tests/integration/test_nuclei.py \
       tests/integration/test_scanner_finding_adapters.py \
       tests/integration/test_themis_scan_outbox.py \
       tests/integration/test_themis_reconciliation.py                # 40 passed
pytest tests/unit -k "favicon or http_apis or ldap or mysql or fingerprint or registry"  # 203 passed, 1 skipped
```

Sin líneas nuevas por encima de 100 columnas (verificado a mano sobre el diff, ya que `pylint --enable=line-too-long` también marca líneas preexistentes fuera del alcance de esta PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)