### PR TITLE
chore: quitar códigos de plan del resto del backend y del SPA

### DIFF
--- a/API/src/modules/accounts/endpoints.py
+++ b/API/src/modules/accounts/endpoints.py
@@ -1,15 +1,21 @@
 """
-Endpoints del catálogo de planes.
+Endpoints de planes, organizaciones y suscripciones.
 
-Dos rutas en esta fase, ninguna de ellas gateada por ABAC:
+Cuatro grupos de rutas, ninguna gateada por ABAC:
 
 - ``GET /plans`` es **público** — es la tabla de precios de la web, la ve quien
-  todavía no tiene cuenta.
-- ``GET /plans/me`` solo pide sesión: consultar tu propio plan no es una
-  capacidad que un administrador conceda o retire.
-
-El gestor del catálogo (alta y edición de planes) llega en una fase posterior y
-va con ``require_role(Role.ROOT)``, no con atributos.
+  todavía no tiene cuenta. ``GET /plans/me`` y ``/me/usage`` solo piden sesión:
+  consultar tu propio plan y tu consumo no es una capacidad que un
+  administrador conceda o retire.
+- ``/organizations/*`` cubre la creación, la gestión de miembros y las
+  invitaciones. Cada ruta que actúa sobre una organización concreta exige
+  además ``require_organization_owner``.
+- ``/plans/subscriptions/<user_id>`` es el ciclo de vida de una suscripción —
+  el mismo puerto que usará la pasarela de pago el día que se enchufe, hoy
+  operado a mano por root.
+- El resto (``/plans/all``, ``/plans/limit-keys``, alta/edición/borrado de
+  planes y sus límites) es el gestor del catálogo. Va con
+  ``require_role(Role.ROOT)``, no con atributos.
 """
 
 import logging

--- a/API/src/modules/accounts/managers/invitations.py
+++ b/API/src/modules/accounts/managers/invitations.py
@@ -56,7 +56,7 @@ class InvitationManager:
         Raises:
             OrganizationNotAllowedError: la suscripción del dueño no está
                 vigente o perdió el toggle. Mientras no paga no puede crecer
-                (§12.8) — lo que ya tiene sigue en pie, pero no suma gente.
+                — lo que ya tiene sigue en pie, pero no suma gente.
             AlreadyInOrganizationError: esa persona ya está en una organización.
             QuotaExceededError: se alcanzó el tope de miembros del plan.
         """

--- a/API/src/modules/accounts/managers/organizations.py
+++ b/API/src/modules/accounts/managers/organizations.py
@@ -129,8 +129,8 @@ class OrganizationManager:
         """Miembros de la organización, con lo justo para identificarlos.
 
         Datos de identidad y nada más: ni sus escaneos, ni sus análisis, ni el
-        contenido de sus bóvedas. Eso no lo ve el dueño (§8.4 del diseño), y no
-        es una carencia — es la garantía que se vende.
+        contenido de sus bóvedas. Eso no lo ve el dueño, y no es una carencia
+        — es la garantía que se vende.
         """
         get_owned_organization(user_id, organization_id)
 
@@ -193,7 +193,7 @@ class OrganizationManager:
         """El toggle de organización, que es lo único que el plan sí "concede".
 
         No es un atributo ABAC a propósito: los atributos los escribe una
-        persona y esto lo escribe el cobro (§5.1).
+        persona y esto lo escribe el cobro.
         """
         subscription = build_repository(SubscriptionRepository).get_by_user(user_id)
         if not is_effective(subscription, utcnow_naive()) or not subscription.organization_enabled:

--- a/API/src/modules/accounts/managers/plans.py
+++ b/API/src/modules/accounts/managers/plans.py
@@ -1,10 +1,8 @@
 """
-Lógica de negocio de la capa comercial.
-
-En esta fase solo hay lectura: el catálogo de planes y el plan efectivo de
-quien pregunta. Quien mueve suscripciones (``SubscriptionManager``, con las
-seis operaciones del ciclo de vida) y quien cuenta el consumo
-(``QuotaManager``) llegan en fases posteriores.
+Lógica de negocio del catálogo de planes: lectura pública, plan efectivo y
+consumo de quien pregunta, y alta/edición del catálogo para root. Quien mueve
+suscripciones vive aparte, en ``SubscriptionManager`` (las seis operaciones
+del ciclo de vida); quien cuenta el consumo, en ``QuotaManager``.
 """
 
 import logging
@@ -127,8 +125,8 @@ class PlanManager:
                 state = quota_manager.state(user_id, key)
             except (ValueError, NotImplementedError):
                 # ValueError: la fila referencia una clave que ya no existe en
-                # el enum. NotImplementedError: es de existencias y todavía no
-                # tiene contador (llegan en la fase 3). Ninguna de las dos es
+                # el enum. NotImplementedError: es de existencias y no tiene
+                # contador registrado en STOCK_COUNTERS. Ninguna de las dos es
                 # motivo para tumbar la vista entera.
                 usage[limit.limit_key] = entry
                 continue

--- a/API/src/modules/accounts/managers/subscriptions.py
+++ b/API/src/modules/accounts/managers/subscriptions.py
@@ -11,7 +11,7 @@ Hoy quien las mueve es root desde el panel. Son dos clientes del mismo puerto,
 no dos caminos, y por eso la máquina de estados se puede probar entera sin
 pasarela.
 
-Lo que **no** hace ninguna de las seis (§12.7): escribir en ``UserAttribute``,
+Lo que **no** hace ninguna de las seis: escribir en ``UserAttribute``,
 cambiar ``User.role``, crear o borrar una ``Organization``, tocar
 ``UsageCounter`` o borrar datos de nadie. Un pago escribe ``Subscription``, y se
 acabó.

--- a/API/src/modules/accounts/model.py
+++ b/API/src/modules/accounts/model.py
@@ -7,9 +7,8 @@ Tres grupos de tablas:
 - **Titularidad**: ``Subscription`` — quién tiene qué y hasta cuándo.
 - **Organización**: ``Organization``, ``OrganizationMember`` y
   ``OrganizationInvitation`` — un titular paga, sus miembros heredan derechos.
-  Nacen aquí pero no se usan hasta la fase 5.
 
-Más ``UsageCounter``, el contador de consumo que estrena la fase 2.
+Más ``UsageCounter``, el contador de consumo del motor de cuotas.
 
 Nota de alcance: una organización comparte **plan y factura**, nunca datos. No
 hay ninguna relación de aquí hacia bóvedas, escaneos o análisis, y los filtros
@@ -234,7 +233,7 @@ class Subscription(Base):
 
 
 # =========================================================================
-# ORGANIZACIÓN — creadas aquí, en uso desde la fase 5
+# ORGANIZACIÓN
 # =========================================================================
 
 class Organization(Base):
@@ -334,7 +333,7 @@ class OrganizationInvitation(Base):
 
 
 # =========================================================================
-# CONSUMO — creada aquí, en uso desde la fase 2
+# CONSUMO
 # =========================================================================
 
 class UsageCounter(Base):

--- a/API/src/modules/accounts/services/entitlements.py
+++ b/API/src/modules/accounts/services/entitlements.py
@@ -8,9 +8,10 @@ tampoco ninguno que pueda olvidarse de aplicarla — que es como fallan estos
 sistemas en todas partes: el cron nocturno no corre un fin de semana y hay
 cuentas disfrutando gratis de un plan caducado sin que nadie se entere.
 
-En esta fase la única fuente de derechos es el plan personal. La unión con los
-derechos derivados de la organización (el ``max()`` del §4 del diseño) llega
-con la fase 5, cuando ``OrganizationMember`` tenga filas.
+Hay dos fuentes de derechos que nunca se anulan entre sí: el plan personal y lo
+que un usuario recibe por pertenecer a una organización cuyo dueño paga. Gana
+el ``max()`` de las dos — ver ``resolve_entitlement`` para el detalle de quién
+paga cuando empatan.
 """
 
 from __future__ import annotations
@@ -129,14 +130,14 @@ class Entitlement:
 
     Attributes:
         limit: Tope. ``None`` es ilimitado; ``0``, no incluido en el plan.
-        holder_kind / holder_id: a quién se le carga el consumo. Hoy siempre el
-            propio usuario; en la fase 5, la organización cuando sea ella quien
-            conceda el derecho (bolsa común).
+        holder_kind / holder_id: a quién se le carga el consumo — el propio
+            usuario, o la organización cuando es ella quien concede el
+            derecho (bolsa común entre sus miembros).
         source: de dónde viene el derecho — ``"personal"`` (su suscripción
-            vigente), ``"default"`` (el plan gratuito) o, desde la fase 5,
-            ``"organization"``. No es adorno: la vista "Mi plan" tiene que poder
-            decir "ilimitado, cortesía de tu organización", porque de eso
-            depende que el usuario entienda qué pierde si se va.
+            vigente), ``"default"`` (el plan gratuito) u ``"organization"``.
+            No es adorno: la vista "Mi plan" tiene que poder decir
+            "ilimitado, cortesía de tu organización", porque de eso depende
+            que el usuario entienda qué pierde si se va.
     """
 
     key: LimitKey
@@ -187,7 +188,7 @@ def resolve_organization_grant(
     Returns:
         ``(tope, organization_id)``. ``(0, None)`` si no pertenece a ninguna, o
         si la suscripción del dueño no está vigente o perdió el toggle — que es
-        justo lo que pasa cuando el dueño deja de pagar (§12.8): los miembros
+        justo lo que pasa cuando el dueño deja de pagar: los miembros
         conservan cuenta, datos y plan personal, y solo dejan de recibir lo
         heredado.
     """

--- a/API/src/modules/accounts/services/limits.py
+++ b/API/src/modules/accounts/services/limits.py
@@ -6,8 +6,8 @@ compartido entre la tabla ``PlanLimit`` (lo que un plan concede) y el motor de
 cuotas (lo que se ha consumido).
 
 Aquí solo vive la **declaración**: qué se mide y con qué periodicidad. El motor
-que cuenta y corta —``LimitSpec``, los contadores de existencias y el
-``QuotaManager``— llega con la fase 2; hasta entonces nadie consume nada.
+que cuenta y corta vive aparte, en ``QuotaManager`` (``services/quotas.py``),
+que importa este catálogo en vez de duplicarlo.
 
 Disciplina, la misma que ``AttributeType``: el valor del enum es lo que se
 guarda en base de datos, así que renombrar un miembro no basta — habría que
@@ -231,8 +231,9 @@ def _count_organization_members(session, user_ids: list[int]) -> int:
 #: datos ya sabe la respuesta.
 #:
 #: Recibe una lista de ``user_ids`` y no uno solo porque la bolsa de una
-#: organización suma la de todos sus miembros (fase 5). Hoy la lista siempre
-#: tiene un elemento.
+#: organización suma la de todos sus miembros: cuando el titular es la
+#: organización, la lista trae los ids de todos ellos; cuando es un usuario
+#: suelto, trae solo el suyo.
 #:
 #: Pedir una clave que no esté aquí es un error de programación, no del usuario,
 #: y ``QuotaManager`` lo dice como tal en vez de responder un 402.

--- a/API/src/modules/accounts/services/quotas.py
+++ b/API/src/modules/accounts/services/quotas.py
@@ -1,7 +1,7 @@
 """
 Motor de cuotas: cuenta lo consumido y corta cuando el plan se acaba.
 
-Dos naturalezas, dos formas de contar (§6.2 del diseño):
+Dos naturalezas, dos formas de contar:
 
 - **Consumo** (``month`` / ``day``): hay contador en ``UsageCounter``. Sube y no
   baja, y se reinicia solo al cambiar de periodo — no hay ningún proceso que
@@ -131,7 +131,7 @@ class QuotaManager:
             self._consume_counter(entitlement, amount)
 
     def consume_many(self, user_id: int, keys: list[LimitKey], amount: int = 1) -> None:
-        """Consume varias claves como una única operación: todas o ninguna (B09).
+        """Consume varias claves como una única operación: todas o ninguna.
 
         Encadenar ``consume()`` a pelo dos veces deja un cobro a medias si la
         segunda llamada falla -- el caso real es ``generate_ai_summary()``,

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -726,10 +726,10 @@ def get_smtp_environment() -> dict[str, str]:
 
 # Los cuatro escáneres de Themis, cada uno con su propio bloque bajo
 # ``features.themis.scanners``: mismos ``prompts`` y ``colorPalette``, más los
-# ajustes que cada herramienta necesite. OpenVAS salió de esta lista al
-# retirarse (roadmap §7/§6.3, Ronda 2 — E2).
+# ajustes que cada herramienta necesite. OpenVAS se retiró del producto y no
+# aparece en esta lista.
 #
-# Derivado de ScanType (A1) en vez de repetido a mano: un escáner nuevo que
+# Derivado de ScanType en vez de repetido a mano: un escáner nuevo que
 # se registre en el enum aparece aquí solo, en vez de quedarse fuera hasta
 # que alguien se acuerde de tocar esta tupla también. Import perezoso
 # (dentro de la función, no a nivel de módulo): config_reading.py lo importa
@@ -869,13 +869,13 @@ class LybraConfig:
     """Interruptores de operador del motor propio.
 
     Ambos van a ``True`` por defecto: el registro de objetivos autorizados por
-    usuario (roadmap §6, ``AuthorizedTargetManager``) es la verdadera puerta —
+    usuario (``AuthorizedTargetManager``) es la verdadera puerta —
     Lybra solo toca un objetivo que el llamante haya autorizado explícitamente,
     valga lo que valga este flag. Existen como interruptor de emergencia para
     desactivar la funcionalidad en todo el despliegue.
 
     Los **parámetros de red** —timeouts, concurrencia, ritmo, presupuestos—
-    viven aparte, en :class:`LybraEngineConfig` (L39): un interruptor de
+    viven aparte, en :class:`LybraEngineConfig`: un interruptor de
     despliegue y un dial de afinado son cosas distintas, y mezclarlos haría el
     bloque ilegible en cuanto pasara de dos campos.
     """
@@ -889,19 +889,14 @@ class LybraConfig:
 class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
     """Los diales de red del motor: cuánto tarda, cuánta carga mete y qué mira.
 
-    Hasta L39 cada uno de estos valores era un literal en la firma de un
-    constructor —``concurrency=200``, ``timeout=2.0``, ``min_interval=0.2``— y
-    el manager instanciaba las sondas sin argumentos, así que no había forma de
-    tocarlos sin editar código. OpenVAS lleva veinte años teniendo *scan
-    configs* por una razón: un escaneo contra un enlace lento, contra un
+    Son configurables porque un escaneo contra un enlace lento, contra un
     appliance frágil o contra un rango grande necesita otros números, y quien
-    opera el escáner es quien sabe cuáles.
+    opera el escáner es quien sabe cuáles — la misma razón por la que OpenVAS
+    lleva veinte años ofreciendo *scan configs*.
 
-    **Los valores por defecto son exactamente los que estaban a fuego**, así
-    que el cambio es invisible hasta que alguien mueve un dial. Cada campo tiene
-    un consumidor real en ``managers/lybra/engine.py`` — no hay ningún dial que
-    no llegue a una sonda, porque un parámetro que nadie lee es peor que uno a
-    fuego: parece configurable y no lo es.
+    Cada campo tiene un consumidor real en ``managers/lybra/engine.py`` — no
+    hay ningún dial que no llegue a una sonda, porque un parámetro que nadie
+    lee es peor que uno a fuego: parece configurable y no lo es.
     """
 
     # --- Descubrimiento TCP (transport.AsyncConnectScanner / scan_ports_sync)
@@ -928,7 +923,7 @@ class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
     Agotarlo **no** marca nada como cerrado: los puertos que no han contestado
     se dan por no observados, que es lo que ya eran."""
 
-    # --- Ritmo por host (checks.HostRateLimiter) y paralelismo (L23)
+    # --- Ritmo por host (checks.HostRateLimiter) y paralelismo
     rate_limit_interval: float = 0.2
     """Intervalo mínimo, en segundos, entre dos peticiones al mismo
     host. Es la cortesía con el objetivo, y manda por encima del pool."""
@@ -969,8 +964,8 @@ class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
 
     # --- DSL de checks: payloads/fuzzing (checks.CheckRuntime)
     max_payload_expansions: int = 25
-    """Tope duro de peticiones que un check con ``payloads`` puede expandir
-    (L30). Un payload es una lista de valores —veinte nombres de fichero de
+    """Tope duro de peticiones que un check con ``payloads`` puede expandir.
+    Un payload es una lista de valores —veinte nombres de fichero de
     copia de seguridad, pongamos— que se sustituyen en la petición, y sin un
     tope el producto cartesiano de varias listas convierte un check en un
     barrido de fuerza bruta de horas. El motor corta en cuanto alcanza este
@@ -981,12 +976,12 @@ class LybraEngineConfig:  # pylint: disable=too-many-instance-attributes
 @config_block("features.themis.scanners.lybra.ingest")
 @dataclass(frozen=True)
 class LybraIngestConfig:
-    """Ingesta de plantillas de Nuclei al runtime propio de Lybra (Fase R)."""
+    """Ingesta de plantillas de Nuclei al runtime propio de Lybra."""
 
     enabled: bool = False
     """**Por defecto desactivado, y a conciencia.** El código está construido y
     probado, pero la decisión de si la ingesta merece la pena la toma el número
-    del censo de la Fase U4 (``tools/nuclei_template_census.py``), que solo puede
+    del censo (``tools/nuclei_template_census.py``), que solo puede
     medirse en una máquina con el feed instalado. Hasta que ese número exista, el
     interruptor existe pero no se activa: el flag decide la *activación*, no la
     existencia del código."""
@@ -1023,7 +1018,7 @@ class NucleiConfig:
     )
     """Perfil acotado por defecto cuando el caller no especifica severidades.
 
-    Excluye ``info`` a propósito (roadmap Fase U1, punto 1): son miles de
+    Excluye ``info`` a propósito: son miles de
     plantillas de tech-detect, y al ser ``confirmed=True`` sin CVSS el suelo de
     ``score_finding`` las subiría todas a MEDIO. Activarlas es una elección
     explícita del usuario en el formulario, no un default.
@@ -1055,7 +1050,7 @@ class NucleiConfig:
         dice dónde está. Tres consumidores dependen de esa respuesta y ninguno
         debe resolverla por su cuenta: ``NucleiScanTask`` (que se la pasa al
         binario por ``-templates``), la ingesta de plantillas al runtime propio y
-        el censo de ingestibilidad (roadmap Fases R y U4).
+        el censo de ingestibilidad (``tools/nuclei_template_census.py``).
 
         Prioridad, de más explícito a más implícito: 1) ``templatesDir`` en
         SecOpsConfig.json, 2) ``NUCLEI_TEMPLATES_DIR`` en el entorno, 3) las
@@ -1154,7 +1149,7 @@ def lybra_engine_config() -> LybraEngineConfig:
 @config_block("features.themis.scanners.lybra.evidence")
 @dataclass(frozen=True)
 class LybraEvidenceConfig:
-    """La captura de evidencia cruda por hallazgo (Fase E, L44).
+    """La captura de evidencia cruda por hallazgo.
 
     Un hallazgo dice qué encontró y con qué regla, pero ``feed_version`` +
     ``check_id`` dan reproducibilidad lógica, no guardan lo que el objetivo
@@ -1188,14 +1183,14 @@ def lybra_ingest_config() -> LybraIngestConfig:
 @config_block("features.themis.scanners.lybra.credentials")
 @dataclass(frozen=True)
 class LybraCredentialsConfig:
-    """El presupuesto del motor de credenciales por defecto (Fase D, L31).
+    """El presupuesto del motor de credenciales por defecto.
 
     Es la única fase del motor que **escribe** en el objetivo — cada intento es
     un login real —, así que el único dial que expone es el que evita que se
     convierta en un ataque de fuerza bruta: cuántas contraseñas se prueban
     contra una misma cuenta antes de rendirse con ella. No hay ``enabled``:
     el motor entero está detrás de la doble puerta de :func:`aggressive
-    mode <>` — objetivo autorizado y petición explícita del usuario (L40) —,
+    mode <>` — objetivo autorizado y petición explícita del usuario —,
     así que un interruptor aparte sería una tercera puerta redundante.
     """
 
@@ -1347,7 +1342,7 @@ def general_config() -> GeneralConfig:
 @config_block("general.registration")
 @dataclass(frozen=True)
 class RegistrationConfig:
-    """Alta pública de cuentas (§7 de planes-y-organizaciones.md).
+    """Alta pública de cuentas.
 
     Es de las pocas cosas de la capa comercial que sí son configuración de
     instancia y no de negocio: los planes y sus topes viven en base de datos
@@ -1644,35 +1639,35 @@ class HygeiaLimits:  # pylint: disable=too-many-instance-attributes
     """Topes defensivos sobre lo que un agente puede mandar en un heartbeat.
 
     No son ajustes de comodidad: cada uno acota un recurso que un agente
-    comprometido —o simplemente mal configurado— podría agotar (§16).
+    comprometido —o simplemente mal configurado— podría agotar.
     """
 
     max_body_bytes: int = 1048576
-    """Tamaño máximo (comprimido) del cuerpo de un heartbeat, en bytes (§16.1)."""
+    """Tamaño máximo (comprimido) del cuerpo de un heartbeat, en bytes."""
 
     max_decompressed_bytes: int = 4194304
-    """Tope de descompresión de un heartbeat gzip (defensa anti gzip-bomb, §16.1)."""
+    """Tope de descompresión de un heartbeat gzip (defensa anti gzip-bomb)."""
 
     max_processes: int = 20
-    """Máximo de procesos en topCpu/topMem por heartbeat (§16.1)."""
+    """Máximo de procesos en topCpu/topMem por heartbeat."""
 
     max_disk_mounts: int = 64
-    """Máximo de puntos de montaje reportados por heartbeat (§16.1)."""
+    """Máximo de puntos de montaje reportados por heartbeat."""
 
     max_net_interfaces: int = 64
-    """Máximo de interfaces de red reportadas por heartbeat (§16.1)."""
+    """Máximo de interfaces de red reportadas por heartbeat."""
 
     max_inventory_items: int = 2000
-    """Máximo de aplicaciones en un escaneo de inventario de software (§16.1)."""
+    """Máximo de aplicaciones en un escaneo de inventario de software."""
 
     max_series_points: int = 1000
-    """Máximo de puntos devueltos por la serie temporal de un activo (§5)."""
+    """Máximo de puntos devueltos por la serie temporal de un activo."""
 
     min_interval_sec: int = 5
-    """Suelo de cadencia entre heartbeats de una misma clave, en segundos (§16.2)."""
+    """Suelo de cadencia entre heartbeats de una misma clave, en segundos."""
 
     clock_skew_sec: int = 300
-    """Cuánto puede ADELANTARSE el ``collectedAt`` del agente al reloj del servidor (§16.3).
+    """Cuánto puede ADELANTARSE el ``collectedAt`` del agente al reloj del servidor.
 
     Solo acota el futuro. Un heartbeat fechado por delante del servidor no
     tiene explicación legítima —ningún retardo de red produce eso— así que un
@@ -1681,23 +1676,22 @@ class HygeiaLimits:  # pylint: disable=too-many-instance-attributes
     """
 
     max_backfill_sec: int = 86400
-    """Cuánto puede ATRASARSE el ``collectedAt`` respecto al servidor (§16.3).
+    """Cuánto puede ATRASARSE el ``collectedAt`` respecto al servidor.
 
     Un heartbeat viejo sí tiene explicación legítima, y es la razón de ser del
     buffer en disco del agente: si el backend estuvo caído, el agente guarda
-    los heartbeats y los entrega al recuperar la conexión. Con la ventana
-    simétrica de 300 s anterior ese buffer era decorativo — el agente retiene
-    horas de histórico y el servidor rechazaba todo lo de más de cinco
-    minutos, así que una caída larga se perdía entera pese a estar guardada.
+    los heartbeats y los entrega al recuperar la conexión — por eso esta
+    ventana es mucho más generosa que ``clock_skew_sec``, que solo acota el
+    futuro.
 
-    Ampliarlo no reabre el riesgo del §16.3 (una clave robada inyectando
-    snapshots que envenenen el orden de la serie o tapen un hueco de
-    presencia): tanto el histórico como el detector de presencia se ordenan
-    por ``received_at``, el reloj del SERVIDOR, nunca por este campo.
+    Ampliarlo no reabre el riesgo de una clave robada inyectando snapshots que
+    envenenen el orden de la serie o tapen un hueco de presencia: tanto el
+    histórico como el detector de presencia se ordenan por ``received_at``, el
+    reloj del SERVIDOR, nunca por este campo.
     """
 
     max_assets_per_user: int = 500
-    """Cuota de activos monitorizados que puede dar de alta un usuario (§16.4)."""
+    """Cuota de activos monitorizados que puede dar de alta un usuario."""
 
 
 @config_block("features.hygeia")
@@ -1712,7 +1706,7 @@ class HygeiaConfig:
     """Heartbeats perdidos (sobre el intervalo efectivo) para pasar de stale a offline."""
 
     retention_days: int = 30
-    """Antigüedad máxima de un AssetSnapshot antes de podarlo (§7.3)."""
+    """Antigüedad máxima de un AssetSnapshot antes de podarlo."""
 
     retention_cron: str = "0 4 * * *"
     """Expresión cron del job diario de poda de snapshots."""
@@ -1725,7 +1719,7 @@ class HygeiaConfig:
     """
 
     energy_price_per_kwh: float = 0.15
-    """Precio de la electricidad usado para convertir kWh en coste (Fase 3).
+    """Precio de la electricidad usado para convertir kWh en coste.
 
     Clave global y no por activo ni por agente: el precio depende del país,
     el contrato y la hora del día, no de la máquina que se mide, así que
@@ -1810,7 +1804,7 @@ class IrisConfig:  # pylint: disable=too-many-instance-attributes
     """Tope diario de análisis auto-ingeridos, **por conexión** (no global).
 
     Una conexión mal configurada (carpeta ruidosa, bucle de reenvíos) no debe
-    poder generar análisis sin límite — ver roadmap-ellysia.md §8.1.
+    poder generar análisis sin límite.
     """
 
     max_inbox_attempts: int = 5
@@ -1837,8 +1831,7 @@ class IrisConfig:  # pylint: disable=too-many-instance-attributes
     ``suspicious_threshold``), un veredicto Phishing se considera de "alta
     confianza" (M08): se notifica siempre de inmediato, sin que el
     silenciado temporal ni el digest diario del usuario puedan retrasarlo o
-    suprimirlo — el criterio de cierre del issue exige que nunca se pierda
-    una incidencia crítica.
+    suprimirlo, para que nunca se pierda una incidencia crítica.
     """
 
     notification_check_interval_minutes: int = 60
@@ -1922,7 +1915,7 @@ def get_iris_data(key: str):
 
 @_lazy_load
 def get_iris_scoring_weight(weight_key: str, default: float) -> float:
-    """Peso de scoring configurable de una regla de Iris (recalibración §19/S6).
+    """Peso de scoring configurable de una regla de Iris, para recalibrarla.
 
     ``features.iris.scoring.<weight_key>`` puede pisar la magnitud de
     penalización que una regla define en código sin necesidad de redeploy. El
@@ -1934,7 +1927,7 @@ def get_iris_scoring_weight(weight_key: str, default: float) -> float:
 
 
 # =============================================================================
-# CONECTOR DE BUZÓN DE IRIS (Fase 3-4 del plan mailbox-connector)
+# CONECTOR DE BUZÓN DE IRIS
 # =============================================================================
 # Los ajustes del conector (cuotas, cadencia de sondeo) viven en ``IrisConfig``;
 # aquí solo quedan las credenciales OAuth de las apps, que son secretos de .env.

--- a/API/src/modules/system/taskqueue/outbox.py
+++ b/API/src/modules/system/taskqueue/outbox.py
@@ -1,14 +1,15 @@
 """
-Outbox transaccional para TaskQueue (B08) -- modelo y (de)serialización.
+Outbox transaccional para TaskQueue -- modelo y (de)serialización.
 
 **El problema**: varios managers seguían el patrón "crear entidad → confirmar
 en BD → encolar en Redis" con el ``submit()`` fuera de la transacción de la
 entidad. Entre esos dos pasos hay una ventana real: si la API se reinicia o
 Redis falla justo ahí, la fila queda en BD en estado ``pending`` sin ningún
 trabajo que la vaya a procesar nunca -- y nada lo nota hasta que alguien mira
-esa fila y se pregunta por qué no avanza. La caída de B04 (Fase 0) atendía la
-mitad de esto -- reconciliar un job que sí se encoló pero cuyo estado quedó
-inconsistente --, no la mitad en la que el ``submit()`` nunca llegó a pasar.
+esa fila y se pregunta por qué no avanza. La reconciliación de trabajo
+huérfano que arranca ``_configure_scheduling()`` atiende solo la mitad de
+esto -- un job que sí se encoló pero cuyo estado quedó inconsistente --, no
+la mitad en la que el ``submit()`` nunca llegó a pasar.
 
 **La solución**: ``TaskDispatch`` es la intención de publicar, persistida en
 la MISMA transacción que la entidad que la origina (mismo commit, o ninguno

--- a/API/src/modules/tools/scribe/generator.py
+++ b/API/src/modules/tools/scribe/generator.py
@@ -93,8 +93,7 @@ class AIGenerator:
 
         Registra el tamaño estimado incluso cuando no excede el límite —
         observabilidad para diagnosticar el próximo 429 sin depender de que
-        el backend lo reporte, que es exactamente lo que faltó para
-        diagnosticar el caso original de este issue.
+        el backend lo reporte.
         """
         import src.modules.system.config_reading as CR
 

--- a/API/tests/conftest.py
+++ b/API/tests/conftest.py
@@ -245,7 +245,7 @@ def _redis_always_unavailable():
 # 3-ter. Ningún socket sale de loopback
 # ---------------------------------------------------------------------------
 
-# Los objetivos reales declarados (L48) los comparten este sello y el banco de
+# Los objetivos reales declarados los comparten este sello y el banco de
 # paridad. Se cargan por ruta y no por nombre porque ``conftest`` es ambiguo:
 # hay más de uno en el árbol (``tests/postgres/conftest.py``) y cuál gana
 # depende del orden de recolección.
@@ -284,7 +284,7 @@ def _no_outbound_sockets():
 
     Se corta en ``socket.connect``, no sonda a sonda, porque es el único punto
     por el que pasan todas: urllib (``HttpProbe``), TLS, las sesiones TCP
-    crudas de la Fase N y el descubrimiento de puertos. Un ``ConnectionRefused``
+    crudas del descubrimiento de puertos. Un ``ConnectionRefused``
     instantáneo es indistinguible de un host inalcanzable para el código bajo
     test — que trata cualquier ``OSError`` como "no hay servicio" — solo que
     sin la espera.
@@ -292,7 +292,7 @@ def _no_outbound_sockets():
     Loopback sí se permite: los tests de herald levantan un servidor SMTP real
     (aiosmtpd) en 127.0.0.1 y tienen que poder hablar con él.
 
-    Y, desde L48, también las direcciones que el operador haya declarado en
+    También se permiten las direcciones que el operador haya declarado en
     ``LYBRA_REAL_TARGETS`` (ver :func:`declared_real_targets`). Es una lista
     blanca de direcciones concretas, resueltas antes de instalar el sello, no
     un interruptor que lo apague: sin esa variable —el caso por defecto, y el
@@ -697,9 +697,9 @@ def set_plan_limits(app, _unlimited_default_plan):
 def make_subscription(app, seeded_plans):
     """Factory que da de alta una suscripción para un usuario.
 
-    Sin llamar a ningún manager: en esta fase no existe todavía quien mueva
-    suscripciones (eso es el ciclo de vida de la fase 6), así que los tests
-    escriben la fila directamente.
+    Sin llamar a ``SubscriptionManager``: escribe la fila directamente para
+    dejar el test libre de tener que pasar por las seis operaciones del ciclo
+    de vida cuando lo único que le importa es partir de un estado ya dado.
     """
     from src.modules.accounts.model import Subscription
 

--- a/API/tests/integration/test_aegis_outbox.py
+++ b/API/tests/integration/test_aegis_outbox.py
@@ -1,4 +1,4 @@
-"""#551: Aegis crea la entidad y su encolado en una sola transacción.
+"""Aegis crea la entidad y su encolado en una sola transacción.
 
 Aegis era el caso más desprotegido de todo el proyecto. Sus dos puntos de
 create-then-enqueue —lanzar una campaña y generar una píldora— no tenían

--- a/API/tests/integration/test_kb_repository.py
+++ b/API/tests/integration/test_kb_repository.py
@@ -1,4 +1,4 @@
-"""Integration tests for the Lybra KB repository (Fase 2).
+"""Integration tests for the Lybra KB repository.
 
 Exercises the matcher's central query (``cves_for_cpe``) and the upsert
 idempotency against the (SQLite) database, without any network.
@@ -42,7 +42,7 @@ def test_cves_for_cpe_respects_version_range(app):
 
 
 def test_cves_for_cpe_tags_result_with_required_os(app):
-    """#118: a match gated behind a platform (CpeMatch.required_os) must
+    """A match gated behind a platform (CpeMatch.required_os) must
     surface on the returned CveEntry so the caller (LybraEngine) can avoid
     treating an unverifiable OS precondition as a confirmed risk."""
     match = {"vendor": "apache", "product": "http_server", "exact_version": "2.4.59",
@@ -111,7 +111,7 @@ def test_upsert_cve_is_idempotent_and_replaces_matches(app):
     assert now[0].cvss_score == 9.8     # fields updated
 
 
-# ------------------------------------------------- Fase I-b, paso 2: índice CPE
+# --------------------------------------------------------------- índice CPE
 
 def _match(vendor, product):
     return {"vendor": vendor, "product": product, "exact_version": "1.0",
@@ -395,7 +395,7 @@ def test_query_manager_enriches_with_kev_and_epss(app):
     assert quiet.kev is False and quiet.epss is None
 
 
-# ───────────────────────────── estado de sincronización (L36)
+# ─────────────────── estado de sincronización
 #
 # Una sincronización que funciona ya se nota: aparecen datos. Una que falla no
 # dejaba más rastro que una línea de log, así que el job podía llevar semanas
@@ -447,9 +447,8 @@ def test_a_source_never_synced_counts_as_stale(app):
         status = KbSyncManager().status()
         by_source = {entry["source"]: entry for entry in status["sources"]}
 
-        # Las cuatro fuentes configuradas, `oval` incluida: al añadir el feed
-        # de avisos de distribución (Fase O) heredó este registro sin tocar
-        # nada, que era medio motivo para hacer L36 antes que L32.
+        # Las cuatro fuentes configuradas, `oval` incluida (el feed de avisos
+        # de distribución).
         assert set(by_source) == {"nvd", "kev", "epss", "oval"}
         assert all(entry["neverSynced"] for entry in by_source.values())
         assert all(entry["isStale"] for entry in by_source.values())
@@ -509,7 +508,7 @@ def test_the_kb_status_endpoint_requires_authentication(client):
     assert client.get("/themis/kb/status").status_code == 401
 
 
-# ───────────────────────── ranking de nombres sin resolver (L37)
+# ─────────── ranking de nombres sin resolver
 
 
 def test_the_ranking_counts_by_name_and_origin(app):

--- a/API/tests/integration/test_organizations.py
+++ b/API/tests/integration/test_organizations.py
@@ -209,7 +209,7 @@ def test_the_bag_runs_out_for_everyone(client, app, owner, make_user, auth_heade
             QuotaManager().consume(second.id, LimitKey.IRIS_ANALYSES)
 
 
-# ------------------------------------------- el dueño deja de pagar (§12.8)
+# ------------------------------------------------- el dueño deja de pagar
 
 def test_when_the_owner_stops_paying_nothing_is_destroyed(
     client, app, owner, regular_user, auth_headers, make_subscription
@@ -407,7 +407,7 @@ def test_leaving_without_an_organization_is_a_404(client, regular_user, auth_hea
                          headers=auth_headers(regular_user)).status_code == 404
 
 
-# --------------------------------------- el dueño gestiona a los suyos (§8.6)
+# ------------------------------------------- el dueño gestiona a los suyos
 
 def test_the_owner_manages_the_attributes_of_their_members(
     client, app, owner, make_user, auth_headers

--- a/API/tests/integration/test_plans.py
+++ b/API/tests/integration/test_plans.py
@@ -142,8 +142,9 @@ def test_past_due_within_grace_keeps_the_plan(
 def test_limits_carry_no_usage_counters_yet(
     client, seeded_plans, regular_user, auth_headers
 ):
-    """Frontera con la fase 2: aquí solo se dice cuánto incluye el plan, nunca
-    cuánto se lleva gastado. El día que aparezca "used", que sea a propósito."""
+    """/plans/me solo dice cuánto incluye el plan, nunca cuánto se lleva
+    gastado -- eso vive aparte, en /plans/me/usage. Que "used" no aparezca
+    aquí es a propósito, no un olvido."""
     body = client.get("/plans/me", headers=auth_headers(regular_user)).get_json()
     for limit in body["limits"].values():
         assert set(limit) == {"value", "period"}

--- a/API/tests/integration/test_quotas.py
+++ b/API/tests/integration/test_quotas.py
@@ -148,8 +148,8 @@ def test_consume_many_accepts_an_amount(app, regular_user, set_plan_limits):
 
 
 def test_quotas_are_per_user(app, make_user, set_plan_limits):
-    """Dos usuarios con el mismo plan no comparten bolsa. La compartirán los
-    miembros de una misma organización, y eso llega en la fase 5."""
+    """Dos usuarios con el mismo plan no comparten bolsa -- solo la comparten
+    los miembros de una misma organización, que aquí no lo son."""
     set_plan_limits({LimitKey.AI_REQUESTS: 1})
     first, second = make_user(), make_user()
 
@@ -211,7 +211,7 @@ def test_stock_key_without_counter_is_a_programming_error(
             QuotaManager().consume(regular_user.id, LimitKey.HYGEIA_ASSETS)
 
 
-# --------------------------------------------- las claves de la fase 3, por HTTP
+# ------------------------------------------------------ claves de HTTP
 
 def test_iris_analyses_are_capped(client, regular_user, auth_headers, set_plan_limits):
     """El corte llega antes de encolar el análisis.

--- a/API/tests/integration/test_registration.py
+++ b/API/tests/integration/test_registration.py
@@ -147,7 +147,7 @@ def test_register_can_be_closed_by_configuration(client, sent_emails, monkeypatc
 def test_an_unverified_account_can_look_but_not_spend(
     client, app, auth_headers, make_user
 ):
-    """La frontera de la fase 4, en un test.
+    """La frontera entre "tener cuenta" y "poder gastar", en un test.
 
     Entrar y consultar, sí. Dar de alta un activo —que es lo que empieza a
     costar dinero— no, hasta confirmar el correo.

--- a/API/tests/integration/test_taskqueue_outbox.py
+++ b/API/tests/integration/test_taskqueue_outbox.py
@@ -3,9 +3,9 @@
 ``TaskDispatch`` es la intención de publicar un job, guardada en la misma
 transacción que la entidad que la origina. Estos tests cubren el
 ``OutboxDispatcher`` de forma aislada (con un ``ITaskQueue`` doble, sin Redis
-real) y, al final, el escenario íntegro que el issue pide: la API puede
-reiniciarse entre el commit del análisis y la publicación del job sin perder
-el trabajo ni duplicarlo.
+real) y, al final, el escenario íntegro que sostiene todo lo anterior: la API
+puede reiniciarse entre el commit del análisis y la publicación del job sin
+perder el trabajo ni duplicarlo.
 """
 
 from __future__ import annotations
@@ -246,7 +246,7 @@ def test_dispatch_pending_skips_rows_already_dispatched(app, monkeypatch):
 def test_analyze_survives_a_restart_between_commit_and_publish(
     app, regular_user, set_plan_limits, monkeypatch,
 ):
-    """El criterio de cierre del issue, de punta a punta: se crea el
+    """El escenario de punta a punta que justifica la outbox: se crea el
     análisis con Redis caído en ese instante (simulando el momento exacto en
     que la API podría reiniciarse o Redis fallar), y luego una llamada
     aparte -- como la reconciliación de arranque en run.py -- termina de

--- a/API/tests/integration/test_users.py
+++ b/API/tests/integration/test_users.py
@@ -144,11 +144,10 @@ def test_admin_can_actually_revoke_an_attribute(client, admin_user, regular_user
 def test_role_user_cannot_grant_attributes_to_itself(client, regular_user, auth_headers):
     """Un usuario normal no puede autoconcederse permisos.
 
-    Hoy lo tapa `require_role(Role.ADMIN)` en el endpoint. Cuando la fase 5 lo
-    retire para que el dueño de una organización pueda gestionar a los suyos, la
-    única barrera será `can_manage_user` — que empieza con
-    `if actor_id == target_id: return True` y convertiría esta llamada en una
-    escalada de privilegios. Este test es el que lo impedirá.
+    El endpoint delega en `can_administer_user`, que a propósito NO hereda el
+    `actor_id == target_id → True` de `can_manage_user` (válido para leer los
+    propios atributos, pero una escalada de privilegios si valiera también
+    para escribirlos): aquí nadie se gestiona a sí mismo salvo root.
     """
     resp = client.put(f"/users/{regular_user.id}/attributes",
                       headers=auth_headers(regular_user),

--- a/API/tests/postgres/test_migrations.py
+++ b/API/tests/postgres/test_migrations.py
@@ -110,7 +110,7 @@ def test_the_whole_chain_applies_to_an_empty_database(alembic_config, migrations
 )
 def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_config,
                                                                    migrations_url):
-    """Las cuatro migraciones de la fase 0, en los dos sentidos.
+    """Las cuatro migraciones de Iris cubiertas por este test, en los dos sentidos.
 
     Bajar y volver a subir es lo que hace falta cuando un despliegue se
     revierte, y es donde se ve si una bajada olvidó una columna: la subida
@@ -134,7 +134,7 @@ def test_the_phase_0_columns_survive_a_downgrade_and_a_new_upgrade(alembic_confi
     finally:
         engine.dispose()
 
-    # Cuatro pasos atrás: las cuatro migraciones de la fase 0.
+    # Cuatro pasos atrás: las cuatro migraciones cubiertas por este test.
     command.downgrade(alembic_config, "-4")
     command.upgrade(alembic_config, "head")
 

--- a/API/tests/unit/test_accounts_limit_coverage.py
+++ b/API/tests/unit/test_accounts_limit_coverage.py
@@ -25,8 +25,8 @@ from src.modules.accounts.services.limits import (
 pytestmark = pytest.mark.unit
 
 
-#: Claves que todavía no se exigen, y por qué. Vaciar esta lista es el objetivo,
-#: y desde la fase 5 está vacía: todas pasan por caja.
+#: Claves que todavía no se exigen, y por qué. Está vacía: todas pasan por
+#: caja, y así debe seguir.
 DEFERRED: dict[LimitKey, str] = {}
 
 SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "modules"

--- a/API/tests/unit/test_shared_exposure.py
+++ b/API/tests/unit/test_shared_exposure.py
@@ -1,4 +1,4 @@
-"""La única verdad sobre si un objetivo está expuesto a internet (L38).
+"""La única verdad sobre si un objetivo está expuesto a internet.
 
 La clasificación acota la prioridad de todo hallazgo en red privada (tope HIGH
 en ``score_finding``) y entra en el prompt del informe, que le dice al modelo

--- a/API/tests/unit/test_themis_ai_writer.py
+++ b/API/tests/unit/test_themis_ai_writer.py
@@ -153,10 +153,9 @@ def test_la_cola_se_recorta_por_prioridad_y_nunca_descarta_confirmados(monkeypat
 
 
 def test_confirmados_y_kev_tambien_se_recortan_al_tope(monkeypatch):
-    """#118: antes solo la cola ('rest') tenía tope — un scan con más
-    confirmados/KEV que _MAX_HIGHLIGHTED_FINDINGS generaba un payload sin
-    límite real pese a la constante. Deben recortarse igual, priorizando por
-    severidad."""
+    """Los hallazgos confirmados y los que están en KEV también se recortan
+    al tope cuando los hay de sobra, priorizando por severidad — no solo la
+    cola de hallazgos restantes."""
     muchos_confirmados = [
         _finding(
             title=f"CVE-2021-{40000 + i}", cve_ids=[f"CVE-2021-{40000 + i}"],
@@ -180,8 +179,8 @@ def test_confirmados_y_kev_tambien_se_recortan_al_tope(monkeypatch):
 
 
 def test_hallazgo_confirmado_y_en_kev_no_se_duplica_en_el_payload(monkeypatch):
-    """Antes de deduplicar, un hallazgo confirmado Y en KEV a la vez entraba
-    dos veces en la lista destacada (concatenación ingenua confirmed + kev)."""
+    """Un hallazgo confirmado Y en KEV a la vez no se duplica en la lista
+    destacada."""
     doble = _finding(confirmed=True, in_kev=True)
 
     hallazgos = _build([doble], monkeypatch)["hallazgos"]
@@ -190,8 +189,8 @@ def test_hallazgo_confirmado_y_en_kev_no_se_duplica_en_el_payload(monkeypatch):
 
 
 def test_rollup_de_servicios_se_recorta_al_tope_priorizando_severidad(monkeypatch):
-    """#118: un objetivo con muchos productos/puertos distintos (un rango de
-    red, no un solo host) podía generar un 'services_json' sin límite."""
+    """Un objetivo con muchos productos/puertos distintos (un rango de
+    red, no un solo host) también recorta 'services_json' al tope."""
     muchos_servicios = [
         _finding(
             title=f"Servicio {i}", cve_ids=[f"CVE-2020-{10000 + i}"],
@@ -256,7 +255,7 @@ def _build_nmap(open_ports: list, monkeypatch) -> dict:
 
 
 def test_ports_se_recortan_al_tope_pero_total_ports_sigue_siendo_el_real(monkeypatch):
-    """#118: un host con muchos más puertos abiertos que el tope no debe
+    """Un host con muchos más puertos abiertos que el tope no debe
     generar un 'ports_json' sin límite, pero '{{total_ports}}' debe seguir
     reportando el recuento real — nunca menos puertos de los que hay."""
     open_ports = [_open_port(1000 + i) for i in range(NmapAIWriter._MAX_PORTS + 25)]

--- a/web/app/src/assets/css/shared.css
+++ b/web/app/src/assets/css/shared.css
@@ -432,7 +432,7 @@ select option { background: var(--surface); color: var(--text); }
    seguía ganando en toda propiedad que el bloque scoped no declarase. Su
    `opacity: 0` volvía el toast invisible en cuanto Vue retiraba
    `.toast-enter-active` al acabar la animación de entrada (0.42 s), y su
-   `left: 50%` + `transform: translateX(-50%)` lo descolocaban. Ver #127. */
+   `left: 50%` + `transform: translateX(-50%)` lo descolocaban. */
 
 .badge {
   display: inline-block; padding: 2px 7px; border-radius: 4px;

--- a/web/app/src/components/shared/AccountMenu.vue
+++ b/web/app/src/components/shared/AccountMenu.vue
@@ -139,7 +139,7 @@ async function resend() {
   }
 }
 
-/** El toggle de organización es lo único que el plan sí "concede" (§5.1). */
+/** El toggle de organización es lo único que el plan sí "concede". */
 const canCreateOrganization = computed(() => account.plan?.organizationEnabled === true)
 
 function logout() {
@@ -153,9 +153,9 @@ let clickOutside = null
 onMounted(() => {
   // El plan y la organización se piden aquí y no en el arranque de la sesión:
   // este menú es el único que los necesita para decidir qué entradas enseña, y
-  // lo monta toda la aplicación. Cargarlos solo en MyPlanView dejaba el menú
+  // lo monta toda la aplicación. Cargarlos solo en MyPlanView dejaría el menú
   // sin la tarjeta del plan ni las entradas de organización en cualquier otra
-  // vista — que es justo lo que el §10.2 del diseño quería resolver.
+  // vista.
   if (auth.isAuthenticated && !account.plan) account.loadAll()
   if (auth.isAuthenticated && !profileStore.profile.first_name && !profileStore.profile.last_name) profileStore.loadProfile()
 

--- a/web/app/src/components/themis/ScanForm.vue
+++ b/web/app/src/components/themis/ScanForm.vue
@@ -45,9 +45,9 @@
       </div>
       <div v-if="type === 'nuclei'" class="nuclei-row">
         <div class="field field-lg">
-          <!-- "info" queda fuera por defecto (roadmap Fase U1, punto 1): son
-               miles de plantillas de tech-detect que, al ser confirmed=true
-               sin CVSS, el suelo de score_finding subiría todas a MEDIO. -->
+          <!-- "info" queda fuera por defecto: son miles de plantillas de
+               tech-detect que, al ser confirmed=true sin CVSS, el suelo de
+               score_finding subiría todas a MEDIO. -->
           <label>Severidades</label>
           <div class="strategy-picker" role="group" aria-label="Severidades de Nuclei">
             <button v-for="sev in NUCLEI_SEVERITIES" :key="sev.id" type="button"

--- a/web/app/src/components/themis/lybra/LybraLaunchPanel.vue
+++ b/web/app/src/components/themis/lybra/LybraLaunchPanel.vue
@@ -47,7 +47,7 @@
         <div v-if="showAuthRegister" class="auth-register-body">
           <p class="auth-register-hint">
             Objetivos (IP o CIDR) que has declarado autorizados para el autodescubrimiento, el fingerprinting
-            propio y las comprobaciones activas de Lybra (roadmap §6).
+            propio y las comprobaciones activas de Lybra.
           </p>
           <div v-if="authTargetsLoading" class="auth-loading">Cargando…</div>
           <ul v-else-if="authorizedTargets.length" class="auth-chip-list">
@@ -94,9 +94,9 @@ const props = defineProps({
 const emit = defineEmits(['launch', 'add-authorized-target', 'remove-authorized-target'])
 
 // Un solo modo: Lybra descubre los puertos del objetivo con su propio
-// transporte. Hubo un segundo modo —analizar los servicios de un escaneo Nmap
-// ya hecho— retirado en L52 junto al interruptor de "segunda opinión" que
-// lanzaba Nmap, Nikto y Nuclei como corroboradores.
+// transporte. No hay un modo que analice los servicios de un escaneo Nmap ya
+// hecho, ni un interruptor de "segunda opinión" que lance Nmap, Nikto y
+// Nuclei como corroboradores.
 const target = ref('')
 const ports = ref('')
 const timeout = ref(120)
@@ -184,7 +184,7 @@ function handleLaunch() {
 .btn-launch.loading .btn-spin { display: block; }
 .btn-spin { display: none; position: absolute; left: 50%; top: 50%; margin: -7px 0 0 -7px; width: 14px; height: 14px; border: 2px solid rgba(0,0,0,0.25); border-top-color: currentColor; border-radius: 50%; animation: seq-spin 0.6s linear infinite; }
 
-/* ── Estado de autorización del objetivo (roadmap §6) ── */
+/* ── Estado de autorización del objetivo ── */
 .auth-status {
   display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
   padding: 0.5rem 0.7rem; margin-top: -0.15rem;

--- a/web/app/src/components/themis/lybra/LybraResults.vue
+++ b/web/app/src/components/themis/lybra/LybraResults.vue
@@ -168,7 +168,8 @@
                               <!-- Desmentir un hallazgo y aceptar su riesgo son
                                    decisiones opuestas: la primera dice que el motor
                                    se equivocó, la segunda que el problema es real y
-                                   se asume. Hasta L35 compartían casilla. -->
+                                   se asume. Por eso llevan cada una su propio estado
+                                   en vez de compartir casilla. -->
                               <div class="f-actions">
                                 <template v-if="deciding === f.id">
                                   <input v-model="decisionReason" class="f-reason" type="text"
@@ -216,10 +217,11 @@
                 completo.
               </div>
 
-              <!-- No se muestra para un escaneo de agente (Fase I, `assetId`): ahí el
-                   fingerprinting y las comprobaciones activas están desactivados
-                   siempre, por diseño (modo payload) — autorizar el objetivo no
-                   cambiaría nada, así que sugerirlo sería un consejo sin efecto. -->
+              <!-- No se muestra para un escaneo de agente (uno nacido del inventario
+                   de un activo Hygeia, con `assetId`): ahí el fingerprinting y las
+                   comprobaciones activas están desactivados siempre, por diseño
+                   (modo payload) — autorizar el objetivo no cambiaría nada, así que
+                   sugerirlo sería un consejo sin efecto. -->
               <div v-if="scan.status === 'finished' && scan.targetAuthorized === false && !scan.assetId" class="body-unauth-hint">
                 Objetivo no autorizado: el fingerprinting propio y las comprobaciones activas de Lybra no se
                 ejecutaron sobre '{{ scan.target }}'. Autorízalo en el panel de lanzamiento para un análisis más completo.
@@ -518,13 +520,14 @@ function summary(scan) {
 }
 
 /**
- * Detecta un análisis de inventario (Fase I) con paquetes sin identificar.
+ * Detecta un análisis de inventario (nacido del inventario de software de un
+ * activo Hygeia) con paquetes sin identificar.
  *
- * `cpeResolved` (Fase I-b, `Finding.cpe_resolved`) da el número exacto de
- * paquetes que el matcher no pudo ni resolver a un CPE — ya no es una
- * heurística sobre ausencia de detecciones, que mezclaba eso con "KB sin
- * sincronizar" o simplemente "comprobado y limpio". El recuento lo hace ahora
- * el servidor, que ya tenía las filas delante.
+ * `cpeResolved` (`Finding.cpe_resolved`) da el número exacto de paquetes que
+ * el matcher no pudo ni resolver a un CPE — no es una heurística sobre
+ * ausencia de detecciones, que mezclaría eso con "KB sin sincronizar" o
+ * simplemente "comprobado y limpio". El recuento lo hace el servidor, que ya
+ * tiene las filas delante.
  *
  * Devuelve `null` si no aplica (sin paquetes, o todos resueltos), o
  * `{ packages, unresolved }` cuando el aviso debe mostrarse.

--- a/web/app/src/composables/useEml.js
+++ b/web/app/src/composables/useEml.js
@@ -5,8 +5,8 @@
  * decodificando las palabras codificadas MIME (=?charset?B/Q?...?=) habituales.
  * Se usa solo para rellenar el formulario (vista previa); el texto completo
  * del .eml se envía aparte a la API en el campo `message`, para que las
- * reglas de Fase 2 (enlaces del cuerpo, adjuntos reales, cadena Received)
- * puedan analizarlo.
+ * reglas de análisis más profundo (enlaces del cuerpo, adjuntos reales,
+ * cadena Received) puedan analizarlo.
  *
  * @example
  * import { parseEml } from '@/composables/useEml'

--- a/web/app/src/stores/accountStore.js
+++ b/web/app/src/stores/accountStore.js
@@ -6,9 +6,9 @@ import { useToastStore } from '@/stores/toastStore'
 /**
  * Store de la capa comercial: plan efectivo, consumo y organización.
  *
- * El plan NO viaja en el JWT a propósito (ver el §14 del documento de diseño):
- * un cambio de plan tiene que notarse en la siguiente petición, no cuando
- * caduque el token. Por eso se pide al servidor y se guarda aquí.
+ * El plan NO viaja en el JWT a propósito: un cambio de plan tiene que
+ * notarse en la siguiente petición, no cuando caduque el token. Por eso se
+ * pide al servidor y se guarda aquí.
  *
  * @module accountStore
  */

--- a/web/app/src/stores/themisStore.js
+++ b/web/app/src/stores/themisStore.js
@@ -25,11 +25,11 @@ export const useThemisStore = defineStore('themis', () => {
 
   /* ════════════════════════════════ MUNDOS ═════════════════════════════ */
   // Themis vive en tres mundos: el motor propio (Lybra), los escáneres
-  // externos (Nmap/Nikto/Nuclei) y los agentes de Hygeia (Fase I: escaneos
-  // Lybra nacidos del inventario de software de un activo, que se navegan por
+  // externos (Nmap/Nikto/Nuclei) y los agentes de Hygeia (escaneos Lybra
+  // nacidos del inventario de software de un activo, que se navegan por
   // agente en vez de mezclarse en la feed del motor). El toggle de ThemisView
-  // conmuta entre ellos. Lybra es el mundo por defecto (roadmap Fase 6: el
-  // motor propio es el protagonista, los externos son segunda opinión).
+  // conmuta entre ellos. Lybra es el mundo por defecto: el motor propio es el
+  // protagonista, los externos son segunda opinión.
   const world = ref('lybra') // 'external' | 'lybra' | 'agents'
   function setWorld(w) { world.value = w }
 
@@ -51,7 +51,7 @@ export const useThemisStore = defineStore('themis', () => {
     nikto:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
     lybra:   { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
     nuclei:  { results: [], loading: false, page: 1, totalCount: 0, perPage: 10, loadedPages: 1, error: null },
-    // Fase I: los escaneos del activo Hygeia seleccionado. Mismo tipo de
+    // Los escaneos del activo Hygeia seleccionado. Mismo tipo de
     // escaneo que `lybra` y misma forma de estado —por eso `LybraResults` se
     // reutiliza tal cual—, pero su propia lista: el backend los sirve por
     // separado (`assetId`) y jamás los mezcla con los del panel.
@@ -60,7 +60,7 @@ export const useThemisStore = defineStore('themis', () => {
 
   // Escaneos Nmap terminados, para el modo "analizar un Nmap existente" de Lybra.
 
-  // Registro de objetivos autorizados (roadmap §6): gate legal por-usuario que
+  // Registro de objetivos autorizados: gate legal por-usuario que
   // desbloquea el autodescubrimiento, el fingerprinting propio y las
   // comprobaciones activas de Lybra sobre un objetivo concreto.
   const authorizedTargets = reactive({ items: [], loading: false, error: null })
@@ -256,7 +256,7 @@ export const useThemisStore = defineStore('themis', () => {
   async function launchNikto(payload) {
     return _launch('/themis/nikto', payload, 'nikto')
   }
-  /** Lanza un escaneo Nuclei (roadmap Fase U1). */
+  /** Lanza un escaneo Nuclei. */
   async function launchNuclei(payload) {
     return _launch('/themis/nuclei', payload, 'nuclei')
   }
@@ -274,13 +274,11 @@ export const useThemisStore = defineStore('themis', () => {
    * tarjetas ya visibles (que vive en `LybraResults`, indexado por id de
    * escaneo, y por tanto sobrevive a que la lista se vuelva a pintar).
    *
-   * Antes esto pedía la página siguiente y la concatenaba, avanzando `d.page`.
-   * Ese avance era el fallo: `loadScans` lee el mismo campo entendiendo que es
-   * la única página a mostrar, así que el siguiente refresco reemplazaba los
-   * treinta escaneos en pantalla por los diez de la tercera página. Ahora sólo
-   * se agranda la ventana y se recarga con la ruta normal — una petición, sin
-   * dos caminos que puedan divergir, y sin el duplicado que aparecía cuando
-   * entraba un escaneo nuevo entre una página y la siguiente.
+   * Solo se agranda la ventana (`d.loadedPages`) y se recarga con la ruta
+   * normal de `loadScans`, que entiende ese campo como el número de páginas
+   * a mostrar de una sola vez — una única petición, sin un `d.page` que avance
+   * por separado y pueda desincronizarse de la ventana visible, y sin
+   * duplicados cuando entra un escaneo nuevo entre una página y la siguiente.
    */
   async function loadMoreLybraScans(type = 'lybra') {
     const d = _scandata(type)
@@ -289,7 +287,7 @@ export const useThemisStore = defineStore('themis', () => {
     await loadScans(type)
   }
 
-  /* ── AGENTES (Fase I: escaneos nacidos del inventario de Hygeia) ── */
+  /* ── AGENTES (escaneos nacidos del inventario de Hygeia) ── */
 
   /**
    * Selecciona un activo de Hygeia y carga sus escaneos.
@@ -325,7 +323,7 @@ export const useThemisStore = defineStore('themis', () => {
     finally { authorizedTargets.loading = false }
   }
 
-  /* ── FRESCURA DE LA BASE DE CONOCIMIENTO (L36) ── */
+  /* ── FRESCURA DE LA BASE DE CONOCIMIENTO ── */
 
   /**
    * Estado de sincronización de NVD, KEV y EPSS.
@@ -390,13 +388,7 @@ export const useThemisStore = defineStore('themis', () => {
     return true
   }
 
-  /**
-   * Lanza un escaneo Lybra: { target, ports?, timeout }.
-   *
-   * Hubo un segundo modo, { sourceScanId }, que analizaba los servicios de un
-   * escaneo Nmap previo, y un flag { deep } que lanzaba Nmap, Nikto y Nuclei
-   * como corroboradores. Ambos se retiraron en L52.
-   */
+  /** Lanza un escaneo Lybra: { target, ports?, timeout }. */
   async function launchLybra(payload) {
     launching.value = true
     try {

--- a/web/app/src/views/LandingView.vue
+++ b/web/app/src/views/LandingView.vue
@@ -402,9 +402,9 @@ const philosophyTextRef = ref(null)
 // la misma página gastaba dos peticiones para pintar el mismo número.
 const { version: appVersion } = useAppVersion()
 
-/* Cerrar al pulsar fuera y con Escape, con el composable de la Fase 5 en vez
-   del listener a mano que había en onMounted. El menú móvil se cierra también
-   al pulsar su propio botón, así que el selector cubre los dos. */
+/* Cerrar al pulsar fuera y con Escape, con el composable `useDismissable` en
+   vez de un listener a mano. El menú móvil se cierra también al pulsar su
+   propio botón, así que el selector cubre los dos. */
 useDismissable('.nav-dd', () => { toolsOpen.value = false; docsOpen.value = false })
 useDismissable('.mobile-menu, .menu-toggle', () => { mobileOpen.value = false })
 

--- a/web/app/src/views/MyPlanView.vue
+++ b/web/app/src/views/MyPlanView.vue
@@ -25,9 +25,9 @@
 
         <section v-if="source" class="source">{{ source }}</section>
 
-        <!-- Sin pasarela de pago no hay autoservicio real (§1 del diseño): el
-             plan lo asigna root a mano. Decirlo aquí es más honesto que un
-             botón "Cambiar de plan" que no haría nada al pulsarlo. -->
+        <!-- Sin pasarela de pago no hay autoservicio real: el plan lo asigna
+             root a mano. Decirlo aquí es más honesto que un botón "Cambiar
+             de plan" que no haría nada al pulsarlo. -->
         <p class="upgrade-hint">
           ¿Quieres subir de plan? Escribe a quien administre tu cuenta —
           todavía no hay cambio de plan en autoservicio.

--- a/web/app/src/views/PlansView.vue
+++ b/web/app/src/views/PlansView.vue
@@ -87,8 +87,8 @@ const auth = useAuthStore()
 /**
  * ¿Es el plan que tiene contratado ahora mismo?
  *
- * Sin pasarela no hay autoservicio de verdad — el §1 del diseño dice que el
- * plan lo asigna root a mano — así que el resto de tarjetas no llevan a
+ * Sin pasarela no hay autoservicio de verdad — el plan lo asigna root a
+ * mano — así que el resto de tarjetas no llevan a
  * ningún sitio que haga algo: mostrar cuál es la propia es lo único honesto
  * que esta pantalla puede ofrecer sin fingir una acción que no existe.
  */
@@ -181,9 +181,9 @@ onMounted(async () => {
 .card-cta--current { background: transparent; }
 
 /* No es un botón: no hay ninguna acción que hacer desde aquí. Sin pasarela,
-   el cambio de plan lo mueve root a mano (§1 del diseño) — decir "Entrar" o
-   "Ver mi plan" en una tarjeta que no es la propia prometía una acción que
-   la pantalla nunca cumplía. */
+   el cambio de plan lo mueve root a mano — decir "Entrar" o "Ver mi plan" en
+   una tarjeta que no es la propia prometía una acción que la pantalla nunca
+   cumplía. */
 .card-cta--muted {
   background: transparent; border-color: var(--border-med);
   color: var(--text-muted); font-weight: 500; cursor: default;

--- a/web/app/src/views/ThemisView.vue
+++ b/web/app/src/views/ThemisView.vue
@@ -79,7 +79,7 @@
         </template>
       </div>
 
-      <!-- ═══════════ MUNDO: AGENTES (Fase I) ═══════════ -->
+      <!-- ═══════════ MUNDO: AGENTES ═══════════ -->
       <div v-else-if="store.world === 'agents'" key="agents" class="world-block">
         <AgentScansPanel
           :assets="hygeiaStore.state.assets"
@@ -297,7 +297,7 @@ const selectableFolders = computed(() =>
 // la SPA: si el usuario cambió a "escáneres externos" y vuelve a entrar a
 // Themis después, sin esto vería el mundo que dejó seleccionado la vez
 // anterior en vez de entrar siempre por Lybra (el motor propio, protagonista
-// del roadmap). El hub de Themis puede forzar un mundo/vista concretos vía
+// de Themis). El hub de Themis puede forzar un mundo/vista concretos vía
 // query params (?world=external&view=history) para sus atajos rápidos.
 onMounted(() => {
   const world = ['external', 'agents'].includes(route.query.world) ? route.query.world : 'lybra'


### PR DESCRIPTION
## El problema

Último bloque del plan de limpieza (Iris → [#565](https://github.com/ProjectEllysia/EllysiaServer/pull/565)/[#567](https://github.com/ProjectEllysia/EllysiaServer/pull/567), Hygeia → [#566](https://github.com/ProjectEllysia/EllysiaServer/pull/566), Themis/Lybra → [#569](https://github.com/ProjectEllysia/EllysiaServer/pull/569)/[#570](https://github.com/ProjectEllysia/EllysiaServer/pull/570)): lo que quedaba en `accounts`, `system` (incluida `config_reading.py`, el fichero con más citas de todo el lote — apuntaba a `plans/roadmap-ellysia.md`, `plans/planes-y-organizaciones.md` y `plans/mailbox-connector.md` por secciones sueltas), `tools/scribe`, sus tests, y los comentarios del SPA que citaban las mismas fases (el store y las vistas de Lybra en Themis, el diseño de planes en `MyPlanView`/`PlansView`, el JWT sin plan en `accountStore`).

## Qué cambia

Mismo criterio que en los PRs anteriores del lote: etiqueta redundante → se borra; etiqueta que sustituía una explicación real → se cambia por la explicación en prosa; narración puramente histórica → se elimina.

**Con una diferencia importante en este lote**: varios docstrings no solo citaban un apartado del plan, estaban **desactualizados de verdad** — describían funcionalidad como pendiente de "una fase futura" cuando ya lleva tiempo implementada y en uso. Se verificó cada caso contra el código antes de corregirlo, no se tocó a ciegas:

- `accounts/managers/plans.py` y `services/entitlements.py` decían que `SubscriptionManager`, `QuotaManager` y la resolución de cupos por organización "llegan en una fase posterior" — ya existen y están conectados (`resolve_entitlement` ya hace el `max()` entre cupo personal y de organización).
- `accounts/services/limits.py` documentaba una clase `LimitSpec` que nunca llegó a construirse.
- `accounts/model.py` marcaba `Organization` y `UsageCounter` como "sin usar todavía".
- `tests/integration/test_users.py::test_role_user_cannot_grant_attributes_to_itself` describía una migración de `can_manage_user` como algo futuro; el modelo de permisos consciente de organización ya está implementado en `users/managers.py`.

## Qué NO cambia

Solo texto: docstrings y comentarios, tanto en Python como en el SPA. Ningún nombre de función, clase, variable, componente o test se ha tocado; ninguna lógica se ha movido ni reescrito.

## Validación

```
pytest -m unit -k "config or accounts or users or system or shared or herald or scribe"   # 398 passed, 2 skipped
pytest tests/integration/test_kb_repository.py test_aegis_outbox.py test_organizations.py \
       test_password_reset.py test_plans.py test_quotas.py test_registration.py \
       test_taskqueue_outbox.py test_users.py                                             # 183 passed
```

SPA:
```
npm run test:hygeia            # 74 passed
node test/iris.intake.test.mjs # 23 passed
```
Los `.vue` tocados se validaron con `@vue/compiler-sfc` (`parse`/`compileScript`/`compileTemplate`/`compileStyle`) porque `npm run build` falla en este entorno por una dependencia privada no instalada (`@projectellysia/acheron-core-web`), ajena a esta PR.

Sin líneas nuevas por encima de 100 columnas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)