### PR TITLE
fix(iris): el informe de un reenvío describe el mensaje que produjo el veredicto (B15)

### DIFF
--- a/API/alembic/versions/e2a9c4d7f1b3_add_iris_analysis_context_metadata.py
+++ b/API/alembic/versions/e2a9c4d7f1b3_add_iris_analysis_context_metadata.py
@@ -1,0 +1,52 @@
+"""iris: contexto ganador de un reenvío (IrisAnalysis + IrisRuleResult)
+
+Un reenvío "reportar phishing" trae dos mensajes —el envoltorio y el original
+adjunto— y el motor se queda con el peor veredicto de los dos. Sin guardar
+cuál ganó, el informe describía siempre el original aunque el veredicto
+viniera del envoltorio. Estas columnas guardan el contexto ganador, por qué
+ganó, un resumen del otro, y a qué contexto pertenece cada fila de regla.
+
+Revision ID: e2a9c4d7f1b3
+Revises: d8b3f2c05e91
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e2a9c4d7f1b3'
+down_revision: Union[str, Sequence[str], None] = 'd8b3f2c05e91'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisAnalysis', sa.Column('winning_context', sa.String(length=16), nullable=True))
+    op.add_column('IrisAnalysis', sa.Column('winning_reason', sa.Text(), nullable=True))
+    op.add_column('IrisAnalysis', sa.Column('secondary_context',
+                                            postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('IrisRuleResult', sa.Column('context_type', sa.String(length=16), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Borra antes las filas de regla del contexto secundario: sin la columna
+    ``context_type`` se mezclarían con las del ganador y el informe mostraría
+    las reglas de los dos mensajes como si fueran de uno solo.
+    """
+    op.execute(
+        'DELETE FROM "IrisRuleResult" r USING "IrisAnalysis" a '
+        'WHERE r.analysis_id = a.id AND a.winning_context IS NOT NULL '
+        'AND r.context_type IS NOT NULL AND r.context_type <> a.winning_context'
+    )
+    op.drop_column('IrisRuleResult', 'context_type')
+    op.drop_column('IrisAnalysis', 'secondary_context')
+    op.drop_column('IrisAnalysis', 'winning_reason')
+    op.drop_column('IrisAnalysis', 'winning_context')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -53,7 +53,15 @@ from ..services.failures import (
     classify_failure,
 )
 from ..services.parsers import build_path, parse_received_line
-from ..services.quality import AnalysisQuality, assess_quality, cap_verdict, detector_version
+from ..services.contexts import (
+    CONTEXT_INNER,
+    CONTEXT_WRAPPER,
+    ContextEvaluation,
+    choose_winning_evaluation,
+    context_of_type,
+    preview_headers,
+)
+from ..services.quality import assess_quality, cap_verdict, detector_version
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
 
@@ -326,23 +334,29 @@ class IrisManager(TaskTrackingMixin):
         return self.task_progress_of(analysis_id)
 
     def get_analysis_results(self, analysis_id: int) -> Dict[str, Any]:
-        """Return the full analysis report for a finished analysis.
+        """Informe completo de un análisis terminado.
 
-        The report includes the original headers, per-rule results,
-        the total score, the textual verdict, and a flat list of
-        actionable recommendations.
+        Todo lo que describe el mensaje —reglas, señales principales,
+        recomendaciones y vista previa de cabeceras— sale del **contexto
+        ganador** (``IrisAnalysis.winning_context``): en un reenvío cuyo
+        envoltorio es más grave que el original, el informe habla del
+        envoltorio, porque es el que produjo el veredicto. El otro mensaje
+        viaja aparte en ``secondaryContext``.
 
         Args:
-            analysis_id: Primary key of the finished analysis.
+            analysis_id: Primary key del análisis terminado.
 
         Returns:
-            A dict with keys: analysisId, status, rawHeaders, totalScore,
-            verdict, startedAt, finishedAt, user, rules, recommendations.
+            dict: El informe con claves camelCase (``analysisId``,
+                ``verdict``, ``totalScore``, ``rules``, ``winningContext``,
+                ``secondaryContext``, ``previewHeaders``…; ver
+                ``AnalysisDetailResponseSchema``). ``secondaryContext`` es
+                ``None`` cuando el mensaje no era un reenvío.
 
         Raises:
-            IrisAnalysisNotFoundError: If *analysis_id* does not exist.
-            IrisAnalysisNotReadyError: If the analysis is not yet
-                ``finished`` (callers should poll ``/status`` first).
+            IrisAnalysisNotFoundError: Si *analysis_id* no existe.
+            IrisAnalysisNotReadyError: Si el análisis aún no está
+                ``finished`` (el llamante debe sondear ``/status`` antes).
         """
         analysis = build_repository(IrisAnalysisRepository).get_by_id(analysis_id)
         if not analysis:
@@ -351,34 +365,37 @@ class IrisManager(TaskTrackingMixin):
         if analysis.status != "finished":
             raise IrisAnalysisNotReadyError(analysis_id, analysis.status)
 
-        rules = build_repository(IrisRuleResultRepository).get_by_analysis(analysis_id)
-
-        rules_data = [
-            {
-                "ruleName": rule.rule_name,
-                "category": rule.category,
-                "score": rule.score,
-                "verdict": rule.verdict,
-                "details": rule.details,
-                "recommendation": rule.recommendation,
-            }
-            for rule in rules
-        ]
+        rule_repo = build_repository(IrisRuleResultRepository)
+        # Un análisis sin contexto ganador guardado solo tiene filas del
+        # contexto que ganó, sin marcar: se leen todas, como siempre.
+        rules = rule_repo.get_by_analysis(analysis_id, context_type=analysis.winning_context)
+        rules_data = [self._rule_to_dict(rule) for rule in rules]
 
         recommendations = [
             rule["recommendation"] for rule in rules_data
             if rule["recommendation"] is not None
         ]
 
+        secondary_context = None
+        if analysis.secondary_context:
+            secondary_rules = rule_repo.get_by_analysis(
+                analysis_id, context_type=analysis.secondary_context.get("contextType"),
+            )
+            secondary_context = {
+                **analysis.secondary_context,
+                "rules": [self._rule_to_dict(rule) for rule in secondary_rules],
+            }
+
         from src.modules.users import UserManager
         user = UserManager().get_user_by_id(analysis.user_id)
         username = user.username if user else "unknown"
 
-        # Re-parsed on demand (same no-extra-column pattern as
-        # get_analysis_path/get_analysis_iocs) purely to surface whether
-        # this analysis unwrapped a "report phishing" forward — the
-        # persisted rule results already reflect the unwrapped original.
+        # Se reparsea bajo demanda para la identidad del envoltorio y la vista
+        # previa: el raw ya está guardado y cifrado, y duplicar sus cabeceras
+        # en columnas sería otra copia que purgar en la retención.
         context = parse_raw_message(analysis.raw_headers or "")
+        winning_message = context_of_type(context, analysis.winning_context)
+        preview = preview_headers(winning_message) if analysis.raw_headers else None
 
         return {
             "analysisId": analysis.id,
@@ -396,6 +413,10 @@ class IrisManager(TaskTrackingMixin):
             "unwrappedFromForward": context.unwrapped_from_forward,
             "wrapperFrom": context.wrapper_from or None,
             "wrapperSubject": context.wrapper_subject or None,
+            "winningContext": analysis.winning_context,
+            "winningReason": analysis.winning_reason,
+            "secondaryContext": secondary_context,
+            "previewHeaders": preview,
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
             "analysisQuality": analysis.analysis_quality,
@@ -406,6 +427,26 @@ class IrisManager(TaskTrackingMixin):
             "user": username,
             "rules": rules_data,
             "recommendations": recommendations,
+        }
+
+    @staticmethod
+    def _rule_to_dict(rule: IrisRuleResult) -> Dict[str, Any]:
+        """Serializa una fila de regla con las claves camelCase de la API.
+
+        Args:
+            rule: Fila ``IrisRuleResult`` persistida.
+
+        Returns:
+            dict: ``ruleName``, ``category``, ``score``, ``verdict``,
+                ``details`` y ``recommendation``.
+        """
+        return {
+            "ruleName": rule.rule_name,
+            "category": rule.category,
+            "score": rule.score,
+            "verdict": rule.verdict,
+            "details": rule.details,
+            "recommendation": rule.recommendation,
         }
 
     @classmethod
@@ -459,12 +500,21 @@ class IrisManager(TaskTrackingMixin):
         return self.analyze(analysis.raw_headers, user_id, title=title)
 
     def get_analysis_path(self, analysis_id: int, user_id: int) -> Dict[str, Any]:
-        """Return the parsed Received-chain path for an analysis.
+        """Cadena Received del mensaje que produjo el veredicto.
 
-        The path is derived on demand from ``raw_headers`` — no extra
-        column is needed. Returns ``available: false`` for headers-only
-        submissions (no full ``.eml`` means no Received chain to
-        inspect).
+        Se deriva bajo demanda del raw, del contexto ganador del análisis (el
+        envoltorio de un reenvío si fue él quien decidió el veredicto; si no,
+        el original). ``available: false`` en envíos de solo cabeceras sin
+        cadena Received que inspeccionar.
+
+        Args:
+            analysis_id: Primary key del análisis.
+            user_id: Usuario que pide la vista; debe ser el dueño.
+
+        Returns:
+            dict: ``analysisId``, ``contextType`` (el contexto ganador, o
+                ``None`` en análisis que no lo guardaron) y los campos de
+                ``build_path`` (``available``, ``hops``, ``transitions``…).
 
         Raises:
             IrisRawMessagePurgedError: La retención ya purgó el raw de este
@@ -472,13 +522,34 @@ class IrisManager(TaskTrackingMixin):
                 aquí no hay ningún raw que parsear, ni cabeceras.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
-        if analysis.raw_headers is None:
-            raise IrisRawMessagePurgedError(analysis_id)
-        context = parse_raw_message(analysis.raw_headers or "")
+        context = self._winning_message_context(analysis)
         return {
             "analysisId": analysis.id,
+            "contextType": analysis.winning_context,
             **build_path(context.received_headers),
         }
+
+    @staticmethod
+    def _winning_message_context(analysis: IrisAnalysis):
+        """Parsea el raw del análisis y devuelve el contexto que ganó.
+
+        Las vistas derivadas del raw (cadena Received, IOCs) tienen que
+        describir el mismo mensaje que el veredicto: en un reenvío cuyo
+        envoltorio fue más grave, el envoltorio.
+
+        Args:
+            analysis: Análisis ya cargado y con su propiedad comprobada.
+
+        Returns:
+            MessageContext: El contexto ganador (el interno si el análisis no
+                guardó ninguno).
+
+        Raises:
+            IrisRawMessagePurgedError: La retención ya purgó el raw.
+        """
+        if analysis.raw_headers is None:
+            raise IrisRawMessagePurgedError(analysis.id)
+        return context_of_type(parse_raw_message(analysis.raw_headers), analysis.winning_context)
 
     _EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+")
 
@@ -491,9 +562,12 @@ class IrisManager(TaskTrackingMixin):
         the parsed ``MessageContext`` already gives a uniform view of
         headers, body links and the Received chain regardless of which
         rules fired, so this stays correct as rules are added/changed.
+        Los IOCs salen del contexto ganador, el mismo mensaje que describe el
+        veredicto (ver ``_winning_message_context``).
 
         Returns:
-            A dict with ``domains``, ``urls``, ``ips``, ``emails`` and
+            A dict with ``analysisId``, ``contextType`` (contexto ganador, o
+            ``None`` en análisis que no lo guardaron), ``domains``, ``urls``, ``ips``, ``emails`` and
             ``hashes`` (SHA256 of every attachment, not just ones a rule
             flagged — an analyst pivoting to a threat-intel lookup wants
             the hash regardless of whether a heuristic fired) — each a
@@ -505,9 +579,7 @@ class IrisManager(TaskTrackingMixin):
                 análisis.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
-        if analysis.raw_headers is None:
-            raise IrisRawMessagePurgedError(analysis_id)
-        context = parse_raw_message(analysis.raw_headers or "")
+        context = self._winning_message_context(analysis)
 
         domains: set[str] = set()
         emails: set[str] = set()
@@ -544,6 +616,7 @@ class IrisManager(TaskTrackingMixin):
 
         return {
             "analysisId": analysis.id,
+            "contextType": analysis.winning_context,
             "domains": sorted(domains),
             "urls": sorted(urls),
             "ips": sorted(ips),
@@ -1011,14 +1084,18 @@ class IrisManager(TaskTrackingMixin):
                 # `_persist_analysis_results`), y leer el registro dos veces
                 # los desalinearía si alguien registrara una regla entremedias.
                 rules_defs = iris_rules.get_rules()
-                chosen = self._evaluate_contexts(analysis_id, context, job, rules_defs)
-                if chosen is None:
+                evaluations = self._evaluate_contexts(analysis_id, context, job, rules_defs)
+                if evaluations is None:
                     return  # cancelado: no es un fallo, no hay nada que persistir
-                verdict, total_score, gate_reasons, results, quality = chosen
+                winner, secondary, winning_reason = choose_winning_evaluation(
+                    evaluations, _VERDICT_SEVERITY,
+                )
+                verdict, total_score = winner.verdict, winner.total_score
 
-                self._persist_analysis_results(analysis_id, rules_defs, results,
-                                               verdict, total_score, gate_reasons,
-                                               quality, detector_version(rules_defs))
+                self._persist_analysis_results(analysis_id, rules_defs, winner,
+                                               detector_version(rules_defs),
+                                               secondary=secondary,
+                                               winning_reason=winning_reason)
             except Exception as e:
                 logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
                 self._fail_analysis(analysis_id, classify_failure(e))
@@ -1030,19 +1107,27 @@ class IrisManager(TaskTrackingMixin):
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
 
     def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
-                           ) -> Optional[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]]:
-        """Ejecuta el catálogo de reglas y devuelve la evaluación ganadora.
+                           ) -> Optional[List[ContextEvaluation]]:
+        """Ejecuta el catálogo de reglas sobre cada contexto del mensaje.
 
-        Extraído de :meth:`_run_analysis` al envolver esa función en un único
-        manejador de ciclo de vida: el bucle es la parte larga, y
-        dejarlo en línea dentro del ``try`` habría escondido qué se está
-        protegiendo exactamente.
+        Vive aparte de :meth:`_run_analysis` para que el ``try`` de ciclo de
+        vida de esa función deje ver qué protege: el bucle es la parte larga.
+        Elegir el ganador no se hace aquí sino en
+        ``services/contexts.choose_winning_evaluation``.
+
+        Args:
+            analysis_id: Primary key del análisis (solo para el log).
+            context: ``MessageContext`` parseado; si trae ``wrapper_context``,
+                se evalúa también el envoltorio.
+            job: Contexto del job de TaskQueue (cancelación y progreso).
+            rules_defs: Catálogo de reglas, leído una sola vez por análisis.
 
         Returns:
-            La tupla ``(verdict, total_score, gate_reasons, results, quality)``
-            de la evaluación ganadora, o ``None`` si fue cancelada a mitad
-            (que no es un fallo: no se persiste nada y la cancelación ya dejó
-            su propio estado terminal).
+            Optional[List[ContextEvaluation]]: Una evaluación por contexto,
+                primero la del interno (``CONTEXT_INNER``) y, en un reenvío,
+                después la del envoltorio (``CONTEXT_WRAPPER``). ``None`` si el
+                análisis se canceló a mitad, que no es un fallo: no se persiste
+                nada y la cancelación ya dejó su propio estado terminal.
         """
         # A "report phishing" forward is safe to unwrap unconditionally
         # for a human-submitted analysis, but the same message/rfc822
@@ -1052,15 +1137,15 @@ class IrisManager(TaskTrackingMixin):
         # mail entirely. Evaluate both when a wrapper exists and keep the
         # worse verdict; this matters most for unattended ingestion
         # (mailbox ingestion), where there is no human eyeballing the wrapper first.
-        contexts_to_evaluate = [context]
+        contexts_to_evaluate = [(CONTEXT_INNER, context)]
         if context.wrapper_context is not None:
-            contexts_to_evaluate.append(context.wrapper_context)
+            contexts_to_evaluate.append((CONTEXT_WRAPPER, context.wrapper_context))
 
         total_steps = len(rules_defs) * len(contexts_to_evaluate)
         completed_steps = 0
 
-        evaluations: List[tuple[str, float, list[str], List[RuleResult], AnalysisQuality]] = []
-        for evaluated_context in contexts_to_evaluate:
+        evaluations: List[ContextEvaluation] = []
+        for context_type, evaluated_context in contexts_to_evaluate:
             results: List[RuleResult] = []
             named_results: Dict[str, RuleResult] = {}
 
@@ -1105,65 +1190,82 @@ class IrisManager(TaskTrackingMixin):
             # aparte de la interfaz.
             quality = assess_quality(rules_defs, results)
             verdict, quality_reasons = cap_verdict(verdict, quality)
-            evaluations.append((verdict, total_score, gate_reasons + quality_reasons,
-                                results, quality))
+            evaluations.append(ContextEvaluation(
+                context_type=context_type, verdict=verdict, total_score=total_score,
+                gate_reasons=gate_reasons + quality_reasons, results=results, quality=quality,
+            ))
 
-        # Worse verdict wins across contexts; on a tie, keep the first
-        # (the unwrapped/inner message — the one ``contexts_to_evaluate``
-        # is ordered by, and the one every other persisted field
-        # describes) rather than the wrapper.
-        chosen = evaluations[0]
-        for evaluation in evaluations[1:]:
-            if _VERDICT_SEVERITY[evaluation[0]] > _VERDICT_SEVERITY[chosen[0]]:
-                chosen = evaluation
-        return chosen
+        return evaluations
 
     @staticmethod
-    def _persist_analysis_results(analysis_id: int, rules_defs: List[dict], results: List[RuleResult],
-                                   verdict: str, total_score: float, gate_reasons: list[str],
-                                   quality: AnalysisQuality, detector: str) -> None:
-        """Persiste todas las filas de regla y el estado final del análisis
-        en una única transacción.
+    def _persist_analysis_results(analysis_id: int, rules_defs: List[dict],
+                                   winner: ContextEvaluation, detector: str,
+                                   secondary: Optional[ContextEvaluation] = None,
+                                   winning_reason: Optional[str] = None) -> None:
+        """Persiste las filas de regla y el estado final del análisis en una
+        única transacción.
 
-        Antes cada regla abría (y confirmaba) su propio ``UnitOfWork`` --
-        unos 40 commits por análisis, y una cancelación a mitad de bucle
-        dejaba huérfanas las filas ya confirmadas de un análisis
-        ``cancelled``. Una sola transacción para todo el lote
-        arregla las dos cosas: es atómica, y un ``return`` antes de este
-        punto (cancelación) ya no deja nada confirmado.
+        Una sola transacción para todo el lote hace que una cancelación a
+        mitad de bucle (un ``return`` antes de este punto) no deje filas de
+        regla confirmadas de un análisis ``cancelled``.
 
-        La escritura final de ``status="finished"`` (junto con los
-        campos de score/veredicto que la acompañan) pasa por
-        ``IrisAnalysisRepository.transition_if_state()``, que solo la
-        aplica si la fila sigue ``running``. Sin esa condición, una
-        cancelación que ``cancel_analysis()`` confirme en el hueco estrecho
-        entre que este método lee la fila y este método confirma su propia
-        transacción se sobreescribiría en silencio de vuelta a ``finished``
-        -- exactamente la carrera que este issue viene a cerrar. Las filas
-        de regla de arriba se escriben de todos modos: son ciertas pase lo
-        que pase, y nunca quedan huérfanas gracias al agrupado en una sola
-        transacción que ya describe este docstring.
+        Se guardan las reglas de **los dos** contextos de un reenvío, cada
+        fila con su ``context_type``, para que el informe pueda enseñar las
+        del ganador y conservar las otras como contexto secundario. El
+        análisis registra qué contexto ganó, por qué, y un resumen del otro.
+
+        La escritura final de ``status="finished"`` (con score, veredicto y
+        contexto) pasa por ``IrisAnalysisRepository.transition_if_state()``,
+        que solo la aplica si la fila sigue ``running``: así una cancelación
+        que ``cancel_analysis()`` confirme entre la lectura y este commit no
+        se sobreescribe en silencio de vuelta a ``finished``. Las filas de
+        regla se escriben de todos modos: son ciertas pase lo que pase.
+
+        Args:
+            analysis_id: Primary key del análisis.
+            rules_defs: Catálogo evaluado; se empareja por posición con los
+                ``results`` de cada evaluación.
+            winner: Evaluación que decide el veredicto.
+            detector: Marca del catálogo (``detector_version``).
+            secondary: Evaluación del otro contexto de un reenvío. Por defecto
+                ``None`` (el mensaje no era un reenvío).
+            winning_reason: Por qué ganó ``winner``; ``None`` sin reenvío.
         """
         with UnitOfWork() as uow:
             rule_repo = IrisRuleResultRepository(uow)
-            for position, (rule_def, rule_result) in enumerate(zip(rules_defs, results)):
-                rule_repo.save(IrisRuleResult(
-                    analysis_id=analysis_id,
-                    rule_name=rule_def["name"],
-                    category=rule_def["category"],
-                    score=rule_result.score,
-                    verdict=rule_result.verdict,
-                    details=rule_result.details,
-                    recommendation=rule_result.recommendation,
-                    position=position,
-                ))
+            for evaluation in (winner, secondary):
+                if evaluation is None:
+                    continue
+                for position, (rule_def, rule_result) in enumerate(zip(rules_defs, evaluation.results)):
+                    rule_repo.save(IrisRuleResult(
+                        analysis_id=analysis_id,
+                        rule_name=rule_def["name"],
+                        category=rule_def["category"],
+                        score=rule_result.score,
+                        verdict=rule_result.verdict,
+                        details=rule_result.details,
+                        recommendation=rule_result.recommendation,
+                        position=position,
+                        context_type=evaluation.context_type,
+                    ))
+
+            secondary_summary = None
+            if secondary is not None:
+                secondary_summary = {
+                    "contextType": secondary.context_type,
+                    "verdict": secondary.verdict,
+                    "totalScore": secondary.total_score,
+                    "analysisQuality": secondary.quality.quality,
+                }
 
             analysis_repo = IrisAnalysisRepository(uow)
             transitioned = analysis_repo.transition_if_state(
                 analysis_id, ["running"],
-                status="finished", total_score=total_score, verdict=verdict,
-                gate_reasons=gate_reasons, analysis_quality=quality.quality,
-                failed_rules=quality.failed_rules or None, detector_version=detector,
+                status="finished", total_score=winner.total_score, verdict=winner.verdict,
+                gate_reasons=winner.gate_reasons, analysis_quality=winner.quality.quality,
+                failed_rules=winner.quality.failed_rules or None, detector_version=detector,
+                winning_context=winner.context_type, winning_reason=winning_reason,
+                secondary_context=secondary_summary,
                 finished_at=utcnow_naive(),
             )
             if not transitioned:

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -61,6 +61,18 @@ class IrisAnalysis(Base):
         detector_version: Marca del catálogo de reglas que produjo el
                  resultado (``iris-rules:<n>:<hash>``). Sin ella, un informe
                  guardado deja de ser interpretable cuando el catálogo cambia.
+        winning_context: Qué mensaje produjo el veredicto: "inner" (el
+                 original desenvuelto de un reenvío, o el único mensaje si no
+                 lo era) o "wrapper" (el envoltorio del reenvío, cuando es más
+                 grave que el original). NULL en análisis anteriores a que se
+                 guardara, que se leen como "inner". Ver
+                 ``services/contexts.py``.
+        winning_reason: Frase legible que explica por qué ganó ese contexto;
+                 NULL cuando el mensaje no era un reenvío.
+        secondary_context: Resumen del contexto que perdió en un reenvío
+                 (``contextType``, ``verdict``, ``totalScore``,
+                 ``analysisQuality``); NULL cuando no hubo reenvío. Sus
+                 reglas están en ``IrisRuleResult`` con su ``context_type``.
         failure_code: Why a ``failed`` analysis failed — "invalid_input"
                  (the submitted text is not an analysable message) or
                  "internal_error" (the pipeline broke). NULL for every
@@ -116,6 +128,9 @@ class IrisAnalysis(Base):
     analysis_quality = Column(String(16), nullable=True)
     failed_rules = Column(JSONB, nullable=True)
     detector_version = Column(String(64), nullable=True)
+    winning_context = Column(String(16), nullable=True)
+    winning_reason = Column(Text, nullable=True)
+    secondary_context = Column(JSONB, nullable=True)
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
@@ -447,7 +462,13 @@ class IrisRuleResult(Base):
         details: JSONB blob with rule-specific findings and evidence.
         recommendation: Human-readable advice for the user when the
                         rule flagged a problem; null if the rule passed.
-        position: Execution order (0-based) within the analysis.
+        position: Execution order (0-based) within its context.
+        context_type: Qué mensaje evaluó esta fila: "inner" o "wrapper" (ver
+                        ``IrisAnalysis.winning_context``). En un reenvío se
+                        guardan las reglas de los dos contextos; el informe
+                        muestra las del ganador y deja las otras como
+                        contexto secundario. NULL en filas anteriores a que se
+                        guardara, que solo existían para el contexto ganador.
         analysis: SQLAlchemy back-reference to the parent IrisAnalysis.
     """
     __tablename__ = "IrisRuleResult"
@@ -461,6 +482,7 @@ class IrisRuleResult(Base):
     details = Column(JSONB, nullable=True)
     recommendation = Column(Text, nullable=True)
     position = Column(SmallInteger, nullable=False, default=0)
+    context_type = Column(String(16), nullable=True)
 
     analysis = relationship("IrisAnalysis", back_populates="rule_results")
 

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -496,14 +496,25 @@ class IrisRuleResultRepository(BaseRepository[IrisRuleResult]):
 
     _MODEL = IrisRuleResult
 
-    def get_by_analysis(self, analysis_id: int) -> List[IrisRuleResult]:
-        """Return all rule results for an analysis, ordered by position."""
-        return (
-            self._session.query(IrisRuleResult)
-            .filter(IrisRuleResult.analysis_id == analysis_id)
-            .order_by(IrisRuleResult.position)
-            .all()
+    def get_by_analysis(self, analysis_id: int,
+                        context_type: Optional[str] = None) -> List[IrisRuleResult]:
+        """Filas de regla de un análisis, ordenadas por posición.
+
+        Args:
+            analysis_id: Primary key del ``IrisAnalysis``.
+            context_type: Si se da (``"inner"`` o ``"wrapper"``), solo las
+                filas de ese contexto del reenvío. Por defecto ``None``:
+                todas las filas, de cualquier contexto.
+
+        Returns:
+            List[IrisRuleResult]: Las filas pedidas; lista vacía si no hay.
+        """
+        query = self._session.query(IrisRuleResult).filter(
+            IrisRuleResult.analysis_id == analysis_id
         )
+        if context_type is not None:
+            query = query.filter(IrisRuleResult.context_type == context_type)
+        return query.order_by(IrisRuleResult.position).all()
 
     def delete_by_analysis(self, analysis_id: int) -> None:
         """Delete all rule results belonging to an analysis."""

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -157,8 +157,41 @@ class FailedRuleSchema(Schema):
     category = fields.String(load_default=None, allow_none=True)
 
 
+class PreviewHeadersSchema(Schema):
+    """Cabeceras de la vista previa del mensaje que produjo el veredicto.
+
+    Salen del contexto ganador (ver ``winningContext``): en un reenvío cuyo
+    envoltorio es más grave que el original, son las del envoltorio.
+    """
+    subject = fields.String(load_default=None, allow_none=True)
+    from_ = fields.String(data_key="from", attribute="from", load_default=None, allow_none=True)
+    to = fields.String(load_default=None, allow_none=True)
+    replyTo = fields.String(load_default=None, allow_none=True)
+    returnPath = fields.String(load_default=None, allow_none=True)
+    date = fields.String(load_default=None, allow_none=True)
+
+
+class SecondaryContextSchema(Schema):
+    """El otro mensaje de un reenvío: el que **no** decidió el veredicto.
+
+    Se conserva entero —veredicto, score y reglas— para que el analista pueda
+    ver por qué perdió sin que se mezcle con la evidencia del ganador.
+    """
+    contextType = fields.String()
+    verdict = fields.String(load_default=None, allow_none=True)
+    totalScore = fields.Float(load_default=None, allow_none=True)
+    analysisQuality = fields.String(load_default=None, allow_none=True)
+    rules = fields.List(fields.Nested(RuleResultSchema), load_default=None)
+
+
 class AnalysisDetailResponseSchema(Schema):
-    """Full analysis report: headers, per-rule results, verdict."""
+    """Full analysis report: headers, per-rule results, verdict.
+
+    ``winningContext`` dice qué mensaje produjo el veredicto (``inner`` o
+    ``wrapper``); ``rules``, ``topSignals``, ``previewHeaders`` y los IOCs
+    describen siempre ese mensaje. ``secondaryContext`` trae el otro, solo
+    en reenvíos.
+    """
     analysisId = fields.Integer()
     title = fields.String(load_default=None)
     status = fields.String()
@@ -177,6 +210,10 @@ class AnalysisDetailResponseSchema(Schema):
     unwrappedFromForward = fields.Boolean(load_default=False)
     wrapperFrom = fields.String(load_default=None, allow_none=True)
     wrapperSubject = fields.String(load_default=None, allow_none=True)
+    winningContext = fields.String(load_default=None, allow_none=True)
+    winningReason = fields.String(load_default=None, allow_none=True)
+    secondaryContext = fields.Nested(SecondaryContextSchema, load_default=None, allow_none=True)
+    previewHeaders = fields.Nested(PreviewHeadersSchema, load_default=None, allow_none=True)
     startedAt = fields.String(load_default=None)
     finishedAt = fields.String(load_default=None)
     failureCode = fields.String(load_default=None, allow_none=True)
@@ -266,9 +303,11 @@ class ReceivedPathResponseSchema(Schema):
     """Response for ``GET /iris/results/<id>/path``.
 
     ``hops`` and ``transitions`` are empty when no Received chain is
-    available (e.g. headers-only submissions).
+    available (e.g. headers-only submissions). ``contextType`` dice de qué
+    mensaje del reenvío sale la cadena: el mismo que decidió el veredicto.
     """
     analysisId = fields.Integer()
+    contextType = fields.String(load_default=None, allow_none=True)
     available = fields.Boolean()
     hopsCount = fields.Integer()
     hops = fields.List(fields.Nested(ReceivedHopSchema))
@@ -282,9 +321,11 @@ class AnalysisIocsResponseSchema(Schema):
     Each field is a sorted, deduplicated list of pivotable indicators
     derived from the analyzed message — empty lists (not null) when a
     category yields nothing (e.g. no body links in a headers-only
-    submission).
+    submission). ``contextType`` dice de qué mensaje del reenvío salen: el
+    mismo que decidió el veredicto.
     """
     analysisId = fields.Integer()
+    contextType = fields.String(load_default=None, allow_none=True)
     domains = fields.List(fields.String())
     urls = fields.List(fields.String())
     ips = fields.List(fields.String())

--- a/API/src/modules/features/iris/services/contexts.py
+++ b/API/src/modules/features/iris/services/contexts.py
@@ -1,0 +1,162 @@
+"""
+Contexto ganador de un análisis: qué mensaje produjo el veredicto.
+
+Un reenvío "reportar phishing" trae dos mensajes: el envoltorio que llegó al
+buzón y el original adjunto como ``message/rfc822``. El motor evalúa los dos y
+se queda con el peor veredicto (ver ``MessageContext`` en ``parsers.py`` para
+por qué analizar solo el interno no es seguro). Este módulo fija qué contexto
+ganó, por qué, y cómo recuperar ese mismo contexto al servir el informe, para
+que el veredicto, el score, las reglas, la vista previa, los IOCs y el PDF
+describan siempre el mismo mensaje.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+
+from .parsers import MessageContext, decode_mime_words
+
+#: El mensaje analizado por defecto: el original desenvuelto de un reenvío, o
+#: el único mensaje cuando no hay reenvío.
+CONTEXT_INNER = "inner"
+
+#: El envoltorio de un reenvío ``message/rfc822``.
+CONTEXT_WRAPPER = "wrapper"
+
+#: Cabeceras que resume la vista previa del informe, en el orden en que se
+#: muestran, con la clave camelCase que viaja por la API.
+_PREVIEW_HEADERS = (
+    ("subject", "subject"),
+    ("from", "from"),
+    ("to", "to"),
+    ("reply-to", "replyTo"),
+    ("return-path", "returnPath"),
+    ("date", "date"),
+)
+
+
+@dataclass(frozen=True)
+class ContextEvaluation:
+    """Resultado de ejecutar el catálogo de reglas sobre un contexto.
+
+    Attributes:
+        context_type: Qué mensaje se evaluó: ``CONTEXT_INNER`` o
+            ``CONTEXT_WRAPPER``.
+        verdict: Veredicto final de este contexto tras gates y política de
+            calidad (``Legitimate``, ``Suspicious`` o ``Phishing``).
+        total_score: Score agregado 0–100 de este contexto.
+        gate_reasons: Motivos de los gates y de la degradación que fijaron el
+            veredicto.
+        results: Un ``RuleResult`` por regla, emparejado por posición con el
+            catálogo evaluado.
+        quality: ``AnalysisQuality`` de este contexto.
+    """
+
+    context_type: str
+    verdict: str
+    total_score: float
+    gate_reasons: List[str]
+    results: List[Any]
+    quality: Any
+
+
+def choose_winning_evaluation(
+    evaluations: List[ContextEvaluation],
+    severity: Mapping[str, int],
+) -> tuple[ContextEvaluation, Optional[ContextEvaluation], Optional[str]]:
+    """Elige la evaluación que decide el veredicto del análisis.
+
+    Gana la de veredicto más grave. En empate gana la primera de la lista —el
+    mensaje interno, que es el que el usuario quería analizar al reenviar—,
+    porque el envoltorio no aporta nada peor que justifique desplazarlo.
+
+    Args:
+        evaluations: Evaluaciones en orden de preferencia en caso de empate;
+            la primera es siempre la del contexto interno. Nunca vacía.
+        severity: Gravedad de cada veredicto (mayor = peor), la misma tabla
+            que usan los gates.
+
+    Returns:
+        tuple: ``(ganadora, secundaria, motivo)``. ``secundaria`` y ``motivo``
+            son ``None`` cuando solo hubo un contexto (no era un reenvío); en un
+            reenvío, ``secundaria`` es la evaluación que perdió y ``motivo`` es
+            una frase legible que explica por qué ganó la otra.
+    """
+    chosen = evaluations[0]
+    for evaluation in evaluations[1:]:
+        if severity[evaluation.verdict] > severity[chosen.verdict]:
+            chosen = evaluation
+
+    others = [evaluation for evaluation in evaluations if evaluation is not chosen]
+    if not others:
+        return chosen, None, None
+
+    secondary = others[0]
+    return chosen, secondary, _winning_reason(chosen, secondary)
+
+
+def _winning_reason(winner: ContextEvaluation, secondary: ContextEvaluation) -> str:
+    """Frase que explica al analista por qué el veredicto sale de ``winner``.
+
+    Args:
+        winner: Evaluación que decidió el veredicto.
+        secondary: Evaluación del otro mensaje del reenvío.
+
+    Returns:
+        str: Explicación en castellano, lista para la UI y el PDF.
+    """
+    if winner.context_type == CONTEXT_WRAPPER:
+        return (
+            f"El envoltorio del reenvío ({winner.verdict}) es más grave que el "
+            f"correo original adjunto ({secondary.verdict}): el veredicto, las "
+            "reglas y la evidencia describen el envoltorio."
+        )
+    if winner.verdict == secondary.verdict:
+        return (
+            f"El correo original adjunto y el envoltorio del reenvío tienen el "
+            f"mismo veredicto ({winner.verdict}); se muestra el original."
+        )
+    return (
+        f"El correo original adjunto ({winner.verdict}) es más grave que el "
+        f"envoltorio del reenvío ({secondary.verdict}): el veredicto, las "
+        "reglas y la evidencia describen el original."
+    )
+
+
+def context_of_type(parsed: MessageContext, context_type: Optional[str]) -> MessageContext:
+    """Devuelve, de un mensaje ya parseado, el contexto indicado.
+
+    Args:
+        parsed: Resultado de ``parse_raw_message`` sobre el raw del análisis.
+        context_type: ``CONTEXT_WRAPPER`` para el envoltorio; cualquier otro
+            valor —``CONTEXT_INNER`` o ``None`` en análisis que no guardaron
+            contexto ganador— devuelve el contexto interno.
+
+    Returns:
+        MessageContext: El envoltorio si se pidió y existe; si no, ``parsed``.
+    """
+    if context_type == CONTEXT_WRAPPER and parsed.wrapper_context is not None:
+        return parsed.wrapper_context
+    return parsed
+
+
+def preview_headers(context: MessageContext) -> Dict[str, Optional[str]]:
+    """Cabeceras de la vista previa (asunto, remitente, destinatario…) de un contexto.
+
+    El informe y el PDF muestran estas cabeceras junto al veredicto; se sacan
+    del contexto ganador para que la vista previa hable del mismo mensaje que
+    el veredicto.
+
+    Args:
+        context: Contexto del que leer las cabeceras.
+
+    Returns:
+        dict: ``subject``, ``from``, ``to``, ``replyTo``, ``returnPath`` y
+            ``date``, cada una decodificada (RFC 2047) o ``None`` si falta.
+    """
+    preview: Dict[str, Optional[str]] = {}
+    for header_name, key in _PREVIEW_HEADERS:
+        value = context.headers.get(header_name)
+        preview[key] = decode_mime_words(value) if value else None
+    return preview

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -366,23 +366,30 @@ class IrisPDFCreator:
         se resalta porque una discrepancia entre ambos es una señal clásica
         de fraude BEC (el atacante quiere que las respuestas vayan a un
         buzón distinto del remitente que se ve a simple vista).
+
+        Las cabeceras salen de ``previewHeaders``, que el manager toma del
+        contexto que produjo el veredicto; si el informe no las trae (un
+        informe construido a mano), se leen del raw.
         """
-        raw = self.report.get("rawHeaders")
-        if not raw:
-            return
+        preview = self.report.get("previewHeaders")
+        if preview is None:
+            raw = self.report.get("rawHeaders")
+            if not raw:
+                return
+            headers = parse_raw_headers(raw)
+            preview = {
+                key: (decode_mime_words(headers[name]) if headers.get(name) else None)
+                for name, key in (("subject", "subject"), ("from", "from"), ("to", "to"),
+                                  ("reply-to", "replyTo"), ("return-path", "returnPath"),
+                                  ("date", "date"))
+            }
 
-        headers = parse_raw_headers(raw)
-
-        def _get(name: str) -> Optional[str]:
-            value = headers.get(name)
-            return decode_mime_words(value) if value else None
-
-        subject = _get("subject")
-        from_ = _get("from")
-        to_address = _get("to")
-        reply_to = _get("reply-to")
-        return_path = _get("return-path")
-        date = _get("date")
+        subject = preview.get("subject")
+        from_ = preview.get("from")
+        to_address = preview.get("to")
+        reply_to = preview.get("replyTo")
+        return_path = preview.get("returnPath")
+        date = preview.get("date")
 
         if not any([subject, from_, to_address, reply_to, return_path, date]):
             return
@@ -446,12 +453,24 @@ class IrisPDFCreator:
             elements.append(Spacer(1, 0.1 * inch))
             wrapper_from = self.report.get("wrapperFrom")
             wrapper_subject = self.report.get("wrapperSubject")
-            note = "Este análisis corresponde al correo original reenviado"
+            if self.report.get("winningContext") == "wrapper":
+                note = "Este análisis corresponde al envoltorio del reenvío"
+            else:
+                note = "Este análisis corresponde al correo original reenviado"
             if wrapper_from:
                 note += f" por {_esc(wrapper_from)}"
             if wrapper_subject:
                 note += f" (asunto del reenvío: «{_esc(wrapper_subject)}»)"
             note += "."
+            winning_reason = self.report.get("winningReason")
+            if winning_reason:
+                note += f" {_esc(winning_reason)}"
+            secondary = self.report.get("secondaryContext")
+            if secondary:
+                note += (
+                    f" El otro mensaje ({'envoltorio' if secondary.get('contextType') == 'wrapper' else 'original'})"
+                    f" obtuvo {_esc(secondary.get('verdict'))} con {_esc(secondary.get('totalScore'))} puntos."
+                )
             elements.append(Paragraph(note, theme.body))
 
         elements.append(Spacer(1, 0.22 * inch))

--- a/API/tests/integration/test_iris_cancellation.py
+++ b/API/tests/integration/test_iris_cancellation.py
@@ -22,6 +22,7 @@ import src.modules.features.iris.managers.analysis as managers_mod
 from src.modules.features.iris.managers.analysis import IrisManager
 from src.modules.features.iris.model import IrisAnalysis
 from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisRuleResultRepository
+from src.modules.features.iris.services.contexts import CONTEXT_INNER, ContextEvaluation
 from src.modules.features.iris.services.quality import AnalysisQuality
 from src.modules.features.iris.services.registry import RuleResult
 from src.modules.infrastructure import UnitOfWork
@@ -194,11 +195,14 @@ def test_persist_analysis_results_does_not_overwrite_a_cancellation(app, regular
         IrisManager._persist_analysis_results(
             analysis_id,
             rules_defs=[{"name": "SPF", "category": "auth"}],
-            results=[RuleResult(
-                score=-10.0, verdict="fail", details={}, recommendation="revisa SPF",
-            )],
-            verdict="Phishing", total_score=10.0, gate_reasons=[],
-            quality=AnalysisQuality(quality="complete"), detector="test:1",
+            winner=ContextEvaluation(
+                context_type=CONTEXT_INNER, verdict="Phishing", total_score=10.0,
+                gate_reasons=[], quality=AnalysisQuality(quality="complete"),
+                results=[RuleResult(
+                    score=-10.0, verdict="fail", details={}, recommendation="revisa SPF",
+                )],
+            ),
+            detector="test:1",
         )
 
     reloaded = _reload(app, analysis_id)
@@ -222,9 +226,12 @@ def test_persist_analysis_results_finishes_a_still_running_analysis(app, regular
         IrisManager._persist_analysis_results(
             analysis_id,
             rules_defs=[{"name": "SPF", "category": "auth"}],
-            results=[RuleResult(score=2.0, verdict="pass", details={})],
-            verdict="Legitimate", total_score=90.0, gate_reasons=[],
-            quality=AnalysisQuality(quality="complete"), detector="test:1",
+            winner=ContextEvaluation(
+                context_type=CONTEXT_INNER, verdict="Legitimate", total_score=90.0,
+                gate_reasons=[], quality=AnalysisQuality(quality="complete"),
+                results=[RuleResult(score=2.0, verdict="pass", details={})],
+            ),
+            detector="test:1",
         )
 
     reloaded = _reload(app, analysis_id)

--- a/API/tests/integration/test_iris_forward_context.py
+++ b/API/tests/integration/test_iris_forward_context.py
@@ -1,0 +1,217 @@
+"""El informe de un reenvío describe el mensaje que produjo el veredicto.
+
+Un reenvío "reportar phishing" trae dos mensajes: el envoltorio y el original
+adjunto como ``message/rfc822``. El motor evalúa los dos y se queda con el
+peor veredicto. Estos tests fijan que, gane el que gane, el veredicto, el
+score, las reglas, la vista previa de cabeceras, la cadena Received y los IOCs
+hablan del **mismo** mensaje, y que el otro se conserva como secundario.
+
+Se usa un catálogo mínimo en vez del real: una regla que penaliza cualquier
+remitente de ``evil.example`` basta para decidir qué contexto gana sin
+depender de los pesos del catálogo, que cambian con cada recalibración.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis, IrisRuleResult
+from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisRuleResultRepository
+from src.modules.features.iris.services.contexts import CONTEXT_INNER, CONTEXT_WRAPPER
+from src.modules.features.iris.services.registry import RuleResult
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+_EVIL_SENDER = "Soporte <alerta@evil.example>"
+_BENIGN_SENDER = "Compañero <colega@corp.example>"
+
+
+def _sender_rule(headers: dict) -> RuleResult:
+    """Penaliza con fuerza cualquier remitente de ``evil.example``."""
+    if "evil.example" in headers.get("from", ""):
+        return RuleResult(score=-60.0, verdict="fail", details={"from": headers.get("from")},
+                          recommendation="No responder al remitente.")
+    return RuleResult(score=0.0, verdict="pass", details={})
+
+
+_CATALOG = [{
+    "func": _sender_rule, "name": "Sender Test", "category": "identity",
+    "description": "", "needs_context": False, "family": "",
+}]
+
+
+def _forward(wrapper_from: str, inner_from: str) -> str:
+    """Construye un reenvío con el original adjunto como ``message/rfc822``."""
+    return (
+        f"From: {wrapper_from}\r\n"
+        "To: buzon@corp.example\r\n"
+        "Subject: FW: revisa esto\r\n"
+        "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "Received: from wrapper-relay.example (wrapper-relay.example [198.51.100.7])"
+        " by mx.corp.example; Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "MIME-Version: 1.0\r\n"
+        "Content-Type: multipart/mixed; boundary=\"OUTER\"\r\n"
+        "\r\n"
+        "--OUTER\r\n"
+        "Content-Type: text/html; charset=utf-8\r\n"
+        "\r\n"
+        "<html><body><a href=\"https://wrapper-link.example/x\">abrir</a></body></html>\r\n"
+        "--OUTER\r\n"
+        "Content-Type: message/rfc822\r\n"
+        "Content-Disposition: attachment; filename=\"original.eml\"\r\n"
+        "\r\n"
+        f"From: {inner_from}\r\n"
+        "To: victima@corp.example\r\n"
+        "Subject: Original adjunto\r\n"
+        "Date: Mon, 1 Jan 2026 09:00:00 +0000\r\n"
+        "Received: from inner-relay.example (inner-relay.example [203.0.113.9])"
+        " by mx.other.example; Mon, 1 Jan 2026 09:00:00 +0000\r\n"
+        "Content-Type: text/html; charset=utf-8\r\n"
+        "\r\n"
+        "<html><body><a href=\"https://inner-link.example/y\">ver</a></body></html>\r\n"
+        "--OUTER--\r\n"
+    )
+
+
+def _analyze(app, user_id: int, raw: str) -> int:
+    """Crea el análisis y lo ejecuta como lo haría el worker, con el catálogo mínimo."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        with mock.patch.object(iris_rules, "get_rules", return_value=list(_CATALOG)):
+            IrisManager()._run_analysis(analysis_id, raw)
+    return analysis_id
+
+
+def _report(app, analysis_id: int, user_id: int) -> tuple[dict, dict, dict]:
+    """Informe, IOCs y cadena Received del análisis, tal y como los sirve la API."""
+    with app.app_context():
+        manager = IrisManager()
+        return (
+            manager.get_analysis_results(analysis_id),
+            manager.get_analysis_iocs(analysis_id, user_id),
+            manager.get_analysis_path(analysis_id, user_id),
+        )
+
+
+def test_a_malicious_wrapper_over_a_benign_original_reports_the_wrapper(app, regular_user):
+    """El atacante manda su phishing como envoltorio y grapa un ``.eml``
+    benigno: el veredicto viene del envoltorio, y todo el informe tiene que
+    describir el envoltorio, no el original."""
+    analysis_id = _analyze(app, regular_user.id, _forward(_EVIL_SENDER, _BENIGN_SENDER))
+
+    report, iocs, path = _report(app, analysis_id, regular_user.id)
+
+    assert report["verdict"] == "Phishing"
+    assert report["totalScore"] == 40.0
+    assert report["winningContext"] == CONTEXT_WRAPPER
+    assert "envoltorio" in report["winningReason"]
+    assert [rule["verdict"] for rule in report["rules"]] == ["fail"]
+    assert report["topSignals"][0]["ruleName"] == "Sender Test"
+    assert report["previewHeaders"]["from"] == _EVIL_SENDER
+    assert report["previewHeaders"]["subject"] == "FW: revisa esto"
+
+    assert report["secondaryContext"]["contextType"] == CONTEXT_INNER
+    assert report["secondaryContext"]["verdict"] == "Legitimate"
+    assert [rule["verdict"] for rule in report["secondaryContext"]["rules"]] == ["pass"]
+
+    assert iocs["contextType"] == CONTEXT_WRAPPER
+    assert "wrapper-link.example" in iocs["domains"]
+    assert "inner-link.example" not in iocs["domains"]
+    assert "evil.example" in iocs["domains"]
+
+    assert path["contextType"] == CONTEXT_WRAPPER
+    assert [hop["fromIp"] for hop in path["hops"]] == ["198.51.100.7"]
+
+
+def test_a_malicious_original_inside_a_benign_wrapper_reports_the_original(app, regular_user):
+    """El caso habitual de "reportar phishing": el envoltorio es el empleado
+    que reenvía, el original es el phishing. Todo el informe describe el
+    original."""
+    analysis_id = _analyze(app, regular_user.id, _forward(_BENIGN_SENDER, _EVIL_SENDER))
+
+    report, iocs, path = _report(app, analysis_id, regular_user.id)
+
+    assert report["verdict"] == "Phishing"
+    assert report["winningContext"] == CONTEXT_INNER
+    assert "original" in report["winningReason"]
+    assert report["previewHeaders"]["from"] == _EVIL_SENDER
+    assert report["previewHeaders"]["subject"] == "Original adjunto"
+    assert report["secondaryContext"]["contextType"] == CONTEXT_WRAPPER
+    assert report["secondaryContext"]["verdict"] == "Legitimate"
+
+    assert iocs["contextType"] == CONTEXT_INNER
+    assert "inner-link.example" in iocs["domains"]
+    assert "wrapper-link.example" not in iocs["domains"]
+
+    assert [hop["fromIp"] for hop in path["hops"]] == ["203.0.113.9"]
+
+
+def test_both_contexts_keep_their_own_rule_rows(app, regular_user):
+    """Las reglas de los dos mensajes se guardan, cada fila con su contexto,
+    y ninguna del secundario se cuela en la lista del ganador."""
+    analysis_id = _analyze(app, regular_user.id, _forward(_EVIL_SENDER, _BENIGN_SENDER))
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            rows = IrisRuleResultRepository(uow).get_by_analysis(analysis_id)
+            by_context = {row.context_type: row.verdict for row in rows}
+
+    assert by_context == {CONTEXT_WRAPPER: "fail", CONTEXT_INNER: "pass"}
+
+
+def test_a_tie_keeps_the_original_as_the_winner(app, regular_user):
+    """Con el mismo veredicto en los dos, se muestra el original: es el que
+    el usuario quería analizar al reenviar."""
+    analysis_id = _analyze(app, regular_user.id, _forward(_EVIL_SENDER, _EVIL_SENDER))
+
+    report, _, _ = _report(app, analysis_id, regular_user.id)
+
+    assert report["winningContext"] == CONTEXT_INNER
+    assert "mismo veredicto" in report["winningReason"]
+
+
+def test_a_plain_message_has_no_secondary_context(app, regular_user):
+    """Sin reenvío solo hay un contexto: el interno, sin motivo ni secundario."""
+    raw = (
+        f"From: {_EVIL_SENDER}\r\nTo: victima@corp.example\r\nSubject: Hola\r\n"
+        "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n\r\nCuerpo.\r\n"
+    )
+    analysis_id = _analyze(app, regular_user.id, raw)
+
+    report, _, _ = _report(app, analysis_id, regular_user.id)
+
+    assert report["winningContext"] == CONTEXT_INNER
+    assert report["winningReason"] is None
+    assert report["secondaryContext"] is None
+    assert report["previewHeaders"]["from"] == _EVIL_SENDER
+
+
+def test_an_analysis_without_stored_context_still_reads_all_its_rules(app, regular_user):
+    """Un análisis sin contexto ganador guardado conserva sus filas sin
+    marcar: el informe las sigue mostrando todas y describe el interno."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(
+                raw_headers=_forward(_EVIL_SENDER, _BENIGN_SENDER), user_id=regular_user.id,
+                status="finished", verdict="Legitimate", total_score=100.0,
+            )
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+            IrisRuleResultRepository(uow).save(IrisRuleResult(
+                analysis_id=analysis_id, rule_name="SPF", category="auth",
+                score=0.0, verdict="pass", position=0,
+            ))
+
+    report, _, _ = _report(app, analysis_id, regular_user.id)
+
+    assert report["winningContext"] is None
+    assert [rule["ruleName"] for rule in report["rules"]] == ["SPF"]
+    assert report["previewHeaders"]["from"] == _BENIGN_SENDER

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -206,3 +206,53 @@ def test_raw_headers_dump_is_not_redacted_when_disabled_in_config():
         rendered = _rendered_raw_headers_text(report)
 
     assert "bystander@example.com" in rendered
+
+
+# ------------------------------------------------ contexto ganador de un reenvío
+
+def _rendered_preview_text(report: dict) -> str:
+    """Llama a append_email_preview() y concatena el texto de los Paragraph,
+    tanto sueltos como dentro de las celdas de la tabla de vista previa."""
+    creator = IrisPDFCreator(report=report)
+    elements: list = []
+    creator.append_email_preview(elements, _theme())
+    texts = []
+    for element in elements:
+        if hasattr(element, "text"):
+            texts.append(element.text)
+        for row in getattr(element, "_cellvalues", []):
+            for cell in row:
+                texts.append(cell.text if hasattr(cell, "text") else str(cell))
+    return "\n".join(texts)
+
+
+def test_preview_uses_the_winning_context_headers_over_the_raw():
+    """La vista previa describe el mensaje que produjo el veredicto, aunque
+    el raw empiece por las cabeceras de otro."""
+    report = _sample_report(
+        rawHeaders="From: original@corp.example\nSubject: Original\n",
+        previewHeaders={"subject": "FW: revisa esto", "from": "alerta@evil.example",
+                        "to": None, "replyTo": None, "returnPath": None, "date": None},
+    )
+    text = _rendered_preview_text(report)
+    assert "alerta@evil.example" in text
+    assert "FW: revisa esto" in text
+    assert "original@corp.example" not in text
+
+
+def test_preview_note_says_the_wrapper_won_and_summarises_the_original():
+    report = _sample_report(
+        unwrappedFromForward=True, wrapperFrom="alerta@evil.example",
+        winningContext="wrapper",
+        winningReason="El envoltorio del reenvío (Phishing) es más grave.",
+        secondaryContext={"contextType": "inner", "verdict": "Legitimate", "totalScore": 100.0},
+    )
+    text = _rendered_preview_text(report)
+    assert "envoltorio del reenvío" in text
+    assert "El otro mensaje (original) obtuvo Legitimate" in text
+
+
+def test_preview_note_says_the_original_won_by_default():
+    report = _sample_report(unwrappedFromForward=True, wrapperFrom="colega@corp.example")
+    text = _rendered_preview_text(report)
+    assert "correo original reenviado" in text

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -679,7 +679,7 @@ def test_aggregate_score_floored_at_zero():
 
 def _iocs_for(monkeypatch, raw_message):
     from types import SimpleNamespace
-    fake_analysis = SimpleNamespace(id=42, raw_headers=raw_message)
+    fake_analysis = SimpleNamespace(id=42, raw_headers=raw_message, winning_context=None)
     monkeypatch.setattr(
         IrisManager, "assert_analysis_ownership",
         classmethod(lambda cls, analysis_id, user_id: fake_analysis),

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -71,12 +71,23 @@
       </div>
 
       <!-- Aviso: el mensaje enviado era un reenvío que envolvía el correo -->
-      <!-- original como adjunto .eml; se analizó el interno, no el envoltorio -->
+      <!-- original como adjunto .eml. Se evalúan los dos y el informe describe -->
+      <!-- el que produjo el veredicto (winningContext); el otro queda como secundario -->
       <div v-if="reportData.unwrappedFromForward" class="rv-unwrap-notice">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="unwrap-icon"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M22 7l-10 6L2 7"/></svg>
         <div class="unwrap-text">
           <strong>Correo reenviado como adjunto detectado.</strong>
-          Se analizó el mensaje original adjunto (.eml), no el envoltorio del reenvío.
+          <template v-if="reportData.winningContext === 'wrapper'">
+            El veredicto sale del envoltorio del reenvío, no del mensaje original adjunto.
+          </template>
+          <template v-else>
+            Se analizó el mensaje original adjunto (.eml), no el envoltorio del reenvío.
+          </template>
+          <span v-if="reportData.winningReason" class="unwrap-wrapper-info">{{ reportData.winningReason }}</span>
+          <span v-if="reportData.secondaryContext" class="unwrap-wrapper-info">
+            {{ reportData.secondaryContext.contextType === 'wrapper' ? 'Envoltorio' : 'Original' }}:
+            {{ reportData.secondaryContext.verdict }} ({{ reportData.secondaryContext.totalScore }} puntos)
+          </span>
           <span v-if="reportData.wrapperFrom || reportData.wrapperSubject" class="unwrap-wrapper-info">
             Envoltorio: <template v-if="reportData.wrapperFrom">de {{ reportData.wrapperFrom }}</template>
             <template v-if="reportData.wrapperSubject">— «{{ reportData.wrapperSubject }}»</template>


### PR DESCRIPTION
## El problema

Cuando alguien pulsa "reportar phishing" en Outlook o Gmail, el correo sospechoso no se reenvía citado en el cuerpo: se **adjunta entero** como un fichero `.eml` (una parte MIME de tipo `message/rfc822`). Iris recibe entonces dos mensajes en uno: el **envoltorio** (el reenvío, con su propio remitente, asunto y enlaces) y el **original** adjunto.

El motor de Iris ya evaluaba los dos y se quedaba con el peor veredicto. Hace falta porque un atacante puede mandar su phishing como envoltorio y grapar un `.eml` inofensivo: si solo se analizara el adjunto, el phishing real pasaría sin mirar.

Lo que no hacía era **guardar cuál de los dos había ganado**. Al servir el informe, `get_analysis_results()` volvía a leer el correo y describía siempre el original. Resultado: si ganaba el envoltorio, el analista veía un veredicto `Phishing` junto a las reglas, la vista previa, los IOCs y el PDF de un mensaje **benigno**: un veredicto que la evidencia mostrada no justificaba.

Cierra #228 (iniciativa `B15`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

- **Se guarda qué contexto ganó.** `IrisAnalysis` gana tres columnas:
  - `winning_context`: `inner` (el original, o el único mensaje si no era un reenvío) o `wrapper` (el envoltorio).
  - `winning_reason`: una frase legible que explica por qué ganó.
  - `secondary_context`: un resumen del mensaje que perdió (veredicto, score, calidad).
- **Se guardan las reglas de los dos mensajes.** Cada fila de `IrisRuleResult` lleva `context_type`. El informe muestra las del ganador y devuelve las del otro aparte, en `secondaryContext.rules`, sin mezclarlas.
- **Todo lo que describe el mensaje sale del contexto ganador:** las reglas y señales principales, la vista previa de cabeceras (nuevo campo `previewHeaders`), `GET /results/<id>/iocs` y `GET /results/<id>/path`. Estos dos últimos devuelven además `contextType`.
- **Criterio de desempate.** En empate gana el original: es el que el usuario quería analizar al reenviar. Es lo mismo que hacía el código antes, ahora explícito en `services/contexts.py`.
- **PDF y UI dicen qué mensaje decidió.** El aviso de "correo reenviado" ya no afirma siempre que se analizó el original: dice cuál decidió el veredicto, por qué, y qué obtuvo el otro.

La lógica nueva (elegir el ganador, construir el motivo, recuperar el contexto y sus cabeceras) vive en `services/contexts.py`; el manager solo orquesta.

**Análisis antiguos.** Los análisis anteriores a esta migración no tienen contexto guardado (`winning_context = NULL`). Se leen como antes: todas sus filas de regla, describiendo el original.

## Migración

`e2a9c4d7f1b3_add_iris_analysis_context_metadata`: tres columnas en `IrisAnalysis` y una en `IrisRuleResult`, todas nulables.

El `downgrade` borra antes las filas de regla del contexto secundario. Si no, al quitar `context_type` las reglas de los dos mensajes quedarían mezcladas como si fueran de uno solo.

## Validación

- **`test_iris_forward_context.py` (nuevo, integración).** Cubre el criterio de cierre del issue:
  - Envoltorio malicioso con original benigno, y al revés. En los dos casos, veredicto, score, reglas, señales principales, vista previa, IOCs y cadena Received describen el mismo mensaje, y el otro queda como secundario.
  - También cubre las filas de regla por contexto, el empate, un correo que no es reenvío, y un análisis antiguo sin contexto guardado.
- **`test_iris_reports.py`.** El PDF usa `previewHeaders` antes que el raw, y la nota del reenvío dice qué mensaje ganó.
- **`test_iris_cancellation.py`.** Adaptado a la nueva firma de `_persist_analysis_results`: recibe la evaluación ganadora en vez de sus campos sueltos.
- **`pytest tests/ -k iris`:** todo en verde.
- **`pylint src`:** 10.00/10.
- **`IrisReportViewer.vue`:** compilado con `@vue/compiler-sfc`. `npm run build` no se ha podido ejecutar en este entorno porque falta el paquete privado `@projectellysia/acheron-core-web`, que requiere el token del registry. El fallo no tiene relación con este cambio.

## Notas

- **Tests de PostgreSQL.** `tests/postgres/` no se ha ejecutado por falta de Postgres local. La migración es solo de columnas nulables y un `DELETE` en el `downgrade`.
- **Fuera de alcance.** `parse_raw_headers` sigue leyendo líneas `Clave: valor` más allá de la primera línea en blanco. Por eso, las cabeceras que el envoltorio no trae pueden tomarse de las partes MIME de dentro. Como gana la primera aparición, el remitente y el asunto del envoltorio sí son los suyos. Es un comportamiento anterior a este cambio y no lo toco aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
