### PR TITLE
feat(iris): confianza, cobertura e incertidumbre explícitas en el veredicto (M02)

### DIFF
--- a/API/alembic/versions/f4b8d1e6a2c9_add_iris_analysis_confidence_coverage.py
+++ b/API/alembic/versions/f4b8d1e6a2c9_add_iris_analysis_confidence_coverage.py
@@ -1,0 +1,40 @@
+"""iris: confianza, cobertura e incertidumbre del veredicto
+
+El score de Iris es una escala de riesgo, no una probabilidad, y un análisis
+de solo cabeceras no lo señalaba en ningún sitio. Estas columnas guardan una
+confianza ordinal (high/medium/low), qué partes del mensaje se inspeccionaron
+y los motivos que restan confianza.
+
+Revision ID: f4b8d1e6a2c9
+Revises: e2a9c4d7f1b3
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f4b8d1e6a2c9'
+down_revision: Union[str, Sequence[str], None] = 'e2a9c4d7f1b3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisAnalysis', sa.Column('confidence', sa.String(length=16), nullable=True))
+    op.add_column('IrisAnalysis', sa.Column('coverage',
+                                            postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('IrisAnalysis', sa.Column('uncertainty_reasons',
+                                            postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisAnalysis', 'uncertainty_reasons')
+    op.drop_column('IrisAnalysis', 'coverage')
+    op.drop_column('IrisAnalysis', 'confidence')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -61,7 +61,14 @@ from ..services.contexts import (
     context_of_type,
     preview_headers,
 )
-from ..services.quality import assess_quality, cap_verdict, detector_version
+from ..services.quality import (
+    ConfidenceAssessment,
+    assess_confidence,
+    assess_coverage,
+    assess_quality,
+    cap_verdict,
+    detector_version,
+)
 from ..services.ai_writer import IrisAIWriter
 from .notifications import IrisPhishingNotifyManager
 
@@ -420,6 +427,9 @@ class IrisManager(TaskTrackingMixin):
             "startedAt": isoformat_utc(analysis.started_at),
             "finishedAt": isoformat_utc(analysis.finished_at),
             "analysisQuality": analysis.analysis_quality,
+            "confidence": analysis.confidence,
+            "coverage": analysis.coverage,
+            "uncertaintyReasons": analysis.uncertainty_reasons or [],
             "failedRules": analysis.failed_rules or [],
             "detectorVersion": analysis.detector_version,
             "failureCode": analysis.failure_code,
@@ -975,6 +985,7 @@ class IrisManager(TaskTrackingMixin):
                 "status": analysis_record.status,
                 "failureCode": analysis_record.failure_code,
                 "analysisQuality": analysis_record.analysis_quality,
+                "confidence": analysis_record.confidence,
                 "totalScore": analysis_record.total_score,
                 "verdict": analysis_record.verdict,
                 "startedAt": isoformat_utc(analysis_record.started_at), # type: ignore
@@ -1091,11 +1102,16 @@ class IrisManager(TaskTrackingMixin):
                     evaluations, _VERDICT_SEVERITY,
                 )
                 verdict, total_score = winner.verdict, winner.total_score
+                config = CR.iris_config()
+                confidence = assess_confidence(winner, secondary,
+                                               config.legitimate_threshold,
+                                               config.suspicious_threshold)
 
                 self._persist_analysis_results(analysis_id, rules_defs, winner,
                                                detector_version(rules_defs),
                                                secondary=secondary,
-                                               winning_reason=winning_reason)
+                                               winning_reason=winning_reason,
+                                               confidence=confidence)
             except Exception as e:
                 logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
                 self._fail_analysis(analysis_id, classify_failure(e))
@@ -1193,6 +1209,7 @@ class IrisManager(TaskTrackingMixin):
             evaluations.append(ContextEvaluation(
                 context_type=context_type, verdict=verdict, total_score=total_score,
                 gate_reasons=gate_reasons + quality_reasons, results=results, quality=quality,
+                coverage=assess_coverage(evaluated_context, rules_defs),
             ))
 
         return evaluations
@@ -1201,7 +1218,8 @@ class IrisManager(TaskTrackingMixin):
     def _persist_analysis_results(analysis_id: int, rules_defs: List[dict],
                                    winner: ContextEvaluation, detector: str,
                                    secondary: Optional[ContextEvaluation] = None,
-                                   winning_reason: Optional[str] = None) -> None:
+                                   winning_reason: Optional[str] = None,
+                                   confidence: Optional[ConfidenceAssessment] = None) -> None:
         """Persiste las filas de regla y el estado final del análisis en una
         única transacción.
 
@@ -1230,6 +1248,9 @@ class IrisManager(TaskTrackingMixin):
             secondary: Evaluación del otro contexto de un reenvío. Por defecto
                 ``None`` (el mensaje no era un reenvío).
             winning_reason: Por qué ganó ``winner``; ``None`` sin reenvío.
+            confidence: Confianza ordinal y motivos de incertidumbre del
+                veredicto. Por defecto ``None``: las columnas de confianza
+                quedan a NULL (se lee como "sin evaluar").
         """
         with UnitOfWork() as uow:
             rule_repo = IrisRuleResultRepository(uow)
@@ -1266,6 +1287,9 @@ class IrisManager(TaskTrackingMixin):
                 failed_rules=winner.quality.failed_rules or None, detector_version=detector,
                 winning_context=winner.context_type, winning_reason=winning_reason,
                 secondary_context=secondary_summary,
+                confidence=confidence.level if confidence else None,
+                coverage=winner.coverage or None,
+                uncertainty_reasons=confidence.reasons if confidence else None,
                 finished_at=utcnow_naive(),
             )
             if not transitioned:

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -61,6 +61,17 @@ class IrisAnalysis(Base):
         detector_version: Marca del catálogo de reglas que produjo el
                  resultado (``iris-rules:<n>:<hash>``). Sin ella, un informe
                  guardado deja de ser interpretable cuando el catálogo cambia.
+        confidence: Confianza ordinal del veredicto: "high", "medium" o "low".
+                 **No es una probabilidad** (el score no está calibrado); sale
+                 de reglas deterministas y va siempre con sus motivos en
+                 ``uncertainty_reasons``. NULL en análisis anteriores a que se
+                 calculara. Ver ``services/quality.assess_confidence``.
+        coverage: Qué partes del mensaje se inspeccionaron: ``mode``
+                 ("full_message" o "headers_only") y ``uncoveredRules``, las
+                 reglas de cuerpo, enlaces y adjuntos que no tuvieron
+                 contenido que mirar. NULL en análisis antiguos.
+        uncertainty_reasons: Frases legibles que explican por qué la
+                 confianza no es "high"; lista vacía o NULL si no hay motivos.
         winning_context: Qué mensaje produjo el veredicto: "inner" (el
                  original desenvuelto de un reenvío, o el único mensaje si no
                  lo era) o "wrapper" (el envoltorio del reenvío, cuando es más
@@ -128,6 +139,9 @@ class IrisAnalysis(Base):
     analysis_quality = Column(String(16), nullable=True)
     failed_rules = Column(JSONB, nullable=True)
     detector_version = Column(String(64), nullable=True)
+    confidence = Column(String(16), nullable=True)
+    coverage = Column(JSONB, nullable=True)
+    uncertainty_reasons = Column(JSONB, nullable=True)
     winning_context = Column(String(16), nullable=True)
     winning_reason = Column(Text, nullable=True)
     secondary_context = Column(JSONB, nullable=True)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -157,6 +157,17 @@ class FailedRuleSchema(Schema):
     category = fields.String(load_default=None, allow_none=True)
 
 
+class CoverageSchema(Schema):
+    """Qué partes del mensaje se pudieron inspeccionar.
+
+    ``mode`` es ``full_message`` (había cuerpo o adjuntos) o ``headers_only``;
+    en este último, ``uncoveredRules`` lista las reglas de cuerpo, enlaces y
+    adjuntos que no tuvieron nada que mirar.
+    """
+    mode = fields.String()
+    uncoveredRules = fields.List(fields.String(), load_default=None)
+
+
 class PreviewHeadersSchema(Schema):
     """Cabeceras de la vista previa del mensaje que produjo el veredicto.
 
@@ -191,6 +202,10 @@ class AnalysisDetailResponseSchema(Schema):
     ``wrapper``); ``rules``, ``topSignals``, ``previewHeaders`` y los IOCs
     describen siempre ese mensaje. ``secondaryContext`` trae el otro, solo
     en reenvíos.
+
+    ``confidence`` es ordinal (``high``/``medium``/``low``), **no** una
+    probabilidad; ``uncertaintyReasons`` explica por qué no es ``high`` y
+    ``coverage`` dice si se inspeccionó el mensaje completo o solo cabeceras.
     """
     analysisId = fields.Integer()
     title = fields.String(load_default=None)
@@ -202,6 +217,9 @@ class AnalysisDetailResponseSchema(Schema):
     analysisQuality = fields.String(load_default=None, allow_none=True)
     failedRules = fields.List(fields.Nested(FailedRuleSchema), load_default=None)
     detectorVersion = fields.String(load_default=None, allow_none=True)
+    confidence = fields.String(load_default=None, allow_none=True)
+    coverage = fields.Nested(CoverageSchema, load_default=None, allow_none=True)
+    uncertaintyReasons = fields.List(fields.String(), load_default=None)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)
     aiSummaryStatus = fields.String(load_default=None, allow_none=True)
@@ -230,6 +248,7 @@ class AnalysisListItemSchema(Schema):
     status = fields.String()
     failureCode = fields.String(load_default=None, allow_none=True)
     analysisQuality = fields.String(load_default=None, allow_none=True)
+    confidence = fields.String(load_default=None, allow_none=True)
     totalScore = fields.Float(load_default=None)
     verdict = fields.String(load_default=None)
     startedAt = fields.String(load_default=None)

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -28,6 +28,11 @@ from src.modules.tools.scribe.exceptions import AIResponseError
 
 _VALID_CONFIDENCE = {"ALTA", "MEDIA", "BAJA"}
 
+#: Confianza del análisis (``IrisAnalysis.confidence``) en la escala del
+#: resumen. El resumen no puede saber más que el análisis del que parte, así
+#: que cuando el análisis trae confianza, el resumen usa la misma.
+_ANALYSIS_CONFIDENCE_LABELS = {"high": "ALTA", "medium": "MEDIA", "low": "BAJA"}
+
 
 def _extract_json_with_regex(raw: str) -> Optional[dict]:
     """Best-effort JSON recovery from a model response that failed ``json.loads``.
@@ -115,6 +120,38 @@ class IrisAIWriter:
             "ausencia de hallazgos."
         )
 
+    @staticmethod
+    def _confidence_note(report: Dict[str, Any]) -> str:
+        """Aviso de confianza y cobertura que se añade al final del prompt.
+
+        Va anexado, igual que ``_degradation_note``, para no depender de que la
+        plantilla desplegada en ``SecOpsConfig.json`` tenga un marcador nuevo.
+        Le da al modelo la misma confianza ordinal y los mismos motivos que ve
+        el analista en la UI y en el PDF, y le prohíbe convertirla en un
+        porcentaje: el score no está calibrado y un número inventaría precisión.
+
+        Args:
+            report: Informe de ``IrisManager.get_analysis_results``; se leen
+                ``confidence``, ``coverage`` y ``uncertaintyReasons``.
+
+        Returns:
+            str: El aviso, o cadena vacía si el informe no trae confianza
+                (análisis anteriores a que se calculara).
+        """
+        label = _ANALYSIS_CONFIDENCE_LABELS.get(report.get("confidence") or "")
+        if label is None:
+            return ""
+        coverage = report.get("coverage") or {}
+        coverage_text = ("solo cabeceras (no se inspeccionó cuerpo ni adjuntos)"
+                         if coverage.get("mode") == "headers_only" else "mensaje completo")
+        reasons = report.get("uncertaintyReasons") or []
+        reasons_text = (" Motivos: " + " ".join(reasons)) if reasons else ""
+        return (
+            f"\n\nCONFIANZA DEL ANÁLISIS: {label}. Cobertura: {coverage_text}.{reasons_text} "
+            "Usa exactamente esta confianza en el campo \"confidence\", no la "
+            "expreses como porcentaje y no afirmes más certeza de la que indica."
+        )
+
     def _build_user_prompt(self, report: Dict[str, Any]) -> str:
         failed_rules = [
             {
@@ -135,7 +172,7 @@ class IrisAIWriter:
             .replace("{{gate_reasons_json}}", json.dumps(report.get("gateReasons") or [], ensure_ascii=False))
             .replace("{{failed_rules_json}}", json.dumps(failed_rules, indent=2, ensure_ascii=False))
         )
-        return prompt + self._degradation_note(report)
+        return prompt + self._degradation_note(report) + self._confidence_note(report)
 
     def generate(self, report: Dict[str, Any]) -> dict:
         """Generate the AI narrative for a finished analysis report dict.
@@ -146,7 +183,10 @@ class IrisAIWriter:
 
         Returns:
             ``{"executive_summary", "attacker_intent", "recommendations",
-            "confidence"}``.
+            "confidence"}``. ``confidence`` es la del propio análisis
+            (``ALTA``/``MEDIA``/``BAJA``) cuando el informe la trae, aunque el
+            modelo responda otra: el resumen no puede saber más que el
+            análisis del que parte.
 
         Raises:
             AIResponseError, AIFallbackExhaustedError, CircuitBreakerOpenError:
@@ -169,7 +209,11 @@ class IrisAIWriter:
         )
 
         result = self._generator.digest(ai_input)
-        return self._parse_response(result.text)
+        parsed = self._parse_response(result.text)
+        analysis_label = _ANALYSIS_CONFIDENCE_LABELS.get(report.get("confidence") or "")
+        if analysis_label is not None:
+            parsed["confidence"] = analysis_label
+        return parsed
 
     def _parse_response(self, raw: str, attempt: int = 0) -> dict:
         if not raw:

--- a/API/src/modules/features/iris/services/contexts.py
+++ b/API/src/modules/features/iris/services/contexts.py
@@ -12,7 +12,7 @@ describan siempre el mismo mensaje.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Optional
 
 from .parsers import MessageContext, decode_mime_words
@@ -51,6 +51,9 @@ class ContextEvaluation:
         results: Un ``RuleResult`` por regla, emparejado por posición con el
             catálogo evaluado.
         quality: ``AnalysisQuality`` de este contexto.
+        coverage: Cobertura de este contexto (``mode`` y ``uncoveredRules``,
+            ver ``services/quality.assess_coverage``). Por defecto un dict
+            vacío, que se lee como "sin información de cobertura".
     """
 
     context_type: str
@@ -59,6 +62,7 @@ class ContextEvaluation:
     gate_reasons: List[str]
     results: List[Any]
     quality: Any
+    coverage: Dict[str, Any] = field(default_factory=dict)
 
 
 def choose_winning_evaluation(

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -120,6 +120,152 @@ def detector_version(rules_defs: List[dict]) -> str:
     return f"iris-rules:{len(names)}:{digest}"
 
 
+COVERAGE_FULL_MESSAGE = "full_message"
+COVERAGE_HEADERS_ONLY = "headers_only"
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_LOW = "low"
+
+#: Puntos de score por debajo de los cuales un veredicto que sale del score se
+#: considera pegado al umbral: una sola regla de peso pequeño lo cambiaría.
+BORDERLINE_MARGIN = 5.0
+
+
+def assess_coverage(context: Any, rules_defs: List[dict]) -> Dict[str, Any]:
+    """Resume qué partes del mensaje se pudieron inspeccionar.
+
+    Un análisis de solo cabeceras ejecuta igualmente las reglas de cuerpo,
+    enlaces y adjuntos, pero sobre un mensaje vacío: no encuentran nada porque
+    no hay nada que mirar, no porque el contenido sea limpio. Esta función lo
+    hace explícito.
+
+    Args:
+        context: ``MessageContext`` evaluado (cabeceras más cuerpo, enlaces y
+            adjuntos si el envío traía el ``.eml`` completo).
+        rules_defs: Catálogo evaluado; se usa el flag ``is_body_dependent`` de
+            cada regla.
+
+    Returns:
+        dict: ``mode`` —``full_message`` si el mensaje traía cuerpo o
+            adjuntos, ``headers_only`` si no— y ``uncoveredRules``, los nombres
+            de las reglas que dependen del cuerpo y no tuvieron nada que
+            inspeccionar (lista vacía en ``full_message``).
+    """
+    has_content = bool(context.body_text or context.body_html or context.attachments)
+    if has_content:
+        return {"mode": COVERAGE_FULL_MESSAGE, "uncoveredRules": []}
+    return {
+        "mode": COVERAGE_HEADERS_ONLY,
+        "uncoveredRules": [
+            rule_def["name"] for rule_def in rules_defs if rule_def.get("is_body_dependent")
+        ],
+    }
+
+
+@dataclass(frozen=True)
+class ConfidenceAssessment:
+    """Cuánto se puede sostener un veredicto, en una escala ordinal.
+
+    **No es una probabilidad.** El score de Iris es una escala de riesgo sin
+    calibración estadística detrás, así que un número de confianza («92 %»)
+    afirmaría una precisión que nadie ha medido. En su lugar hay tres niveles
+    que salen de reglas deterministas y siempre van acompañados de sus motivos.
+
+    Attributes:
+        level: ``high`` (nada resta confianza), ``medium`` (hay motivos de
+            incertidumbre que no invalidan el veredicto) o ``low`` (el
+            veredicto afirma algo que el análisis no llegó a comprobar: un
+            ``Legitimate`` sin contenido que inspeccionar, o una regla de
+            autenticación o de adjuntos que no se ejecutó).
+        reasons: Frases legibles, una por motivo; vacía cuando ``level`` es
+            ``high``.
+    """
+
+    level: str
+    reasons: List[str] = field(default_factory=list)
+
+
+def assess_confidence(winner: Any, secondary: Any,
+                      legitimate_threshold: float, suspicious_threshold: float) -> ConfidenceAssessment:
+    """Evalúa la confianza del veredicto ganador y sus motivos de incertidumbre.
+
+    Motivos que se tienen en cuenta:
+
+    - **Solo cabeceras**: las reglas de cuerpo, enlaces y adjuntos no tuvieron
+      nada que inspeccionar. Si además el veredicto es ``Legitimate``, la
+      confianza es ``low``: el mensaje no está limpio, simplemente no se miró.
+    - **Análisis degradado**: alguna regla no se ejecutó. Es ``low`` si era de
+      una familia que bloquea el veredicto limpio (``DEGRADING_FAMILIES``).
+    - **Score pegado a un umbral**: solo cuando el veredicto sale del score (no
+      de un gate) y está a menos de ``BORDERLINE_MARGIN`` puntos de un umbral.
+    - **Reenvío en desacuerdo**: el envoltorio y el original tienen
+      veredictos distintos.
+
+    Args:
+        winner: ``ContextEvaluation`` que decidió el veredicto.
+        secondary: ``ContextEvaluation`` del otro mensaje de un reenvío, o
+            ``None`` si no lo era.
+        legitimate_threshold: Umbral de score de ``Legitimate`` (0–100).
+        suspicious_threshold: Umbral de score de ``Suspicious`` (0–100).
+
+    Returns:
+        ConfidenceAssessment: Nivel y motivos. ``high`` sin motivos cuando no
+            hay nada que reste confianza.
+    """
+    reasons: List[str] = []
+    is_low = False
+
+    coverage = winner.coverage or {}
+    if coverage.get("mode") == COVERAGE_HEADERS_ONLY:
+        uncovered_count = len(coverage.get("uncoveredRules") or [])
+        reasons.append(
+            f"Solo se analizaron las cabeceras: {uncovered_count} reglas de cuerpo, "
+            "enlaces y adjuntos no tuvieron contenido que inspeccionar."
+        )
+        if winner.verdict == "Legitimate":
+            is_low = True
+            reasons.append(
+                "Un veredicto Legítimo sin cuerpo ni adjuntos solo dice que las "
+                "cabeceras no muestran señales, no que el contenido sea seguro."
+            )
+
+    if winner.quality.is_degraded:
+        reasons.append(
+            f"No se pudieron ejecutar {len(winner.quality.failed_rules)} reglas, así "
+            "que una parte del mensaje no se inspeccionó."
+        )
+        if winner.quality.blocks_clean_verdict:
+            is_low = True
+
+    score = float(winner.total_score)
+    if score >= legitimate_threshold:
+        score_verdict = "Legitimate"
+    elif score >= suspicious_threshold:
+        score_verdict = "Suspicious"
+    else:
+        score_verdict = "Phishing"
+    if score_verdict == winner.verdict:
+        for threshold in (legitimate_threshold, suspicious_threshold):
+            if abs(score - threshold) < BORDERLINE_MARGIN:
+                reasons.append(
+                    f"El score ({score:g}) está a menos de {BORDERLINE_MARGIN:g} puntos "
+                    f"del umbral {threshold:g}: una sola señal pequeña cambiaría el veredicto."
+                )
+                break
+
+    if secondary is not None and secondary.verdict != winner.verdict:
+        reasons.append(
+            "Los dos mensajes del reenvío no coinciden "
+            f"({winner.verdict} frente a {secondary.verdict})."
+        )
+
+    if is_low:
+        return ConfidenceAssessment(level=CONFIDENCE_LOW, reasons=reasons)
+    return ConfidenceAssessment(level=CONFIDENCE_MEDIUM if reasons else CONFIDENCE_HIGH,
+                                reasons=reasons)
+
+
 def cap_verdict(verdict: str, quality: AnalysisQuality) -> tuple[str, List[str]]:
     """Aplica la política conservadora del análisis degradado.
 

--- a/API/src/modules/features/iris/services/registry.py
+++ b/API/src/modules/features/iris/services/registry.py
@@ -53,7 +53,7 @@ class RuleRegistry:
 
     def register(self, name: str, category: str = "general",
                  description: str = "", needs_context: bool = False,
-                 family: str = ""):
+                 family: str = "", is_body_dependent: bool = False):
         """Decorator that registers a function as an analysis rule.
 
         Args:
@@ -69,6 +69,13 @@ class RuleRegistry:
                 "identity") para que ``_aggregate_score`` limite la suma de
                 penalizaciones de la familia y no cuente el mismo hecho varias
                 veces. Cadena vacía = sin techo.
+            is_body_dependent: ``True`` si la regla lee el cuerpo, los enlaces
+                o los adjuntos del mensaje, es decir, si en un análisis de solo
+                cabeceras no tiene nada que inspeccionar. Es lo que alimenta la
+                cobertura del análisis (``services/quality.assess_coverage``).
+                No equivale a ``needs_context``: varias reglas de contexto solo
+                leen la cadena Received, que sí existe sin cuerpo. Por defecto
+                ``False``.
 
         Returns:
             A decorator that appends the function to the internal rule list.
@@ -81,6 +88,7 @@ class RuleRegistry:
                 "description": description,
                 "needs_context": needs_context,
                 "family": family,
+                "is_body_dependent": is_body_dependent,
             })
             return func
         return decorator

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -475,6 +475,54 @@ class IrisPDFCreator:
 
         elements.append(Spacer(1, 0.22 * inch))
 
+    _CONFIDENCE_LABELS = {"high": "Alta", "medium": "Media", "low": "Baja"}
+
+    def append_confidence(self, elements: list, theme: IrisReportTheme) -> None:
+        """Confianza y cobertura del veredicto, justo debajo de él.
+
+        Usa la misma semántica que la API y la UI: una confianza ordinal
+        (alta/media/baja), nunca un porcentaje, con sus motivos, y si se
+        inspeccionó el mensaje completo o solo sus cabeceras. No aparece en
+        informes de análisis anteriores a que se calculara.
+
+        Args:
+            elements: Lista de flowables del documento, a la que se añade.
+            theme: Tema del informe (estilos y paleta).
+        """
+        label = self._CONFIDENCE_LABELS.get(self.report.get("confidence") or "")
+        if label is None:
+            return
+
+        coverage = self.report.get("coverage") or {}
+        if coverage.get("mode") == "headers_only":
+            uncovered = coverage.get("uncoveredRules") or []
+            coverage_text = (
+                "solo cabeceras. Estas reglas no tuvieron cuerpo, enlaces ni "
+                f"adjuntos que inspeccionar: {_esc(', '.join(uncovered)) or 'ninguna'}."
+            )
+        else:
+            coverage_text = "mensaje completo."
+
+        text = (
+            f"<b>Confianza del análisis: {label}.</b> Es una escala ordinal, no "
+            "una probabilidad: el score mide riesgo y no está calibrado "
+            f"estadísticamente.<br/><b>Cobertura:</b> {coverage_text}"
+        )
+        for reason in self.report.get("uncertaintyReasons") or []:
+            text += f"<br/>• {_esc(reason)}"
+
+        card = Table([[Paragraph(text, theme.body)]], colWidths=[6.4 * inch])
+        card.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, -1), colors.HexColor(theme.palette["white"])),
+            ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor(theme.palette["light"])),
+            ("LEFTPADDING", (0, 0), (-1, -1), 14),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 14),
+            ("TOPPADDING", (0, 0), (-1, -1), 10),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 10),
+        ]))
+        elements.append(card)
+        elements.append(Spacer(1, 0.22 * inch))
+
     def append_quality_warning(self, elements: list, theme: IrisReportTheme) -> None:
         """Aviso de análisis degradado, justo debajo del veredicto.
 
@@ -800,6 +848,7 @@ class IrisPDFCreator:
 
         self.append_cover_page(elements, theme)
         self.append_verdict_hero(elements, theme)
+        self.append_confidence(elements, theme)
         self.append_quality_warning(elements, theme)
         self.append_email_preview(elements, theme)
         self.append_gate_reasons(elements, theme)

--- a/API/src/modules/features/iris/services/rules/attachment_media_rules.py
+++ b/API/src/modules/features/iris/services/rules/attachment_media_rules.py
@@ -36,7 +36,7 @@ _IMG_SRC_RE = re.compile(r'<img\b[^>]*src\s*=\s*["\']([^"\']+)["\']',
 
 
 @iris_rules.register(
-    name="External Image Tracking",
+    name="External Image Tracking", is_body_dependent=True,
     category="content_analysis", family="attachment",
     description=(
         "Detecta imágenes (u otros recursos) embebidos desde un dominio "
@@ -116,7 +116,7 @@ _SRC_RE = re.compile(r'src\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE)
 
 
 @iris_rules.register(
-    name="Image-Only Email",
+    name="Image-Only Email", is_body_dependent=True,
     category="content_analysis", family="attachment",
     description=(
         "Detecta correos cuyo contenido visible es esencialmente una sola "
@@ -333,7 +333,7 @@ def _check_headers_fallback(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Suspicious Attachments", category="content_analysis", family="attachment",
+    name="Suspicious Attachments", is_body_dependent=True, category="content_analysis", family="attachment",
     description=(
         "Inspecciona los adjuntos MIME reales (extensiones peligrosas, doble "
         "extensión, macros, HTML smuggling, ZIP con ejecutables); recurre a la "

--- a/API/src/modules/features/iris/services/rules/body_content_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_content_rules.py
@@ -179,7 +179,7 @@ def _has_evasive_hidden_text(body_html: str) -> bool:
 
 
 @iris_rules.register(
-    name="Body Content", category="content_analysis", family="content",
+    name="Body Content", is_body_dependent=True, category="content_analysis", family="content",
     description=(
         "Escanea el cuerpo del correo en busca de frases de phishing "
         "(credenciales/pago) y técnicas de texto oculto."
@@ -229,7 +229,7 @@ def check_body_content(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="BEC Wire Transfer Pattern",
+    name="BEC Wire Transfer Pattern", is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patrón típico de BEC (Business Email Compromise): "
@@ -306,7 +306,7 @@ def check_bec_wire_pattern(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Generic Greeting",
+    name="Generic Greeting", is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patrón clásico de phishing masivo: saludo genérico "
@@ -463,7 +463,7 @@ def _mixed_script(text: str) -> str | None:
 
 
 @iris_rules.register(
-    name="Unicode Evasion", category="content_analysis", family="content",
+    name="Unicode Evasion", is_body_dependent=True, category="content_analysis", family="content",
     description=(
         "Detecta caracteres de control bidireccional (RLO/LRO - spoofing de "
         "extension de archivo) y mezcla de scripts confusables (cirilico/"
@@ -640,7 +640,7 @@ _PHONE_RE = re.compile(r"(?:\+\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?
 
 
 @iris_rules.register(
-    name="TOAD Callback Pattern",
+    name="TOAD Callback Pattern", is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patron TOAD (Telephone-Oriented Attack Delivery): un "

--- a/API/src/modules/features/iris/services/rules/body_links_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_links_rules.py
@@ -40,7 +40,7 @@ def _max_score_floor() -> float:
 
 
 @iris_rules.register(
-    name="Body Links", category="content_analysis", family="links",
+    name="Body Links", is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Analiza los enlaces reales del cuerpo: texto visible vs href, "
         "punycode/IDN, IPs literales, acortadores de URL, credenciales en la "
@@ -108,7 +108,7 @@ def _decode_qr_urls(image_bytes: bytes) -> list[str]:
 
 
 @iris_rules.register(
-    name="QR Code Links", category="content_analysis", family="links",
+    name="QR Code Links", is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Decodifica códigos QR en imágenes inline/adjuntas y analiza la URL "
         "resultante con la misma batería de chequeos que Body Links "
@@ -176,7 +176,7 @@ def _looks_opaque_path(path: str) -> bool:
 
 
 @iris_rules.register(
-    name="Compromised Legitimate Domain",
+    name="Compromised Legitimate Domain", is_body_dependent=True,
     category="content_analysis", family="links",
     description=(
         "Detecta enlaces a dominios legítimos que probablemente han sido "
@@ -247,7 +247,7 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="External Login Link",
+    name="External Login Link", is_body_dependent=True,
     category="content_analysis",
     description=(
         "Señal informativa (score 0): ¿hay algún enlace del cuerpo cuyo "

--- a/API/tests/integration/test_iris_confidence.py
+++ b/API/tests/integration/test_iris_confidence.py
@@ -1,0 +1,102 @@
+"""Confianza, cobertura e incertidumbre del veredicto, de punta a punta.
+
+El score de Iris es una escala de riesgo, no una probabilidad, y un análisis
+de solo cabeceras ejecutaba las reglas de cuerpo sobre un mensaje vacío sin
+decirlo. Estos tests ejecutan el catálogo real como lo haría el worker y
+comprueban qué se persiste y qué devuelve la API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.quality import (
+    CONFIDENCE_LOW,
+    COVERAGE_FULL_MESSAGE,
+    COVERAGE_HEADERS_ONLY,
+)
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+_HEADERS = (
+    "From: equipo@example.com\r\n"
+    "To: destinatario@example.com\r\n"
+    "Subject: Acta de la reunión\r\n"
+    "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+    "Message-ID: <abc123@example.com>\r\n"
+)
+_FULL_MESSAGE = _HEADERS + "Content-Type: text/plain\r\n\r\nAdjunto el acta de ayer.\r\n"
+
+
+def _analyze(app, user_id: int, raw: str) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        IrisManager()._run_analysis(analysis_id, raw)
+    return analysis_id
+
+
+def _body_dependent_rule_names() -> list[str]:
+    return [rule_def["name"] for rule_def in iris_rules.get_rules() if rule_def["is_body_dependent"]]
+
+
+def test_a_clean_headers_only_analysis_is_legitimate_with_low_confidence(
+        client, app, root_user, root_headers):
+    """Un Legítimo de solo cabeceras no puede presentarse con la misma
+    seguridad que uno que inspeccionó el contenido: la API lo dice."""
+    analysis_id = _analyze(app, root_user.id, _HEADERS)
+
+    response = client.get(f"/iris/results/{analysis_id}", headers=root_headers)
+
+    assert response.status_code == 200
+    report = response.get_json()
+    assert report["verdict"] == "Legitimate"
+    assert report["confidence"] == CONFIDENCE_LOW
+    assert report["coverage"]["mode"] == COVERAGE_HEADERS_ONLY
+    assert report["coverage"]["uncoveredRules"] == _body_dependent_rule_names()
+    assert any("Solo se analizaron las cabeceras" in reason
+               for reason in report["uncertaintyReasons"])
+
+
+def test_a_full_message_analysis_has_full_coverage(client, app, root_user, root_headers):
+    analysis_id = _analyze(app, root_user.id, _FULL_MESSAGE)
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    assert report["coverage"] == {"mode": COVERAGE_FULL_MESSAGE, "uncoveredRules": []}
+    assert report["confidence"] != CONFIDENCE_LOW
+    assert not any("cabeceras" in reason for reason in report["uncertaintyReasons"])
+
+
+def test_the_listing_carries_the_confidence(client, app, root_user, root_headers):
+    """El historial también la muestra, para que el triaje no tenga que abrir
+    cada análisis para saber cuáles sostienen su veredicto."""
+    analysis_id = _analyze(app, root_user.id, _HEADERS)
+
+    listing = client.get("/iris/results", headers=root_headers).get_json()
+
+    item = next(entry for entry in listing["analyses"] if entry["analysisId"] == analysis_id)
+    assert item["confidence"] == CONFIDENCE_LOW
+
+
+def test_an_analysis_without_confidence_serializes_nulls(client, app, root_user, root_headers):
+    """Los análisis anteriores a esta columna siguen leyéndose sin error."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=_HEADERS, user_id=root_user.id,
+                                    status="finished", verdict="Legitimate", total_score=100.0)
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    assert report["confidence"] is None
+    assert report["coverage"] is None
+    assert report["uncertaintyReasons"] == []

--- a/API/tests/unit/test_iris_ai_writer.py
+++ b/API/tests/unit/test_iris_ai_writer.py
@@ -117,3 +117,37 @@ def test_user_prompt_includes_verdict_score_and_only_failed_rules(monkeypatch):
     assert "Lookalike Sender Domain" in prompt
     # SPF passed (score 0) -- must not appear in the failed-rules list.
     assert '"name": "SPF"' not in prompt
+
+
+def test_user_prompt_carries_the_analysis_confidence_and_coverage(monkeypatch):
+    """El resumen recibe la misma confianza, cobertura y motivos que ve el
+    analista, y la instrucción de no convertirlos en porcentaje."""
+    monkeypatch.setattr(CR, "iris_config", lambda: CR.IrisConfig(prompts=_FAKE_PROMPTS))
+    writer = IrisAIWriter(generator=_FakeGenerator("{}"))
+    report = _sample_report() | {
+        "confidence": "low",
+        "coverage": {"mode": "headers_only", "uncoveredRules": ["Body Links"]},
+        "uncertaintyReasons": ["Solo se analizaron las cabeceras."],
+    }
+    prompt = writer._build_user_prompt(report)
+
+    assert "CONFIANZA DEL ANÁLISIS: BAJA" in prompt
+    assert "solo cabeceras" in prompt
+    assert "Solo se analizaron las cabeceras." in prompt
+    assert "porcentaje" in prompt
+
+
+def test_user_prompt_has_no_confidence_note_for_old_reports(monkeypatch):
+    monkeypatch.setattr(CR, "iris_config", lambda: CR.IrisConfig(prompts=_FAKE_PROMPTS))
+    writer = IrisAIWriter(generator=_FakeGenerator("{}"))
+    assert "CONFIANZA DEL ANÁLISIS" not in writer._build_user_prompt(_sample_report())
+
+
+def test_generate_reports_the_analysis_confidence_not_the_model_one(monkeypatch):
+    """El modelo no puede saber más que el análisis del que parte: aunque
+    responda ALTA, el resumen lleva la confianza del análisis."""
+    monkeypatch.setattr(CR, "iris_config", lambda: CR.IrisConfig(prompts=_FAKE_PROMPTS))
+    raw = '{"executive_summary": "x", "attacker_intent": "y", "confidence": "ALTA"}'
+    writer = IrisAIWriter(generator=_FakeGenerator(raw))
+    result = writer.generate(_sample_report() | {"confidence": "medium"})
+    assert result["confidence"] == "MEDIA"

--- a/API/tests/unit/test_iris_quality.py
+++ b/API/tests/unit/test_iris_quality.py
@@ -141,3 +141,111 @@ def test_detector_version_fits_the_column():
     rules = [_rule(f"Regla número {i} con nombre largo") for i in range(200)]
 
     assert len(detector_version(rules)) <= 64
+
+
+# ------------------------------------------------ cobertura y confianza
+
+import inspect
+import re
+
+from src.modules.features.iris.services.contexts import ContextEvaluation
+from src.modules.features.iris.services.parsers import parse_raw_message
+from src.modules.features.iris.services.quality import (
+    CONFIDENCE_HIGH,
+    CONFIDENCE_LOW,
+    CONFIDENCE_MEDIUM,
+    COVERAGE_FULL_MESSAGE,
+    COVERAGE_HEADERS_ONLY,
+    AnalysisQuality,
+    assess_confidence,
+    assess_coverage,
+)
+from src.modules.features.iris.services.rules import iris_rules
+
+_HEADERS_ONLY = "From: a@corp.example\r\nTo: b@corp.example\r\nSubject: Hola\r\n"
+_FULL_MESSAGE = _HEADERS_ONLY + "Content-Type: text/plain\r\n\r\nCuerpo del mensaje.\r\n"
+
+
+def _evaluation(verdict="Legitimate", score=100.0, mode=COVERAGE_FULL_MESSAGE,
+                quality=None, context_type="inner"):
+    return ContextEvaluation(
+        context_type=context_type, verdict=verdict, total_score=score, gate_reasons=[],
+        results=[], quality=quality or AnalysisQuality(quality=QUALITY_COMPLETE),
+        coverage={"mode": mode, "uncoveredRules": ["Body Links"] if mode == COVERAGE_HEADERS_ONLY else []},
+    )
+
+
+def test_headers_only_coverage_lists_the_body_dependent_rules():
+    rules_defs = [_rule("Body Links") | {"is_body_dependent": True}, _rule("SPF")]
+    coverage = assess_coverage(parse_raw_message(_HEADERS_ONLY), rules_defs)
+    assert coverage == {"mode": COVERAGE_HEADERS_ONLY, "uncoveredRules": ["Body Links"]}
+
+
+def test_a_message_with_a_body_has_full_coverage():
+    rules_defs = [_rule("Body Links") | {"is_body_dependent": True}]
+    coverage = assess_coverage(parse_raw_message(_FULL_MESSAGE), rules_defs)
+    assert coverage == {"mode": COVERAGE_FULL_MESSAGE, "uncoveredRules": []}
+
+
+def test_a_clean_full_analysis_has_high_confidence_and_no_reasons():
+    assessment = assess_confidence(_evaluation(), None, 80, 55)
+    assert assessment.level == CONFIDENCE_HIGH
+    assert assessment.reasons == []
+
+
+def test_a_legitimate_verdict_on_headers_only_is_low_confidence():
+    """Un Legítimo sin contenido que mirar no dice que el mensaje sea seguro."""
+    assessment = assess_confidence(_evaluation(mode=COVERAGE_HEADERS_ONLY), None, 80, 55)
+    assert assessment.level == CONFIDENCE_LOW
+    assert any("Solo se analizaron las cabeceras" in reason for reason in assessment.reasons)
+
+
+def test_a_phishing_verdict_on_headers_only_is_only_medium():
+    """Las cabeceras bastaron para ver phishing: falta contenido, pero el
+    veredicto no afirma nada que no se haya comprobado."""
+    assessment = assess_confidence(
+        _evaluation(verdict="Phishing", score=20.0, mode=COVERAGE_HEADERS_ONLY), None, 80, 55,
+    )
+    assert assessment.level == CONFIDENCE_MEDIUM
+
+
+def test_a_blocking_degradation_is_low_and_a_minor_one_is_medium():
+    blocking = AnalysisQuality(quality=QUALITY_DEGRADED, failed_rules=[{"name": "SPF"}],
+                               blocks_clean_verdict=True)
+    minor = AnalysisQuality(quality=QUALITY_DEGRADED, failed_rules=[{"name": "Generic Greeting"}])
+    assert assess_confidence(_evaluation(verdict="Suspicious", score=70.0, quality=blocking),
+                             None, 80, 55).level == CONFIDENCE_LOW
+    assert assess_confidence(_evaluation(verdict="Suspicious", score=70.0, quality=minor),
+                             None, 80, 55).level == CONFIDENCE_MEDIUM
+
+
+def test_a_score_next_to_a_threshold_is_medium():
+    assessment = assess_confidence(_evaluation(score=82.0), None, 80, 55)
+    assert assessment.level == CONFIDENCE_MEDIUM
+    assert any("umbral 80" in reason for reason in assessment.reasons)
+
+
+def test_a_gated_verdict_is_not_borderline_even_near_a_threshold():
+    """Si un gate decidió el veredicto, que el score esté cerca de un umbral
+    no lo hace frágil: cambiar el score no lo cambiaría."""
+    assessment = assess_confidence(_evaluation(verdict="Phishing", score=82.0), None, 80, 55)
+    assert assessment.level == CONFIDENCE_HIGH
+
+
+def test_a_forward_whose_messages_disagree_is_medium():
+    secondary = _evaluation(verdict="Legitimate", context_type="wrapper")
+    assessment = assess_confidence(_evaluation(verdict="Phishing", score=20.0), secondary, 80, 55)
+    assert assessment.level == CONFIDENCE_MEDIUM
+    assert any("no coinciden" in reason for reason in assessment.reasons)
+
+
+_BODY_ACCESS_RE = re.compile(r"\.(body_text|body_html|links|attachments)\b")
+
+
+def test_every_rule_that_reads_the_body_declares_it():
+    """``is_body_dependent`` alimenta la cobertura: si una regla lee cuerpo,
+    enlaces o adjuntos sin declararlo, un análisis de solo cabeceras diría
+    que la cubrió cuando no tuvo nada que mirar."""
+    for rule_def in iris_rules.get_rules():
+        reads_body = bool(_BODY_ACCESS_RE.search(inspect.getsource(rule_def["func"])))
+        assert rule_def["is_body_dependent"] == reads_body, rule_def["name"]

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -256,3 +256,35 @@ def test_preview_note_says_the_original_won_by_default():
     report = _sample_report(unwrappedFromForward=True, wrapperFrom="colega@corp.example")
     text = _rendered_preview_text(report)
     assert "correo original reenviado" in text
+
+
+# ------------------------------------------------ confianza y cobertura
+
+def _rendered_confidence_text(report: dict) -> str:
+    creator = IrisPDFCreator(report=report)
+    elements: list = []
+    creator.append_confidence(elements, _theme())
+    texts = []
+    for element in elements:
+        for row in getattr(element, "_cellvalues", []):
+            texts.extend(cell.text for cell in row if hasattr(cell, "text"))
+    return "\n".join(texts)
+
+
+def test_confidence_card_shows_level_coverage_and_reasons_without_a_percentage():
+    report = _sample_report(
+        confidence="low",
+        coverage={"mode": "headers_only", "uncoveredRules": ["Body Links", "Body Content"]},
+        uncertaintyReasons=["Solo se analizaron las cabeceras."],
+    )
+    text = _rendered_confidence_text(report)
+    assert "Confianza del análisis: Baja" in text
+    assert "no una probabilidad" in text
+    assert "solo cabeceras" in text
+    assert "Body Links, Body Content" in text
+    assert "Solo se analizaron las cabeceras." in text
+    assert "%" not in text
+
+
+def test_confidence_card_is_omitted_for_reports_without_confidence():
+    assert _rendered_confidence_text(_sample_report()) == ""

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -96,7 +96,25 @@
       </div>
 
       <!-- Score + Verdict hero -->
-      <IrisVerdictHero :score="reportData.totalScore" :verdict="reportData.verdict" />
+      <IrisVerdictHero
+        :score="reportData.totalScore"
+        :verdict="reportData.verdict"
+        :confidence="reportData.confidence"
+        :coverage-mode="reportData.coverage?.mode ?? null"
+      />
+
+      <!-- Incertidumbre: por qué la confianza no es alta. Va junto al veredicto
+           porque lo matiza; en solo cabeceras lista además qué reglas no
+           tuvieron cuerpo, enlaces ni adjuntos que inspeccionar. -->
+      <div v-if="uncertaintyReasons.length || uncoveredRules.length" class="rv-uncertainty">
+        <strong class="uncertainty-title">Qué limita este veredicto</strong>
+        <ul v-if="uncertaintyReasons.length" class="uncertainty-list">
+          <li v-for="(reason, i) in uncertaintyReasons" :key="i">{{ reason }}</li>
+        </ul>
+        <p v-if="uncoveredRules.length" class="uncertainty-rules">
+          Sin contenido que inspeccionar: {{ uncoveredRules.join(' · ') }}
+        </p>
+      </div>
 
       <!-- Análisis degradado: alguna regla no llegó a ejecutarse, así que
            una parte del mensaje no se ha inspeccionado. Va inmediatamente
@@ -345,6 +363,15 @@ const failedRuleNames = computed(() =>
 )
 const isDegraded = computed(() =>
   props.reportData?.analysisQuality === 'degraded' || failedRuleNames.value.length > 0
+)
+// Confianza ordinal y cobertura (ver IrisVerdictHero). Los motivos y las
+// reglas sin contenido vienen ya calculados por la API: el componente no
+// reinterpreta nada, para que UI, PDF y resumen de IA digan lo mismo.
+const uncertaintyReasons = computed(() => props.reportData?.uncertaintyReasons ?? [])
+const uncoveredRules = computed(() =>
+  props.reportData?.coverage?.mode === 'headers_only'
+    ? (props.reportData.coverage.uncoveredRules ?? [])
+    : []
 )
 const passedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict === 'pass'))
 const passedRulesOpen = ref(false)
@@ -866,6 +893,35 @@ watch(
 }
 
 .degraded-rules {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
+.rv-uncertainty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border-med);
+  color: var(--text);
+}
+
+.uncertainty-title {
+  font-size: var(--fs-md);
+}
+
+.uncertainty-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: var(--fs-md);
+  line-height: 1.6;
+}
+
+.uncertainty-rules {
   margin: 0;
   font-size: var(--fs-sm);
   color: var(--text-muted);

--- a/web/app/src/components/iris/IrisVerdictHero.vue
+++ b/web/app/src/components/iris/IrisVerdictHero.vue
@@ -7,6 +7,9 @@
     <div class="rv-hero-verdict">
       <span class="verdict-badge" :class="`verdict--${verdictClass}`">{{ verdict }}</span>
       <span class="verdict-status">{{ statusLabel }}</span>
+      <span v-if="confidenceLabel" class="verdict-confidence" :class="`confidence--${confidence}`">
+        Confianza {{ confidenceLabel }} · {{ coverageLabel }}
+      </span>
     </div>
   </div>
 </template>
@@ -22,7 +25,18 @@ import { computed } from 'vue'
 const props = defineProps({
   score: { type: [Number, null], default: null },
   verdict: { type: [String, null], default: null },
+  // Confianza ordinal del análisis ('high' | 'medium' | 'low'). No es una
+  // probabilidad: el score no está calibrado, así que nunca se muestra como %.
+  confidence: { type: [String, null], default: null },
+  // 'full_message' | 'headers_only'
+  coverageMode: { type: [String, null], default: null },
 })
+
+const CONFIDENCE_LABELS = { high: 'alta', medium: 'media', low: 'baja' }
+const confidenceLabel = computed(() => CONFIDENCE_LABELS[props.confidence] ?? '')
+const coverageLabel = computed(() =>
+  props.coverageMode === 'headers_only' ? 'solo cabeceras' : 'mensaje completo'
+)
 
 const verdictClass = computed(() => {
   const v = props.verdict?.toLowerCase() ?? ''
@@ -110,4 +124,11 @@ const statusLabel = computed(() => {
   font-size: var(--fs-lg);
   color: var(--text-dim);
 }
+
+.verdict-confidence {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+.confidence--low { color: var(--warn); }
 </style>


### PR DESCRIPTION
## El problema

El score de Iris va de 0 a 100 y mide **riesgo**: parte de 100 y cada señal sospechosa resta puntos. No es una probabilidad. Aun así, un "92/100" se lee fácilmente como "92 % de certeza de que es legítimo", y eso no lo sostiene nada: nadie ha medido con qué frecuencia acierta cada tramo del score.

Además, un análisis puede hacerse de dos formas: pegando **solo las cabeceras** del correo o subiendo el **`.eml` completo**. En modo solo cabeceras, las reglas que miran el cuerpo, los enlaces o los adjuntos se ejecutaban igualmente sobre un mensaje vacío. No encontraban nada porque no había nada que mirar, y el resultado podía salir `Legitimate` sin avisar de que la mitad del examen no se había hecho.

Cierra #223 (iniciativa `M02`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

**Cobertura.** Cada análisis guarda qué partes del mensaje se inspeccionaron (`coverage`):
- `mode`: `full_message` si había cuerpo o adjuntos, `headers_only` si no.
- `uncoveredRules`: en modo solo cabeceras, las reglas de cuerpo, enlaces y adjuntos que no tuvieron nada que mirar.

Para saber cuáles son, las 12 reglas que leen cuerpo, enlaces o adjuntos lo declaran ahora con `is_body_dependent=True` en su registro. No se puede usar `needs_context`: varias reglas que lo tienen solo leen la cadena `Received`, que sí existe sin cuerpo. Un test recorre el código de cada regla y falla si alguna lee el cuerpo sin declararlo, o lo declara sin leerlo.

**Confianza ordinal, no numérica.** `confidence` vale `high`, `medium` o `low`, siempre con sus motivos en `uncertaintyReasons`. Sale de reglas fijas (`services/quality.assess_confidence`):

| Motivo | Efecto |
|---|---|
| Solo cabeceras | `medium`; **`low`** si además el veredicto es `Legitimate`, porque decir "limpio" sin haber mirado el contenido es afirmar algo que no se comprobó |
| Alguna regla no se pudo ejecutar (análisis degradado) | `medium`; **`low`** si era de autenticación o de adjuntos, las dos familias que ya impiden el veredicto limpio |
| Score a menos de 5 puntos de un umbral | `medium`, solo si el veredicto sale del score: si lo decidió un gate, mover el score no lo cambiaría |
| En un reenvío, el envoltorio y el original no coinciden | `medium` |

Nunca se muestra un porcentaje. Un número de confianza afirmaría una precisión que nadie ha medido; eso llegará, si llega, con la calibración de `M05` y el feedback de `M04`.

**La misma semántica en todas partes:**
- **API:** `GET /iris/results/<id>` devuelve `confidence`, `coverage` y `uncertaintyReasons`; el listado, `confidence`.
- **UI:** bajo el veredicto aparece "Confianza baja · solo cabeceras", más un bloque con los motivos y las reglas sin contenido.
- **PDF:** una tarjeta nueva bajo el veredicto, que aclara que la escala es ordinal y no una probabilidad.
- **Resumen de IA:** recibe la misma confianza, cobertura y motivos, con la instrucción de no convertirlos en porcentaje. El campo `confidence` del resumen se fija al del análisis aunque el modelo responda otra cosa, porque el resumen no puede saber más que el análisis del que parte.

## Migración

`f4b8d1e6a2c9_add_iris_analysis_confidence_coverage`: tres columnas nulables en `IrisAnalysis`. Los análisis antiguos se leen con `null` y la UI y el PDF simplemente no muestran el bloque.

## Validación

- **`test_iris_quality.py`.** Cobertura en solo cabeceras y en mensaje completo. Cada nivel de confianza y cada motivo, incluido el caso en que un gate decide el veredicto y el score cercano al umbral no cuenta. Y el guard del flag `is_body_dependent`.
- **`test_iris_confidence.py` (nuevo, integración, catálogo real).** Un correo limpio de solo cabeceras sale `Legitimate` con confianza `low` y las 12 reglas sin contenido listadas. El mismo correo con cuerpo tiene cobertura completa. El listado lleva la confianza. Un análisis antiguo se serializa con `null`.
- **`test_iris_ai_writer.py`.** El prompt lleva la confianza y la cobertura, y el `confidence` del resumen es el del análisis.
- **`test_iris_reports.py`.** La tarjeta del PDF muestra nivel, cobertura y motivos, sin `%`.
- **`pytest tests/ -k iris`:** todo en verde. **`pylint src`:** 10.00/10.
- **`IrisReportViewer.vue` e `IrisVerdictHero.vue`:** compilados con `@vue/compiler-sfc`. `npm run build` sigue sin poder ejecutarse aquí: falta el paquete privado `@projectellysia/acheron-core-web`.

## Notas

- **Margen del umbral.** Es una constante (`BORDERLINE_MARGIN = 5`), no configuración: los perfiles de sensibilidad y los umbrales versionados llegan con `M05`, que es donde tiene sentido hacerlo configurable.
- **Qué se considera cuerpo.** La cobertura considera "mensaje completo" cualquier envío con cuerpo o adjuntos. Un `.eml` completo con el cuerpo vacío se trata como solo cabeceras, lo cual es correcto: tampoco había contenido que mirar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
