### PR TITLE
fix(web): traducir la etiqueta de periodo "tier" en el panel de planes

### DIFF
--- a/web/app/src/views/AdminPlansView.vue
+++ b/web/app/src/views/AdminPlansView.vue
@@ -251,7 +251,7 @@ import { useToastStore } from '@/stores/toastStore'
 const { apiFetch, apiError } = useApi()
 const toast = useToastStore()
 
-const PERIODS = { month: 'mensual', day: 'diario', stock: 'existencias' }
+const PERIODS = { month: 'mensual', day: 'diario', stock: 'existencias', tier: 'nivel' }
 
 const plans = ref([])
 const limitKeys = ref([])


### PR DESCRIPTION
## Summary

En el panel de administración de planes, la tabla de "Topes" de un plan enseña, para cada clave de
límite, con qué periodicidad se mide (mensual, diario, existencias...). Esa traducción vivía en un
mapa local del componente Vue que cubría tres de los cuatro periodos posibles del backend; al
periodo que representa un **nivel** (no una cantidad que se consume, sino un escalón que el plan
concede — hoy solo lo usa `aegis.white_label`, el alcance del white-labeling de una campaña) le
faltaba entrada, así que su fila mostraba el código interno `tier` en crudo en vez de un texto en
castellano. Es lo que se reportó como "la etiqueta de white label de aegis no se muestra
correctamente".

## Related Issue

Closes ProjectEllysia/EllysiaServer#575

## Implementation

Una sola fase: se añadió la entrada que faltaba (`tier: 'nivel'`) al mapa `PERIODS` de
`web/app/src/views/AdminPlansView.vue`, con el mismo nombre que ya usa el backend para describir
ese periodo en su propia documentación (`LimitPeriod.TIER`, en
`API/src/modules/accounts/services/limits.py`). No hace falta ningún cambio de backend: el
identificador que sirve `GET /plans/limit-keys` (`tier`) es correcto, solo faltaba su traducción en
el front.

## Validation

- `npx vite build` sobre la SPA: el chunk de `AdminPlansView` compila sin errores con el cambio
  aplicado (el build completo falla más adelante por un paquete local no resuelto en
  `LoginView.vue`, ajeno a este cambio y ya presente antes de tocar nada).
- No existen tests automatizados para este componente ni para su tabla de topes, así que no hay
  suite que ejecutar contra el cambio; es una traducción estática sin lógica que cubrir.

## Notes

- No se ha tocado la forma en que se editan los valores de una clave de tipo nivel (hoy son inputs
  numéricos igual que las de tipo cantidad, en vez de un selector de escalón): no era el problema
  reportado y cambiarlo sería una decisión de producto aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)