### PR TITLE
feat(iris): evidencia anclada a cabeceras, MIME, cuerpo y adjuntos (M01)

### DIFF
--- a/API/alembic/versions/a7c3e9f15b28_add_iris_rule_result_evidence.py
+++ b/API/alembic/versions/a7c3e9f15b28_add_iris_rule_result_evidence.py
@@ -1,0 +1,36 @@
+"""iris: evidencia anclada de cada hallazgo (IrisRuleResult)
+
+Cada regla que penaliza dice ahora dónde está lo que encontró —cabecera y
+aparición, rango del cuerpo, parte MIME, adjunto o URL— con un extracto ya
+desactivado, o por qué no se puede anclar a un fragmento concreto.
+
+Revision ID: a7c3e9f15b28
+Revises: f4b8d1e6a2c9
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7c3e9f15b28'
+down_revision: Union[str, Sequence[str], None] = 'f4b8d1e6a2c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisRuleResult', sa.Column('evidence',
+                                              postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('IrisRuleResult', sa.Column('evidence_unavailable_reason', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisRuleResult', 'evidence_unavailable_reason')
+    op.drop_column('IrisRuleResult', 'evidence')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -448,7 +448,8 @@ class IrisManager(TaskTrackingMixin):
 
         Returns:
             dict: ``ruleName``, ``category``, ``score``, ``verdict``,
-                ``details`` y ``recommendation``.
+                ``details``, ``recommendation``, ``evidence`` (lista, vacía si
+                no hay) y ``evidenceUnavailableReason``.
         """
         return {
             "ruleName": rule.rule_name,
@@ -457,6 +458,8 @@ class IrisManager(TaskTrackingMixin):
             "verdict": rule.verdict,
             "details": rule.details,
             "recommendation": rule.recommendation,
+            "evidence": rule.evidence or [],
+            "evidenceUnavailableReason": rule.evidence_unavailable_reason,
         }
 
     @classmethod
@@ -1268,6 +1271,8 @@ class IrisManager(TaskTrackingMixin):
                         recommendation=rule_result.recommendation,
                         position=position,
                         context_type=evaluation.context_type,
+                        evidence=rule_result.evidence or None,
+                        evidence_unavailable_reason=rule_result.evidence_unavailable_reason,
                     ))
 
             secondary_summary = None

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -483,6 +483,14 @@ class IrisRuleResult(Base):
                         muestra las del ganador y deja las otras como
                         contexto secundario. NULL en filas anteriores a que se
                         guardara, que solo existían para el contexto ganador.
+        evidence: Dónde está, dentro del mensaje, lo que la regla encontró:
+                        lista de ``{kind, locator, excerpt}`` con el contrato
+                        de ``services/evidence.py`` (cabecera y aparición,
+                        rango del cuerpo, parte MIME, adjunto o URL), con el
+                        extracto ya desactivado. NULL si la regla no penalizó
+                        o no pudo anclarse.
+        evidence_unavailable_reason: Por qué un hallazgo no se puede anclar;
+                        NULL si tiene evidencia o si la regla no penalizó.
         analysis: SQLAlchemy back-reference to the parent IrisAnalysis.
     """
     __tablename__ = "IrisRuleResult"
@@ -497,6 +505,8 @@ class IrisRuleResult(Base):
     recommendation = Column(Text, nullable=True)
     position = Column(SmallInteger, nullable=False, default=0)
     context_type = Column(String(16), nullable=True)
+    evidence = Column(JSONB, nullable=True)
+    evidence_unavailable_reason = Column(Text, nullable=True)
 
     analysis = relationship("IrisAnalysis", back_populates="rule_results")
 

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -119,14 +119,34 @@ class AnalysisStatusResponseSchema(Schema):
     failureReason = fields.String(load_default=None, allow_none=True)
 
 
+class EvidenceSchema(Schema):
+    """Dónde está, dentro del mensaje, lo que una regla encontró.
+
+    ``kind`` es ``header``, ``body``, ``mime_part``, ``attachment`` o ``url``;
+    ``locator`` dice cómo encontrarlo (p. ej. ``{"header": "from",
+    "occurrence": 0}`` o ``{"linkIndex": 2}``) y ``excerpt`` es el fragmento
+    con URLs, dominios y direcciones ya desactivados (``hxxp``, ``[.]``,
+    ``[@]``). Ver ``services/evidence.py``.
+    """
+    kind = fields.String()
+    locator = fields.Dict()
+    excerpt = fields.String()
+
+
 class RuleResultSchema(Schema):
-    """Outcome of a single rule within a finished analysis."""
+    """Outcome of a single rule within a finished analysis.
+
+    Una regla que penaliza trae ``evidence`` o, si su hallazgo no se puede
+    anclar a un fragmento del mensaje, ``evidenceUnavailableReason``.
+    """
     ruleName = fields.String()
     category = fields.String(load_default=None)
     score = fields.Float()
     verdict = fields.String()
     details = fields.Dict(load_default=None)
     recommendation = fields.String(load_default=None)
+    evidence = fields.List(fields.Nested(EvidenceSchema), load_default=None)
+    evidenceUnavailableReason = fields.String(load_default=None, allow_none=True)
 
 
 class TopSignalSchema(Schema):

--- a/API/src/modules/features/iris/services/evidence.py
+++ b/API/src/modules/features/iris/services/evidence.py
@@ -1,0 +1,326 @@
+"""
+Evidencia anclada: dónde, dentro del mensaje, está lo que una regla encontró.
+
+Un hallazgo sin ancla obliga al analista a reconstruir la decisión leyendo el
+raw entero. Este módulo define el contrato de evidencia que acompaña a cada
+``RuleResult`` que penaliza, los constructores que usan las reglas para
+producirla y la desactivación (*defang*) de URLs, dominios y direcciones, que
+permite mostrar un extracto en la UI o en un PDF sin dejar un enlace vivo.
+
+Cada elemento de evidencia es un dict serializable tal cual a JSONB::
+
+    {"kind": "header", "locator": {"header": "from", "occurrence": 0},
+     "excerpt": "Soporte <alerta[@]evil[.]example>"}
+
+``kind`` dice qué parte del mensaje señala y ``locator`` cómo encontrarla:
+
+- ``header``: ``header`` (nombre en minúsculas) y ``occurrence`` (0 = la
+  primera aparición, que para cabeceras de traza como ``Received`` es la más
+  reciente).
+- ``body``: ``part`` (``text`` o ``html``), ``start`` y ``end`` (offsets).
+- ``mime_part``: ``partIndex``.
+- ``attachment``: ``attachmentIndex`` (posición en
+  ``MessageContext.attachments``), más ``filename``, ``contentType``, ``size``
+  y ``sha256`` cuando se conocen.
+- ``url``: ``linkIndex`` (posición en ``MessageContext.links``) o
+  ``attachmentIndex`` si la URL salió de un adjunto (un QR), con ``source``.
+
+``excerpt`` es siempre texto ya desactivado y recortado.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import replace
+from typing import Any, Dict, Iterable, List, Sequence
+
+logger = logging.getLogger(__name__)
+
+EVIDENCE_HEADER = "header"
+EVIDENCE_BODY = "body"
+EVIDENCE_MIME_PART = "mime_part"
+EVIDENCE_ATTACHMENT = "attachment"
+EVIDENCE_URL = "url"
+
+#: Claves de ``locator`` obligatorias por tipo. ``url`` va aparte porque le
+#: basta una de dos (``_URL_LOCATOR_KEYS``).
+_REQUIRED_LOCATOR_KEYS = {
+    EVIDENCE_HEADER: ("header", "occurrence"),
+    EVIDENCE_BODY: ("part", "start", "end"),
+    EVIDENCE_MIME_PART: ("partIndex",),
+    EVIDENCE_ATTACHMENT: ("attachmentIndex",),
+}
+_URL_LOCATOR_KEYS = ("linkIndex", "attachmentIndex")
+
+#: Longitud máxima de un extracto: suficiente para leer una cabecera o una
+#: URL, corto para que un informe no se convierta en una copia del raw.
+MAX_EXCERPT_LENGTH = 240
+
+#: Cuántas apariciones de una cabecera repetida (``Received``) se anclan.
+MAX_REPEATED_HEADER_OCCURRENCES = 10
+
+_URL_SCHEME_RE = re.compile(r"(?i)\bhttp(s?)(?=://)")
+#: Un token con forma de dominio: etiquetas separadas por puntos cuya última
+#: empieza por letra. Así una IP (``203.0.113.9``) queda legible — en la cadena
+#: Received es evidencia forense, no un enlace.
+_DOMAIN_TOKEN_RE = re.compile(r"\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z][A-Za-z0-9-]*\b")
+
+
+def defang(text: str) -> str:
+    """Desactiva URLs, dominios y direcciones de un texto y lo recorta.
+
+    ``https://evil.example/x`` pasa a ``hxxps://evil[.]example/x`` y
+    ``a@evil.example`` a ``a[@]evil[.]example``: el analista sigue leyendo el
+    indicador, pero ni el visor de PDF ni el navegador lo convierten en un
+    enlace que se pueda pulsar por error.
+
+    Args:
+        text: Texto original (valor de cabecera, URL, nombre de fichero…).
+
+    Returns:
+        str: El texto desactivado, de como mucho ``MAX_EXCERPT_LENGTH``
+            caracteres (termina en ``…`` si se recortó).
+    """
+    defanged = _URL_SCHEME_RE.sub(lambda match: f"hxxp{match.group(1)}", text or "")
+    defanged = _DOMAIN_TOKEN_RE.sub(lambda match: match.group(0).replace(".", "[.]"), defanged)
+    defanged = defanged.replace("@", "[@]")
+    if len(defanged) > MAX_EXCERPT_LENGTH:
+        defanged = defanged[:MAX_EXCERPT_LENGTH - 1] + "…"
+    return defanged
+
+
+def validate_evidence(item: Any) -> None:
+    """Comprueba que un elemento de evidencia cumple el contrato del módulo.
+
+    Args:
+        item: Elemento que una regla devolvió en ``RuleResult.evidence``.
+
+    Raises:
+        ValueError: Si no es un dict con ``kind`` conocido, ``locator`` con
+            las claves que ese tipo exige y ``excerpt`` de texto.
+    """
+    if not isinstance(item, dict):
+        raise ValueError(f"La evidencia debe ser un dict, no {type(item).__name__}.")
+    kind = item.get("kind")
+    locator = item.get("locator")
+    if not isinstance(locator, dict):
+        raise ValueError(f"La evidencia de tipo {kind!r} no trae un locator.")
+    if not isinstance(item.get("excerpt"), str):
+        raise ValueError(f"La evidencia de tipo {kind!r} no trae un extracto de texto.")
+    if kind == EVIDENCE_URL:
+        if not any(key in locator for key in _URL_LOCATOR_KEYS):
+            raise ValueError("La evidencia de tipo 'url' necesita linkIndex o attachmentIndex.")
+        return
+    required = _REQUIRED_LOCATOR_KEYS.get(kind)
+    if required is None:
+        raise ValueError(f"Tipo de evidencia desconocido: {kind!r}.")
+    missing = [key for key in required if key not in locator]
+    if missing:
+        raise ValueError(f"A la evidencia de tipo {kind!r} le faltan claves en el locator: {missing}.")
+
+
+def _header_item(header_name: str, occurrence: int, value: str) -> Dict[str, Any]:
+    """Construye la evidencia de una aparición concreta de una cabecera.
+
+    Args:
+        header_name: Nombre de la cabecera en minúsculas.
+        occurrence: Aparición (0 = la primera del mensaje).
+        value: Valor de la cabecera, sin desactivar.
+
+    Returns:
+        dict: Elemento de evidencia de tipo ``header``.
+    """
+    return {
+        "kind": EVIDENCE_HEADER,
+        "locator": {"header": header_name, "occurrence": occurrence},
+        "excerpt": defang(value),
+    }
+
+
+def header_evidence(rule_input: Any, header_names: Sequence[str]) -> List[Dict[str, Any]]:
+    """Evidencia de las cabeceras indicadas que existen en el mensaje.
+
+    Las que faltan se omiten: señalar una cabecera ausente no ancla nada.
+    ``received`` se ancla aparición por aparición (hasta
+    ``MAX_REPEATED_HEADER_OCCURRENCES``) cuando la entrada es un
+    ``MessageContext``, porque las reglas de la cadena Received hablan de la
+    cadena entera; con un dict de cabeceras solo existe la primera.
+
+    Args:
+        rule_input: Lo que recibió la regla: un ``MessageContext`` o el dict
+            de cabeceras (claves en minúsculas).
+        header_names: Cabeceras a anclar, en minúsculas y en el orden en que
+            se quieren mostrar.
+
+    Returns:
+        List[dict]: Un elemento ``header`` por aparición encontrada; lista
+            vacía si no existe ninguna.
+    """
+    headers = getattr(rule_input, "headers", rule_input) or {}
+    received_lines = getattr(rule_input, "received_headers", None)
+    items: List[Dict[str, Any]] = []
+    for header_name in header_names:
+        if header_name == "received" and received_lines:
+            for occurrence, line in enumerate(received_lines[:MAX_REPEATED_HEADER_OCCURRENCES]):
+                items.append(_header_item(header_name, occurrence, line))
+            continue
+        value = headers.get(header_name)
+        if value:
+            items.append(_header_item(header_name, 0, value))
+    return items
+
+
+def received_hop_evidence(received_lines: Sequence[str], hop_index: int) -> Dict[str, Any]:
+    """Evidencia de un salto concreto de la cadena Received.
+
+    Args:
+        received_lines: ``MessageContext.received_headers`` (el primero es el
+            salto más reciente).
+        hop_index: Posición del salto en esa lista.
+
+    Returns:
+        dict: Elemento ``header`` de ``received`` con esa aparición.
+    """
+    return _header_item("received", hop_index, received_lines[hop_index])
+
+
+def link_evidence(link_index: int, link: Any) -> Dict[str, Any]:
+    """Evidencia de un enlace del cuerpo.
+
+    Args:
+        link_index: Posición del enlace en ``MessageContext.links``.
+        link: El ``Link`` (``href`` y texto visible).
+
+    Returns:
+        dict: Elemento ``url`` con el destino desactivado y, si difiere, el
+            texto visible entre comillas latinas.
+    """
+    href = link.href or ""
+    excerpt = href
+    if link.text and link.text != href:
+        excerpt = f"{href} («{link.text}»)"
+    return {"kind": EVIDENCE_URL, "locator": {"linkIndex": link_index}, "excerpt": defang(excerpt)}
+
+
+def qr_url_evidence(attachment_index: int, url: str) -> Dict[str, Any]:
+    """Evidencia de una URL decodificada de un código QR de un adjunto.
+
+    Args:
+        attachment_index: Posición de la imagen en ``MessageContext.attachments``.
+        url: URL decodificada del QR.
+
+    Returns:
+        dict: Elemento ``url`` con ``source="qr_code"``.
+    """
+    return {
+        "kind": EVIDENCE_URL,
+        "locator": {"attachmentIndex": attachment_index, "source": "qr_code"},
+        "excerpt": defang(url),
+    }
+
+
+def attachment_evidence(attachment_index: int, attachment: Any) -> Dict[str, Any]:
+    """Evidencia de un adjunto: cuál es, qué tipo declara y su huella.
+
+    Args:
+        attachment_index: Posición en ``MessageContext.attachments``.
+        attachment: El ``Attachment`` parseado.
+
+    Returns:
+        dict: Elemento ``attachment`` con ``filename``, ``contentType``,
+            ``size`` y ``sha256`` (``None`` si el adjunto no trae contenido).
+    """
+    content = attachment.content or b""
+    filename = attachment.filename or "sin nombre"
+    return {
+        "kind": EVIDENCE_ATTACHMENT,
+        "locator": {
+            "attachmentIndex": attachment_index,
+            "filename": attachment.filename,
+            "contentType": attachment.content_type,
+            "size": attachment.size,
+            "sha256": hashlib.sha256(content).hexdigest() if content else None,
+        },
+        "excerpt": defang(f"{filename} ({attachment.content_type}, {attachment.size} bytes)"),
+    }
+
+
+def unique_evidence(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Quita elementos repetidos conservando el orden.
+
+    Una regla puede anclar la misma cabecera por dos motivos (p. ej. el
+    remitente con un carácter de control y con alfabetos mezclados); el
+    analista solo necesita verla una vez.
+
+    Args:
+        items: Elementos de evidencia.
+
+    Returns:
+        List[dict]: Los mismos elementos sin duplicados de ``kind`` y
+            ``locator``.
+    """
+    seen = set()
+    unique: List[Dict[str, Any]] = []
+    for item in items:
+        key = (item["kind"], tuple(sorted(item["locator"].items())))
+        if key not in seen:
+            seen.add(key)
+            unique.append(item)
+    return unique
+
+
+def anchor_result(result: Any, rule_input: Any, evidence_headers: Sequence[str],
+                  unanchorable_reason: str, rule_name: str) -> Any:
+    """Asegura que un resultado que penaliza lleva evidencia o dice por qué no.
+
+    Es lo que el registro de reglas ejecuta tras cada regla. Solo actúa sobre
+    resultados que restan puntos (``score < 0``): lo que no penaliza no es un
+    hallazgo que justificar. En orden:
+
+    1. Si la regla ya trajo evidencia, se valida y se deja tal cual.
+    2. Si declaró cabeceras, se anclan las que existan; si no existe
+       ninguna, el motivo dice que la señal es precisamente su ausencia.
+    3. Si declaró un motivo de no anclaje, se usa ese motivo.
+    4. Si no hay nada de lo anterior (una regla que se ancla sola pero no lo
+       hizo en este camino), se deja constancia en el log y en el resultado,
+       sin tumbar la regla: la detección vale más que su presentación.
+
+    Args:
+        result: ``RuleResult`` devuelto por la regla.
+        rule_input: Lo que recibió la regla (``MessageContext`` o cabeceras).
+        evidence_headers: Cabeceras declaradas por la regla; puede estar vacío.
+        unanchorable_reason: Motivo declarado de no anclaje; puede estar vacío.
+        rule_name: Nombre de la regla, para el log.
+
+    Returns:
+        RuleResult: El mismo resultado si no penaliza o ya traía evidencia; si
+            no, una copia con ``evidence`` o con ``evidence_unavailable_reason``.
+
+    Raises:
+        ValueError: Si la evidencia que trajo la regla no cumple el contrato
+            (ver ``validate_evidence``). Es un error de programación de la
+            regla y el motor lo trata como una regla que falló.
+    """
+    for item in result.evidence:
+        validate_evidence(item)
+
+    if float(result.score) >= 0 or result.evidence or result.evidence_unavailable_reason:
+        return result
+
+    if evidence_headers:
+        items = header_evidence(rule_input, evidence_headers)
+        if items:
+            return replace(result, evidence=items)
+        return replace(result, evidence_unavailable_reason=(
+            f"Ninguna de las cabeceras que examina la regla ({', '.join(evidence_headers)}) "
+            "está presente: la señal es precisamente su ausencia, así que no hay "
+            "ningún fragmento del mensaje que señalar."
+        ))
+
+    if unanchorable_reason:
+        return replace(result, evidence_unavailable_reason=unanchorable_reason)
+
+    logger.warning("La regla '%s' penalizó sin aportar evidencia", rule_name)
+    return replace(result, evidence_unavailable_reason="La regla no aportó evidencia para este hallazgo.")

--- a/API/src/modules/features/iris/services/registry.py
+++ b/API/src/modules/features/iris/services/registry.py
@@ -12,8 +12,11 @@ contiene el mecanismo de registro.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from .evidence import anchor_result
 
 
 @dataclass
@@ -28,11 +31,21 @@ class RuleResult:
         details: Arbitrary structured data with rule-specific findings.
         recommendation: Human-readable advice shown when the rule
                         indicates a problem.  None when the rule passes.
+        evidence: Dónde está, dentro del mensaje, lo que la regla encontró:
+                  lista de elementos con el contrato de
+                  ``services/evidence.py`` (``kind``, ``locator``, ``excerpt``).
+                  Vacía por defecto; el registro la rellena con las cabeceras
+                  declaradas cuando la regla penaliza sin aportarla.
+        evidence_unavailable_reason: Por qué un hallazgo no se puede anclar a
+                  un fragmento del mensaje; ``None`` si tiene evidencia o si
+                  la regla no penalizó.
     """
     score: float
     verdict: str
     details: Dict[str, Any] = field(default_factory=dict)
     recommendation: Optional[str] = None
+    evidence: List[Dict[str, Any]] = field(default_factory=list)
+    evidence_unavailable_reason: Optional[str] = None
 
 
 class RuleRegistry:
@@ -53,8 +66,16 @@ class RuleRegistry:
 
     def register(self, name: str, category: str = "general",
                  description: str = "", needs_context: bool = False,
-                 family: str = "", is_body_dependent: bool = False):
+                 family: str = "", is_body_dependent: bool = False,
+                 evidence_headers: Sequence[str] = (), is_self_anchoring: bool = False,
+                 unanchorable_reason: str = ""):
         """Decorator that registers a function as an analysis rule.
+
+        La regla se guarda envuelta: tras ejecutarla, el envoltorio garantiza
+        que un resultado que penaliza lleva evidencia anclada o dice por qué
+        no (``services/evidence.anchor_result``). El decorador devuelve la
+        función original, así que llamarla directamente no pasa por el
+        envoltorio.
 
         Args:
             name: Human-readable rule name (e.g. "SPF", "DKIM").
@@ -76,19 +97,51 @@ class RuleRegistry:
                 No equivale a ``needs_context``: varias reglas de contexto solo
                 leen la cadena Received, que sí existe sin cuerpo. Por defecto
                 ``False``.
+            evidence_headers: Cabeceras (en minúsculas) donde vive la señal de
+                la regla, en el orden en que se muestran. Si la regla penaliza
+                sin aportar evidencia propia, se anclan las que existan. Por
+                defecto vacío.
+            is_self_anchoring: ``True`` si la regla construye su propia
+                evidencia (qué enlace, qué adjunto, qué salto Received) en
+                ``RuleResult.evidence``. Por defecto ``False``.
+            unanchorable_reason: Motivo, en castellano y para el analista, por
+                el que los hallazgos de la regla no se pueden anclar a un
+                fragmento concreto. Por defecto vacío.
+
+            Toda regla declara al menos una de las tres últimas: el catálogo no
+            admite reglas cuyos hallazgos no digan dónde están ni por qué no.
 
         Returns:
             A decorator that appends the function to the internal rule list.
+
+        Raises:
+            ValueError: Si la regla no declara ni ``evidence_headers``, ni
+                ``is_self_anchoring``, ni ``unanchorable_reason``.
         """
+        if not (evidence_headers or is_self_anchoring or unanchorable_reason):
+            raise ValueError(
+                f"La regla '{name}' debe declarar cómo ancla su evidencia: "
+                "evidence_headers, is_self_anchoring o unanchorable_reason."
+            )
+        header_names = tuple(evidence_headers)
+
         def decorator(func: Callable) -> Callable:
+            @functools.wraps(func)
+            def anchored(rule_input: Any) -> RuleResult:
+                return anchor_result(func(rule_input), rule_input, header_names,
+                                     unanchorable_reason, name)
+
             self._rules.append({
-                "func": func,
+                "func": anchored,
                 "name": name,
                 "category": category,
                 "description": description,
                 "needs_context": needs_context,
                 "family": family,
                 "is_body_dependent": is_body_dependent,
+                "evidence_headers": header_names,
+                "is_self_anchoring": is_self_anchoring,
+                "unanchorable_reason": unanchorable_reason,
             })
             return func
         return decorator

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -477,6 +477,9 @@ class IrisPDFCreator:
 
     _CONFIDENCE_LABELS = {"high": "Alta", "medium": "Media", "low": "Baja"}
 
+    #: Extractos de evidencia por hallazgo en el PDF; el resto se resume.
+    _EVIDENCE_PER_RULE = 3
+
     def append_confidence(self, elements: list, theme: IrisReportTheme) -> None:
         """Confianza y cobertura del veredicto, justo debajo de él.
 
@@ -653,6 +656,15 @@ class IrisPDFCreator:
             elements.append(Spacer(1, 0.08 * inch))
             for flagged_rule in flagged:
                 text = f"<b>{_esc(flagged_rule.get('ruleName'))}:</b> {_esc(flagged_rule.get('recommendation'))}"
+                # El extracto ya viene desactivado (hxxp, [.], [@]): el PDF sale
+                # del panel autenticado y no debe llevar enlaces vivos.
+                evidence = flagged_rule.get("evidence") or []
+                for item in evidence[:self._EVIDENCE_PER_RULE]:
+                    text += f"<br/>Evidencia: <font face='Courier'>{_esc(item.get('excerpt'))}</font>"
+                if len(evidence) > self._EVIDENCE_PER_RULE:
+                    text += f"<br/>(y {len(evidence) - self._EVIDENCE_PER_RULE} fragmentos más)"
+                if not evidence and flagged_rule.get("evidenceUnavailableReason"):
+                    text += f"<br/><i>Sin evidencia anclada: {_esc(flagged_rule['evidenceUnavailableReason'])}</i>"
                 elements.append(Paragraph(text, theme.body))
             elements.append(Spacer(1, 0.15 * inch))
 

--- a/API/src/modules/features/iris/services/rules/attachment_media_rules.py
+++ b/API/src/modules/features/iris/services/rules/attachment_media_rules.py
@@ -25,6 +25,7 @@ import zipfile
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..evidence import attachment_evidence, header_evidence
 from ..wordlists import (
     dangerous_extensions, esp_tracker_domains,
     macro_extensions, suspicious_mime_types,
@@ -36,7 +37,9 @@ _IMG_SRC_RE = re.compile(r'<img\b[^>]*src\s*=\s*["\']([^"\']+)["\']',
 
 
 @iris_rules.register(
-    name="External Image Tracking", is_body_dependent=True,
+    name="External Image Tracking", unanchorable_reason=(
+        "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
+    ), is_body_dependent=True,
     category="content_analysis", family="attachment",
     description=(
         "Detecta imágenes (u otros recursos) embebidos desde un dominio "
@@ -116,7 +119,9 @@ _SRC_RE = re.compile(r'src\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE)
 
 
 @iris_rules.register(
-    name="Image-Only Email", is_body_dependent=True,
+    name="Image-Only Email", unanchorable_reason=(
+        "La señal es la proporción entre imágenes y texto de todo el cuerpo, no un fragmento concreto."
+    ), is_body_dependent=True,
     category="content_analysis", family="attachment",
     description=(
         "Detecta correos cuyo contenido visible es esencialmente una sola "
@@ -323,6 +328,7 @@ def _check_headers_fallback(headers: dict) -> RuleResult:
             "content_disposition": content_disposition,
             "findings": findings,
         },
+        evidence=header_evidence(headers, ("content-disposition", "content-type")),
         recommendation=(
             f"El correo incluye archivos adjuntos con extensiones potencialmente peligrosas: "
             f"{', '.join(ext_descriptions)}. "
@@ -333,7 +339,7 @@ def _check_headers_fallback(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Suspicious Attachments", is_body_dependent=True, category="content_analysis", family="attachment",
+    name="Suspicious Attachments", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="attachment",
     description=(
         "Inspecciona los adjuntos MIME reales (extensiones peligrosas, doble "
         "extensión, macros, HTML smuggling, ZIP con ejecutables); recurre a la "
@@ -348,7 +354,8 @@ def check_suspicious_attachments(context) -> RuleResult:
         return _check_headers_fallback(context.headers)
 
     findings: list[dict] = []
-    for att in attachments:
+    anchored_evidence: list[dict] = []
+    for attachment_index, att in enumerate(attachments):
         finding = _inspect_real_attachment(att)
         if not finding:
             continue
@@ -356,6 +363,7 @@ def check_suspicious_attachments(context) -> RuleResult:
         if hashes:
             finding.update(hashes)
         findings.append(finding)
+        anchored_evidence.append(attachment_evidence(attachment_index, att))
 
     if not findings:
         return RuleResult(score=0, verdict="pass", details={"attachment_count": len(attachments)})
@@ -367,6 +375,7 @@ def check_suspicious_attachments(context) -> RuleResult:
     return RuleResult(
         score=score, verdict="fail",
         details={"attachment_count": len(attachments), "findings": findings},
+        evidence=anchored_evidence,
         recommendation=(
             "El correo incluye adjuntos potencialmente peligrosos: "
             + ", ".join(finding.get("filename") or finding["reason"] for finding in findings) + ". "

--- a/API/src/modules/features/iris/services/rules/auth_rules.py
+++ b/API/src/modules/features/iris/services/rules/auth_rules.py
@@ -60,7 +60,7 @@ def _dmarc_is_conclusive(auth_lower: str) -> bool:
 
 
 @iris_rules.register(
-    name="SPF", category="authentication", family="auth",
+    name="SPF", evidence_headers=("received-spf", "authentication-results"), category="authentication", family="auth",
     description="Verifica que el servidor remitente esté autorizado por el SPF del dominio",
 )
 def check_spf(headers: dict) -> RuleResult:
@@ -157,7 +157,7 @@ def check_spf(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="DKIM", category="authentication", family="auth",
+    name="DKIM", evidence_headers=("authentication-results", "dkim-signature"), category="authentication", family="auth",
     description="Verifica la firma DKIM del correo",
 )
 def check_dkim(headers: dict) -> RuleResult:
@@ -208,7 +208,7 @@ def check_dkim(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="DMARC", category="authentication", family="auth",
+    name="DMARC", evidence_headers=("authentication-results",), category="authentication", family="auth",
     description="Verifica la política DMARC del dominio remitente",
 )
 def check_dmarc(headers: dict) -> RuleResult:
@@ -297,7 +297,7 @@ def _spf_mailfrom_domain(headers: dict) -> str | None:
 
 
 @iris_rules.register(
-    name="Domain Alignment", category="authentication", family="auth",
+    name="Domain Alignment", evidence_headers=("from", "authentication-results"), category="authentication", family="auth",
     description="Comprueba que el dominio autenticado por SPF/DKIM coincide con el dominio del remitente (alineación DMARC)",
 )
 def check_domain_alignment(headers: dict) -> RuleResult:
@@ -394,7 +394,7 @@ _ARC_CV_RE = re.compile(r"\bcv=(\w+)", re.IGNORECASE)
 
 
 @iris_rules.register(
-    name="ARC Chain", category="authentication",
+    name="ARC Chain", evidence_headers=("arc-seal", "arc-authentication-results"), category="authentication",
     description=(
         "Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated "
         "Received Chain, RFC 8617) y si la validó un verificador de confianza"
@@ -501,7 +501,7 @@ _AUTHSERV_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\.[a-z]{2,}$")
 
 
 @iris_rules.register(
-    name="Auth Results Provenance", category="authentication", family="auth",
+    name="Auth Results Provenance", evidence_headers=("authentication-results",), category="authentication", family="auth",
     description=(
         "Comprueba que el authserv-id de Authentication-Results pertenezca a "
         "algún host `by` de la propia cadena Received del mensaje -- una "

--- a/API/src/modules/features/iris/services/rules/body_content_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_content_rules.py
@@ -27,6 +27,7 @@ import re
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..evidence import attachment_evidence, header_evidence, unique_evidence
 from ..wordlists import alarming_emojis, exotic_charsets, phrase_matches, suspicious_tlds
 from ..text import (
     extract_display_name, extract_domain, is_free_provider,
@@ -61,7 +62,7 @@ def _score_by_weight(weight: int) -> tuple[float, str, str | None]:
 
 
 @iris_rules.register(
-    name="Alarming Keywords", category="content_analysis", family="content",
+    name="Alarming Keywords", evidence_headers=("subject", "from"), category="content_analysis", family="content",
     description="Detecta palabras y frases alarmantes en el asunto y nombre del remitente (inglés/español)",
 )
 def check_alarming_keywords(headers: dict) -> RuleResult:
@@ -179,7 +180,9 @@ def _has_evasive_hidden_text(body_html: str) -> bool:
 
 
 @iris_rules.register(
-    name="Body Content", is_body_dependent=True, category="content_analysis", family="content",
+    name="Body Content", unanchorable_reason=(
+        "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
+    ), is_body_dependent=True, category="content_analysis", family="content",
     description=(
         "Escanea el cuerpo del correo en busca de frases de phishing "
         "(credenciales/pago) y técnicas de texto oculto."
@@ -229,7 +232,9 @@ def check_body_content(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="BEC Wire Transfer Pattern", is_body_dependent=True,
+    name="BEC Wire Transfer Pattern", unanchorable_reason=(
+        "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
+    ), is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patrón típico de BEC (Business Email Compromise): "
@@ -306,7 +311,9 @@ def check_bec_wire_pattern(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Generic Greeting", is_body_dependent=True,
+    name="Generic Greeting", unanchorable_reason=(
+        "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
+    ), is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patrón clásico de phishing masivo: saludo genérico "
@@ -379,7 +386,7 @@ def _contains_url(text: str) -> list[str]:
 
 
 @iris_rules.register(
-    name="URL in Subject", category="content_analysis", family="content",
+    name="URL in Subject", evidence_headers=("subject",), category="content_analysis", family="content",
     description="Detecta si el asunto del correo contiene URLs (común en phishing)",
 )
 def check_url_in_subject(headers: dict) -> RuleResult:
@@ -463,7 +470,7 @@ def _mixed_script(text: str) -> str | None:
 
 
 @iris_rules.register(
-    name="Unicode Evasion", is_body_dependent=True, category="content_analysis", family="content",
+    name="Unicode Evasion", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="content",
     description=(
         "Detecta caracteres de control bidireccional (RLO/LRO - spoofing de "
         "extension de archivo) y mezcla de scripts confusables (cirilico/"
@@ -480,14 +487,16 @@ def check_unicode_evasion(context) -> RuleResult:
 
     findings: list[dict] = []
     score = 0
+    anchored_evidence: list[dict] = []
 
     for field_name, value in (("subject", subject), ("from", from_header)):
         controls = _find_bidi_controls(value)
         if controls:
             findings.append({"type": "bidi_control", "field": field_name, "controls": controls})
+            anchored_evidence.extend(header_evidence(headers, (field_name,)))
             score += CR.get_iris_scoring_weight("unicode_evasion.bidi_control", -15)
 
-    for att in context.attachments:
+    for attachment_index, att in enumerate(context.attachments):
         filename = att.filename or ""
         controls = _find_bidi_controls(filename)
         if controls:
@@ -495,17 +504,21 @@ def check_unicode_evasion(context) -> RuleResult:
                 "type": "bidi_control", "field": "filename",
                 "filename": filename, "controls": controls,
             })
+            anchored_evidence.append(attachment_evidence(attachment_index, att))
             score += CR.get_iris_scoring_weight("unicode_evasion.bidi_control_filename", -15)
 
     for field_name, value in (("display_name", display_name), ("subject", subject)):
         script = _mixed_script(value)
         if script:
             findings.append({"type": "mixed_script", "field": field_name, "script": script, "value": value})
+            header_name = "from" if field_name == "display_name" else field_name
+            anchored_evidence.extend(header_evidence(headers, (header_name,)))
             score += CR.get_iris_scoring_weight("unicode_evasion.mixed_script", -10)
 
     domain_script = _mixed_script(domain)
     if domain_script:
         findings.append({"type": "mixed_script", "field": "domain", "script": domain_script, "value": domain})
+        anchored_evidence.extend(header_evidence(headers, ("from",)))
         score += CR.get_iris_scoring_weight("unicode_evasion.mixed_script_domain", -12)
 
     if not findings:
@@ -515,6 +528,7 @@ def check_unicode_evasion(context) -> RuleResult:
     return RuleResult(
         score=max(score, _unicode_evasion_score_floor()), verdict="fail",
         details={"findings": findings, "types": types},
+        evidence=unique_evidence(anchored_evidence),
         recommendation=(
             "Se detectaron caracteres Unicode sospechosos (controles de "
             "override direccional o mezcla de alfabetos) - tecnica usada para "
@@ -601,7 +615,7 @@ def _encoded_word_finding_scores() -> dict[str, float]:
 
 
 @iris_rules.register(
-    name="Encoded-Word Abuse", category="content_analysis", family="content",
+    name="Encoded-Word Abuse", evidence_headers=("subject", "from"), category="content_analysis", family="content",
     description=(
         "Detecta abuso de encoded-words RFC 2047 en Subject/From: bloques "
         "encadenados para evadir filtros de keywords, charsets exoticos "
@@ -640,7 +654,9 @@ _PHONE_RE = re.compile(r"(?:\+\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?
 
 
 @iris_rules.register(
-    name="TOAD Callback Pattern", is_body_dependent=True,
+    name="TOAD Callback Pattern", unanchorable_reason=(
+        "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
+    ), is_body_dependent=True,
     category="content_analysis", family="content",
     description=(
         "Detecta el patron TOAD (Telephone-Oriented Attack Delivery): un "

--- a/API/src/modules/features/iris/services/rules/body_links_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_links_rules.py
@@ -31,6 +31,7 @@ import numpy as np
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..evidence import attachment_evidence, link_evidence, qr_url_evidence, unique_evidence
 from ..wordlists import esp_tracker_domains, redirect_params
 from ..text import analyze_url, extract_domain, registrable_domain, url_host
 
@@ -40,7 +41,7 @@ def _max_score_floor() -> float:
 
 
 @iris_rules.register(
-    name="Body Links", is_body_dependent=True, category="content_analysis", family="links",
+    name="Body Links", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Analiza los enlaces reales del cuerpo: texto visible vs href, "
         "punycode/IDN, IPs literales, acortadores de URL, credenciales en la "
@@ -60,11 +61,14 @@ def check_body_links(context) -> RuleResult:
     score = 0
     seen_types: set[str] = set()
 
-    for link in links:
+    anchored_evidence: list[dict] = []
+    for link_index, link in enumerate(links):
         link_findings, link_score = analyze_url(link.href or "", sender_domain, link.text or "")
         findings.extend(link_findings)
         score += link_score
         seen_types.update(link_finding["type"] for link_finding in link_findings)
+        if link_findings:
+            anchored_evidence.append(link_evidence(link_index, link))
 
     if not findings:
         return RuleResult(score=1, verdict="pass", details={"link_count": len(links)})
@@ -73,6 +77,7 @@ def check_body_links(context) -> RuleResult:
     return RuleResult(
         score=score, verdict="fail",
         details={"link_count": len(links), "findings": findings, "types": sorted(seen_types)},
+        evidence=anchored_evidence,
         recommendation=(
             "Se detectaron enlaces sospechosos en el cuerpo del correo "
             f"({', '.join(sorted(seen_types))}). No hagas clic sin verificar el destino real."
@@ -108,7 +113,7 @@ def _decode_qr_urls(image_bytes: bytes) -> list[str]:
 
 
 @iris_rules.register(
-    name="QR Code Links", is_body_dependent=True, category="content_analysis", family="links",
+    name="QR Code Links", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Decodifica códigos QR en imágenes inline/adjuntas y analiza la URL "
         "resultante con la misma batería de chequeos que Body Links "
@@ -117,7 +122,8 @@ def _decode_qr_urls(image_bytes: bytes) -> list[str]:
     needs_context=True,
 )
 def check_qr_code_links(context) -> RuleResult:
-    images = [att for att in context.attachments if (att.content_type or "").startswith("image/")]
+    images = [(attachment_index, att) for attachment_index, att in enumerate(context.attachments)
+              if (att.content_type or "").startswith("image/")]
     if not images:
         return RuleResult(score=0, verdict="neutral", details={"image_count": 0})
 
@@ -128,7 +134,8 @@ def check_qr_code_links(context) -> RuleResult:
     seen_types: set[str] = set()
     qr_urls: list[str] = []
 
-    for image in images:
+    anchored_evidence: list[dict] = []
+    for attachment_index, image in images:
         for url in _decode_qr_urls(image.content):
             qr_urls.append(url)
             url_findings, url_score = analyze_url(url, sender_domain)
@@ -136,6 +143,9 @@ def check_qr_code_links(context) -> RuleResult:
                 findings.append({**url_finding, "source": "qr_code", "filename": image.filename})
             score += url_score
             seen_types.update(url_finding["type"] for url_finding in url_findings)
+            if url_findings:
+                anchored_evidence.append(attachment_evidence(attachment_index, image))
+                anchored_evidence.append(qr_url_evidence(attachment_index, url))
 
     if not qr_urls:
         return RuleResult(score=0, verdict="pass", details={"image_count": len(images), "qr_count": 0})
@@ -153,6 +163,7 @@ def check_qr_code_links(context) -> RuleResult:
             "image_count": len(images), "qr_count": len(qr_urls),
             "qr_urls": qr_urls, "findings": findings, "types": sorted(seen_types),
         },
+        evidence=unique_evidence(anchored_evidence),
         recommendation=(
             "El correo contiene un código QR que decodifica a una URL sospechosa "
             f"({', '.join(sorted(seen_types))}). No lo escanees: un QR es una forma "
@@ -176,7 +187,7 @@ def _looks_opaque_path(path: str) -> bool:
 
 
 @iris_rules.register(
-    name="Compromised Legitimate Domain", is_body_dependent=True,
+    name="Compromised Legitimate Domain", is_self_anchoring=True, is_body_dependent=True,
     category="content_analysis", family="links",
     description=(
         "Detecta enlaces a dominios legítimos que probablemente han sido "
@@ -195,7 +206,8 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
 
     redirect_param_names = redirect_params()
 
-    for link in links:
+    anchored_evidence: list[dict] = []
+    for link_index, link in enumerate(links):
         href = link.href or ""
         host = url_host(href)
         if not host or not href.startswith(("http://", "https://")):
@@ -225,6 +237,7 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
                 "host": host,
                 "evidence": evidence,
             })
+            anchored_evidence.append(link_evidence(link_index, link))
             score += (
                 CR.get_iris_scoring_weight("compromised_domain.single_evidence", -6)
                 if len(evidence) == 1
@@ -237,6 +250,7 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
     return RuleResult(
         score=score, verdict="fail",
         details={"link_count": len(links), "findings": findings},
+        evidence=anchored_evidence,
         recommendation=(
             "Se detectaron enlaces a dominios aparentemente legítimos con "
             "patrones típicos de sitios comprometidos (open redirectors o "
@@ -247,7 +261,9 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="External Login Link", is_body_dependent=True,
+    name="External Login Link", unanchorable_reason=(
+        "Señal informativa que no resta puntos: resume los dominios externos de todos los enlaces en conjunto."
+    ), is_body_dependent=True,
     category="content_analysis",
     description=(
         "Señal informativa (score 0): ¿hay algún enlace del cuerpo cuyo "

--- a/API/src/modules/features/iris/services/rules/content_trust_rules.py
+++ b/API/src/modules/features/iris/services/rules/content_trust_rules.py
@@ -18,7 +18,7 @@ from ..registry import iris_rules, RuleResult
 
 
 @iris_rules.register(
-    name="List-Unsubscribe", category="header_analysis",
+    name="List-Unsubscribe", evidence_headers=("list-unsubscribe",), category="header_analysis",
     description="Detecta un mecanismo de baja (List-Unsubscribe) válido como señal débil de legitimidad de correo masivo",
 )
 def check_list_unsubscribe(headers: dict) -> RuleResult:

--- a/API/src/modules/features/iris/services/rules/received_timing_rules.py
+++ b/API/src/modules/features/iris/services/rules/received_timing_rules.py
@@ -26,6 +26,7 @@ from typing import List
 
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
+from ..evidence import received_hop_evidence, unique_evidence
 from ..parsers import _hop_timestamp, _is_private_ip, build_path, parse_received_line
 from ..text import extract_domain, registrable_domain
 
@@ -38,7 +39,7 @@ CLOCK_SKEW_TOLERANCE_SECONDS = 300
 
 
 @iris_rules.register(
-    name="Date Header Anomaly", category="header_analysis", family="received",
+    name="Date Header Anomaly", evidence_headers=("date",), category="header_analysis", family="received",
     description="Detecta si la cabecera Date está ausente, en el futuro lejano o en el pasado remoto",
 )
 def check_date_anomaly(headers: dict) -> RuleResult:
@@ -107,7 +108,7 @@ def check_date_anomaly(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Received Chain", category="header_analysis", family="received",
+    name="Received Chain", evidence_headers=("received",), category="header_analysis", family="received",
     description=(
         "Analiza la cadena completa de cabeceras Received: número de saltos y "
         "consistencia temporal con Date. La IP interna del salto de origen se "
@@ -181,7 +182,7 @@ def check_received_chain(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Received Chain Temporal Inconsistency",
+    name="Received Chain Temporal Inconsistency", is_self_anchoring=True,
     category="header_analysis", family="received",
     description=(
         "Detecta cadenas Received: con marcas de tiempo no monótonamente "
@@ -218,6 +219,7 @@ def check_received_chain_temporal_inconsistency(context) -> RuleResult:
     # una inversión de unos segundos entre hops consecutivos sin que haya
     # manipulación real; solo una inversión que exceda ese margen es señal.
     inversions: list[dict] = []
+    anchored_evidence: list[dict] = []
     for i in range(len(timestamps) - 1):
         a, b = timestamps[i], timestamps[i + 1]
         if a is None or b is None:
@@ -229,6 +231,8 @@ def check_received_chain_temporal_inconsistency(context) -> RuleResult:
                 "to_hop": i + 1,
                 "delta_seconds": int(delta),
             })
+            anchored_evidence.append(received_hop_evidence(received, i))
+            anchored_evidence.append(received_hop_evidence(received, i + 1))
 
     if not inversions:
         return RuleResult(
@@ -250,6 +254,7 @@ def check_received_chain_temporal_inconsistency(context) -> RuleResult:
             "parsed_timestamps": parsed_count,
             "inversions": inversions,
         },
+        evidence=unique_evidence(anchored_evidence),
         recommendation=(
             f"La cadena Received: contiene {len(inversions)} inversión(es) "
             "temporal(es) — los hops no están en orden cronológico "
@@ -271,7 +276,7 @@ MISSING_TS_MIN_HOPS = 3
 
 
 @iris_rules.register(
-    name="Received Path Anomaly",
+    name="Received Path Anomaly", evidence_headers=("received",),
     category="header_analysis", family="received",
     description=(
         "Evalúa el recorrido Received: del correo — número de saltos, "
@@ -399,7 +404,7 @@ _HOSTNAME_RE = re.compile(r"[a-zA-Z0-9][\w.-]*\.[a-zA-Z]{2,}")
 
 
 @iris_rules.register(
-    name="Origin HELO Coherence",
+    name="Origin HELO Coherence", evidence_headers=("received",),
     category="header_analysis", family="received",
     description=(
         "Aproximación offline (Iris no resuelve DNS/PTR real) de coherencia "

--- a/API/src/modules/features/iris/services/rules/recipient_rules.py
+++ b/API/src/modules/features/iris/services/rules/recipient_rules.py
@@ -15,7 +15,7 @@ from ..wordlists import undisclosed_patterns
 
 
 @iris_rules.register(
-    name="Undisclosed Recipients", category="header_analysis",
+    name="Undisclosed Recipients", evidence_headers=("to", "cc"), category="header_analysis",
     description="Detecta si el campo To está vacío o contiene destinatarios no revelados (BCC)",
 )
 def check_undisclosed_recipients(headers: dict) -> RuleResult:

--- a/API/src/modules/features/iris/services/rules/reply_path_rules.py
+++ b/API/src/modules/features/iris/services/rules/reply_path_rules.py
@@ -46,7 +46,7 @@ def _is_esp_domain(domain: str | None) -> bool:
 
 
 @iris_rules.register(
-    name="Reply-To check", category="header_analysis", family="reply_path",
+    name="Reply-To check", evidence_headers=("from", "reply-to"), category="header_analysis", family="reply_path",
     description="Detecta si Reply-To difiere del remitente real",
 )
 def check_reply_to(headers: dict) -> RuleResult:
@@ -129,7 +129,7 @@ def check_reply_to(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Reply-To Free Provider", category="header_analysis", family="reply_path",
+    name="Reply-To Free Provider", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="reply_path",
     description="Detecta el patrón BEC: remitente con dominio corporativo pero Reply-To/Return-Path apuntando a un correo gratuito",
 )
 def check_reply_to_free_provider(headers: dict) -> RuleResult:
@@ -170,7 +170,7 @@ def check_reply_to_free_provider(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Return-Path mismatch", category="header_analysis", family="reply_path",
+    name="Return-Path mismatch", evidence_headers=("return-path", "from"), category="header_analysis", family="reply_path",
     description="Detecta si el dominio en Return-Path difiere del remitente visible",
 )
 def check_return_path(headers: dict) -> RuleResult:
@@ -263,7 +263,7 @@ def _triangulation_would_fire(headers: dict) -> bool:
 
 
 @iris_rules.register(
-    name="From Reply-To Return-Path Triangulation",
+    name="From Reply-To Return-Path Triangulation", evidence_headers=("from", "reply-to", "return-path"),
     category="header_analysis", family="reply_path",
     description=(
         "Detecta mensajes donde From, Reply-To y Return-Path apuntan a tres "

--- a/API/src/modules/features/iris/services/rules/sender_identity_rules.py
+++ b/API/src/modules/features/iris/services/rules/sender_identity_rules.py
@@ -43,7 +43,7 @@ from ..parsers import decode_mime_words
 
 
 @iris_rules.register(
-    name="From header check", category="header_analysis", family="identity",
+    name="From header check", evidence_headers=("from",), category="header_analysis", family="identity",
     description="Verifica que la cabecera From esté presente y no esté vacía",
 )
 def check_from_header(headers: dict) -> RuleResult:
@@ -78,7 +78,7 @@ def _domain_matches_trusted(domain: str, trusted_domains: tuple[str, ...]) -> bo
 
 
 @iris_rules.register(
-    name="Display Name Spoofing", category="header_analysis", family="identity",
+    name="Display Name Spoofing", evidence_headers=("from",), category="header_analysis", family="identity",
     description="Detecta si el nombre del remitente suplanta a una marca conocida pero el dominio del correo no pertenece a ella",
 )
 def check_display_name_spoof(headers: dict) -> RuleResult:
@@ -198,7 +198,7 @@ def _is_random_local(local: str) -> bool:
 
 
 @iris_rules.register(
-    name="Display Name Email Mismatch",
+    name="Display Name Email Mismatch", evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el display name suplanta a una organización pero "
@@ -245,7 +245,7 @@ def check_display_name_email_mismatch(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Lookalike Sender Domain", category="header_analysis", family="identity",
+    name="Lookalike Sender Domain", evidence_headers=("from",), category="header_analysis", family="identity",
     description="Detecta si el dominio real del remitente imita a una marca conocida (typosquatting, homóglifos, cousin domain o punycode/IDN)",
 )
 def check_lookalike_domain(headers: dict) -> RuleResult:
@@ -326,7 +326,7 @@ def _is_trusted_brand_domain(domain: str) -> bool:
 
 
 @iris_rules.register(
-    name="Subdomain Impersonation",
+    name="Subdomain Impersonation", evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta trucos de subdominio donde un nombre de marca conocido aparece "
@@ -468,7 +468,7 @@ def _find_typosquats(text: str) -> list[dict]:
 
 
 @iris_rules.register(
-    name="Misspelled Brand Names", category="content_analysis", family="identity",
+    name="Misspelled Brand Names", evidence_headers=("from", "subject"), category="content_analysis", family="identity",
     description="Detecta homóglifos y errores tipográficos de marcas conocidas en el asunto y nombre del remitente",
 )
 def check_misspelled_brands(headers: dict) -> RuleResult:
@@ -518,7 +518,7 @@ def check_misspelled_brands(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Suspicious TLD", category="header_analysis", family="identity",
+    name="Suspicious TLD", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="identity",
     description="Detecta si el dominio del remitente usa TLDs frecuentemente asociados con phishing",
 )
 def check_suspicious_tld(headers: dict) -> RuleResult:
@@ -600,7 +600,7 @@ def _recipient_domain(headers: dict) -> str | None:
 
 
 @iris_rules.register(
-    name="Recipient Domain Lookalike",
+    name="Recipient Domain Lookalike", evidence_headers=("from", "to"),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el dominio del remitente es un typosquat/homoglifo "
@@ -671,7 +671,7 @@ _EMAIL_LIKE_RE = re.compile(r"[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}")
 
 
 @iris_rules.register(
-    name="Display Name Foreign Address",
+    name="Display Name Foreign Address", evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el display name del remitente ES una dirección de "

--- a/API/src/modules/features/iris/services/rules/thread_rules.py
+++ b/API/src/modules/features/iris/services/rules/thread_rules.py
@@ -40,7 +40,7 @@ REPLY_PREFIX_PATTERN = re.compile(
 
 
 @iris_rules.register(
-    name="Fake Reply Chain", category="header_analysis",
+    name="Fake Reply Chain", evidence_headers=("subject", "in-reply-to", "references"), category="header_analysis",
     description="Detecta si el asunto imita una respuesta o reenvío sin los cabeceras In-Reply-To o References",
 )
 def check_fake_reply_chain(headers: dict) -> RuleResult:
@@ -121,7 +121,7 @@ def _strip_brackets(value: str) -> str:
 
 
 @iris_rules.register(
-    name="Self-Referencing In-Reply-To",
+    name="Self-Referencing In-Reply-To", evidence_headers=("in-reply-to", "message-id"),
     category="header_analysis",
     description=(
         "Detecta cuando In-Reply-To (o el primer References) apunta al "
@@ -185,7 +185,7 @@ def check_self_referencing_in_reply_to(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID check", category="header_analysis",
+    name="Message-ID check", evidence_headers=("message-id",), category="header_analysis",
     description="Verifica que el Message-ID esté presente y tenga una longitud razonable",
 )
 def check_message_id(headers: dict) -> RuleResult:
@@ -210,7 +210,7 @@ def check_message_id(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID Domain", category="header_analysis",
+    name="Message-ID Domain", evidence_headers=("message-id", "from"), category="header_analysis",
     description="Compara el dominio del Message-ID con el dominio del remitente",
 )
 def check_msgid_domain(headers: dict) -> RuleResult:
@@ -263,7 +263,7 @@ def check_msgid_domain(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID Received Correlation",
+    name="Message-ID Received Correlation", evidence_headers=("message-id", "received"),
     category="header_analysis",
     description=(
         "Comprueba que el dominio del Message-ID aparezca en algún host "

--- a/API/tests/integration/test_iris_evidence_api.py
+++ b/API/tests/integration/test_iris_evidence_api.py
@@ -1,0 +1,77 @@
+"""La API devuelve la evidencia anclada de cada hallazgo.
+
+Ejecuta el catálogo real sobre un phishing con un enlace a una IP literal y un
+ejecutable adjunto, como lo haría el worker, y comprueba que cada regla que
+penaliza llega por API con evidencia o con el motivo de por qué no la tiene.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+_PHISHING = (
+    "From: PayPal Soporte <alerta@paypa1-secure.example>\r\n"
+    "Reply-To: cobros@gmail.com\r\n"
+    "To: victima@corp.example\r\n"
+    "Subject: Verifique su cuenta urgentemente\r\n"
+    "Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+    "Message-ID: <x1@paypa1-secure.example>\r\n"
+    "MIME-Version: 1.0\r\n"
+    "Content-Type: multipart/mixed; boundary=\"B\"\r\n\r\n"
+    "--B\r\nContent-Type: text/html; charset=utf-8\r\n\r\n"
+    "<p>Estimado cliente, verifique su cuenta.</p>"
+    "<a href=\"http://192.168.10.20/login\">https://www.paypal.com</a>\r\n"
+    "--B\r\nContent-Type: application/octet-stream\r\n"
+    "Content-Disposition: attachment; filename=\"factura.pdf.exe\"\r\n"
+    "Content-Transfer-Encoding: base64\r\n\r\n"
+    + base64.b64encode(b"MZ\x90\x00").decode() + "\r\n--B--\r\n"
+)
+
+
+def _analyze(app, user_id: int, raw: str) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        IrisManager()._run_analysis(analysis_id, raw)
+    return analysis_id
+
+
+def test_every_penalising_rule_has_evidence_or_says_why_not(client, app, root_user, root_headers):
+    analysis_id = _analyze(app, root_user.id, _PHISHING)
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    penalising = [rule for rule in report["rules"] if rule["score"] < 0]
+    assert penalising
+    for rule in penalising:
+        assert rule["evidence"] or rule["evidenceUnavailableReason"], rule["ruleName"]
+
+    by_name = {rule["ruleName"]: rule for rule in report["rules"]}
+    body_links = by_name["Body Links"]["evidence"]
+    assert body_links[0]["kind"] == "url"
+    assert body_links[0]["excerpt"].startswith("hxxp://192.168.10.20/login")
+    attachments = by_name["Suspicious Attachments"]["evidence"]
+    assert attachments[0]["kind"] == "attachment"
+    assert attachments[0]["locator"]["filename"] == "factura.pdf.exe"
+
+
+def test_rules_that_do_not_penalise_carry_no_evidence(client, app, root_user, root_headers):
+    analysis_id = _analyze(app, root_user.id, _PHISHING)
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    for rule in report["rules"]:
+        if rule["score"] >= 0:
+            assert rule["evidence"] == [], rule["ruleName"]
+            assert rule["evidenceUnavailableReason"] is None, rule["ruleName"]

--- a/API/tests/unit/test_iris_evidence.py
+++ b/API/tests/unit/test_iris_evidence.py
@@ -1,0 +1,239 @@
+"""Evidencia anclada: cada hallazgo dice dónde está o por qué no se puede decir.
+
+Cubre el contrato de ``services/evidence.py`` (tipos, locator, desactivación
+de URLs), el envoltorio del registro de reglas que lo aplica, y las reglas de
+más peso del catálogo, que tienen que producir evidencia real.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from src.modules.features.iris.services.evidence import (
+    EVIDENCE_ATTACHMENT,
+    EVIDENCE_URL,
+    MAX_EXCERPT_LENGTH,
+    anchor_result,
+    defang,
+    header_evidence,
+    validate_evidence,
+)
+from src.modules.features.iris.services.parsers import parse_raw_message
+from src.modules.features.iris.services.registry import RuleRegistry, RuleResult
+from src.modules.features.iris.services.rules import iris_rules
+
+pytestmark = pytest.mark.unit
+
+#: Las reglas de mayor penalización del catálogo (ordenadas por su peso por
+#: defecto). El corte en diez cae en un empate a -12, así que se cubren las
+#: trece que llegan a ese peso.
+_HIGHEST_WEIGHTED_RULES = [
+    "Body Links", "QR Code Links", "Suspicious Attachments", "Unicode Evasion",
+    "Recipient Domain Lookalike", "DMARC", "Encoded-Word Abuse", "Lookalike Sender Domain",
+    "Auth Results Provenance", "Display Name Spoofing", "Domain Alignment",
+    "Received Chain Temporal Inconsistency", "Self-Referencing In-Reply-To",
+]
+
+
+def _rule(name: str) -> dict:
+    return next(rule_def for rule_def in iris_rules.get_rules() if rule_def["name"] == name)
+
+
+def _html_message(html: str) -> str:
+    return (
+        "From: Soporte <soporte@corp.example>\r\nTo: victima@corp.example\r\nSubject: Aviso\r\n"
+        "MIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\n\r\n" + html + "\r\n"
+    )
+
+
+def _message_with_attachment(filename: str, content_type: str = "application/octet-stream",
+                             payload: bytes = b"MZ\x90\x00") -> str:
+    encoded = base64.b64encode(payload).decode()
+    return (
+        "From: a@corp.example\r\nTo: b@corp.example\r\nSubject: Factura\r\nMIME-Version: 1.0\r\n"
+        "Content-Type: multipart/mixed; boundary=\"B\"\r\n\r\n"
+        "--B\r\nContent-Type: text/plain\r\n\r\nAdjunto.\r\n"
+        f"--B\r\nContent-Type: {content_type}\r\n"
+        f"Content-Disposition: attachment; filename=\"{filename}\"\r\n"
+        "Content-Transfer-Encoding: base64\r\n\r\n" + encoded + "\r\n--B--\r\n"
+    )
+
+
+# ------------------------------------------------------------------- defang
+
+def test_defang_neutralises_urls_domains_and_addresses():
+    text = defang("Visita https://evil.example.com/login o escribe a jefe@corp.example")
+    assert text == "Visita hxxps://evil[.]example[.]com/login o escribe a jefe[@]corp[.]example"
+
+
+def test_defang_leaves_ip_addresses_readable():
+    """Una IP de la cadena Received es evidencia forense, no un enlace."""
+    assert defang("from 203.0.113.9") == "from 203.0.113.9"
+
+
+def test_defang_truncates_long_excerpts():
+    excerpt = defang("a" * 1000)
+    assert len(excerpt) == MAX_EXCERPT_LENGTH
+    assert excerpt.endswith("…")
+
+
+# ------------------------------------------------------------------- contrato
+
+def test_validate_rejects_unknown_kinds_and_incomplete_locators():
+    with pytest.raises(ValueError):
+        validate_evidence({"kind": "screenshot", "locator": {}, "excerpt": "x"})
+    with pytest.raises(ValueError):
+        validate_evidence({"kind": "header", "locator": {"header": "from"}, "excerpt": "x"})
+    with pytest.raises(ValueError):
+        validate_evidence({"kind": "url", "locator": {}, "excerpt": "x"})
+    validate_evidence({"kind": "url", "locator": {"linkIndex": 0}, "excerpt": "x"})
+
+
+def test_header_evidence_skips_absent_headers_and_lists_every_received_hop():
+    context = parse_raw_message(
+        "Received: from b.example by c.example; Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "Received: from a.example by b.example; Mon, 1 Jan 2026 09:00:00 +0000\r\n"
+        "From: x@corp.example\r\nSubject: hola\r\n"
+    )
+    items = header_evidence(context, ("from", "reply-to", "received"))
+    assert [(item["locator"]["header"], item["locator"]["occurrence"]) for item in items] == [
+        ("from", 0), ("received", 0), ("received", 1),
+    ]
+
+
+def test_a_passing_result_is_left_alone():
+    result = RuleResult(score=0, verdict="pass")
+    assert anchor_result(result, {"from": "a@corp.example"}, ("from",), "", "X") is result
+
+
+def test_a_penalty_is_anchored_to_its_declared_headers():
+    anchored = anchor_result(RuleResult(score=-5, verdict="fail"),
+                             {"from": "Evil <a@evil.example>"}, ("from",), "", "X")
+    assert anchored.evidence == [{
+        "kind": "header", "locator": {"header": "from", "occurrence": 0},
+        "excerpt": "Evil <a[@]evil[.]example>",
+    }]
+
+
+def test_a_penalty_on_absent_headers_says_the_signal_is_their_absence():
+    anchored = anchor_result(RuleResult(score=-5, verdict="fail"), {}, ("list-unsubscribe",), "", "X")
+    assert anchored.evidence == []
+    assert "list-unsubscribe" in anchored.evidence_unavailable_reason
+
+
+def test_an_unanchorable_rule_carries_its_declared_reason():
+    anchored = anchor_result(RuleResult(score=-5, verdict="fail"), {}, (), "Motivo declarado.", "X")
+    assert anchored.evidence_unavailable_reason == "Motivo declarado."
+
+
+def test_invalid_self_provided_evidence_is_rejected():
+    with pytest.raises(ValueError):
+        anchor_result(RuleResult(score=-5, verdict="fail", evidence=[{"kind": "nope"}]), {}, (), "", "X")
+
+
+# ------------------------------------------------------------------- registro
+
+def test_a_rule_that_declares_nothing_cannot_be_registered():
+    with pytest.raises(ValueError):
+        RuleRegistry().register(name="Sin declarar")
+
+
+def test_the_registry_anchors_through_its_wrapper_but_returns_the_original():
+    registry = RuleRegistry()
+
+    @registry.register(name="Falsa", evidence_headers=("from",))
+    def fake_rule(headers):
+        return RuleResult(score=-5, verdict="fail")
+
+    anchored = registry.get_rules()[0]["func"]({"from": "a@evil.example"})
+    assert anchored.evidence[0]["locator"] == {"header": "from", "occurrence": 0}
+    assert fake_rule({"from": "a@evil.example"}).evidence == []
+
+
+def test_every_rule_in_the_catalog_declares_how_it_anchors():
+    for rule_def in iris_rules.get_rules():
+        assert (rule_def["evidence_headers"] or rule_def["is_self_anchoring"]
+                or rule_def["unanchorable_reason"]), rule_def["name"]
+
+
+def test_the_highest_weighted_rules_are_anchorable():
+    """El criterio de cierre: las señales de más peso tienen evidencia
+    clicable; ninguna se escuda en un motivo de no anclaje."""
+    for name in _HIGHEST_WEIGHTED_RULES:
+        rule_def = _rule(name)
+        assert rule_def["evidence_headers"] or rule_def["is_self_anchoring"], name
+
+
+# ------------------------------------------------ reglas que se anclan solas
+
+def test_body_links_anchors_the_offending_link():
+    context = parse_raw_message(_html_message(
+        '<a href="https://corp.example/ok">ok</a> <a href="http://192.168.10.20/login">https://paypal.com</a>'
+    ))
+    result = _rule("Body Links")["func"](context)
+    assert result.score < 0
+    assert [item["locator"] for item in result.evidence] == [{"linkIndex": 1}]
+    assert result.evidence[0]["excerpt"].startswith("hxxp://192.168.10.20/login")
+
+
+def test_compromised_legitimate_domain_anchors_the_link():
+    context = parse_raw_message(_html_message('<a href="https://legit.example/Ab3dE5fG7hJ9kL2">ver</a>'))
+    result = _rule("Compromised Legitimate Domain")["func"](context)
+    assert result.score < 0
+    assert result.evidence[0]["locator"] == {"linkIndex": 0}
+
+
+def test_suspicious_attachments_anchors_the_dangerous_attachment():
+    context = parse_raw_message(_message_with_attachment("factura.pdf.exe"))
+    result = _rule("Suspicious Attachments")["func"](context)
+    assert result.score < 0
+    item = result.evidence[0]
+    assert item["kind"] == EVIDENCE_ATTACHMENT
+    assert item["locator"]["attachmentIndex"] == 0
+    assert item["locator"]["filename"] == "factura.pdf.exe"
+    assert len(item["locator"]["sha256"]) == 64
+
+
+def test_unicode_evasion_anchors_the_subject_with_a_bidi_control():
+    context = parse_raw_message(
+        "From: a@corp.example\r\nTo: b@corp.example\r\nSubject: factura‮fdp.exe\r\n\r\nx\r\n"
+    )
+    result = _rule("Unicode Evasion")["func"](context)
+    assert result.score < 0
+    assert {"header": "subject", "occurrence": 0} in [item["locator"] for item in result.evidence]
+
+
+def test_received_temporal_inconsistency_anchors_both_hops():
+    raw = (
+        "Received: from b.example by c.example; Mon, 1 Jan 2026 10:00:00 +0000\r\n"
+        "Received: from a.example by b.example; Mon, 1 Jan 2026 11:00:00 +0000\r\n"
+        "From: x@corp.example\r\nSubject: hola\r\n\r\ncuerpo\r\n"
+    )
+    result = _rule("Received Chain Temporal Inconsistency")["func"](parse_raw_message(raw))
+    assert result.score < 0
+    assert [item["locator"]["occurrence"] for item in result.evidence] == [0, 1]
+
+
+def test_qr_code_links_anchors_the_image_and_the_decoded_url():
+    cv2 = pytest.importorskip("cv2")
+    if not hasattr(cv2, "QRCodeEncoder"):
+        pytest.skip("Esta build de OpenCV no trae QRCodeEncoder")
+    from src.modules.features.iris.services.rules.body_links_rules import _decode_qr_urls
+
+    url = "http://192.168.10.20/login"
+    image = cv2.QRCodeEncoder.create().encode(url)
+    image = cv2.resize(image, None, fx=8, fy=8, interpolation=cv2.INTER_NEAREST)
+    image = cv2.copyMakeBorder(image, 40, 40, 40, 40, cv2.BORDER_CONSTANT, value=255)
+    png = cv2.imencode(".png", image)[1].tobytes()
+    if _decode_qr_urls(png) != [url]:
+        pytest.skip("OpenCV no decodifica el QR generado en este entorno")
+
+    context = parse_raw_message(_message_with_attachment("qr.png", "image/png", png))
+    result = _rule("QR Code Links")["func"](context)
+
+    assert result.score < 0
+    assert [(item["kind"], item["locator"].get("source")) for item in result.evidence] == [
+        (EVIDENCE_ATTACHMENT, None), (EVIDENCE_URL, "qr_code"),
+    ]

--- a/API/tests/unit/test_iris_reports.py
+++ b/API/tests/unit/test_iris_reports.py
@@ -288,3 +288,23 @@ def test_confidence_card_shows_level_coverage_and_reasons_without_a_percentage()
 
 def test_confidence_card_is_omitted_for_reports_without_confidence():
     assert _rendered_confidence_text(_sample_report()) == ""
+
+
+# ------------------------------------------------ evidencia anclada
+
+def test_finding_detail_shows_the_defanged_evidence_and_the_unanchorable_reason():
+    report = _sample_report(rules=[
+        {"ruleName": "Body Links", "category": "content_analysis", "score": -25, "verdict": "fail",
+         "details": {}, "recommendation": "No hagas clic.",
+         "evidence": [{"kind": "url", "locator": {"linkIndex": 0},
+                       "excerpt": "hxxp://192.168.10.20/login"}]},
+        {"ruleName": "Body Content", "category": "content_analysis", "score": -10, "verdict": "fail",
+         "details": {}, "recommendation": "Cuidado.",
+         "evidence": [], "evidenceUnavailableReason": "La regla evalúa el cuerpo en conjunto."},
+    ])
+    creator = IrisPDFCreator(report=report)
+    elements: list = []
+    creator.append_rules(elements, _theme())
+    text = "\n".join(element.text for element in elements if hasattr(element, "text"))
+    assert "hxxp://192.168.10.20/login" in text
+    assert "Sin evidencia anclada: La regla evalúa el cuerpo en conjunto." in text

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -202,6 +202,7 @@
           :rule="entry.rule"
           :expanded="expandedRule === entry.i"
           @toggle="toggleRule(entry.i)"
+          @jump-evidence="jumpToEvidence"
         />
 
         <!-- Reglas superadas (pass), plegadas por defecto para no alargar el scroll -->
@@ -219,6 +220,7 @@
                 :rule="entry.rule"
                 :expanded="expandedRule === entry.i"
                 @toggle="toggleRule(entry.i)"
+                @jump-evidence="jumpToEvidence"
               />
             </div>
           </Transition>
@@ -287,7 +289,11 @@
           Cabeceras originales
         </button>
         <Transition name="raw-reveal">
-          <pre v-if="rawOpen" class="raw-block">{{ reportData.rawHeaders }}</pre>
+          <pre v-if="rawOpen" ref="rawBlock" class="raw-block"><span
+            v-for="(line, n) in rawLines"
+            :key="n"
+            :class="['raw-line', { 'raw-line--hit': n === highlightedLine }]"
+          >{{ line }}{{ '\n' }}</span></pre>
         </Transition>
       </div>
 
@@ -335,6 +341,42 @@ defineEmits(['cancel', 'delete'])
 const expandedRule = ref(null)
 const rawOpen = ref(false)
 let ruleCardEls = []
+
+// Salto desde la evidencia de una regla a su línea en "Cabeceras originales".
+const rawBlock = ref(null)
+const highlightedLine = ref(null)
+const rawLines = computed(() => (props.reportData?.rawHeaders ?? '').split(/\r?\n/))
+
+/** Índice de línea de la aparición `occurrence` de la cabecera `header`, o
+ * null si no está. En un reenvío cuyo veredicto sale del original adjunto,
+ * sus cabeceras viven dentro de la parte message/rfc822: se busca a partir de
+ * ahí para no caer en la cabecera homónima del envoltorio. */
+function findHeaderLine(lines, header, occurrence) {
+  let start = 0
+  if (props.reportData?.unwrappedFromForward && props.reportData?.winningContext !== 'wrapper') {
+    const nested = lines.findIndex(line => /^content-type:\s*message\/rfc822/i.test(line))
+    if (nested >= 0) start = nested + 1
+  }
+  const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const prefix = new RegExp(`^${escaped}\\s*:`, 'i')
+  let seen = 0
+  for (let n = start; n < lines.length; n++) {
+    if (!prefix.test(lines[n])) continue
+    if (seen === occurrence) return n
+    seen++
+  }
+  return null
+}
+
+async function jumpToEvidence(item) {
+  const line = findHeaderLine(rawLines.value, item.locator?.header ?? '', item.locator?.occurrence ?? 0)
+  rawOpen.value = true
+  highlightedLine.value = line
+  await nextTick()
+  if (line !== null) {
+    rawBlock.value?.querySelectorAll('.raw-line')[line]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+}
 
 function toggleRule(i) {
   expandedRule.value = expandedRule.value === i ? null : i
@@ -926,6 +968,11 @@ watch(
   font-size: var(--fs-sm);
   color: var(--text-muted);
   word-break: break-word;
+}
+
+.raw-line--hit {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  border-radius: 3px;
 }
 
 .rv-gates {

--- a/web/app/src/components/iris/IrisRuleCard.vue
+++ b/web/app/src/components/iris/IrisRuleCard.vue
@@ -19,6 +19,31 @@
             <span class="detail-val" :class="{ 'detail-val--empty': isEmptyValue(v) }">{{ formatDetailValue(v) }}</span>
           </div>
         </div>
+        <!-- Evidencia anclada: dónde está lo que la regla encontró. Las
+             cabeceras saltan a su línea en "Cabeceras originales"; enlaces y
+             adjuntos muestran el extracto, ya desactivado (hxxp, [.], [@]). -->
+        <div v-if="rule.evidence && rule.evidence.length" class="rule-evidence">
+          <span class="evidence-title">Evidencia</span>
+          <template v-for="(item, k) in rule.evidence" :key="k">
+            <button
+              v-if="item.kind === 'header'"
+              type="button"
+              class="evidence-item evidence-item--jump"
+              title="Ver en las cabeceras originales"
+              @click="$emit('jump-evidence', item)"
+            >
+              <span class="evidence-kind">{{ evidenceLabel(item) }}</span>
+              <code class="evidence-excerpt">{{ item.excerpt }}</code>
+            </button>
+            <div v-else class="evidence-item">
+              <span class="evidence-kind">{{ evidenceLabel(item) }}</span>
+              <code class="evidence-excerpt">{{ item.excerpt }}</code>
+            </div>
+          </template>
+        </div>
+        <p v-else-if="rule.evidenceUnavailableReason" class="evidence-unavailable">
+          Sin evidencia anclada: {{ rule.evidenceUnavailableReason }}
+        </p>
         <div v-if="rule.recommendation" class="rule-recommendation">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="rec-icon"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
           {{ rule.recommendation }}
@@ -34,7 +59,21 @@ defineProps({
   expanded: { type: Boolean, default: false },
 })
 
-defineEmits(['toggle'])
+defineEmits(['toggle', 'jump-evidence'])
+
+/** Etiqueta corta de un elemento de evidencia (ver services/evidence.py en la API). */
+function evidenceLabel(item) {
+  const locator = item.locator ?? {}
+  if (item.kind === 'header') {
+    const occurrence = locator.occurrence ? ` #${locator.occurrence + 1}` : ''
+    return `Cabecera ${locator.header}${occurrence}`
+  }
+  if (item.kind === 'url') return locator.source === 'qr_code' ? 'URL en QR' : 'Enlace'
+  if (item.kind === 'attachment') return 'Adjunto'
+  if (item.kind === 'body') return 'Cuerpo'
+  if (item.kind === 'mime_part') return 'Parte MIME'
+  return item.kind
+}
 
 function sign(s) {
   if (s > 0) return '+'
@@ -81,6 +120,58 @@ function formatDetailValue(v) {
 
 .rule-card:hover {
   border-color: var(--border-med);
+}
+
+.rule-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.6rem;
+}
+
+.evidence-title {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.evidence-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+}
+
+.evidence-item--jump {
+  cursor: pointer;
+}
+
+.evidence-item--jump:hover {
+  border-color: var(--accent);
+}
+
+.evidence-kind {
+  flex-shrink: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+.evidence-excerpt {
+  font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
+  font-size: var(--fs-sm);
+  word-break: break-all;
+}
+
+.evidence-unavailable {
+  margin: 0 0 0.6rem;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
 }
 
 .rule-card--expanded {


### PR DESCRIPTION
## El problema

Cuando una regla de Iris detecta algo —"el nombre visible del remitente suplanta a una marca", "un enlace apunta a una IP en vez de a un dominio", "hay un ejecutable adjunto"— guarda el hallazgo en `RuleResult.details`, un diccionario libre donde cada regla mete lo que quiere. No hay un contrato común: ninguna regla dice **dónde** está, dentro del correo, lo que encontró. Ni qué cabecera, ni qué enlace, ni qué adjunto.

Para justificar un veredicto, el analista tenía que leer el raw entero y reconstruir a mano qué vio cada regla.

Cierra #222 (iniciativa `M01`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

**Un contrato de evidencia** (`services/evidence.py`). Cada hallazgo que resta puntos lleva una lista de elementos `{kind, locator, excerpt}`:

| `kind` | Qué señala | `locator` |
|---|---|---|
| `header` | una aparición concreta de una cabecera | `header`, `occurrence` (0 = la primera; en `Received`, el salto más reciente) |
| `url` | un enlace del cuerpo, o una URL decodificada de un QR | `linkIndex`, o `attachmentIndex` + `source: "qr_code"` |
| `attachment` | un adjunto | `attachmentIndex`, `filename`, `contentType`, `size`, `sha256` |
| `body` / `mime_part` | un rango del cuerpo / una parte MIME | `part`+`start`+`end` / `partIndex` (el contrato los admite; hoy ninguna regla los usa) |

`excerpt` es el fragmento con las URLs, dominios y direcciones **desactivados** (*defanged*): `https://evil.example` pasa a `hxxps://evil[.]example` y `a@b.example` a `a[@]b[.]example`. Así el extracto se puede leer en la UI o en un PDF sin que se convierta en un enlace que alguien pulse por error. Las IPs se dejan legibles: en la cadena `Received` son evidencia forense, no enlaces.

**El registro de reglas lo hace cumplir.** Cada regla del catálogo declara, al registrarse, una de estas tres cosas:
- `is_self_anchoring=True`: la regla construye su propia evidencia (qué enlace, qué adjunto, qué salto).
- `evidence_headers=(...)`: las cabeceras donde vive su señal. Si penaliza sin aportar evidencia, se anclan las que existan. Si no existe ninguna, se dice que la señal es precisamente su ausencia.
- `unanchorable_reason="..."`: por qué sus hallazgos no se pueden anclar a un fragmento concreto.

Una regla que no declare nada **no se puede registrar**: el import falla. La regla queda envuelta; el envoltorio aplica el contrato tras cada ejecución y valida la evidencia que trae la regla.

**Reparto en las 46 reglas del catálogo:**
- **6 se anclan solas:** Body Links, QR Code Links, Suspicious Attachments, Unicode Evasion, Received Chain Temporal Inconsistency y Compromised Legitimate Domain.
- **33 declaran sus cabeceras.**
- **7 declaran un motivo:** son reglas de cuerpo que evalúan el texto en conjunto y no registran posiciones. El motivo lo dice así, en vez de inventar un ancla.

**Las señales de más peso tienen evidencia clicable.** El criterio del issue pide "las diez". Ordenando por penalización por defecto, el corte cae en un empate a −12, así que se cubren las **trece** que llegan a ese peso. Un test fija que ninguna de ellas se escude en un motivo de no anclaje.

**Dónde se ve:**
- **API:** cada regla de `GET /iris/results/<id>` trae `evidence` y `evidenceUnavailableReason`.
- **UI:** la tarjeta de cada regla muestra su evidencia. Si es una cabecera, al pulsarla se abre "Cabeceras originales" con esa línea resaltada. En un reenvío cuyo veredicto sale del original, la búsqueda empieza dentro del adjunto `message/rfc822`, para no caer en la cabecera homónima del envoltorio.
- **PDF:** el detalle de hallazgos incluye hasta tres extractos desactivados por regla, o el motivo de por qué no hay evidencia.

## Migración

`a7c3e9f15b28_add_iris_rule_result_evidence`: dos columnas nulables en `IrisRuleResult` (`evidence` JSONB y `evidence_unavailable_reason`).

## Validación

- **`test_iris_evidence.py` (nuevo).**
  - La desactivación: URLs, dominios y direcciones; las IPs se quedan como están; el recorte.
  - El contrato: tipos desconocidos y locators incompletos se rechazan.
  - Los caminos del envoltorio: cabeceras declaradas, cabeceras ausentes, motivo declarado y evidencia inválida.
  - Que una regla sin declaración no se registra, y que toda regla del catálogo declara algo.
  - Que las trece de más peso se pueden anclar.
  - Las seis reglas que se anclan solas producen evidencia real sobre mensajes que las disparan, QR incluido: se genera y decodifica con OpenCV.
- **`test_iris_evidence_api.py` (nuevo, integración, catálogo real).** Sobre un phishing con enlace a IP literal y ejecutable adjunto:
  - toda regla que penaliza llega por API con evidencia o con motivo;
  - Body Links señala el enlace y Suspicious Attachments el adjunto;
  - las reglas que no penalizan no traen nada.
- **`test_iris_reports.py`.** El PDF muestra el extracto desactivado y el motivo.
- **`pytest tests/ -k iris`:** todo en verde, y el guard de `is_body_dependent` de M02 sigue funcionando con la regla envuelta (`inspect.getsource` desenvuelve `functools.wraps`). **`pylint src`:** 10.00/10.
- **`IrisRuleCard.vue` e `IrisReportViewer.vue`:** compilados con `@vue/compiler-sfc`. `npm run build` sigue sin poder ejecutarse aquí por el paquete privado `@projectellysia/acheron-core-web`.

## Notas

- **Cabeceras y reglas de `Received`.** Las cabeceras declaradas se eligieron leyendo qué cabeceras consulta cada regla. En las reglas de la cadena `Received` que no se anclan solas (Received Chain, Received Path Anomaly, Origin HELO Coherence), la evidencia es la cadena entera, hasta diez saltos, porque hablan de la cadena en conjunto.
- **Evidencia de cuerpo con offsets.** El contrato ya admite `body`, pero ninguna regla de cuerpo registra hoy posiciones. Añadirlo es trabajo de cada regla y no cambia el contrato.
- **Tamaño del catálogo.** Tiene **46** reglas, no las 48 que citaba el issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
