### PR TITLE
feat(iris): feedback del analista y corpus versionado de falsos positivos (M04)

### DIFF
--- a/API/alembic/versions/b9d2f6a8c4e1_add_iris_analyst_feedback.py
+++ b/API/alembic/versions/b9d2f6a8c4e1_add_iris_analyst_feedback.py
@@ -1,0 +1,46 @@
+"""iris: feedback del analista (IrisAnalystFeedback)
+
+Iris no tenía forma de aprender del uso real: nadie podía decir "este
+veredicto estaba mal". Esta tabla guarda cada corrección —etiqueta, nota,
+autor y fecha— sin tocar nunca el veredicto emitido, que sigue en
+IrisAnalysis.
+
+Revision ID: b9d2f6a8c4e1
+Revises: a7c3e9f15b28
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b9d2f6a8c4e1'
+down_revision: Union[str, Sequence[str], None] = 'a7c3e9f15b28'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'IrisAnalystFeedback',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('analysis_id', sa.Integer(), nullable=False),
+        sa.Column('author_id', sa.Integer(), nullable=False),
+        sa.Column('label', sa.String(length=16), nullable=False),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['analysis_id'], ['IrisAnalysis.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['author_id'], ['User.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_iris_analyst_feedback_analysis_id', 'IrisAnalystFeedback', ['analysis_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_iris_analyst_feedback_analysis_id', table_name='IrisAnalystFeedback')
+    op.drop_table('IrisAnalystFeedback')

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -33,7 +33,8 @@ from src.modules.shared._exceptions import DocumentError, DocumentNotReadyError
 import src.modules.system.config_reading as CR
 
 from .managers import (
-    IrisManager, IrisReportManager, IrisMailboxManager, IrisNotificationPreferenceManager,
+    IrisFeedbackManager, IrisManager, IrisReportManager, IrisMailboxManager,
+    IrisNotificationPreferenceManager,
 )
 from .exceptions import (
     IrisAnalysisNotFoundError,
@@ -78,6 +79,10 @@ from .schemas import (
     IrisNotificationPreferenceResponseSchema,
     IrisNotificationPreferenceUpdateRequestSchema,
     IrisRetentionReportResponseSchema,
+    IrisFeedbackRequestSchema,
+    IrisFeedbackItemSchema,
+    IrisFeedbackListResponseSchema,
+    IrisFeedbackMetricsResponseSchema,
 )
 
 
@@ -135,6 +140,59 @@ def analyze_headers(data):
 def get_capabilities():
     """Limites y modos de analisis que aplica el servidor"""
     return IrisManager.get_capabilities()
+
+
+@iris_blp.post("/results/<int:analysis_id>/feedback")
+@iris_blp.arguments(IrisFeedbackRequestSchema)
+@iris_blp.response(201, IrisFeedbackItemSchema, description="Analyst feedback recorded")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Analysis not found")
+@iris_blp.alt_response(409, schema=ErrorSchema, description="Analysis not finished")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("120 per hour; 1000 per day")
+@handle_exceptions(default_exception=IrisAnalysisNotFoundError, logger=logger)
+def submit_analysis_feedback(data, analysis_id: int):
+    """Registrar si el veredicto de un análisis era correcto (no lo modifica)"""
+    user = get_current_user()
+    feedback = IrisFeedbackManager().submit_feedback(
+        analysis_id, user.id, data["label"], data.get("note"),
+    )
+    logger.info(f"Feedback '{data['label']}' sobre el análisis {analysis_id} por {user.username}")
+    return feedback
+
+
+@iris_blp.get("/results/<int:analysis_id>/feedback")
+@iris_blp.response(200, IrisFeedbackListResponseSchema, description="Analyst feedback history")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Analysis not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisAnalysisNotFoundError, logger=logger)
+def list_analysis_feedback(analysis_id: int):
+    """Historial de correcciones de un análisis, de la más reciente a la más antigua"""
+    user = get_current_user()
+    return {
+        "analysisId": analysis_id,
+        "feedback": IrisFeedbackManager().list_feedback(analysis_id, user.id),
+    }
+
+
+@iris_blp.get("/feedback/metrics")
+@iris_blp.response(200, IrisFeedbackMetricsResponseSchema, description="Detector metrics from analyst feedback")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("60 per hour; 300 per day")
+@handle_exceptions(logger=logger)
+def get_feedback_metrics():
+    """Precisión, recall, cobertura y desacuerdo del detector según tus correcciones"""
+    user = get_current_user()
+    return IrisFeedbackManager().get_metrics(user.id)
 
 
 @iris_blp.get("/retention-policy")

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -12,6 +12,8 @@ Managers del módulo Iris (análisis de correo).
   cuando la ingesta automática de buzón clasifica un correo como Phishing.
 - ``IrisNotificationPreferenceManager`` (``notifications.py``): lectura y
   escritura de las preferencias de notificación de un usuario.
+- ``IrisFeedbackManager`` (``feedback.py``): correcciones del analista y
+  métricas del detector calculadas a partir de ellas.
 
 Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el
@@ -30,9 +32,11 @@ from .analysis import IrisManager
 from .reports import IrisReportManager
 from .mailbox import IrisMailboxManager
 from .notifications import IrisPhishingNotifyManager, IrisNotificationPreferenceManager
+from .feedback import IrisFeedbackManager
 
 __all__ = [
     "IrisManager",
+    "IrisFeedbackManager",
     "IrisReportManager",
     "IrisMailboxManager",
     "IrisPhishingNotifyManager",

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -404,6 +404,11 @@ class IrisManager(TaskTrackingMixin):
         winning_message = context_of_type(context, analysis.winning_context)
         preview = preview_headers(winning_message) if analysis.raw_headers else None
 
+        # Import tardío: el manager de feedback depende de este para
+        # comprobar la propiedad del análisis.
+        from .feedback import IrisFeedbackManager
+        latest_feedback = IrisFeedbackManager.latest_for_analysis(analysis_id)
+
         return {
             "analysisId": analysis.id,
             "title": analysis.title,
@@ -437,6 +442,7 @@ class IrisManager(TaskTrackingMixin):
             "user": username,
             "rules": rules_data,
             "recommendations": recommendations,
+            "latestFeedback": latest_feedback,
         }
 
     @staticmethod

--- a/API/src/modules/features/iris/managers/feedback.py
+++ b/API/src/modules/features/iris/managers/feedback.py
@@ -1,0 +1,153 @@
+"""
+IrisFeedbackManager — correcciones del analista y métricas del detector.
+
+El analista puede decir si un veredicto era correcto; esa etiqueta alimenta
+las métricas (precisión, recall, cobertura y desacuerdo por familia) y, más
+adelante, la calibración. **Nunca** modifica el veredicto ya emitido: el
+análisis sigue diciendo lo que Iris decidió y el feedback lo que opinó una
+persona después.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.modules.infrastructure import UnitOfWork
+from src.modules.infrastructure.session import build_repository
+from src.modules.shared import isoformat_utc
+
+from ..exceptions import IrisAnalysisNotReadyError, IrisInvalidInputError
+from ..model import IrisAnalystFeedback
+from ..repositories import (
+    IrisAnalysisRepository,
+    IrisAnalystFeedbackRepository,
+    IrisRuleResultRepository,
+)
+from ..services.feedback_metrics import FEEDBACK_LABELS, compute_feedback_metrics, outcome_from_rules
+from ..services.rules import iris_rules
+from .analysis import IrisManager
+
+#: Longitud máxima de la nota del analista.
+MAX_NOTE_LENGTH = 2000
+
+
+class IrisFeedbackManager:
+    """Registra correcciones del analista y calcula las métricas del detector."""
+
+    @staticmethod
+    def feedback_to_dict(feedback: IrisAnalystFeedback) -> Dict[str, Any]:
+        """Serializa una corrección con las claves camelCase de la API.
+
+        Args:
+            feedback: Fila ``IrisAnalystFeedback`` persistida.
+
+        Returns:
+            dict: ``feedbackId``, ``analysisId``, ``label``, ``note``,
+                ``author`` (nombre de usuario) y ``createdAt``.
+        """
+        return {
+            "feedbackId": feedback.id,
+            "analysisId": feedback.analysis_id,
+            "label": feedback.label,
+            "note": feedback.note,
+            "author": feedback.author.username if feedback.author else "unknown",
+            "createdAt": isoformat_utc(feedback.created_at),
+        }
+
+    def submit_feedback(self, analysis_id: int, user_id: int, label: str,
+                        note: Optional[str] = None) -> Dict[str, Any]:
+        """Registra la corrección de un analista sobre un análisis terminado.
+
+        Añade una fila nueva y deja intacto el historial y el veredicto.
+
+        Args:
+            analysis_id: Análisis a corregir; debe ser del usuario.
+            user_id: Analista que corrige; queda como autor.
+            label: ``malicious``, ``legitimate`` o ``unknown``.
+            note: Nota libre opcional; se recorta a ``MAX_NOTE_LENGTH`` y una
+                nota en blanco se guarda como ``None``. Por defecto ``None``.
+
+        Returns:
+            dict: La corrección registrada (ver ``feedback_to_dict``).
+
+        Raises:
+            IrisAnalysisNotFoundError: Si el análisis no existe o no es suyo.
+            IrisAnalysisNotReadyError: Si el análisis no ha terminado: sin
+                veredicto no hay nada que corregir.
+            IrisInvalidInputError: Si la etiqueta no es una de las tres.
+        """
+        analysis = IrisManager.assert_analysis_ownership(analysis_id, user_id)
+        if analysis.status != "finished":
+            raise IrisAnalysisNotReadyError(analysis_id, analysis.status)
+        if label not in FEEDBACK_LABELS:
+            raise IrisInvalidInputError(f"Etiqueta de feedback desconocida: {label!r}.")
+
+        cleaned_note = note.strip()[:MAX_NOTE_LENGTH] if note and note.strip() else None
+        with UnitOfWork() as uow:
+            feedback = IrisAnalystFeedbackRepository(uow).save(IrisAnalystFeedback(
+                analysis_id=analysis_id, author_id=user_id, label=label, note=cleaned_note,
+            ))
+            return self.feedback_to_dict(feedback)
+
+    def list_feedback(self, analysis_id: int, user_id: int) -> List[Dict[str, Any]]:
+        """Historial de correcciones de un análisis, de la más reciente a la más antigua.
+
+        Args:
+            analysis_id: Análisis consultado; debe ser del usuario.
+            user_id: Usuario que consulta.
+
+        Returns:
+            List[dict]: Las correcciones (ver ``feedback_to_dict``).
+
+        Raises:
+            IrisAnalysisNotFoundError: Si el análisis no existe o no es suyo.
+        """
+        IrisManager.assert_analysis_ownership(analysis_id, user_id)
+        repo = build_repository(IrisAnalystFeedbackRepository)
+        return [self.feedback_to_dict(feedback) for feedback in repo.get_by_analysis(analysis_id)]
+
+    @classmethod
+    def latest_for_analysis(cls, analysis_id: int) -> Optional[Dict[str, Any]]:
+        """Corrección vigente de un análisis, ya serializada.
+
+        Args:
+            analysis_id: Primary key del análisis.
+
+        Returns:
+            Optional[dict]: La más reciente, o ``None`` si nadie lo revisó.
+        """
+        feedback = build_repository(IrisAnalystFeedbackRepository).latest_for_analysis(analysis_id)
+        return cls.feedback_to_dict(feedback) if feedback else None
+
+    def get_metrics(self, user_id: int) -> Dict[str, Any]:
+        """Métricas del detector sobre los análisis revisados de un usuario.
+
+        Por cada análisis con etiqueta vigente se toman las reglas del
+        contexto ganador (las que describen el veredicto) y las reglas que no
+        se evaluaron de verdad —las que fallaron y las que no tuvieron
+        contenido que inspeccionar—, que restan cobertura a su familia.
+
+        Args:
+            user_id: Dueño de los análisis.
+
+        Returns:
+            dict: Salida de ``services/feedback_metrics.compute_feedback_metrics``.
+        """
+        family_of = {rule_def["name"]: rule_def.get("family") or "" for rule_def in iris_rules.get_rules()}
+        families = {family for family in family_of.values() if family}
+
+        rule_repo = build_repository(IrisRuleResultRepository)
+        outcomes = []
+        for feedback in build_repository(IrisAnalystFeedbackRepository).latest_per_analysis_for_user(user_id):
+            analysis = feedback.analysis
+            rules = rule_repo.get_by_analysis(analysis.id, context_type=analysis.winning_context)
+            unevaluated = [rule["name"] for rule in (analysis.failed_rules or [])]
+            unevaluated += list((analysis.coverage or {}).get("uncoveredRules") or [])
+            outcomes.append(outcome_from_rules(
+                feedback.label, analysis.verdict,
+                [(rule.rule_name, rule.score) for rule in rules],
+                family_of, unevaluated,
+            ))
+
+        analyses_total = build_repository(IrisAnalysisRepository).count_finished_by_user(user_id)
+        return compute_feedback_metrics(outcomes, families, analyses_total)

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -117,6 +117,9 @@ class IrisAnalysis(Base):
         user_id: Foreign key to the owning User.
         user: SQLAlchemy relationship to User.
         rule_results: Ordered list of IrisRuleResult (per-rule outcomes).
+        feedback: Correcciones del analista sobre este análisis
+                 (``IrisAnalystFeedback``), de la más antigua a la más reciente.
+                 Nunca modifican el veredicto de esta fila.
         connection_id: FK to the IrisMailboxConnection that ingested this
                  message automatically; NULL for manual submissions (the
                  original, still-default flow).
@@ -174,6 +177,11 @@ class IrisAnalysis(Base):
     )
     raw_message = relationship(
         "IrisRawMessage", back_populates="analysis", uselist=False,
+        cascade="all, delete-orphan",
+    )
+    feedback = relationship(
+        "IrisAnalystFeedback", back_populates="analysis",
+        order_by="IrisAnalystFeedback.created_at",
         cascade="all, delete-orphan",
     )
 
@@ -512,6 +520,49 @@ class IrisRuleResult(Base):
 
     __table_args__ = (
         Index("ix_iris_rule_result_analysis_id", "analysis_id"),
+    )
+
+
+class IrisAnalystFeedback(Base):
+    """Corrección de un analista sobre el veredicto de un análisis.
+
+    Es la etiqueta humana —"esto era malicioso", "esto era legítimo", "no se
+    puede saber"— que alimenta la calibración y las métricas del detector.
+    **Nunca cambia el veredicto ya emitido**: ``IrisAnalysis`` sigue diciendo lo
+    que Iris decidió en su momento, y esta tabla dice lo que opinó una persona
+    después. Separarlas es lo que permite medir cuánto se equivoca el motor.
+
+    Cada corrección es una fila nueva, no una edición de la anterior: el
+    historial queda entero (quién cambió de opinión y cuándo), y la etiqueta
+    vigente de un análisis es la más reciente.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        analysis_id: FK al ``IrisAnalysis`` corregido; ``ondelete="CASCADE"``,
+                 la corrección no tiene sentido sin el análisis.
+        author_id: FK al ``User`` que la escribió.
+        label: "malicious", "legitimate" o "unknown" (el analista revisó el
+                 mensaje y no puede decidir; cuenta como revisado, pero no
+                 entra en precisión ni recall).
+        note: Nota libre del analista, opcional (hasta 2000 caracteres).
+        created_at: Cuándo se registró.
+        analysis: Relación inversa a ``IrisAnalysis``.
+        author: Relación al ``User`` autor.
+    """
+    __tablename__ = "IrisAnalystFeedback"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    analysis_id = Column(Integer, ForeignKey("IrisAnalysis.id", ondelete="CASCADE"), nullable=False)
+    author_id = Column(Integer, ForeignKey("User.id"), nullable=False)
+    label = Column(String(16), nullable=False)
+    note = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+
+    analysis = relationship("IrisAnalysis", back_populates="feedback")
+    author = relationship("User")
+
+    __table_args__ = (
+        Index("ix_iris_analyst_feedback_analysis_id", "analysis_id"),
     )
 
 

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Tuple
 
-from sqlalchemy import and_, asc, delete, desc, nullslast, select, update
+from sqlalchemy import and_, asc, delete, desc, func, nullslast, select, update
 from sqlalchemy.orm import joinedload
 
 from src.modules.infrastructure import BaseRepository, DocumentRepository
 from src.modules.shared import utcnow_naive
 
 from .model import (
+    IrisAnalystFeedback,
     IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox, IrisNotificationPreference,
     IrisRawMessage, IrisRuleResult, IrisDocument,
 )
@@ -198,6 +199,24 @@ class IrisAnalysisRepository(BaseRepository[IrisAnalysis]):
         """Cuántos análisis tiene este usuario en total -- para el informe
         de retención, que necesita el denominador."""
         return self._session.query(IrisAnalysis.id).filter(IrisAnalysis.user_id == user_id).count()
+
+    def count_finished_by_user(self, user_id: int) -> int:
+        """Cuántos análisis terminados tiene un usuario.
+
+        Es el denominador de la cobertura de feedback: solo un análisis
+        terminado tiene un veredicto que el analista pueda corregir.
+
+        Args:
+            user_id: Dueño de los análisis.
+
+        Returns:
+            int: Número de análisis en estado ``finished``.
+        """
+        return (
+            self._session.query(IrisAnalysis.id)
+            .filter(IrisAnalysis.user_id == user_id, IrisAnalysis.status == "finished")
+            .count()
+        )
 
     def count_with_raw_retained_by_user(self, user_id: int) -> int:
         """De los análisis de este usuario, cuántos conservan todavía su
@@ -521,6 +540,75 @@ class IrisRuleResultRepository(BaseRepository[IrisRuleResult]):
         self._session.query(IrisRuleResult).filter(
             IrisRuleResult.analysis_id == analysis_id
         ).delete()
+
+
+class IrisAnalystFeedbackRepository(BaseRepository[IrisAnalystFeedback]):
+    """Acceso a las correcciones del analista (``IrisAnalystFeedback``).
+
+    Cada corrección es una fila nueva; la vigente de un análisis es la de
+    ``id`` más alto, que crece junto con ``created_at``.
+    """
+
+    _MODEL = IrisAnalystFeedback
+
+    def get_by_analysis(self, analysis_id: int) -> List[IrisAnalystFeedback]:
+        """Historial de correcciones de un análisis, de la más reciente a la más antigua.
+
+        Args:
+            analysis_id: Primary key del ``IrisAnalysis``.
+
+        Returns:
+            List[IrisAnalystFeedback]: Las correcciones; lista vacía si no hay.
+        """
+        return (
+            self._session.query(IrisAnalystFeedback)
+            .filter(IrisAnalystFeedback.analysis_id == analysis_id)
+            .order_by(IrisAnalystFeedback.id.desc())
+            .all()
+        )
+
+    def latest_for_analysis(self, analysis_id: int) -> Optional[IrisAnalystFeedback]:
+        """Corrección vigente de un análisis.
+
+        Args:
+            analysis_id: Primary key del ``IrisAnalysis``.
+
+        Returns:
+            Optional[IrisAnalystFeedback]: La más reciente, o ``None`` si
+                nadie lo ha revisado.
+        """
+        return (
+            self._session.query(IrisAnalystFeedback)
+            .filter(IrisAnalystFeedback.analysis_id == analysis_id)
+            .order_by(IrisAnalystFeedback.id.desc())
+            .first()
+        )
+
+    def latest_per_analysis_for_user(self, user_id: int) -> List[IrisAnalystFeedback]:
+        """La corrección vigente de cada análisis revisado de un usuario.
+
+        Es la entrada de las métricas: una etiqueta por análisis (la última),
+        no una por corrección, para que cambiar de opinión no cuente dos veces.
+
+        Args:
+            user_id: Dueño de los análisis.
+
+        Returns:
+            List[IrisAnalystFeedback]: Una fila por análisis revisado, con su
+                ``analysis`` ya cargado.
+        """
+        latest_ids = (
+            select(func.max(IrisAnalystFeedback.id))
+            .join(IrisAnalysis, IrisAnalysis.id == IrisAnalystFeedback.analysis_id)
+            .where(IrisAnalysis.user_id == user_id)
+            .group_by(IrisAnalystFeedback.analysis_id)
+        )
+        return (
+            self._session.query(IrisAnalystFeedback)
+            .options(joinedload(IrisAnalystFeedback.analysis))
+            .filter(IrisAnalystFeedback.id.in_(latest_ids))
+            .all()
+        )
 
 
 class IrisNotificationPreferenceRepository(BaseRepository[IrisNotificationPreference]):

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -10,6 +10,8 @@ from marshmallow import Schema, ValidationError, fields, validate, validates_sch
 import src.modules.system.config_reading as CR
 from src.modules.shared import UTCDateTime
 
+from .services.feedback_metrics import FEEDBACK_LABELS
+
 
 class AnalyzeRequestSchema(Schema):
     """Request body for ``POST /iris/analyze``.
@@ -177,6 +179,68 @@ class FailedRuleSchema(Schema):
     category = fields.String(load_default=None, allow_none=True)
 
 
+class IrisFeedbackRequestSchema(Schema):
+    """Corrección del analista sobre el veredicto de un análisis terminado.
+
+    ``label`` es ``malicious``, ``legitimate`` o ``unknown`` (revisado, pero
+    no se puede decidir). No modifica el veredicto: se guarda aparte y
+    alimenta las métricas.
+    """
+    label = fields.String(required=True, validate=validate.OneOf(FEEDBACK_LABELS))
+    note = fields.String(load_default=None, allow_none=True, validate=validate.Length(max=2000))
+
+
+class IrisFeedbackItemSchema(Schema):
+    """Una corrección registrada: etiqueta, nota, autor y fecha."""
+    feedbackId = fields.Integer()
+    analysisId = fields.Integer()
+    label = fields.String()
+    note = fields.String(load_default=None, allow_none=True)
+    author = fields.String()
+    createdAt = fields.String()
+
+
+class IrisFeedbackListResponseSchema(Schema):
+    """Historial de correcciones de un análisis, de la más reciente a la más antigua."""
+    analysisId = fields.Integer()
+    feedback = fields.List(fields.Nested(IrisFeedbackItemSchema))
+
+
+class IrisFeedbackOverallMetricsSchema(Schema):
+    """Matriz de confusión y tasas globales del detector frente a las etiquetas.
+
+    Un veredicto positivo es cualquiera que avisa (``Suspicious`` o
+    ``Phishing``). Las tasas valen ``null`` cuando no hay datos.
+    """
+    truePositives = fields.Integer()
+    falsePositives = fields.Integer()
+    falseNegatives = fields.Integer()
+    trueNegatives = fields.Integer()
+    precision = fields.Float(allow_none=True)
+    recall = fields.Float(allow_none=True)
+    disagreementRate = fields.Float(allow_none=True)
+
+
+class IrisFeedbackFamilyMetricsSchema(Schema):
+    """Métricas de una familia de reglas: ¿disparar esta familia coincide con malicioso?"""
+    family = fields.String()
+    fired = fields.Integer()
+    precision = fields.Float(allow_none=True)
+    recall = fields.Float(allow_none=True)
+    disagreementRate = fields.Float(allow_none=True)
+    coverage = fields.Float(allow_none=True)
+
+
+class IrisFeedbackMetricsResponseSchema(Schema):
+    """Métricas del detector calculadas con las correcciones vigentes del usuario."""
+    analysesTotal = fields.Integer()
+    reviewed = fields.Integer()
+    unknown = fields.Integer()
+    feedbackCoverage = fields.Float(allow_none=True)
+    overall = fields.Nested(IrisFeedbackOverallMetricsSchema)
+    families = fields.List(fields.Nested(IrisFeedbackFamilyMetricsSchema))
+
+
 class CoverageSchema(Schema):
     """Qué partes del mensaje se pudieron inspeccionar.
 
@@ -259,6 +323,7 @@ class AnalysisDetailResponseSchema(Schema):
     user = fields.String()
     rules = fields.List(fields.Nested(RuleResultSchema))
     recommendations = fields.List(fields.String())
+    latestFeedback = fields.Nested(IrisFeedbackItemSchema, load_default=None, allow_none=True)
 
 
 class AnalysisListItemSchema(Schema):

--- a/API/src/modules/features/iris/services/feedback_metrics.py
+++ b/API/src/modules/features/iris/services/feedback_metrics.py
@@ -1,0 +1,185 @@
+"""
+Métricas del detector a partir del feedback del analista.
+
+El veredicto de Iris es una predicción; la etiqueta del analista es la
+verdad que se usa para medirla. Este módulo es puro —sin ORM ni red— para
+que lo usen igual el endpoint de métricas, que lee etiquetas de la base de
+datos, y el corpus versionado de ``tests/fixtures/iris/``, que trae las suyas
+en un manifiesto.
+
+Convenciones:
+
+- Un veredicto **positivo** es cualquiera que avisa (``Suspicious`` o
+  ``Phishing``); ``Legitimate`` es negativo.
+- ``malicious`` y ``legitimate`` son las etiquetas que miden; ``unknown``
+  cuenta como revisado, pero no entra en precisión, recall ni desacuerdo.
+- Una métrica cuyo denominador es cero vale ``None``: "no hay datos" no es lo
+  mismo que "0 %".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional
+
+LABEL_MALICIOUS = "malicious"
+LABEL_LEGITIMATE = "legitimate"
+LABEL_UNKNOWN = "unknown"
+FEEDBACK_LABELS = (LABEL_MALICIOUS, LABEL_LEGITIMATE, LABEL_UNKNOWN)
+
+_POSITIVE_VERDICTS = frozenset({"Suspicious", "Phishing"})
+
+
+@dataclass(frozen=True)
+class LabelledOutcome:
+    """Un análisis etiquetado, reducido a lo que las métricas necesitan.
+
+    Attributes:
+        label: Etiqueta vigente del analista (``malicious``, ``legitimate`` o
+            ``unknown``).
+        verdict: Veredicto que emitió Iris (``Legitimate``, ``Suspicious`` o
+            ``Phishing``).
+        fired_families: Familias de regla con al menos una regla que restó
+            puntos en el contexto ganador.
+        covered_families: Familias que se evaluaron por completo: ninguna de
+            sus reglas falló al ejecutarse ni se quedó sin contenido que
+            inspeccionar.
+    """
+
+    label: str
+    verdict: str
+    fired_families: FrozenSet[str]
+    covered_families: FrozenSet[str]
+
+
+def _ratio(numerator: int, denominator: int) -> Optional[float]:
+    """Cociente redondeado a 4 decimales, o ``None`` si no hay denominador."""
+    return round(numerator / denominator, 4) if denominator else None
+
+
+def _confusion(pairs: Iterable[tuple[bool, bool]]) -> Dict[str, int]:
+    """Matriz de confusión de pares (predicho positivo, etiquetado malicioso).
+
+    Args:
+        pairs: Un par por análisis etiquetado ``malicious`` o ``legitimate``.
+
+    Returns:
+        dict: ``truePositives``, ``falsePositives``, ``falseNegatives`` y
+            ``trueNegatives``.
+    """
+    counts = {"truePositives": 0, "falsePositives": 0, "falseNegatives": 0, "trueNegatives": 0}
+    for predicted, malicious in pairs:
+        if predicted and malicious:
+            counts["truePositives"] += 1
+        elif predicted:
+            counts["falsePositives"] += 1
+        elif malicious:
+            counts["falseNegatives"] += 1
+        else:
+            counts["trueNegatives"] += 1
+    return counts
+
+
+def _rates(counts: Dict[str, int]) -> Dict[str, Optional[float]]:
+    """Precisión, recall y tasa de desacuerdo de una matriz de confusión.
+
+    Args:
+        counts: Salida de ``_confusion``.
+
+    Returns:
+        dict: ``precision`` (de lo que se marcó, cuánto era malicioso),
+            ``recall`` (de lo malicioso, cuánto se marcó) y
+            ``disagreementRate`` (fracción de etiquetados en que la
+            predicción y la etiqueta no coinciden). ``None`` sin datos.
+    """
+    true_positives = counts["truePositives"]
+    false_positives = counts["falsePositives"]
+    false_negatives = counts["falseNegatives"]
+    labelled = sum(counts.values())
+    return {
+        "precision": _ratio(true_positives, true_positives + false_positives),
+        "recall": _ratio(true_positives, true_positives + false_negatives),
+        "disagreementRate": _ratio(false_positives + false_negatives, labelled),
+    }
+
+
+def compute_feedback_metrics(outcomes: List[LabelledOutcome], families: Iterable[str],
+                             analyses_total: int) -> Dict[str, Any]:
+    """Mide el detector contra las etiquetas del analista, en global y por familia.
+
+    En global, la predicción es el veredicto (positivo si avisa). Por familia,
+    la predicción es "la familia disparó": así se ve qué familia genera los
+    falsos positivos y cuál deja pasar lo malicioso, que es lo que necesita una
+    recalibración.
+
+    Args:
+        outcomes: Un ``LabelledOutcome`` por análisis con etiqueta vigente.
+        families: Familias de regla del catálogo a desglosar (p. ej. ``auth``,
+            ``links``).
+        analyses_total: Análisis terminados sobre los que se podría haber
+            dado feedback; es el denominador de la cobertura de feedback.
+
+    Returns:
+        dict: ``analysesTotal``, ``reviewed`` (con cualquier etiqueta),
+            ``unknown``, ``feedbackCoverage`` (revisados / terminados),
+            ``overall`` (matriz de confusión más ``precision``, ``recall`` y
+            ``disagreementRate``) y ``families``: una entrada por familia con
+            ``family``, ``fired``, ``precision``, ``recall``,
+            ``disagreementRate`` y ``coverage`` (fracción de etiquetados en
+            que la familia se evaluó por completo).
+    """
+    decided = [outcome for outcome in outcomes if outcome.label in (LABEL_MALICIOUS, LABEL_LEGITIMATE)]
+
+    overall_counts = _confusion(
+        (outcome.verdict in _POSITIVE_VERDICTS, outcome.label == LABEL_MALICIOUS) for outcome in decided
+    )
+
+    family_metrics = []
+    for family in sorted(set(families)):
+        counts = _confusion(
+            (family in outcome.fired_families, outcome.label == LABEL_MALICIOUS) for outcome in decided
+        )
+        covered = sum(1 for outcome in decided if family in outcome.covered_families)
+        family_metrics.append({
+            "family": family,
+            "fired": counts["truePositives"] + counts["falsePositives"],
+            **_rates(counts),
+            "coverage": _ratio(covered, len(decided)),
+        })
+
+    return {
+        "analysesTotal": analyses_total,
+        "reviewed": len(outcomes),
+        "unknown": len(outcomes) - len(decided),
+        "feedbackCoverage": _ratio(len(outcomes), analyses_total),
+        "overall": {**overall_counts, **_rates(overall_counts)},
+        "families": family_metrics,
+    }
+
+
+def outcome_from_rules(label: str, verdict: str, rules: Iterable[tuple[str, float]],
+                       family_of: Dict[str, str], unevaluated_rules: Iterable[str]) -> LabelledOutcome:
+    """Construye un ``LabelledOutcome`` a partir de los resultados de regla.
+
+    Args:
+        label: Etiqueta vigente del analista.
+        verdict: Veredicto que emitió Iris.
+        rules: Pares ``(nombre de regla, score)`` del contexto ganador.
+        family_of: Familia de cada regla del catálogo (``""`` si no tiene).
+        unevaluated_rules: Reglas que no se evaluaron de verdad: las que
+            fallaron al ejecutarse y las que no tuvieron contenido que
+            inspeccionar.
+
+    Returns:
+        LabelledOutcome: Con las familias que dispararon y las que se
+            evaluaron por completo (todas las del catálogo menos las que
+            contienen alguna regla sin evaluar).
+    """
+    fired = frozenset(
+        family_of.get(name, "") for name, score in rules if score < 0 and family_of.get(name)
+    )
+    unevaluated_families = {family_of.get(name, "") for name in unevaluated_rules}
+    covered = frozenset(
+        family for family in set(family_of.values()) if family and family not in unevaluated_families
+    )
+    return LabelledOutcome(label=label, verdict=verdict, fired_families=fired, covered_families=covered)

--- a/API/tests/fixtures/iris/legit_bank_alert.eml
+++ b/API/tests/fixtures/iris/legit_bank_alert.eml
@@ -1,0 +1,15 @@
+From: "Banco Ejemplo" <alertas@bancoejemplo.com>
+To: cliente@example.com
+Return-Path: <alertas@bancoejemplo.com>
+Subject: Alerta de seguridad: nuevo inicio de sesion detectado
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <alert123@bancoejemplo.com>
+Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=bancoejemplo.com; dkim=pass header.d=bancoejemplo.com; dmarc=pass
+Content-Type: text/plain; charset=utf-8
+
+Estimado cliente,
+
+Hemos detectado un nuevo inicio de sesion en su cuenta desde un dispositivo desconocido. Si no reconoce esta actividad, contactenos de inmediato por telefono.
+
+Atentamente,
+Banco Ejemplo

--- a/API/tests/fixtures/iris/legit_corporate_notice.eml
+++ b/API/tests/fixtures/iris/legit_corporate_notice.eml
@@ -1,0 +1,15 @@
+From: "RRHH Acme" <rrhh@acme.com>
+To: empleados@acme.com
+Return-Path: <rrhh@acme.com>
+Subject: Aviso importante sobre vacaciones
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <xyz789@acme.com>
+Authentication-Results: mx.acme.com; spf=pass smtp.mailfrom=acme.com; dkim=pass header.d=acme.com; dmarc=pass
+Content-Type: text/plain; charset=utf-8
+
+Estimado equipo,
+
+Les recordamos el procedimiento para solicitar vacaciones este ano. Por favor completen el formulario interno antes de fin de mes.
+
+Saludos,
+RRHH

--- a/API/tests/fixtures/iris/legit_newsletter_esp.eml
+++ b/API/tests/fixtures/iris/legit_newsletter_esp.eml
@@ -1,0 +1,12 @@
+From: Acme Corp <news@acme.com>
+Reply-To: reply-abc123@reply.mailchimp.com
+Return-Path: <bounce-abc123@bounce.sendgrid.net>
+To: subscriber@example.com
+Subject: Tu boletin de mayo
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <abc123@mailchimp.com>
+Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=bounce.sendgrid.net; dkim=pass header.d=acme.com; dmarc=pass
+List-Unsubscribe: <https://acme.com/unsubscribe>, <mailto:unsub@acme.com>
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Hola,</p><p>Aqui tienes las novedades de mayo. Gracias por seguir con nosotros y por confiar en nuestro equipo.</p><img src="https://cdn.mailchimp.com/img/logo.png" alt="logo"/></body></html>

--- a/API/tests/fixtures/iris/legit_order_confirmation.eml
+++ b/API/tests/fixtures/iris/legit_order_confirmation.eml
@@ -1,0 +1,16 @@
+From: Acme Store <orders@acmestore.com>
+Reply-To: reply@postmarkapp.com
+Return-Path: <bounce@postmarkapp.com>
+To: buyer@example.com
+Subject: Your order #48213 has shipped
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <order48213@postmarkapp.com>
+Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=postmarkapp.com; dkim=pass header.d=acmestore.com; dmarc=pass
+Content-Type: text/plain; charset=utf-8
+
+Hi there,
+
+Good news! Your order #48213 has shipped and is on its way. You can track your package using the link in your account.
+
+Thanks for shopping with us,
+Acme Store

--- a/API/tests/fixtures/iris/manifest.json
+++ b/API/tests/fixtures/iris/manifest.json
@@ -1,0 +1,48 @@
+{
+  "version": "2026-09-11",
+  "description": "Corpus sintético de Iris: mensajes inventados (ningún correo real ni dato personal), cada uno con la etiqueta que le daría un analista. Lo usan las métricas de feedback y el replay de versiones del detector; añadir o reetiquetar una muestra obliga a subir la versión.",
+  "samples": [
+    {
+      "id": "legit_newsletter_esp",
+      "file": "legit_newsletter_esp.eml",
+      "label": "legitimate",
+      "description": "Boletín de marketing enviado por un ESP (Mailchimp/SendGrid)."
+    },
+    {
+      "id": "legit_corporate_notice",
+      "file": "legit_corporate_notice.eml",
+      "label": "legitimate",
+      "description": "Aviso interno de RRHH con pie de confidencialidad."
+    },
+    {
+      "id": "legit_bank_alert",
+      "file": "legit_bank_alert.eml",
+      "label": "legitimate",
+      "description": "Alerta de seguridad bancaria legítima, sin enlaces."
+    },
+    {
+      "id": "legit_order_confirmation",
+      "file": "legit_order_confirmation.eml",
+      "label": "legitimate",
+      "description": "Recibo transaccional en inglés vía Postmark."
+    },
+    {
+      "id": "phish_credential_lookalike",
+      "file": "phish_credential_lookalike.eml",
+      "label": "malicious",
+      "description": "Suplantación de PayPal con dominio parecido y autenticación fallida."
+    },
+    {
+      "id": "phish_bec_free_provider",
+      "file": "phish_bec_free_provider.eml",
+      "label": "malicious",
+      "description": "Fraude del CEO desde Gmail pidiendo una transferencia."
+    },
+    {
+      "id": "phish_ip_link_executable",
+      "file": "phish_ip_link_executable.eml",
+      "label": "malicious",
+      "description": "Enlace camuflado a una IP literal y ejecutable con doble extensión."
+    }
+  ]
+}

--- a/API/tests/fixtures/iris/phish_bec_free_provider.eml
+++ b/API/tests/fixtures/iris/phish_bec_free_provider.eml
@@ -1,0 +1,12 @@
+From: "Juan Perez (CEO)" <juan.perez.ceo@gmail.com>
+To: finanzas@acme.com
+Subject: Transferencia urgente
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <bec1@gmail.com>
+Authentication-Results: mx.acme.com; spf=pass smtp.mailfrom=gmail.com; dkim=pass header.d=gmail.com; dmarc=pass
+Content-Type: text/plain; charset=utf-8
+
+Necesito que proceses el pago de una factura pendiente hoy mismo, es confidencial, no lo comentes con nadie mas del equipo. Te paso los datos bancarios nuevos en cuanto confirmes que puedes hacerlo.
+
+Gracias,
+Juan

--- a/API/tests/fixtures/iris/phish_credential_lookalike.eml
+++ b/API/tests/fixtures/iris/phish_credential_lookalike.eml
@@ -1,0 +1,10 @@
+From: "PayPal Security" <security@paypa1-verify.tk>
+Reply-To: support@paypa1-verify.tk
+To: victim@example.com
+Subject: Urgent: verify your account now
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <1@paypa1-verify.tk>
+Authentication-Results: mx.example.com; spf=fail smtp.mailfrom=paypa1-verify.tk; dkim=fail; dmarc=fail
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Dear customer,</p><p>Please verify your account immediately or it will be suspended.</p><a href="http://paypa1-verify.tk/login">Verify Now</a></body></html>

--- a/API/tests/fixtures/iris/phish_ip_link_executable.eml
+++ b/API/tests/fixtures/iris/phish_ip_link_executable.eml
@@ -1,0 +1,20 @@
+From: PayPal Soporte <alerta@paypa1-secure.example>
+Reply-To: cobros@gmail.com
+To: victima@corp.example
+Subject: Verifique su cuenta urgentemente
+Date: Mon, 07 Sep 2026 09:30:00 +0000
+Message-ID: <x1@paypa1-secure.example>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="B"
+
+--B
+Content-Type: text/html; charset=utf-8
+
+<p>Estimado cliente, verifique su cuenta.</p><a href="http://192.168.10.20/login">https://www.paypal.com</a>
+--B
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="factura.pdf.exe"
+Content-Transfer-Encoding: base64
+
+TVqQAA==
+--B--

--- a/API/tests/integration/test_iris_feedback.py
+++ b/API/tests/integration/test_iris_feedback.py
@@ -1,0 +1,158 @@
+"""Feedback del analista: corregir un veredicto sin tocarlo, y medir con ello.
+
+Cubre el criterio de cierre: una corrección en una sola petición (dos clics
+en la UI: etiqueta y Guardar), con autor, nota y fecha, que nunca modifica el
+veredicto emitido; el historial completo; y las métricas por familia.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.model import IrisAnalysis, IrisRuleResult
+from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisRuleResultRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.users.services.permissions import AttributeType
+
+pytestmark = pytest.mark.integration
+
+_IRIS_ATTRIBUTES = [attribute.db_name for attribute in (
+    AttributeType.IRIS_READ, AttributeType.IRIS_CREATE,
+    AttributeType.IRIS_UPDATE, AttributeType.IRIS_DELETE,
+)]
+
+
+def _analysis(app, user_id: int, *, verdict: str = "Phishing", score: float = 20.0,
+              status: str = "finished", fired_rules: tuple[str, ...] = ()) -> int:
+    """Crea un análisis con las reglas indicadas penalizando."""
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(
+                raw_headers="From: a@b.example\nSubject: Hola\n", user_id=user_id,
+                status=status, verdict=verdict if status == "finished" else None,
+                total_score=score if status == "finished" else None,
+            )
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+            for position, rule_name in enumerate(fired_rules):
+                IrisRuleResultRepository(uow).save(IrisRuleResult(
+                    analysis_id=analysis_id, rule_name=rule_name, category="x",
+                    score=-10.0, verdict="fail", position=position,
+                ))
+            return analysis_id
+
+
+@pytest.fixture
+def analyst(make_user, auth_headers):
+    user = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    return user, auth_headers(user)
+
+
+def test_an_analyst_corrects_a_verdict_without_changing_it(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id, verdict="Phishing", score=20.0)
+
+    response = client.post(f"/iris/results/{analysis_id}/feedback", headers=headers,
+                           json={"label": "legitimate", "note": "  Newsletter del proveedor.  "})
+
+    assert response.status_code == 201
+    feedback = response.get_json()
+    assert feedback["label"] == "legitimate"
+    assert feedback["note"] == "Newsletter del proveedor."
+    assert feedback["author"] == user.username
+    assert feedback["createdAt"]
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=headers).get_json()
+    assert report["verdict"] == "Phishing"
+    assert report["totalScore"] == 20.0
+    assert report["latestFeedback"]["label"] == "legitimate"
+
+
+def test_every_correction_is_kept_and_the_latest_wins(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id)
+
+    client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "legitimate"})
+    client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "malicious"})
+
+    history = client.get(f"/iris/results/{analysis_id}/feedback", headers=headers).get_json()
+    assert [entry["label"] for entry in history["feedback"]] == ["malicious", "legitimate"]
+    report = client.get(f"/iris/results/{analysis_id}", headers=headers).get_json()
+    assert report["latestFeedback"]["label"] == "malicious"
+
+
+def test_an_unknown_label_is_rejected(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id)
+
+    response = client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "quizas"})
+
+    assert response.status_code == 422
+
+
+def test_an_unfinished_analysis_has_no_verdict_to_correct(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id, status="running")
+
+    response = client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "malicious"})
+
+    assert response.status_code == 409
+
+
+def test_nobody_corrects_someone_elses_analysis(client, app, analyst, make_user):
+    _, headers = analyst
+    owner = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    analysis_id = _analysis(app, owner.id)
+
+    posted = client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "malicious"})
+    listed = client.get(f"/iris/results/{analysis_id}/feedback", headers=headers)
+
+    assert posted.status_code == 404
+    assert listed.status_code == 404
+
+
+def test_metrics_measure_the_detector_per_family(client, app, analyst):
+    """Un acierto (links), un falso positivo (identity), un falso negativo
+    y un indeterminado: la métrica global y la de cada familia salen de ahí."""
+    user, headers = analyst
+    true_positive = _analysis(app, user.id, verdict="Phishing", fired_rules=("Body Links",))
+    false_positive = _analysis(app, user.id, verdict="Phishing", fired_rules=("Display Name Spoofing",))
+    false_negative = _analysis(app, user.id, verdict="Legitimate", score=95.0)
+    undecided = _analysis(app, user.id, verdict="Suspicious", score=60.0)
+    for analysis_id, label in ((true_positive, "malicious"), (false_positive, "legitimate"),
+                               (false_negative, "malicious"), (undecided, "unknown")):
+        client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": label})
+
+    metrics = client.get("/iris/feedback/metrics", headers=headers).get_json()
+
+    assert metrics["analysesTotal"] == 4
+    assert metrics["reviewed"] == 4
+    assert metrics["unknown"] == 1
+    assert metrics["feedbackCoverage"] == 1.0
+    overall = metrics["overall"]
+    assert (overall["truePositives"], overall["falsePositives"], overall["falseNegatives"]) == (1, 1, 1)
+    assert overall["precision"] == 0.5
+    assert overall["recall"] == 0.5
+    assert overall["disagreementRate"] == 0.6667
+
+    by_family = {entry["family"]: entry for entry in metrics["families"]}
+    assert by_family["links"]["fired"] == 1
+    assert by_family["links"]["precision"] == 1.0
+    assert by_family["links"]["recall"] == 0.5
+    assert by_family["identity"]["precision"] == 0.0
+    assert by_family["auth"]["fired"] == 0
+    assert by_family["auth"]["precision"] is None
+    assert by_family["auth"]["coverage"] == 1.0
+
+
+def test_metrics_only_count_the_latest_label_of_each_analysis(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id, verdict="Phishing")
+    client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "legitimate"})
+    client.post(f"/iris/results/{analysis_id}/feedback", headers=headers, json={"label": "malicious"})
+
+    metrics = client.get("/iris/feedback/metrics", headers=headers).get_json()
+
+    assert metrics["reviewed"] == 1
+    assert metrics["overall"]["truePositives"] == 1
+    assert metrics["overall"]["falsePositives"] == 0

--- a/API/tests/integration/test_iris_permissions.py
+++ b/API/tests/integration/test_iris_permissions.py
@@ -82,6 +82,9 @@ _ENDPOINTS = [
     ("get", "/iris/notification-preferences", AttributeType.IRIS_READ, None),
     ("put", "/iris/notification-preferences", AttributeType.IRIS_UPDATE, {}),
     ("get", "/iris/retention-policy", AttributeType.IRIS_READ, None),
+    ("post", "/iris/results/999999/feedback", AttributeType.IRIS_UPDATE, {"label": "malicious"}),
+    ("get", "/iris/results/999999/feedback", AttributeType.IRIS_READ, None),
+    ("get", "/iris/feedback/metrics", AttributeType.IRIS_READ, None),
 ]
 
 _ALL_IRIS_ATTRIBUTES = [

--- a/API/tests/unit/test_iris_feedback_metrics.py
+++ b/API/tests/unit/test_iris_feedback_metrics.py
@@ -1,0 +1,141 @@
+"""Métricas del detector a partir de etiquetas, y el corpus versionado.
+
+``services/feedback_metrics.py`` es puro: lo usan igual el endpoint de
+métricas y este corpus. Aquí se fija la aritmética y se comprueba que el
+catálogo actual clasifica bien las muestras etiquetadas de
+``tests/fixtures/iris/``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.modules.features.iris.managers import IrisManager
+from src.modules.features.iris.services.feedback_metrics import (
+    LABEL_LEGITIMATE,
+    LABEL_MALICIOUS,
+    LABEL_UNKNOWN,
+    LabelledOutcome,
+    compute_feedback_metrics,
+    outcome_from_rules,
+)
+from src.modules.features.iris.services.parsers import parse_raw_message
+from src.modules.features.iris.services.quality import assess_coverage
+from src.modules.features.iris.services.rules import iris_rules
+
+pytestmark = pytest.mark.unit
+
+_CORPUS = Path(__file__).resolve().parents[1] / "fixtures" / "iris"
+
+
+def _outcome(label, verdict, fired=(), covered=("auth", "links")):
+    return LabelledOutcome(label=label, verdict=verdict,
+                           fired_families=frozenset(fired), covered_families=frozenset(covered))
+
+
+def test_metrics_without_labels_have_no_rates():
+    """Sin datos, las tasas valen None: "no se sabe" no es "0 %"."""
+    metrics = compute_feedback_metrics([], ["auth"], analyses_total=3)
+    assert metrics["reviewed"] == 0
+    assert metrics["feedbackCoverage"] == 0.0
+    assert metrics["overall"]["precision"] is None
+    assert metrics["families"][0]["recall"] is None
+
+
+def test_unknown_labels_count_as_reviewed_but_not_as_measured():
+    metrics = compute_feedback_metrics([_outcome(LABEL_UNKNOWN, "Phishing")], ["auth"], analyses_total=1)
+    assert metrics["reviewed"] == 1
+    assert metrics["unknown"] == 1
+    assert metrics["overall"]["disagreementRate"] is None
+
+
+def test_overall_and_family_rates():
+    outcomes = [
+        _outcome(LABEL_MALICIOUS, "Phishing", fired=("links",)),          # acierto
+        _outcome(LABEL_LEGITIMATE, "Suspicious", fired=("links",)),       # falso positivo
+        _outcome(LABEL_MALICIOUS, "Legitimate", covered=("auth",)),       # falso negativo, links sin cubrir
+        _outcome(LABEL_LEGITIMATE, "Legitimate"),                         # acierto negativo
+    ]
+    metrics = compute_feedback_metrics(outcomes, ["links", "auth"], analyses_total=8)
+
+    assert metrics["feedbackCoverage"] == 0.5
+    assert metrics["overall"]["precision"] == 0.5
+    assert metrics["overall"]["recall"] == 0.5
+    assert metrics["overall"]["disagreementRate"] == 0.5
+    links = next(entry for entry in metrics["families"] if entry["family"] == "links")
+    assert links["fired"] == 2
+    assert links["precision"] == 0.5
+    assert links["recall"] == 0.5
+    assert links["coverage"] == 0.75
+
+
+def test_outcome_from_rules_derives_fired_and_covered_families():
+    family_of = {"SPF": "auth", "Body Links": "links", "Generic Greeting": "content", "Threading": ""}
+    outcome = outcome_from_rules(
+        LABEL_MALICIOUS, "Phishing",
+        [("SPF", -8.0), ("Body Links", 0.0), ("Threading", -3.0)],
+        family_of, unevaluated_rules=["Generic Greeting"],
+    )
+    assert outcome.fired_families == frozenset({"auth"})
+    assert outcome.covered_families == frozenset({"auth", "links"})
+
+
+# ------------------------------------------------------------- corpus versionado
+
+def _evaluate(raw: str):
+    """Ejecuta el catálogo sobre *raw* como el motor (sin cola ni base de datos).
+
+    Returns:
+        tuple: ``(veredicto, [(regla, score)], reglas sin contenido)``.
+    """
+    context = parse_raw_message(raw)
+    rules_defs = iris_rules.get_rules()
+    results = []
+    named_results = {}
+    for rule_def in rules_defs:
+        rule_input = context if rule_def.get("needs_context") else context.headers
+        result = rule_def["func"](rule_input)
+        result = replace(result, score=min(0.0, float(result.score)))
+        results.append(result)
+        named_results[rule_def["name"]] = result
+    total_score = IrisManager._aggregate_score(rules_defs, results)
+    verdict, _ = IrisManager._apply_verdict_gates(IrisManager()._determine_verdict(total_score), named_results)
+    rules = [(rule_def["name"], result.score) for rule_def, result in zip(rules_defs, results)]
+    return verdict, rules, assess_coverage(context, rules_defs)["uncoveredRules"]
+
+
+def _corpus():
+    manifest = json.loads((_CORPUS / "manifest.json").read_text(encoding="utf-8"))
+    return manifest, [
+        (sample, (_CORPUS / sample["file"]).read_bytes().decode("utf-8")) for sample in manifest["samples"]
+    ]
+
+
+def test_the_corpus_manifest_is_versioned_and_complete():
+    manifest, samples = _corpus()
+    assert manifest["version"]
+    assert {sample["label"] for sample, _ in samples} == {LABEL_LEGITIMATE, LABEL_MALICIOUS}
+    assert sorted(path.name for path in _CORPUS.glob("*.eml")) == sorted(sample["file"] for sample, _ in samples)
+
+
+def test_the_current_catalog_classifies_the_corpus_without_errors():
+    """Con el catálogo actual, el corpus no tiene ni falsos positivos ni
+    falsos negativos. Si un cambio de reglas rompe esto, el cambio mueve el
+    detector en una dirección que hay que justificar antes de desplegarlo."""
+    family_of = {rule_def["name"]: rule_def.get("family") or "" for rule_def in iris_rules.get_rules()}
+    _, samples = _corpus()
+
+    outcomes = []
+    for sample, raw in samples:
+        verdict, rules, uncovered = _evaluate(raw)
+        outcomes.append(outcome_from_rules(sample["label"], verdict, rules, family_of, uncovered))
+
+    metrics = compute_feedback_metrics(outcomes, set(family_of.values()) - {""}, analyses_total=len(samples))
+    assert metrics["overall"]["falsePositives"] == 0, metrics["overall"]
+    assert metrics["overall"]["falseNegatives"] == 0, metrics["overall"]
+    assert metrics["overall"]["precision"] == 1.0
+    assert metrics["overall"]["recall"] == 1.0

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -116,6 +116,42 @@
         </p>
       </div>
 
+      <!-- Feedback del analista: corrige el resultado en dos clics (etiqueta y
+           Guardar). Nunca cambia el veredicto de arriba; alimenta las métricas
+           y la calibración del detector. -->
+      <div class="rv-feedback">
+        <div class="feedback-row">
+          <span class="feedback-title">¿Es correcto este veredicto?</span>
+          <div class="feedback-actions">
+            <button
+              v-for="option in FEEDBACK_OPTIONS"
+              :key="option.value"
+              type="button"
+              class="feedback-option"
+              :class="{ 'feedback-option--active': feedbackLabel === option.value }"
+              @click="feedbackLabel = option.value"
+            >{{ option.label }}</button>
+          </div>
+        </div>
+        <div v-if="feedbackLabel" class="feedback-form">
+          <textarea
+            v-model="feedbackNote"
+            class="feedback-note"
+            maxlength="2000"
+            rows="2"
+            placeholder="Nota opcional (por qué)"
+          ></textarea>
+          <button type="button" class="feedback-save" :disabled="feedbackSaving" @click="saveFeedback">
+            Guardar
+          </button>
+        </div>
+        <p v-if="reportData.latestFeedback" class="feedback-current">
+          Revisado como <strong>{{ FEEDBACK_LABELS[reportData.latestFeedback.label] }}</strong>
+          por {{ reportData.latestFeedback.author }} · {{ formatDate(reportData.latestFeedback.createdAt) }}
+          <template v-if="reportData.latestFeedback.note"> — «{{ reportData.latestFeedback.note }}»</template>
+        </p>
+      </div>
+
       <!-- Análisis degradado: alguna regla no llegó a ejecutarse, así que
            una parte del mensaje no se ha inspeccionado. Va inmediatamente
            debajo del veredicto porque lo matiza: quien lea el número grande
@@ -417,6 +453,35 @@ const uncoveredRules = computed(() =>
 )
 const passedRules = computed(() => rulesWithIndex.value.filter(entry => entry.rule.verdict === 'pass'))
 const passedRulesOpen = ref(false)
+
+// Feedback del analista (ver el bloque .rv-feedback de la plantilla).
+const FEEDBACK_OPTIONS = [
+  { value: 'malicious', label: 'Es malicioso' },
+  { value: 'legitimate', label: 'Es legítimo' },
+  { value: 'unknown', label: 'No se puede saber' },
+]
+const FEEDBACK_LABELS = { malicious: 'malicioso', legitimate: 'legítimo', unknown: 'indeterminado' }
+const feedbackLabel = ref(null)
+const feedbackNote = ref('')
+const feedbackSaving = ref(false)
+
+watch(() => props.reportData?.analysisId, () => {
+  feedbackLabel.value = null
+  feedbackNote.value = ''
+})
+
+async function saveFeedback() {
+  feedbackSaving.value = true
+  const saved = await irisStore.submitFeedback(props.reportData.analysisId, {
+    label: feedbackLabel.value,
+    note: feedbackNote.value.trim() || null,
+  })
+  feedbackSaving.value = false
+  if (saved) {
+    feedbackLabel.value = null
+    feedbackNote.value = ''
+  }
+}
 
 // Salta a la card de la regla señalada en "Principales señales", la expande
 // y la desplaza a la vista (llamado desde los chips de topSignals). Si la
@@ -968,6 +1033,77 @@ watch(
   font-size: var(--fs-sm);
   color: var(--text-muted);
   word-break: break-word;
+}
+
+.rv-feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.feedback-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.feedback-title {
+  font-size: var(--fs-md);
+  font-weight: 600;
+}
+
+.feedback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.feedback-option,
+.feedback-save {
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-med);
+  background: var(--surface-2);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+}
+
+.feedback-option--active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.feedback-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.feedback-note {
+  flex: 1;
+  min-height: 2.4rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-med);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-sm);
+  resize: vertical;
+}
+
+.feedback-current {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
 }
 
 .raw-line--hit {

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -380,6 +380,27 @@ export const useIrisStore = defineStore('iris', () => {
   }
 
   /**
+   * Registra si el veredicto de un análisis era correcto. No cambia el
+   * veredicto: se relee el informe para mostrar la corrección vigente.
+   * @param {number} id Análisis corregido.
+   * @param {{label: 'malicious'|'legitimate'|'unknown', note?: string|null}} feedback
+   * @returns {Promise<boolean>} true si se guardó.
+   */
+  async function submitFeedback(id, { label, note = null } = {}) {
+    const res = await apiFetch(`/iris/results/${id}/feedback`, {
+      method: 'POST',
+      body: JSON.stringify({ label, note }),
+    })
+    if (!res?.ok) {
+      toast.show(await apiError(res, 'No se pudo guardar la corrección.'), 'error')
+      return false
+    }
+    toast.show('Corrección guardada. El veredicto original no cambia.', 'success')
+    await getReport(id)
+    return true
+  }
+
+  /**
    * Solicita la narrativa ejecutiva IA (IA1) y sondea el informe hasta que
    * aparece `aiSummary` — no hay endpoint de estado propio, la narrativa es
    * simplemente un campo más del informe principal una vez generada.
@@ -608,7 +629,7 @@ export const useIrisStore = defineStore('iris', () => {
     submitAnalysis, fetchResults, getReport, getStatus, pathFor, iocsFor,
     resolvedPathFor, isPathLoadingFor, resolvedIocsFor, isIocsLoadingFor,
     generateAiSummary, checkAiSummary,
-    cancelAnalysis, deleteAnalysis, reanalyzeAnalysis, selectAnalysis,
+    cancelAnalysis, deleteAnalysis, reanalyzeAnalysis, selectAnalysis, submitFeedback,
     startPolling, stopPolling,
     generateDocument, fetchDocuments, getDocumentStatus, downloadDocument, deleteDocument,
     stopDocumentPolling,


### PR DESCRIPTION
## El problema

Iris no tenía ninguna forma de aprender del uso real. Si un analista veía que un correo marcado como `Phishing` era en realidad la newsletter de un proveedor, no había dónde decirlo. Sin esas etiquetas humanas no se puede medir cuánto se equivoca el detector ni en qué familia de reglas falla, y por tanto tampoco recalibrarlo con criterio. El roadmap lo llama la brecha central del producto.

Cierra #225 (iniciativa `M04`, Fase 2 del roadmap de Iris, #202). Es el ítem que desbloquea `M05` (calibración) y, más adelante, `X01` y `X06`.

## Qué cambia

**Correcciones que no tocan el veredicto.** Una tabla nueva, `IrisAnalystFeedback`, guarda cada corrección:
- **Etiqueta:** `malicious`, `legitimate` o `unknown`. `unknown` significa que el analista revisó el correo y no puede decidir: cuenta como revisado, pero no entra en las tasas.
- **Nota** opcional.
- **Autor y fecha.**

El veredicto de `IrisAnalysis` **nunca cambia**: sigue diciendo lo que Iris decidió, y el feedback dice lo que opinó una persona después. Separarlos es lo que permite medir.

Cada corrección es una fila nueva. El historial queda completo, incluido quién cambió de opinión y cuándo, y la etiqueta vigente es la más reciente.

**Endpoints:**

| Método | Ruta | Atributo | Qué hace |
|---|---|---|---|
| `POST` | `/iris/results/<id>/feedback` | `IRIS_UPDATE` | Registra una corrección. Solo sobre análisis terminados (`409` si no) y propios (`404` si no). |
| `GET` | `/iris/results/<id>/feedback` | `IRIS_READ` | Historial, de la más reciente a la más antigua. |
| `GET` | `/iris/feedback/metrics` | `IRIS_READ` | Métricas del detector con las correcciones vigentes del usuario. |

`IRIS_UPDATE` y no `IRIS_CREATE` porque el feedback anota algo que ya existe y no consume cuota: es la misma frontera que documenta el README. `GET /iris/results/<id>` trae además `latestFeedback`.

**Métricas por familia.** Un veredicto que avisa (`Suspicious` o `Phishing`) cuenta como positivo. Con la etiqueta vigente de cada análisis se calculan:
- **En global:** matriz de confusión, precisión (de lo que Iris marcó, cuánto era malicioso), recall (de lo malicioso, cuánto marcó) y tasa de desacuerdo.
- **Por familia de reglas** (`auth`, `links`, `identity`…): las mismas tasas tomando "la familia disparó" como predicción, que es lo que dice qué familia genera falsos positivos. Además, **cobertura**: la fracción de etiquetados en que la familia se evaluó por completo, sin reglas fallidas ni sin contenido que inspeccionar (lo que añadió `M02`).
- **Cobertura de feedback:** revisados sobre terminados.
- **Sin datos:** una tasa sin denominador vale `null`, no `0`.

El cálculo vive en un servicio puro (`services/feedback_metrics.py`), sin ORM ni red, para que lo use igual el endpoint y el corpus.

**Corpus versionado** (`API/tests/fixtures/iris/`). Siete mensajes **sintéticos**, sin correos reales ni datos personales: cuatro legítimos (newsletter vía ESP, aviso interno, alerta bancaria, recibo en inglés) y tres maliciosos (suplantación con dominio parecido y autenticación fallida, fraude del CEO desde Gmail, enlace a IP con ejecutable adjunto). Un `manifest.json` los lista con versión, etiqueta y descripción.

Un test ejecuta el catálogo real sobre el corpus y exige cero falsos positivos y cero falsos negativos. Un cambio de reglas que lo rompa mueve el detector en una dirección que hay que justificar antes de desplegar. `M05` y `F16` construyen el replay sobre este mismo corpus.

**UI.** Bajo el veredicto aparece "¿Es correcto este veredicto?" con tres botones. Se elige uno, se añade una nota si se quiere y se pulsa **Guardar**: dos clics. Debajo se muestra la corrección vigente con autor, fecha y nota.

## Migración

`b9d2f6a8c4e1_add_iris_analyst_feedback`: tabla `IrisAnalystFeedback` con clave foránea a `IrisAnalysis` (`ON DELETE CASCADE`, más la cascada del ORM, porque la retención borra análisis fila a fila) y a `User`.

## Validación

- **`test_iris_feedback.py` (nuevo, integración).**
  - Corregir en una sola petición deja autor, nota recortada y fecha, y el veredicto y el score del análisis **no cambian**.
  - El historial conserva todas las correcciones y gana la última; una etiqueta desconocida da `422`, un análisis sin terminar `409` y el de otro usuario `404`.
  - Las métricas de un caso con acierto, falso positivo, falso negativo e indeterminado salen exactas, en global y por familia, y solo cuenta la última etiqueta de cada análisis.
- **`test_iris_feedback_metrics.py` (nuevo, unitario).** La aritmética (`null` sin datos, `unknown` fuera de las tasas, cobertura por familia), la derivación de familias disparadas y cubiertas, y el corpus: su manifiesto está completo y el catálogo actual lo clasifica sin errores.
- **`test_iris_permissions.py`.** Los tres endpoints entran en la matriz ABAC.
- **`pytest tests/ -k iris`:** todo en verde. **`pylint src`:** 10.00/10.
- **`IrisReportViewer.vue`:** compilado con `@vue/compiler-sfc`. `npm run build` sigue sin poder ejecutarse aquí por el paquete privado `@projectellysia/acheron-core-web`.

## Notas

- **Alcance de las métricas.** Se calculan sobre los análisis del propio usuario. Una vista agregada por organización llega con el modelo de tenant (`F17`, Fase 4); el roadmap prohíbe mezclar datos entre usuarios antes de eso.
- **Coste por análisis.** `get_metrics` lee las reglas de cada análisis revisado, una consulta por análisis. Con el volumen de feedback actual es irrelevante; si crece, se agrega en SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
