### PR TITLE
feat(iris): score versionado, perfiles de sensibilidad y replay offline (M05)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -280,6 +280,7 @@
       },
       "legitimateThreshold": 80,
       "suspiciousThreshold": 55,
+      "sensitivityProfile": "balanced",
       "minHeaders": 2,
       "maxMessageBytes": 10485760,
       "maxConnectionsPerUser": 5,

--- a/API/alembic/versions/c1e5a9d3f7b2_add_iris_analysis_scoring_snapshot.py
+++ b/API/alembic/versions/c1e5a9d3f7b2_add_iris_analysis_scoring_snapshot.py
@@ -1,0 +1,36 @@
+"""iris: snapshot y versión de la política de puntuación de cada análisis
+
+Cambiar umbrales, perfil o pesos cambiaba el significado de todos los
+análisis futuros sin dejar rastro de con qué reglas del juego se decidió cada
+uno. Estas columnas guardan esa política entera y una marca estable.
+
+Revision ID: c1e5a9d3f7b2
+Revises: b9d2f6a8c4e1
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c1e5a9d3f7b2'
+down_revision: Union[str, Sequence[str], None] = 'b9d2f6a8c4e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisAnalysis', sa.Column('scoring_snapshot',
+                                            postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('IrisAnalysis', sa.Column('scoring_version', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisAnalysis', 'scoring_version')
+    op.drop_column('IrisAnalysis', 'scoring_snapshot')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -61,6 +61,7 @@ from ..services.contexts import (
     context_of_type,
     preview_headers,
 )
+from ..services.scoring import ScoringPolicy, current_policy
 from ..services.quality import (
     ConfidenceAssessment,
     assess_confidence,
@@ -81,33 +82,12 @@ logger = logging.getLogger(__name__)
 _VERDICT_ORDER = ["Legitimate", "Suspicious", "Phishing"]
 _VERDICT_SEVERITY = {v: i for i, v in enumerate(_VERDICT_ORDER)}
 
-# Subtractive risk model: an analysis starts from this clean ceiling and
-# rules can only *subtract* from it. A passing rule contributes nothing; a
-# failing rule subtracts its (negative) score. This removes the historical
-# "authentication cushion", where dozens of small positive credits (SPF/DKIM/
-# DMARC pass, etc.) buried a few strong phishing signals — a clean-auth BEC
-# from Gmail used to net *positive* despite a -23 risk payload underneath.
-_CEILING = 100.0
+# El techo, los suelos por familia y los umbrales viven en la política de
+# puntuación (``services/scoring.py``), que se guarda con cada análisis.
 
-# Recalibración de pesos: techos de familia. Varias reglas dentro del
-# mismo cluster suelen corroborar el mismo hecho subyacente (p.ej. SPF+DKIM+
-# DMARC+Domain Alignment todas fallando describen UN fallo de autenticación,
-# no cuatro independientes) -- sin techo, sumarlas todas exagera la
-# confianza del score en un solo hecho. Cada techo es el mínimo (más
-# negativo) que la suma de penalizaciones de esa familia puede alcanzar;
-# reglas sin `family` (Threading, Recipient, List-Unsubscribe) no tienen
-# techo -- ya son individualmente pequeñas. ARC Chain se queda fuera de
-# "auth" a propósito (forense: describe un hecho distinto, la cadena de
-# reenvío, no la autenticación del propio mensaje).
-_FAMILY_SCORE_FLOORS = {
-    "auth": -25.0,
-    "identity": -28.0,
-    "reply_path": -15.0,
-    "content": -25.0,
-    "links": -30.0,
-    "received": -12.0,
-    "attachment": -28.0,
-}
+
+
+
 
 
 class IrisManager(TaskTrackingMixin):
@@ -124,6 +104,16 @@ class IrisManager(TaskTrackingMixin):
     EXTERNAL_ID_PREFIX = "iris-analysis:"
     TASK_CATEGORY = "iris.analyze"
     _TOP_SIGNALS_LIMIT = 5
+
+    _EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+")
+
+    AI_SUMMARY_EXTERNAL_ID_PREFIX = "iris-ai-summary:"
+
+    #: Estados desde los que se puede reclamar una generación de resumen.
+    #: ``None`` es "nunca se pidió" y ``failed`` es un reintento legítimo;
+    #: ``running`` no está porque ya hay una en curso, y ``done`` solo se
+    #: reclama con una regeneración explícita.
+    _AI_SUMMARY_CLAIMABLE = (None, "failed")
 
     # __init__ (task_queue inyectable) lo aporta TaskTrackingMixin.
 
@@ -198,7 +188,8 @@ class IrisManager(TaskTrackingMixin):
         # ya aceptado no debe volver a cobrar ni crear un segundo análisis.
         # El propio checkpoint de mailbox ya evita llegar hasta aquí
         # en el caso común; esto cubre además la llamada directa.
-        if connection_id is not None and source_message_uid is not None:
+        exited_third_party_connection = connection_id is not None and source_message_uid is not None
+        if exited_third_party_connection:
             existing = build_repository(IrisAnalysisRepository).get_by_source(
                 connection_id, source_message_uid,
             )
@@ -208,10 +199,11 @@ class IrisManager(TaskTrackingMixin):
         # Después de validar la entrada: un correo mal pegado no gasta cuota.
         # Aquí y no en el endpoint, porque por este método entra también la
         # ingesta desde un buzón conectado (mailbox sync), que no pasa por HTTP.
-        QuotaManager().consume(user_id, LimitKey.IRIS_ANALYSES)
+        quota_manager = QuotaManager()
+        quota_manager.consume(user_id, LimitKey.IRIS_ANALYSES)
 
         if self.TASK_CATEGORY is None:
-            QuotaManager().refund(user_id, LimitKey.IRIS_ANALYSES)
+            quota_manager.refund(user_id, LimitKey.IRIS_ANALYSES)
             raise IrisExecutionError("Task category is not defined for IrisManager.")
 
         analysis = IrisAnalysis(
@@ -247,8 +239,9 @@ class IrisManager(TaskTrackingMixin):
             # así que la UniqueConstraint sigue siendo la defensa final. Se
             # reembolsa la cuota que se acaba de cobrar por un análisis que
             # nunca llegó a crearse -- nunca se cobra por un duplicado.
-            QuotaManager().refund(user_id, LimitKey.IRIS_ANALYSES)
+            quota_manager.refund(user_id, LimitKey.IRIS_ANALYSES)
             raise
+        
         logger.info(f"Iris analysis {analysis_id} created for user {user_id}")
 
         # Camino feliz: publicar ahora mismo en vez de esperar al barrido
@@ -285,13 +278,14 @@ class IrisManager(TaskTrackingMixin):
         que es la validación que este endpoint describe).
         """
         config = CR.iris_config()
+        policy = current_policy()
         return {
             "maxMessageBytes": config.max_message_bytes,
             "minHeaders": config.min_headers,
             "analysisModes": ["headers", "message"],
             "verdictThresholds": {
-                "legitimate": config.legitimate_threshold,
-                "suspicious": config.suspicious_threshold,
+                "legitimate": policy.legitimate_threshold,
+                "suspicious": policy.suspicious_threshold,
             },
         }
 
@@ -437,6 +431,8 @@ class IrisManager(TaskTrackingMixin):
             "uncertaintyReasons": analysis.uncertainty_reasons or [],
             "failedRules": analysis.failed_rules or [],
             "detectorVersion": analysis.detector_version,
+            "scoringVersion": analysis.scoring_version,
+            "scoringSnapshot": analysis.scoring_snapshot,
             "failureCode": analysis.failure_code,
             "failureReason": analysis.failure_reason,
             "user": username,
@@ -570,7 +566,7 @@ class IrisManager(TaskTrackingMixin):
             raise IrisRawMessagePurgedError(analysis.id)
         return context_of_type(parse_raw_message(analysis.raw_headers), analysis.winning_context)
 
-    _EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+")
+    
 
     def get_analysis_iocs(self, analysis_id: int, user_id: int) -> Dict[str, Any]:
         """Extract Indicators of Compromise (IOCs) from an analysis.
@@ -676,13 +672,7 @@ class IrisManager(TaskTrackingMixin):
             "iocs": iocs,
         }
 
-    AI_SUMMARY_EXTERNAL_ID_PREFIX = "iris-ai-summary:"
 
-    #: Estados desde los que se puede reclamar una generación de resumen.
-    #: ``None`` es "nunca se pidió" y ``failed`` es un reintento legítimo;
-    #: ``running`` no está porque ya hay una en curso, y ``done`` solo se
-    #: reclama con una regeneración explícita.
-    _AI_SUMMARY_CLAIMABLE = (None, "failed")
 
     def generate_ai_summary(self, analysis_id: int, user_id: int,
                             regenerate: bool = False) -> str:
@@ -983,9 +973,10 @@ class IrisManager(TaskTrackingMixin):
             search=search, verdict=verdict, status=status, source=source,
             sort_by=sort_by, sort_dir=sort_dir,
         )
+        policy = current_policy()
         thresholds = {
-            "legitimate": CR.iris_config().legitimate_threshold,
-            "suspicious": CR.iris_config().suspicious_threshold,
+            "legitimate": policy.legitimate_threshold,
+            "suspicious": policy.suspicious_threshold,
         }
         results = [
             {
@@ -1104,23 +1095,27 @@ class IrisManager(TaskTrackingMixin):
                 # `_persist_analysis_results`), y leer el registro dos veces
                 # los desalinearía si alguien registrara una regla entremedias.
                 rules_defs = iris_rules.get_rules()
-                evaluations = self._evaluate_contexts(analysis_id, context, job, rules_defs)
+                # La política se fija una vez por análisis y se guarda con él:
+                # un cambio de configuración a mitad no mezcla dos versiones.
+                policy = current_policy()
+                with CR.scoring_weight_overrides(policy.weight_overrides):
+                    evaluations = self._evaluate_contexts(analysis_id, context, job, rules_defs, policy)
                 if evaluations is None:
                     return  # cancelado: no es un fallo, no hay nada que persistir
                 winner, secondary, winning_reason = choose_winning_evaluation(
                     evaluations, _VERDICT_SEVERITY,
                 )
                 verdict, total_score = winner.verdict, winner.total_score
-                config = CR.iris_config()
                 confidence = assess_confidence(winner, secondary,
-                                               config.legitimate_threshold,
-                                               config.suspicious_threshold)
+                                               policy.legitimate_threshold,
+                                               policy.suspicious_threshold)
 
                 self._persist_analysis_results(analysis_id, rules_defs, winner,
                                                detector_version(rules_defs),
                                                secondary=secondary,
                                                winning_reason=winning_reason,
-                                               confidence=confidence)
+                                               confidence=confidence,
+                                               scoring_policy=policy)
             except Exception as e:
                 logger.error(f"Analysis {analysis_id} failed: {e}", exc_info=True)
                 self._fail_analysis(analysis_id, classify_failure(e))
@@ -1131,8 +1126,89 @@ class IrisManager(TaskTrackingMixin):
 
             logger.info(f"Analysis {analysis_id} completed: score={total_score}, verdict={verdict}")
 
-    def _evaluate_contexts(self, analysis_id: int, context, job, rules_defs: List[dict]
-                           ) -> Optional[List[ContextEvaluation]]:
+    @classmethod
+    def evaluate_raw(cls, raw_input: str, policy: Optional[ScoringPolicy] = None) -> Dict[str, Any]:
+        """Evalúa un mensaje con el motor real, sin crear análisis ni cobrar cuota.
+
+        Es el motor que usan el replay y las comparaciones de versiones: el
+        mismo parseo, las mismas reglas, los mismos gates, la misma política
+        de calidad y la misma elección de contexto que un análisis de verdad,
+        pero bajo la política que se le pase.
+
+        Args:
+            raw_input: Cabeceras o ``.eml`` completo.
+            policy: Política con la que puntuar y decidir. Por defecto
+                ``None``: la vigente (``current_policy``).
+
+        Returns:
+            dict: ``verdict``, ``totalScore``, ``gateReasons``,
+                ``winningContext``, ``rules`` (pares nombre/score del contexto
+                ganador) y ``unevaluatedRules`` (las que fallaron al
+                ejecutarse más las que no tuvieron contenido que inspeccionar).
+
+        Raises:
+            IrisInvalidInputError: Si el texto no tiene cabeceras suficientes.
+        """
+        policy = policy or current_policy()
+        context = parse_raw_message(raw_input)
+        cls._validate_headers_parsed(context.headers)
+        rules_defs = iris_rules.get_rules()
+        with CR.scoring_weight_overrides(policy.weight_overrides):
+            evaluations = cls()._evaluate_contexts(None, context, None, rules_defs, policy)
+        winner, _, _ = choose_winning_evaluation(evaluations, _VERDICT_SEVERITY)
+        unevaluated = [rule["name"] for rule in winner.quality.failed_rules]
+        unevaluated += list((winner.coverage or {}).get("uncoveredRules") or [])
+        return {
+            "verdict": winner.verdict,
+            "totalScore": winner.total_score,
+            "gateReasons": winner.gate_reasons,
+            "winningContext": winner.context_type,
+            "rules": [(rule_def["name"], result.score)
+                      for rule_def, result in zip(rules_defs, winner.results)],
+            "unevaluatedRules": unevaluated,
+        }
+
+    def evaluate_analysis_under(self, analysis_id: int, user_id: int,
+                                policy: ScoringPolicy) -> Dict[str, Any]:
+        """Qué habría decidido Iris sobre un análisis guardado con otra política.
+
+        Vuelve a evaluar el raw conservado sin crear un análisis nuevo. Con la
+        política reconstruida desde el snapshot del propio análisis
+        (``ScoringPolicy.from_snapshot``) responde a "¿qué decidió la versión
+        con la que se hizo?"; con otra, a "¿qué habría decidido esa?".
+
+        Args:
+            analysis_id: Análisis a reevaluar; debe ser del usuario.
+            user_id: Usuario que pregunta.
+            policy: Política con la que reevaluar.
+
+        Returns:
+            dict: ``analysisId``, lo guardado (``storedVerdict``,
+                ``storedScore``, ``storedScoringVersion``) y lo que decide la
+                política (``verdict``, ``totalScore``, ``gateReasons``,
+                ``scoringVersion``).
+
+        Raises:
+            IrisAnalysisNotFoundError: Si el análisis no existe o no es suyo.
+            IrisRawMessagePurgedError: Si la retención ya purgó el raw.
+        """
+        analysis = self.assert_analysis_ownership(analysis_id, user_id)
+        if analysis.raw_headers is None:
+            raise IrisRawMessagePurgedError(analysis_id)
+        result = self.evaluate_raw(analysis.raw_headers, policy)
+        return {
+            "analysisId": analysis.id,
+            "storedVerdict": analysis.verdict,
+            "storedScore": analysis.total_score,
+            "storedScoringVersion": analysis.scoring_version,
+            "verdict": result["verdict"],
+            "totalScore": result["totalScore"],
+            "gateReasons": result["gateReasons"],
+            "scoringVersion": policy.version(detector_version(iris_rules.get_rules())),
+        }
+
+    def _evaluate_contexts(self, analysis_id: Optional[int], context, job, rules_defs: List[dict],
+                           policy: Optional[ScoringPolicy] = None) -> Optional[List[ContextEvaluation]]:
         """Ejecuta el catálogo de reglas sobre cada contexto del mensaje.
 
         Vive aparte de :meth:`_run_analysis` para que el ``try`` de ciclo de
@@ -1141,11 +1217,16 @@ class IrisManager(TaskTrackingMixin):
         ``services/contexts.choose_winning_evaluation``.
 
         Args:
-            analysis_id: Primary key del análisis (solo para el log).
+            analysis_id: Primary key del análisis (solo para el log); ``None``
+                fuera de un análisis (``evaluate_raw``).
             context: ``MessageContext`` parseado; si trae ``wrapper_context``,
                 se evalúa también el envoltorio.
-            job: Contexto del job de TaskQueue (cancelación y progreso).
+            job: Contexto del job de TaskQueue (cancelación y progreso), o
+                ``None`` fuera de la cola: entonces no hay cancelación ni
+                progreso que informar.
             rules_defs: Catálogo de reglas, leído una sola vez por análisis.
+            policy: Política con que se puntúa y decide. Por defecto ``None``:
+                la vigente.
 
         Returns:
             Optional[List[ContextEvaluation]]: Una evaluación por contexto,
@@ -1162,6 +1243,7 @@ class IrisManager(TaskTrackingMixin):
         # mail entirely. Evaluate both when a wrapper exists and keep the
         # worse verdict; this matters most for unattended ingestion
         # (mailbox ingestion), where there is no human eyeballing the wrapper first.
+        policy = policy or current_policy()
         contexts_to_evaluate = [(CONTEXT_INNER, context)]
         if context.wrapper_context is not None:
             contexts_to_evaluate.append((CONTEXT_WRAPPER, context.wrapper_context))
@@ -1175,7 +1257,7 @@ class IrisManager(TaskTrackingMixin):
             named_results: Dict[str, RuleResult] = {}
 
             for rule_def in rules_defs:
-                if job.cancelled():
+                if job is not None and job.cancelled():
                     logger.info(f"Analysis {analysis_id} was cancelled")
                     return None
 
@@ -1202,10 +1284,11 @@ class IrisManager(TaskTrackingMixin):
                 named_results[rule_def["name"]] = result
 
                 completed_steps += 1
-                job.progress(int((completed_steps / total_steps) * 100))
+                if job is not None:
+                    job.progress(int((completed_steps / total_steps) * 100))
 
-            total_score = self._aggregate_score(rules_defs, results)
-            base_verdict = self._determine_verdict(total_score)
+            total_score = policy.aggregate(rules_defs, results)
+            base_verdict = policy.verdict_for(total_score)
             verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
 
             # Una regla que revienta no aborta el análisis, pero tampoco
@@ -1228,7 +1311,8 @@ class IrisManager(TaskTrackingMixin):
                                    winner: ContextEvaluation, detector: str,
                                    secondary: Optional[ContextEvaluation] = None,
                                    winning_reason: Optional[str] = None,
-                                   confidence: Optional[ConfidenceAssessment] = None) -> None:
+                                   confidence: Optional[ConfidenceAssessment] = None,
+                                   scoring_policy: Optional[ScoringPolicy] = None) -> None:
         """Persiste las filas de regla y el estado final del análisis en una
         única transacción.
 
@@ -1260,6 +1344,9 @@ class IrisManager(TaskTrackingMixin):
             confidence: Confianza ordinal y motivos de incertidumbre del
                 veredicto. Por defecto ``None``: las columnas de confianza
                 quedan a NULL (se lee como "sin evaluar").
+            scoring_policy: Política con la que se puntuó; se guarda su
+                snapshot y su versión. Por defecto ``None``: esas columnas
+                quedan a NULL.
         """
         with UnitOfWork() as uow:
             rule_repo = IrisRuleResultRepository(uow)
@@ -1301,6 +1388,8 @@ class IrisManager(TaskTrackingMixin):
                 confidence=confidence.level if confidence else None,
                 coverage=winner.coverage or None,
                 uncertainty_reasons=confidence.reasons if confidence else None,
+                scoring_snapshot=scoring_policy.snapshot(detector) if scoring_policy else None,
+                scoring_version=scoring_policy.version(detector) if scoring_policy else None,
                 finished_at=utcnow_naive(),
             )
             if not transitioned:
@@ -1311,54 +1400,34 @@ class IrisManager(TaskTrackingMixin):
 
     @staticmethod
     def _aggregate_score(rules_defs: List[dict], results: List[RuleResult]) -> float:
-        """Combine per-rule results into a single 0–100 score.
+        """Score de 0 a 100 de unos resultados de regla con la política vigente.
 
-        Subtractive model: start at :data:`_CEILING` and add only the
-        *negative* part of each rule's score (``min(0, score)``), so passing
-        a rule never inflates the total. Clamped to ``[0, _CEILING]``.
+        Delega en ``ScoringPolicy.aggregate`` (modelo sustractivo con suelo
+        por familia).
 
-        Recalibración de pesos: before summing, each rule's penalty is
-        attributed to its ``family`` (if any) and the family's total is
-        floored at ``_FAMILY_SCORE_FLOORS[family]`` — a cluster of rules
-        corroborating the same underlying fact can't out-vote its own cap.
-        Rules with no family pass through unfloored.
+        Args:
+            rules_defs: Catálogo evaluado.
+            results: Un ``RuleResult`` por regla, emparejado por posición.
+
+        Returns:
+            float: El score, acotado a ``[0, 100]``.
         """
-        family_penalties: Dict[str, float] = {}
-        unfamilied_penalties = 0.0
-        for rule_def, result in zip(rules_defs, results):
-            penalty = min(0.0, float(result.score))
-            family = rule_def.get("family") or ""
-            if family:
-                family_penalties[family] = family_penalties.get(family, 0.0) + penalty
-            else:
-                unfamilied_penalties += penalty
-
-        capped_total = unfamilied_penalties
-        for family, penalty in family_penalties.items():
-            floor = _FAMILY_SCORE_FLOORS.get(family)
-            capped_total += max(floor, penalty) if floor is not None else penalty
-
-        return max(0.0, _CEILING + capped_total)
+        return current_policy().aggregate(rules_defs, results)
 
     def _determine_verdict(self, total_score: float) -> str:
-        """Map a numeric 0–100 score to a textual verdict.
+        """Veredicto base de un score con los umbrales de la política vigente.
 
-        Thresholds come from ``SecOpsConfig.json`` (0–100 subtractive scale):
-            - ``iris.legitimate_threshold`` (default 80)
-            - ``iris.suspicious_threshold``  (default 55)
+        Delega en ``ScoringPolicy.verdict_for``: los umbrales configurados con
+        el desplazamiento del perfil de sensibilidad. Los gates de alta
+        confianza pueden empeorarlo después (:meth:`_apply_verdict_gates`).
 
-        A clean message stays near 100; each failing rule subtracts. This is
-        only the numeric baseline — high-confidence findings can still push
-        the verdict to a worse category via :meth:`_apply_verdict_gates`.
+        Args:
+            total_score: Score de 0 a 100.
+
+        Returns:
+            str: ``Legitimate``, ``Suspicious`` o ``Phishing``.
         """
-        legitimate = CR.iris_config().legitimate_threshold
-        suspicious = CR.iris_config().suspicious_threshold
-
-        if total_score >= legitimate:
-            return "Legitimate"
-        if total_score >= suspicious:
-            return "Suspicious"
-        return "Phishing"
+        return current_policy().verdict_for(total_score)
 
     @staticmethod
     def _extract_verdict_signals(named_results: Dict[str, RuleResult]) -> Dict[str, Any]:

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -72,6 +72,15 @@ class IrisAnalysis(Base):
                  contenido que mirar. NULL en análisis antiguos.
         uncertainty_reasons: Frases legibles que explican por qué la
                  confianza no es "high"; lista vacía o NULL si no hay motivos.
+        scoring_snapshot: Política de puntuación con la que se decidió:
+                 perfil, umbrales, techo, suelos por familia, pesos
+                 sobreescritos, huella de datasets, versión de la aplicación y
+                 catálogo (ver ``services/scoring.ScoringPolicy.snapshot``).
+                 Permite reconstruir esa política y responder qué habría
+                 decidido Iris con otra. NULL en análisis anteriores.
+        scoring_version: Marca estable de esa política
+                 (``iris-scoring:<hash>``); dos análisis con la misma marca se
+                 decidieron con las mismas reglas del juego.
         winning_context: Qué mensaje produjo el veredicto: "inner" (el
                  original desenvuelto de un reenvío, o el único mensaje si no
                  lo era) o "wrapper" (el envoltorio del reenvío, cuando es más
@@ -145,6 +154,8 @@ class IrisAnalysis(Base):
     confidence = Column(String(16), nullable=True)
     coverage = Column(JSONB, nullable=True)
     uncertainty_reasons = Column(JSONB, nullable=True)
+    scoring_snapshot = Column(JSONB, nullable=True)
+    scoring_version = Column(String(64), nullable=True)
     winning_context = Column(String(16), nullable=True)
     winning_reason = Column(Text, nullable=True)
     secondary_context = Column(JSONB, nullable=True)

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -303,6 +303,8 @@ class AnalysisDetailResponseSchema(Schema):
     detectorVersion = fields.String(load_default=None, allow_none=True)
     confidence = fields.String(load_default=None, allow_none=True)
     coverage = fields.Nested(CoverageSchema, load_default=None, allow_none=True)
+    scoringVersion = fields.String(load_default=None, allow_none=True)
+    scoringSnapshot = fields.Dict(load_default=None, allow_none=True)
     uncertaintyReasons = fields.List(fields.String(), load_default=None)
     topSignals = fields.List(fields.Nested(TopSignalSchema), load_default=None)
     aiSummary = fields.Nested(AiSummarySchema, load_default=None, allow_none=True)

--- a/API/src/modules/features/iris/services/replay.py
+++ b/API/src/modules/features/iris/services/replay.py
@@ -1,0 +1,151 @@
+"""
+Replay offline: qué habría decidido Iris con otra política de puntuación.
+
+Un cambio de umbrales, de perfil o de pesos puede mover la tasa de falsos
+positivos en cualquier dirección, y sin comparar no hay forma de saber en
+cuál. El replay ejecuta el mismo conjunto de mensajes con dos o más
+``ScoringPolicy`` y devuelve, muestra a muestra, qué veredicto cambió y qué
+gates aparecieron o desaparecieron, más las métricas de cada política frente
+a las etiquetas del corpus.
+
+El módulo no ejecuta reglas por su cuenta: recibe la función que evalúa un
+mensaje bajo una política (en la aplicación, ``IrisManager.evaluate_raw``).
+Así el replay y los análisis reales usan exactamente el mismo motor.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+from .feedback_metrics import compute_feedback_metrics, outcome_from_rules
+from .scoring import ScoringPolicy
+
+#: Evalúa un mensaje crudo bajo una política y devuelve ``verdict``,
+#: ``totalScore``, ``gateReasons``, ``rules`` (pares nombre/score del contexto
+#: ganador) y ``unevaluatedRules``.
+Evaluate = Callable[[str, ScoringPolicy], Dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ReplaySample:
+    """Un mensaje del corpus de replay.
+
+    Attributes:
+        sample_id: Identificador estable de la muestra.
+        raw: Mensaje crudo (cabeceras o ``.eml`` completo).
+        label: Etiqueta conocida (``malicious``, ``legitimate`` o
+            ``unknown``), o ``None`` si la muestra no está etiquetada: se
+            compara igualmente, pero no entra en las métricas.
+    """
+
+    sample_id: str
+    raw: str
+    label: Optional[str] = None
+
+
+def load_corpus(directory: Path) -> tuple[str, List[ReplaySample]]:
+    """Lee un corpus versionado (``manifest.json`` más un fichero por muestra).
+
+    Args:
+        directory: Carpeta con ``manifest.json``, cuyas muestras tienen
+            ``id``, ``file`` y ``label``.
+
+    Returns:
+        tuple: ``(versión del corpus, muestras)`` en el orden del manifiesto.
+    """
+    manifest = json.loads((directory / "manifest.json").read_text(encoding="utf-8"))
+    samples = [
+        ReplaySample(
+            sample_id=entry["id"],
+            raw=(directory / entry["file"]).read_bytes().decode("utf-8"),
+            label=entry.get("label"),
+        )
+        for entry in manifest["samples"]
+    ]
+    return manifest["version"], samples
+
+
+def replay(samples: List[ReplaySample], policies: Mapping[str, ScoringPolicy], evaluate: Evaluate,
+           family_of: Mapping[str, str], detector: str) -> Dict[str, Any]:
+    """Evalúa cada muestra con cada política y compara contra la primera.
+
+    La primera política del mapa es la referencia (normalmente la vigente);
+    las demás son candidatas. Una muestra "cambia" si alguna candidata le da
+    un veredicto distinto del de la referencia.
+
+    Args:
+        samples: Mensajes a evaluar.
+        policies: Nombre → política, en orden; la primera es la referencia.
+        evaluate: Función que evalúa un mensaje bajo una política (ver
+            ``Evaluate``).
+        family_of: Familia de cada regla del catálogo, para las métricas.
+        detector: Marca del catálogo evaluado (``detector_version``).
+
+    Returns:
+        dict: ``baseline`` (nombre de la referencia), ``policies`` (por
+            nombre: ``scoringVersion``, ``snapshot`` y ``metrics`` frente a
+            las etiquetas), ``samples`` (por muestra: ``id``, ``label``,
+            ``results`` por política, ``verdictChanged`` y ``gateChanges``
+            con los gates ``added``/``removed`` de cada candidata) y
+            ``changedCount``.
+
+    Raises:
+        ValueError: Si no se pasa ninguna política.
+    """
+    if not policies:
+        raise ValueError("El replay necesita al menos una política.")
+    names = list(policies)
+    baseline = names[0]
+    families = {family for family in family_of.values() if family}
+
+    outcomes: Dict[str, list] = {name: [] for name in names}
+    sample_reports = []
+    for sample in samples:
+        results = {name: evaluate(sample.raw, policies[name]) for name in names}
+        baseline_gates = set(results[baseline]["gateReasons"])
+        gate_changes = {
+            name: {
+                "added": sorted(set(results[name]["gateReasons"]) - baseline_gates),
+                "removed": sorted(baseline_gates - set(results[name]["gateReasons"])),
+            }
+            for name in names[1:]
+        }
+        sample_reports.append({
+            "id": sample.sample_id,
+            "label": sample.label,
+            "results": {
+                name: {
+                    "verdict": result["verdict"],
+                    "totalScore": result["totalScore"],
+                    "gateReasons": result["gateReasons"],
+                }
+                for name, result in results.items()
+            },
+            "verdictChanged": any(
+                results[name]["verdict"] != results[baseline]["verdict"] for name in names[1:]
+            ),
+            "gateChanges": gate_changes,
+        })
+        if sample.label:
+            for name, result in results.items():
+                outcomes[name].append(outcome_from_rules(
+                    sample.label, result["verdict"], result["rules"], family_of,
+                    result["unevaluatedRules"],
+                ))
+
+    return {
+        "baseline": baseline,
+        "policies": {
+            name: {
+                "scoringVersion": policies[name].version(detector),
+                "snapshot": policies[name].snapshot(detector),
+                "metrics": compute_feedback_metrics(outcomes[name], families, analyses_total=len(samples)),
+            }
+            for name in names
+        },
+        "samples": sample_reports,
+        "changedCount": sum(1 for report in sample_reports if report["verdictChanged"]),
+    }

--- a/API/src/modules/features/iris/services/scoring.py
+++ b/API/src/modules/features/iris/services/scoring.py
@@ -1,0 +1,300 @@
+"""
+Política de puntuación de Iris, versionada.
+
+El score de un análisis depende de más cosas que las reglas: del techo del que
+parte, de los suelos que acotan cada familia, de los umbrales que lo convierten
+en veredicto, del perfil de sensibilidad y de los pesos que la configuración
+sobreescribe. Todo eso cambiaba con la configuración **sin dejar rastro**, y
+un análisis de hace tres meses no decía con qué reglas del juego se decidió.
+
+``ScoringPolicy`` reúne esas piezas en un único objeto que:
+
+- puntúa y decide (``aggregate`` y ``verdict_for``);
+- se guarda con cada análisis como *snapshot* (``snapshot``) y se identifica
+  con una marca estable (``version``);
+- se puede reconstruir desde un snapshot guardado (``from_snapshot``), que es
+  lo que permite preguntar "¿qué habría decidido Iris con la versión
+  anterior?" y volver a ella.
+
+Los pesos por defecto de cada regla viven en su propio código; lo que la
+política recoge son los que ``features.iris.scoring`` sobreescribe. Por eso el
+snapshot incluye también ``appVersion``: dos snapshots iguales de despliegues
+distintos pueden seguir difiriendo en esos defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, List, Mapping
+
+import src.modules.system.config_reading as CR
+
+from .wordlists import datasets_fingerprint
+
+logger = logging.getLogger(__name__)
+
+#: Modelo sustractivo: un análisis parte de este techo y las reglas solo
+#: restan. Una regla superada no aporta nada; una fallida resta su score.
+CEILING = 100.0
+
+#: Suelo de cada familia: el mínimo (más negativo) que puede sumar el conjunto
+#: de penalizaciones de sus reglas. Varias reglas de una familia suelen
+#: corroborar el mismo hecho (SPF, DKIM, DMARC y alineación describen **un**
+#: fallo de autenticación), y sin suelo ese hecho pesaría varias veces. Las
+#: reglas sin familia no tienen suelo porque ya son pequeñas individualmente.
+FAMILY_SCORE_FLOORS = {
+    "auth": -25.0,
+    "identity": -28.0,
+    "reply_path": -15.0,
+    "content": -25.0,
+    "links": -30.0,
+    "received": -12.0,
+    "attachment": -28.0,
+}
+
+PROFILE_STRICT = "strict"
+PROFILE_BALANCED = "balanced"
+PROFILE_LENIENT = "lenient"
+
+#: Cuántos puntos desplaza cada perfil los dos umbrales configurados.
+#: ``strict`` los sube (hace falta un score más alto para salir limpio, así que
+#: avisa antes); ``lenient`` los baja. ``balanced`` usa los configurados tal cual.
+PROFILE_THRESHOLD_OFFSETS = {
+    PROFILE_STRICT: 5.0,
+    PROFILE_BALANCED: 0.0,
+    PROFILE_LENIENT: -5.0,
+}
+
+#: Versión del formato del snapshot; cambia si cambian sus claves.
+SNAPSHOT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ScoringPolicy:
+    """Reglas del juego con las que se puntúa y se decide un análisis.
+
+    Attributes:
+        profile: Perfil de sensibilidad (``strict``, ``balanced`` o
+            ``lenient``).
+        legitimate_threshold: Score (0–100) a partir del cual el veredicto es
+            ``Legitimate``, ya con el desplazamiento del perfil aplicado.
+        suspicious_threshold: Score a partir del cual es ``Suspicious``; por
+            debajo, ``Phishing``. También con el perfil aplicado.
+        ceiling: Techo del modelo sustractivo. Por defecto ``CEILING``.
+        family_floors: Suelo de penalización por familia. Por defecto
+            ``FAMILY_SCORE_FLOORS``.
+        weight_overrides: Pesos de regla que sustituyen a los del código
+            (``features.iris.scoring``); clave ``<regla>.<señal>``. Por
+            defecto vacío: todas las reglas usan sus pesos de código.
+        datasets_fingerprint: Huella de los datasets de detección (marcas,
+            dominios, keywords…) con que se evaluó. Por defecto vacía.
+        app_version: Versión de la aplicación que evaluó, que fija los pesos
+            por defecto del código. Por defecto vacía.
+    """
+
+    profile: str
+    legitimate_threshold: float
+    suspicious_threshold: float
+    ceiling: float = CEILING
+    family_floors: Mapping[str, float] = field(default_factory=lambda: dict(FAMILY_SCORE_FLOORS))
+    weight_overrides: Mapping[str, float] = field(default_factory=dict)
+    datasets_fingerprint: str = ""
+    app_version: str = ""
+
+    def aggregate(self, rules_defs: List[dict], results: List[Any]) -> float:
+        """Combina los resultados de regla en un score de 0 a ``ceiling``.
+
+        Solo cuenta la parte negativa de cada regla; la suma de cada familia
+        se acota a su suelo antes de restarla del techo.
+
+        Args:
+            rules_defs: Catálogo evaluado (se usa ``family`` de cada regla).
+            results: Un ``RuleResult`` por regla, emparejado por posición.
+
+        Returns:
+            float: El score, acotado a ``[0, ceiling]``.
+        """
+        family_penalties: Dict[str, float] = {}
+        unfamilied_penalties = 0.0
+        for rule_def, result in zip(rules_defs, results):
+            penalty = min(0.0, float(result.score))
+            family = rule_def.get("family") or ""
+            if family:
+                family_penalties[family] = family_penalties.get(family, 0.0) + penalty
+            else:
+                unfamilied_penalties += penalty
+
+        capped_total = unfamilied_penalties
+        for family, penalty in family_penalties.items():
+            floor = self.family_floors.get(family)
+            capped_total += max(floor, penalty) if floor is not None else penalty
+
+        return max(0.0, self.ceiling + capped_total)
+
+    def verdict_for(self, total_score: float) -> str:
+        """Traduce un score a veredicto con los umbrales de la política.
+
+        Es solo la base numérica: los gates de alta confianza pueden empeorar
+        el veredicto después, nunca mejorarlo.
+
+        Args:
+            total_score: Score de 0 a ``ceiling``.
+
+        Returns:
+            str: ``Legitimate``, ``Suspicious`` o ``Phishing``.
+        """
+        if total_score >= self.legitimate_threshold:
+            return "Legitimate"
+        if total_score >= self.suspicious_threshold:
+            return "Suspicious"
+        return "Phishing"
+
+    def snapshot(self, detector: str) -> Dict[str, Any]:
+        """Todo lo que decide un veredicto, en un dict serializable a JSONB.
+
+        Args:
+            detector: Marca del catálogo de reglas (``detector_version``).
+
+        Returns:
+            dict: Perfil, umbrales, techo, suelos por familia, pesos
+                sobreescritos, huella de datasets, versión de la aplicación,
+                catálogo y versión del formato.
+        """
+        return {
+            "schemaVersion": SNAPSHOT_SCHEMA_VERSION,
+            "profile": self.profile,
+            "legitimateThreshold": self.legitimate_threshold,
+            "suspiciousThreshold": self.suspicious_threshold,
+            "ceiling": self.ceiling,
+            "familyFloors": dict(sorted(self.family_floors.items())),
+            "weightOverrides": dict(sorted(self.weight_overrides.items())),
+            "datasetsFingerprint": self.datasets_fingerprint,
+            "appVersion": self.app_version,
+            "detectorVersion": detector,
+        }
+
+    def version(self, detector: str) -> str:
+        """Marca estable de la política junto con el catálogo que la aplicó.
+
+        Dos análisis con la misma marca se decidieron con las mismas reglas
+        del juego; cualquier cambio en umbrales, perfil, suelos, pesos,
+        datasets, catálogo o versión de la aplicación la cambia.
+
+        Args:
+            detector: Marca del catálogo de reglas (``detector_version``).
+
+        Returns:
+            str: ``iris-scoring:<12 hexadecimales>`` (cabe en 64 caracteres).
+        """
+        material = json.dumps(self.snapshot(detector), sort_keys=True)
+        return "iris-scoring:" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Mapping[str, Any]) -> "ScoringPolicy":
+        """Reconstruye la política con la que se decidió un análisis guardado.
+
+        Args:
+            snapshot: ``IrisAnalysis.scoring_snapshot`` (ver ``snapshot``).
+
+        Returns:
+            ScoringPolicy: La misma política. Los pesos por defecto del código
+                son los del despliegue actual, no los de ``appVersion``.
+        """
+        return cls(
+            profile=snapshot["profile"],
+            legitimate_threshold=float(snapshot["legitimateThreshold"]),
+            suspicious_threshold=float(snapshot["suspiciousThreshold"]),
+            ceiling=float(snapshot.get("ceiling", CEILING)),
+            family_floors={family: float(floor) for family, floor in (snapshot.get("familyFloors") or {}).items()},
+            weight_overrides={key: float(value) for key, value in (snapshot.get("weightOverrides") or {}).items()},
+            datasets_fingerprint=snapshot.get("datasetsFingerprint", ""),
+            app_version=snapshot.get("appVersion", ""),
+        )
+
+    def with_profile(self, profile: str) -> "ScoringPolicy":
+        """Misma política con otro perfil de sensibilidad.
+
+        Los umbrales se recalculan desde los de ``balanced`` para que cambiar
+        de perfil dos veces no acumule desplazamientos.
+
+        Args:
+            profile: ``strict``, ``balanced`` o ``lenient``.
+
+        Returns:
+            ScoringPolicy: Copia con el perfil y los umbrales nuevos.
+
+        Raises:
+            ValueError: Si el perfil no existe.
+        """
+        if profile not in PROFILE_THRESHOLD_OFFSETS:
+            raise ValueError(f"Perfil de sensibilidad desconocido: {profile!r}.")
+        base_offset = PROFILE_THRESHOLD_OFFSETS[self.profile]
+        offset = PROFILE_THRESHOLD_OFFSETS[profile]
+        return replace(
+            self, profile=profile,
+            legitimate_threshold=self.legitimate_threshold - base_offset + offset,
+            suspicious_threshold=self.suspicious_threshold - base_offset + offset,
+        )
+
+    def with_weight_overrides(self, weight_overrides: Mapping[str, float]) -> "ScoringPolicy":
+        """Misma política con otros pesos de regla (un candidato de recalibración).
+
+        Args:
+            weight_overrides: Mapa ``<regla>.<señal>`` → peso que **sustituye**
+                al de la política actual.
+
+        Returns:
+            ScoringPolicy: Copia con esos pesos.
+        """
+        return replace(self, weight_overrides=dict(weight_overrides))
+
+
+def policy_for_profile(profile: str, base_legitimate_threshold: float,
+                       base_suspicious_threshold: float, **extra: Any) -> ScoringPolicy:
+    """Construye una política aplicando el desplazamiento de un perfil.
+
+    Args:
+        profile: ``strict``, ``balanced`` o ``lenient``; uno desconocido se
+            trata como ``balanced`` y se avisa en el log, para que un error
+            tipográfico en la configuración no tumbe los análisis.
+        base_legitimate_threshold: Umbral de ``Legitimate`` configurado.
+        base_suspicious_threshold: Umbral de ``Suspicious`` configurado.
+        **extra: Resto de campos de ``ScoringPolicy`` (pesos, huella…).
+
+    Returns:
+        ScoringPolicy: La política con los umbrales desplazados.
+    """
+    if profile not in PROFILE_THRESHOLD_OFFSETS:
+        logger.warning("Perfil de sensibilidad de Iris desconocido %r; se usa 'balanced'", profile)
+        profile = PROFILE_BALANCED
+    offset = PROFILE_THRESHOLD_OFFSETS[profile]
+    return ScoringPolicy(
+        profile=profile,
+        legitimate_threshold=float(base_legitimate_threshold) + offset,
+        suspicious_threshold=float(base_suspicious_threshold) + offset,
+        **extra,
+    )
+
+
+def current_policy() -> ScoringPolicy:
+    """La política que rige ahora mismo, leída de la configuración.
+
+    Se lee en cada llamada (no se hornea al importar) para que un cambio vía
+    ``PUT /system`` o una edición del fichero que el worker recarga surta
+    efecto en el siguiente análisis.
+
+    Returns:
+        ScoringPolicy: Perfil ``features.iris.sensitivityProfile`` aplicado a
+            los umbrales configurados, con los pesos de
+            ``features.iris.scoring``, la huella de datasets y la versión.
+    """
+    config = CR.iris_config()
+    return policy_for_profile(
+        config.sensitivity_profile, config.legitimate_threshold, config.suspicious_threshold,
+        weight_overrides=CR.get_iris_scoring_overrides(),
+        datasets_fingerprint=datasets_fingerprint(),
+        app_version=str(CR.get_app_version()),
+    )

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -16,6 +16,8 @@ dataset, vive aquí; si necesitan una utilidad de texto/dominio, vive en
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from functools import lru_cache
 from typing import Any
@@ -464,6 +466,44 @@ def _set_of(key: str) -> frozenset[str]:
 
 def _tuple_of(key: str) -> tuple[str, ...]:
     return _cached_tuple(CR.config_version(), key)
+
+
+#: Datasets que viven solo en la configuración (sin default en ``_DEFAULTS``)
+#: y que también cambian el resultado de un análisis.
+_FINGERPRINT_EXTRA_KEYS = ("trusted_authserv_ids",)
+
+
+@lru_cache(maxsize=_CACHE_SIZE)
+def _datasets_fingerprint(config_version: tuple) -> str:
+    """Huella de los datasets efectivos para una versión de configuración.
+
+    Args:
+        config_version: ``CR.config_version()``; forma parte de la clave de
+            caché por el mismo motivo que en el resto de este módulo.
+
+    Returns:
+        str: ``iris-data:<12 hexadecimales>``.
+    """
+    effective = {key: _data(key) for key in sorted(_DEFAULTS)}
+    for key in _FINGERPRINT_EXTRA_KEYS:
+        effective.setdefault(key, CR.get_iris_data(key))
+    material = json.dumps(effective, sort_keys=True, ensure_ascii=False, default=list)
+    return "iris-data:" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+
+
+def datasets_fingerprint() -> str:
+    """Huella de los datasets de detección con que se evalúa ahora mismo.
+
+    Marcas, proveedores, keywords, TLDs… cambian lo que deciden las reglas tanto
+    como sus pesos. Se calcula sobre los valores **efectivos** (configuración, o
+    el default de este módulo si falta), así que cambia en cuanto cambia lo que
+    ven las reglas, y se cachea por versión de configuración como los propios
+    datasets.
+
+    Returns:
+        str: ``iris-data:<12 hexadecimales>``.
+    """
+    return _datasets_fingerprint(CR.config_version())
 
 
 # --- Accessors públicos (uno por dataset) ------------------------------------

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
 from functools import wraps
@@ -1781,6 +1783,15 @@ class IrisConfig:  # pylint: disable=too-many-instance-attributes
     """Por debajo de ``legitimate_threshold`` y a partir de aquí, Sospechoso;
     por debajo de aquí, Phishing."""
 
+    sensitivity_profile: str = "balanced"
+    """Perfil de sensibilidad: ``strict``, ``balanced`` o ``lenient``.
+
+    Desplaza los dos umbrales de arriba (``strict`` +5, ``lenient`` -5; ver
+    ``iris/services/scoring.py``). Cada análisis guarda el perfil y los
+    umbrales efectivos en su snapshot de puntuación, así que cambiarlo no
+    reinterpreta en silencio los análisis ya hechos. Un valor desconocido se
+    trata como ``balanced``."""
+
     min_headers: int = 2
     """Cabeceras mínimas para considerar analizable un mensaje."""
 
@@ -1913,6 +1924,37 @@ def get_iris_data(key: str):
     return _cfg(f"features.iris.data.{key}")
 
 
+#: Pesos de scoring de Iris que sustituyen a ``features.iris.scoring`` mientras
+#: dura un ``scoring_weight_overrides``. ``None`` fuera de ese bloque.
+_iris_scoring_weight_overrides: ContextVar[Optional[dict]] = ContextVar(
+    "iris_scoring_weight_overrides", default=None,
+)
+
+
+@contextmanager
+def scoring_weight_overrides(overrides: Optional[dict]):
+    """Evalúa con otro mapa de pesos de Iris sin tocar la configuración.
+
+    Es lo que usa el replay para comparar una política candidata con la
+    vigente: dentro del bloque, ``get_iris_scoring_weight`` lee de
+    ``overrides`` en vez de ``features.iris.scoring``. Al ser un
+    ``ContextVar``, no afecta a otros hilos ni a otras peticiones.
+
+    Args:
+        overrides: Mapa ``<regla>.<señal>`` → peso que **sustituye** entero al
+            configurado (una clave ausente usa el default del código). ``None``
+            deja la configuración tal cual.
+
+    Yields:
+        None
+    """
+    token = _iris_scoring_weight_overrides.set(dict(overrides) if overrides is not None else None)
+    try:
+        yield
+    finally:
+        _iris_scoring_weight_overrides.reset(token)
+
+
 @_lazy_load
 def get_iris_scoring_weight(weight_key: str, default: float) -> float:
     """Peso de scoring configurable de una regla de Iris, para recalibrarla.
@@ -1922,8 +1964,26 @@ def get_iris_scoring_weight(weight_key: str, default: float) -> float:
     propio ``default`` que cada llamada pasa (el valor calibrado por el consejo,
     ver STUDY.md) es el que se usa si la clave no está en la config, así que el
     comportamiento no cambia hasta que alguien la añade explícitamente.
+
+    Dentro de un ``scoring_weight_overrides`` se lee de ese mapa en su lugar.
     """
+    overrides = _iris_scoring_weight_overrides.get()
+    if overrides is not None:
+        return float(overrides.get(weight_key, default))
     return _cfg(f"features.iris.scoring.{weight_key}", default, float)
+
+
+@_lazy_load
+def get_iris_scoring_overrides() -> dict:
+    """Pesos de Iris que la configuración sobreescribe (``features.iris.scoring``).
+
+    Es la parte de los pesos que cambia sin desplegar, y por eso entra en el
+    snapshot de puntuación de cada análisis.
+
+    Returns:
+        dict: Copia plana ``<regla>.<señal>`` → peso; vacía si no hay ninguno.
+    """
+    return {key: float(value) for key, value in (_cfg("features.iris.scoring", {}) or {}).items()}
 
 
 # =============================================================================

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -108,6 +108,7 @@ def test_a_message_at_the_published_limit_is_accepted(client, regular_user, auth
         min_headers = 2
         legitimate_threshold = 80
         suspicious_threshold = 55
+        sensitivity_profile = "balanced"
 
     monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
     monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
@@ -139,6 +140,7 @@ def test_a_message_over_the_published_limit_is_rejected(client, regular_user, au
         min_headers = 2
         legitimate_threshold = 80
         suspicious_threshold = 55
+        sensitivity_profile = "balanced"
 
     monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
     monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())

--- a/API/tests/integration/test_iris_scoring_snapshot.py
+++ b/API/tests/integration/test_iris_scoring_snapshot.py
@@ -1,0 +1,85 @@
+"""Cada análisis guarda la política con la que se decidió.
+
+Cambiar umbrales, perfil o pesos ya no reinterpreta en silencio los análisis
+hechos: cada uno lleva su snapshot y su versión, y con ellos se puede
+reconstruir esa política —volver a ella— o preguntar qué habría decidido otra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.scoring import PROFILE_STRICT, ScoringPolicy
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+_LEGIT = (Path(__file__).resolve().parents[1] / "fixtures" / "iris" / "legit_bank_alert.eml").read_text(
+    encoding="utf-8")
+
+
+def _analyze(app, user_id: int, raw: str) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        IrisManager()._run_analysis(analysis_id, raw)
+    return analysis_id
+
+
+def test_an_analysis_stores_its_scoring_snapshot_and_version(client, app, root_user, root_headers):
+    analysis_id = _analyze(app, root_user.id, _LEGIT)
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    snapshot = report["scoringSnapshot"]
+    assert snapshot["profile"] == "balanced"
+    assert (snapshot["legitimateThreshold"], snapshot["suspiciousThreshold"]) == (80, 55)
+    assert snapshot["detectorVersion"] == report["detectorVersion"]
+    assert snapshot["datasetsFingerprint"].startswith("iris-data:")
+    assert report["scoringVersion"].startswith("iris-scoring:")
+
+
+def test_the_sensitivity_profile_is_recorded_with_the_analysis(app, root_user, monkeypatch):
+    monkeypatch.setattr(CR, "iris_config", lambda: CR.IrisConfig(sensitivity_profile=PROFILE_STRICT))
+    analysis_id = _analyze(app, root_user.id, _LEGIT)
+
+    with app.app_context():
+        with UnitOfWork() as uow:
+            snapshot = IrisAnalysisRepository(uow).get_by_id(analysis_id).scoring_snapshot
+
+    assert snapshot["profile"] == PROFILE_STRICT
+    assert snapshot["legitimateThreshold"] == 85
+
+
+def test_a_stored_snapshot_reproduces_the_stored_verdict_and_another_policy_can_differ(app, root_user):
+    """Rollback: la política reconstruida desde el snapshot decide lo mismo
+    que decidió; una política distinta responde qué habría pasado con ella."""
+    analysis_id = _analyze(app, root_user.id, _LEGIT)
+
+    with app.app_context():
+        manager = IrisManager()
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysisRepository(uow).get_by_id(analysis_id)
+            stored_policy = ScoringPolicy.from_snapshot(analysis.scoring_snapshot)
+            stored_verdict, stored_version = analysis.verdict, analysis.scoring_version
+
+        same = manager.evaluate_analysis_under(analysis_id, root_user.id, stored_policy)
+        other = manager.evaluate_analysis_under(
+            analysis_id, root_user.id, replace(stored_policy, legitimate_threshold=101.0),
+        )
+
+    assert stored_verdict == "Legitimate"
+    assert same["verdict"] == stored_verdict
+    assert same["scoringVersion"] == stored_version
+    assert same["storedScoringVersion"] == stored_version
+    assert other["verdict"] != stored_verdict
+    assert other["scoringVersion"] != stored_version

--- a/API/tests/unit/test_iris_feedback_metrics.py
+++ b/API/tests/unit/test_iris_feedback_metrics.py
@@ -9,7 +9,6 @@ catálogo actual clasifica bien las muestras etiquetadas de
 from __future__ import annotations
 
 import json
-from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -23,8 +22,6 @@ from src.modules.features.iris.services.feedback_metrics import (
     compute_feedback_metrics,
     outcome_from_rules,
 )
-from src.modules.features.iris.services.parsers import parse_raw_message
-from src.modules.features.iris.services.quality import assess_coverage
 from src.modules.features.iris.services.rules import iris_rules
 
 pytestmark = pytest.mark.unit
@@ -87,25 +84,13 @@ def test_outcome_from_rules_derives_fired_and_covered_families():
 # ------------------------------------------------------------- corpus versionado
 
 def _evaluate(raw: str):
-    """Ejecuta el catálogo sobre *raw* como el motor (sin cola ni base de datos).
+    """Ejecuta el motor real sobre *raw* (sin cola ni base de datos).
 
     Returns:
-        tuple: ``(veredicto, [(regla, score)], reglas sin contenido)``.
+        tuple: ``(veredicto, [(regla, score)], reglas sin evaluar)``.
     """
-    context = parse_raw_message(raw)
-    rules_defs = iris_rules.get_rules()
-    results = []
-    named_results = {}
-    for rule_def in rules_defs:
-        rule_input = context if rule_def.get("needs_context") else context.headers
-        result = rule_def["func"](rule_input)
-        result = replace(result, score=min(0.0, float(result.score)))
-        results.append(result)
-        named_results[rule_def["name"]] = result
-    total_score = IrisManager._aggregate_score(rules_defs, results)
-    verdict, _ = IrisManager._apply_verdict_gates(IrisManager()._determine_verdict(total_score), named_results)
-    rules = [(rule_def["name"], result.score) for rule_def, result in zip(rules_defs, results)]
-    return verdict, rules, assess_coverage(context, rules_defs)["uncoveredRules"]
+    result = IrisManager.evaluate_raw(raw)
+    return result["verdict"], result["rules"], result["unevaluatedRules"]
 
 
 def _corpus():

--- a/API/tests/unit/test_iris_replay.py
+++ b/API/tests/unit/test_iris_replay.py
@@ -1,0 +1,84 @@
+"""Replay offline de políticas de puntuación.
+
+``services/replay.py`` responde a "¿qué habría decidido Iris con otra
+versión?" sobre un corpus: qué veredictos cambian, qué gates aparecen o
+desaparecen y cómo quedan los falsos positivos y negativos de cada política.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.modules.features.iris.managers import IrisManager
+from src.modules.features.iris.services.quality import detector_version
+from src.modules.features.iris.services.replay import ReplaySample, load_corpus, replay
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.features.iris.services.scoring import PROFILE_STRICT, current_policy, policy_for_profile
+
+pytestmark = pytest.mark.unit
+
+_CORPUS = Path(__file__).resolve().parents[1] / "fixtures" / "iris"
+
+
+def _fake_evaluate(raw: str, policy):
+    """Motor de juguete: el mensaje es su propio score; strict añade un gate."""
+    score = float(raw)
+    return {
+        "verdict": policy.verdict_for(score),
+        "totalScore": score,
+        "gateReasons": ["gate estricto"] if policy.profile == PROFILE_STRICT else [],
+        "rules": [("Body Links", -10.0)] if score < 80 else [],
+        "unevaluatedRules": [],
+    }
+
+
+def test_replay_reports_what_changes_against_the_baseline():
+    samples = [
+        ReplaySample("limpio", "95", "legitimate"),
+        ReplaySample("frontera", "82", "legitimate"),
+        ReplaySample("sospechoso", "60", "malicious"),
+    ]
+    policies = {"vigente": policy_for_profile("balanced", 80, 55),
+                "estricta": policy_for_profile(PROFILE_STRICT, 80, 55)}
+
+    report = replay(samples, policies, _fake_evaluate, {"Body Links": "links"}, "iris-rules:1:x")
+
+    assert report["baseline"] == "vigente"
+    assert report["changedCount"] == 1
+    by_id = {entry["id"]: entry for entry in report["samples"]}
+    assert by_id["frontera"]["verdictChanged"] is True
+    assert by_id["frontera"]["results"]["vigente"]["verdict"] == "Legitimate"
+    assert by_id["frontera"]["results"]["estricta"]["verdict"] == "Suspicious"
+    assert by_id["limpio"]["gateChanges"]["estricta"] == {"added": ["gate estricto"], "removed": []}
+    assert report["policies"]["vigente"]["metrics"]["overall"]["falsePositives"] == 0
+    assert report["policies"]["estricta"]["metrics"]["overall"]["falsePositives"] == 1
+    assert report["policies"]["vigente"]["scoringVersion"] != report["policies"]["estricta"]["scoringVersion"]
+
+
+def test_replay_needs_at_least_one_policy():
+    with pytest.raises(ValueError):
+        replay([], {}, _fake_evaluate, {}, "d")
+
+
+def test_the_real_engine_over_the_corpus_measures_a_candidate_before_deploying():
+    """El caso de uso: comparar la política vigente con una candidata sobre el
+    corpus. Una candidata absurda (nada puede salir Legitimate) se delata como
+    cuatro falsos positivos nuevos antes de llegar a producción."""
+    version, samples = load_corpus(_CORPUS)
+    rules_defs = iris_rules.get_rules()
+    family_of = {rule_def["name"]: rule_def.get("family") or "" for rule_def in rules_defs}
+    baseline = current_policy()
+    candidate = replace(baseline, legitimate_threshold=101.0)
+
+    report = replay(samples, {"vigente": baseline, "candidata": candidate},
+                    IrisManager.evaluate_raw, family_of, detector_version(rules_defs))
+
+    assert version
+    vigente = report["policies"]["vigente"]["metrics"]["overall"]
+    candidata = report["policies"]["candidata"]["metrics"]["overall"]
+    assert (vigente["falsePositives"], vigente["falseNegatives"]) == (0, 0)
+    assert candidata["falsePositives"] == 4
+    assert report["changedCount"] == 4

--- a/API/tests/unit/test_iris_scoring.py
+++ b/API/tests/unit/test_iris_scoring.py
@@ -1,0 +1,106 @@
+"""Política de puntuación versionada y perfiles de sensibilidad.
+
+``services/scoring.py`` reúne techo, suelos, umbrales, perfil y pesos en una
+política que se guarda con cada análisis. Estos tests fijan cómo se desplazan
+los umbrales, que la versión cambie con cualquier regla del juego y que un
+snapshot guardado reconstruya la misma política.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import src.modules.system.config_reading as CR
+from src.modules.features.iris.services.registry import RuleResult
+from src.modules.features.iris.services.scoring import (
+    PROFILE_BALANCED,
+    PROFILE_LENIENT,
+    PROFILE_STRICT,
+    ScoringPolicy,
+    current_policy,
+    policy_for_profile,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _policy(profile: str = PROFILE_BALANCED, **extra) -> ScoringPolicy:
+    return policy_for_profile(profile, 80, 55, **extra)
+
+
+def test_profiles_shift_both_thresholds():
+    assert (_policy(PROFILE_BALANCED).legitimate_threshold, _policy(PROFILE_BALANCED).suspicious_threshold) == (80, 55)
+    assert (_policy(PROFILE_STRICT).legitimate_threshold, _policy(PROFILE_STRICT).suspicious_threshold) == (85, 60)
+    assert (_policy(PROFILE_LENIENT).legitimate_threshold, _policy(PROFILE_LENIENT).suspicious_threshold) == (75, 50)
+
+
+def test_an_unknown_profile_falls_back_to_balanced(caplog):
+    with caplog.at_level(logging.WARNING):
+        policy = _policy("paranoico")
+    assert policy.profile == PROFILE_BALANCED
+    assert policy.legitimate_threshold == 80
+    assert "paranoico" in caplog.text
+
+
+def test_changing_profile_twice_does_not_accumulate_offsets():
+    policy = _policy(PROFILE_STRICT).with_profile(PROFILE_LENIENT).with_profile(PROFILE_BALANCED)
+    assert (policy.legitimate_threshold, policy.suspicious_threshold) == (80, 55)
+
+
+def test_verdict_for_uses_the_policy_thresholds():
+    assert _policy(PROFILE_LENIENT).verdict_for(77) == "Legitimate"
+    assert _policy(PROFILE_BALANCED).verdict_for(77) == "Suspicious"
+    assert _policy(PROFILE_STRICT).verdict_for(57) == "Phishing"
+
+
+def test_aggregate_floors_each_family_but_not_unfamilied_rules():
+    rules_defs = [{"family": "links"}, {"family": "links"}, {"family": ""}]
+    results = [RuleResult(score=-25, verdict="fail"), RuleResult(score=-25, verdict="fail"),
+               RuleResult(score=-3, verdict="fail")]
+    assert _policy().aggregate(rules_defs, results) == 100 - 30 - 3
+
+
+def test_a_passing_rule_never_adds_points():
+    assert _policy().aggregate([{"family": "auth"}], [RuleResult(score=5, verdict="pass")]) == 100
+
+
+def test_the_snapshot_round_trips_to_the_same_policy():
+    policy = _policy(PROFILE_STRICT, weight_overrides={"body_links.floor": -20.0},
+                     datasets_fingerprint="iris-data:abc", app_version="0.5.10")
+    assert ScoringPolicy.from_snapshot(policy.snapshot("iris-rules:46:x")) == policy
+
+
+def test_the_version_is_stable_and_changes_with_any_rule_of_the_game():
+    policy = _policy(datasets_fingerprint="iris-data:abc")
+    version = policy.version("iris-rules:46:x")
+
+    assert version.startswith("iris-scoring:")
+    assert len(version) <= 64
+    assert _policy(datasets_fingerprint="iris-data:abc").version("iris-rules:46:x") == version
+    assert policy.with_profile(PROFILE_STRICT).version("iris-rules:46:x") != version
+    assert policy.with_weight_overrides({"dmarc.fail": -20}).version("iris-rules:46:x") != version
+    assert _policy(datasets_fingerprint="iris-data:def").version("iris-rules:46:x") != version
+    assert policy.version("iris-rules:47:y") != version
+
+
+def test_current_policy_reads_the_configuration(monkeypatch):
+    monkeypatch.setattr(CR, "iris_config", lambda: CR.IrisConfig(sensitivity_profile=PROFILE_STRICT))
+    monkeypatch.setattr(CR, "get_iris_scoring_overrides", lambda: {"dmarc.fail": -20.0})
+
+    policy = current_policy()
+
+    assert policy.profile == PROFILE_STRICT
+    assert (policy.legitimate_threshold, policy.suspicious_threshold) == (85, 60)
+    assert policy.weight_overrides == {"dmarc.fail": -20.0}
+    assert policy.datasets_fingerprint.startswith("iris-data:")
+
+
+def test_weight_overrides_apply_only_inside_their_block():
+    """El replay compara pesos sin tocar la configuración compartida."""
+    assert CR.get_iris_scoring_weight("demo.weight", -4) == -4
+    with CR.scoring_weight_overrides({"demo.weight": -9}):
+        assert CR.get_iris_scoring_weight("demo.weight", -4) == -9
+        assert CR.get_iris_scoring_weight("otro.peso", -2) == -2
+    assert CR.get_iris_scoring_weight("demo.weight", -4) == -4

--- a/web/app/src/views/ConfigView.vue
+++ b/web/app/src/views/ConfigView.vue
@@ -231,6 +231,15 @@
               <div class="cfg-grid">
                 <div class="form-group"><label>Umbral legítimo</label><input v-model.number="store.configFlat['features.iris.legitimateThreshold']" type="number" class="inp" /></div>
                 <div class="form-group"><label>Umbral sospechoso</label><input v-model.number="store.configFlat['features.iris.suspiciousThreshold']" type="number" class="inp" /></div>
+                <div class="form-group">
+                  <label>Perfil de sensibilidad</label>
+                  <select v-model="store.configFlat['features.iris.sensitivityProfile']" class="inp sel">
+                    <option value="strict">Estricto</option>
+                    <option value="balanced">Equilibrado</option>
+                    <option value="lenient">Permisivo</option>
+                  </select>
+                  <span class="field-hint">Estricto sube los dos umbrales 5 puntos (avisa antes); permisivo los baja 5</span>
+                </div>
                 <div class="form-group"><label>Cabeceras mínimas</label><input v-model.number="store.configFlat['features.iris.minHeaders']" type="number" min="0" max="50" class="inp" /></div>
                 <div class="form-group"><label>Tamaño máx. del mensaje (bytes)</label><input v-model.number="store.configFlat['features.iris.maxMessageBytes']" type="number" min="1024" step="1024" class="inp" /><span class="field-hint">10485760 = 10 MiB</span></div>
               </div>


### PR DESCRIPTION
## El problema

El score de un análisis de Iris no depende solo de las reglas. Depende también de:
- el **techo** del que parte (100);
- los **suelos** que acotan cuánto puede restar cada familia de reglas;
- los **umbrales** que convierten el número en `Legitimate`, `Suspicious` o `Phishing`;
- los **pesos** que la configuración sobreescribe a cada regla.

Todo eso cambiaba al editar la configuración **sin dejar rastro**. Cambiar el umbral de 80 a 75 cambiaba el significado de todos los análisis futuros, y ninguno guardaba con qué umbral se había decidido.

Por eso no se podía responder "¿qué habría decidido Iris con la versión anterior?", ni comparar una recalibración contra la actual antes de desplegarla, ni volver atrás.

Cierra #241 (iniciativa `M05`, Fase 2 del roadmap de Iris, #202). Se apoya en el corpus y las métricas de `M04`; el simulador de administración de `F16` se construye sobre el replay de este PR.

## Qué cambia

**Una política de puntuación con nombre** (`services/scoring.py`). `ScoringPolicy` reúne techo, suelos por familia, umbrales, perfil de sensibilidad, pesos sobreescritos (`features.iris.scoring`), huella de los datasets de detección y versión de la aplicación. El manager puntúa y decide a través de ella; las constantes que antes vivían sueltas en `managers/analysis.py` se mudan aquí.

**Perfiles de sensibilidad.** Una clave nueva, `features.iris.sensitivityProfile`, elige entre `strict`, `balanced` (por defecto) y `lenient`. El perfil **desplaza** los dos umbrales configurados: `strict` los sube 5 puntos, así que hace falta un score más alto para salir limpio y avisa antes; `lenient` los baja 5. Un valor desconocido se trata como `balanced` con un aviso en el log, para que una errata no tumbe los análisis. Se elige desde ConfigView.

**Cada análisis guarda su política:**
- `IrisAnalysis.scoring_snapshot` guarda la política entera.
- `IrisAnalysis.scoring_version` guarda una marca estable, `iris-scoring:<hash>`. Cambia con cualquier regla del juego: umbrales, perfil, suelos, pesos, datasets, catálogo o versión de la aplicación.
- La API los devuelve en `GET /iris/results/<id>`.

La huella de datasets (marcas, dominios, keywords, TLDs…) se calcula sobre los valores **efectivos** —configuración, o default si falta— y se cachea por versión de configuración, igual que los propios datasets desde `B18`.

**"¿Qué habría decidido Iris con otra versión?"**
- `ScoringPolicy.from_snapshot()` reconstruye la política con la que se decidió un análisis guardado. Esa es la **vuelta atrás**: aplicarla reproduce el veredicto guardado.
- `IrisManager.evaluate_analysis_under()` reevalúa el raw conservado de un análisis con cualquier política, sin crear otro análisis ni cobrar cuota.
- `IrisManager.evaluate_raw()` expone el motor real (mismo parseo, reglas, gates, política de calidad y elección de contexto de un reenvío) para usarlo fuera de la cola.

**Replay offline** (`services/replay.py`). Evalúa un corpus con dos o más políticas (la primera es la referencia) y devuelve:
- **muestra a muestra:** qué veredicto cambió y qué gates aparecieron o desaparecieron;
- **por política:** su versión, su snapshot y sus métricas frente a las etiquetas, con falsos positivos y negativos, precisión, recall y desglose por familia (el servicio de `M04`).

El replay no ejecuta reglas por su cuenta: recibe la función de evaluación (`IrisManager.evaluate_raw`), así que compara con exactamente el mismo motor que los análisis reales. Los pesos de una política candidata se aplican con un `ContextVar` en `config_reading` (`scoring_weight_overrides`): dentro del bloque, `get_iris_scoring_weight` lee el mapa candidato, y fuera no cambia nada. No se toca la configuración compartida y no afecta a otras peticiones.

**Coherencia.** `/iris/capabilities` y el listado sirven ya los umbrales con el perfil aplicado. El score cercano al umbral de `M02` usa los de la política.

## Migración

`c1e5a9d3f7b2_add_iris_analysis_scoring_snapshot`: `scoring_snapshot` (JSONB) y `scoring_version` en `IrisAnalysis`, nulables.

## Validación

- **`test_iris_scoring.py` (nuevo).**
  - Los tres perfiles desplazan los umbrales, uno desconocido cae a `balanced` y cambiar de perfil dos veces no acumula desplazamientos.
  - Los suelos por familia se aplican y una regla superada nunca suma.
  - El snapshot reconstruye la misma política; la versión es estable y cambia con cualquier pieza.
  - `current_policy()` lee la configuración, y los pesos sustituidos solo rigen dentro de su bloque.
- **`test_iris_replay.py` (nuevo).**
  - Con un motor de juguete: qué cambia contra la referencia, los gates añadidos y las métricas por política.
  - Con el motor real sobre el corpus de `M04`: la política vigente no tiene ni falsos positivos ni negativos. Una candidata donde nada puede salir `Legitimate` se delata como cuatro falsos positivos nuevos antes de llegar a producción.
- **`test_iris_scoring_snapshot.py` (nuevo, integración).**
  - Un análisis guarda su snapshot y su versión, y la API los devuelve; el perfil configurado queda registrado.
  - La política reconstruida desde el snapshot reproduce el veredicto guardado, y otra política da una respuesta distinta.
- **`test_iris_feedback_metrics.py`:** usa ahora el motor real (`evaluate_raw`) en vez de su copia del bucle de reglas.
- **`test_iris.py`:** el doble de configuración que usan dos tests incluye el campo nuevo `sensitivity_profile`.
- **`test_config_shape.py` y `test_config_view_paths.py`:** en verde con la clave nueva en el JSON, el bloque y ConfigView.
- **Suite completa (`pytest`):** sin fallos. **`pylint src`:** 10.00/10. **`ConfigView.vue`:** compilado con `@vue/compiler-sfc`. `npm run build` sigue sin poder ejecutarse aquí por el paquete privado `@projectellysia/acheron-core-web`.

## Notas y límites

- **Pesos por defecto.** Los pesos por defecto de cada regla viven en su propio código. La política guarda los que la configuración sobreescribe más la versión de la aplicación, que es la que fija los defaults. Al reconstruir un snapshot de otro despliegue, los defaults son los del código actual.
- **Datasets.** La huella se guarda, pero el replay evalúa con los datasets vigentes: comparar dos versiones de datasets exigiría conservarlos, y queda fuera de este PR.
- **Editar pesos en producción.** Guardar pesos o umbrales con `PUT /system` no se bloquea todavía. Lo que este PR añade es poder medir el cambio antes (replay) y reconstruir la política anterior después (snapshot). El control desde el producto llega con el simulador de administración de `F16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
