### PR TITLE
Romper el ciclo de imports que escondía src/__init__.py

### DIFF
--- a/API/run.py
+++ b/API/run.py
@@ -41,7 +41,8 @@ from src.modules.shared._exceptions import (
     EllysiaException,
     create_error_response
 )
-from src.modules.system     import configure_logging, config_reading, system_blp, ping_redis
+from src.modules.system     import configure_logging, config_reading, ping_redis
+from src.modules.system.endpoints import system_blp
 from src.modules.users      import (
     UserManager,
     oauth_blp,

--- a/API/src/__init__.py
+++ b/API/src/__init__.py
@@ -1,13 +1,8 @@
-"""
-src - Aliases para backwards compatibility
-"""
+"""Paquete raíz del backend.
 
-from src.modules.shared import Base, Document
-from src.modules.features.themis import NmapScanManager, NiktoScanManager
-
-__all__ = [
-    'Base',
-    'Document',
-    'NmapScanManager',
-    'NiktoScanManager',
-]
+Vacío a propósito: Python ejecuta este fichero antes que cualquier
+``src.modules.x.y``, así que todo lo que se importe aquí se carga en cada import
+del proyecto. Un import de un módulo de dominio en este sitio arrastra la
+aplicación entera y oculta ciclos de imports. Cada módulo se importa desde su
+propia ruta (``src.modules.<módulo>``).
+"""

--- a/API/src/modules/accounts/endpoints.py
+++ b/API/src/modules/accounts/endpoints.py
@@ -25,10 +25,7 @@ from flask_smorest import Blueprint as SmorestBlueprint
 from src.modules.infrastructure.session import build_repository
 from src.modules.shared import handle_exceptions, limiter
 from src.modules.shared.schemas import ErrorSchema, SuccessMessageSchema
-from src.modules.users import require_oauth_token, require_role, get_current_user
-# Role no está entre lo que re-exporta el paquete users, y pedírselo al paquete
-# durante su propia inicialización rompe el ciclo. El submódulo sí está cargado.
-from src.modules.users.services.permissions import Role
+from src.modules.users import Role, require_oauth_token, require_role, get_current_user
 
 from .exceptions import AccountsError
 from .managers import (

--- a/API/src/modules/system/__init__.py
+++ b/API/src/modules/system/__init__.py
@@ -1,16 +1,19 @@
 """
 system/__init__.py
-Módulo de gestión de configuración de SecOps.
-Proporciona endpoints para leer y escribir SecOpsConfig.json.
+Mecanismo transversal: logging, configuración y TaskQueue.
+
+No importa ``endpoints`` a propósito: el blueprint de ``/system`` necesita los
+decoradores de permisos de ``users``, y casi todo el proyecto importa este paquete
+(``config_reading``, la cola) muy pronto. Cargar aquí los endpoints haría que
+cualquier lectura de la configuración arrastrase ``users`` y cerrase un ciclo de
+imports. ``run.py`` importa ``system_blp`` directamente de ``system.endpoints``.
 """
 
 from .logging import configure_logging
-from .endpoints import system_blp
 from .taskqueue import TaskQueue, Task, TaskStatus, ping_redis
 
 __all__ = [
     "configure_logging",
-    "system_blp",
     "TaskQueue",
     "Task",
     "TaskStatus",

--- a/API/src/modules/system/config_reading.py
+++ b/API/src/modules/system/config_reading.py
@@ -11,7 +11,7 @@ import os
 
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
-from functools import wraps
+from functools import cache, wraps
 from pathlib import Path
 from typing import Optional, TypeVar, get_origin
 
@@ -731,16 +731,43 @@ def get_smtp_environment() -> dict[str, str]:
 #
 # Derivado de ScanType en vez de repetido a mano: un escáner nuevo que
 # se registre en el enum aparece aquí solo, en vez de quedarse fuera hasta
-# que alguien se acuerde de tocar esta tupla también. Import perezoso
-# (dentro de la función, no a nivel de módulo): config_reading.py lo importa
-# casi todo el proyecto muy pronto, y no debe depender en su superficie
-# global de un modelo de un módulo de features concreto.
-def _themis_scanner_values() -> tuple:
+# que alguien se acuerde de tocar esta tupla también.
+@cache
+def _themis_scanner_values() -> tuple[str, ...]:
+    """Devuelve los valores de ``ScanType``: los escáneres de Themis con bloque de config.
+
+    El import de ``ScanType`` ocurre en la primera llamada, nunca al cargar este
+    módulo. Cargar ``themis/model.py`` ejecuta antes ``features/themis/__init__.py``,
+    que arrastra managers, ``accounts`` y ``users``; y casi todo el proyecto importa
+    ``config_reading`` muy pronto, así que hacerlo al cargar cierra un ciclo de imports.
+
+    Returns:
+        tuple[str, ...]: Los valores del enum (``"nmap"``, ``"nikto"``, ``"lybra"``,
+            ``"nuclei"``), en el orden en que se declaran.
+    """
     from src.modules.features.themis.model import ScanType
     return tuple(scan_type.value for scan_type in ScanType)
 
 
-THEMIS_SCANNERS = _themis_scanner_values()
+def __getattr__(name: str):
+    """Resuelve ``CR.THEMIS_SCANNERS`` al pedirlo, en vez de al cargar el módulo.
+
+    Mantiene el nombre público de siempre sin pagar el import de Themis en la
+    carga (ver ``_themis_scanner_values``). Dentro de este fichero se llama a
+    ``_themis_scanner_values()`` directamente: un nombre suelto no pasa por aquí.
+
+    Args:
+        name: Atributo del módulo que no se encontró por la vía normal.
+
+    Returns:
+        tuple[str, ...]: Los escáneres de Themis, si ``name`` es ``"THEMIS_SCANNERS"``.
+
+    Raises:
+        AttributeError: Para cualquier otro nombre.
+    """
+    if name == "THEMIS_SCANNERS":
+        return _themis_scanner_values()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @config_block("features.themis")
@@ -1219,7 +1246,7 @@ def nuclei_config() -> NucleiConfig:
 def get_prompts_config() -> dict:
     return {
         scanner: _cfg(f"features.themis.scanners.{scanner}.prompts", {})
-        for scanner in THEMIS_SCANNERS
+        for scanner in _themis_scanner_values()
     }
 
 

--- a/API/src/modules/system/endpoints.py
+++ b/API/src/modules/system/endpoints.py
@@ -6,7 +6,6 @@ import psutil
 from flask_smorest import Blueprint as SmorestBlueprint
 from flask import jsonify, request
 
-from src.modules.users.services.permissions import Role
 from src.modules.shared._endpoints import limiter, current_actor
 from src.modules.shared._exceptions import (
     handle_exceptions,
@@ -14,7 +13,7 @@ from src.modules.shared._exceptions import (
     ValidationError,
 )
 from src.modules.shared.schemas import ErrorSchema
-from src.modules.users import require_oauth_token, require_role
+from src.modules.users import Role, require_oauth_token, require_role
 from src.modules.system.taskqueue import TaskQueue, Task, TaskStatus
 from .schemas import (
     HelloResponseSchema,

--- a/API/src/modules/users/__init__.py
+++ b/API/src/modules/users/__init__.py
@@ -7,7 +7,7 @@ from .model import (
     MFARecoveryCode,
     MFAChallenge,
 )
-from .services import require_oauth_token, require_attributes, require_role, AttributeType
+from .services import require_oauth_token, require_attributes, require_role, AttributeType, Role
 from .endpoints import oauth_blp, users_blp, get_current_user
 from .managers import UserManager, OAuthTokenManager, MFAManager
 from src.modules.features.acheron.model import Vault
@@ -61,5 +61,6 @@ __all__ = [
     "require_attributes",
     "require_role",
     "AttributeType",
+    "Role",
     "get_current_user",
 ]

--- a/API/tests/unit/test_code_conventions.py
+++ b/API/tests/unit/test_code_conventions.py
@@ -809,8 +809,6 @@ KNOWN_VIOLATIONS: dict[tuple[str, str, str], str] = {
     ("private-method", "src/modules/users/services/scheduling.py", "UsersScheduler._run_mfa_reminders"):
         _PLAN_PRIVATE_METHOD,
     # --- module-internals-import
-    ("module-internals-import", "src/modules/accounts/endpoints.py", "src.modules.users.services.permissions.Role"):
-        _PLAN_MODULE_INTERNALS,
     ("module-internals-import", "src/modules/accounts/managers/invitations.py", "src.modules.users.repositories.UserRepository"):
         _PLAN_MODULE_INTERNALS,
     ("module-internals-import", "src/modules/accounts/managers/invitations.py", "src.modules.users.services.secrets.generate_opaque_token"):
@@ -822,8 +820,6 @@ KNOWN_VIOLATIONS: dict[tuple[str, str, str], str] = {
     ("module-internals-import", "src/modules/features/hygeia/services/enrollment.py", "src.modules.users.services.secrets.hash_password"):
         _PLAN_MODULE_INTERNALS,
     ("module-internals-import", "src/modules/features/hygeia/services/enrollment.py", "src.modules.users.services.secrets.verify_password"):
-        _PLAN_MODULE_INTERNALS,
-    ("module-internals-import", "src/modules/system/endpoints.py", "src.modules.users.services.permissions.Role"):
         _PLAN_MODULE_INTERNALS,
     ("module-internals-import", "src/modules/users/managers.py", "src.modules.accounts.repositories.OrganizationMemberRepository"):
         _PLAN_MODULE_INTERNALS,
@@ -871,11 +867,11 @@ KNOWN_VIOLATIONS: dict[tuple[str, str, str], str] = {
         _PLAN_DIRECTION,
     ("module-direction", "src/modules/shared/_endpoints.py", "src.modules.system.config_reading"):
         _PLAN_DIRECTION,
+    ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.Role"):
+        _PLAN_DIRECTION,
     ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.require_oauth_token"):
         _PLAN_DIRECTION,
     ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.require_role"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.services.permissions.Role"):
         _PLAN_DIRECTION,
     ("module-direction", "src/modules/users/__init__.py", "src.modules.features.acheron.model.Vault"):
         _PLAN_DIRECTION,

--- a/API/tests/unit/test_code_conventions.py
+++ b/API/tests/unit/test_code_conventions.py
@@ -68,6 +68,12 @@ _AUTHORIZED_DIRECTION_EXCEPTIONS = {
     # CR.THEMIS_SCANNERS se deriva de ScanType a propósito (CLAUDE.md § Configuración).
     ("src/modules/system/config_reading.py", "features.themis"),
 }
+#: ``config_reading`` es una hoja (solo depende de la stdlib y de ``shared._exceptions``):
+#: cualquier módulo puede leer la configuración, también ``shared`` e ``infrastructure``.
+_CONFIG_READING_MODULE = "src.modules.system.config_reading"
+#: Un ``endpoints.py`` es un borde HTTP: puede usar la superficie pública de este
+#: módulo (los decoradores de permisos) aunque el suyo tenga un rango menor.
+_AUTHORIZATION_MODULE = "users"
 
 #: Métodos privados que sobrescriben un método de una librería externa; el grafo de
 #: herencia de ``src/`` no los ve. Clave: (ruta, ``Clase._método``); valor: la librería.
@@ -859,19 +865,7 @@ KNOWN_VIOLATIONS: dict[tuple[str, str, str], str] = {
         _PLAN_DIRECTION,
     ("module-direction", "src/modules/accounts/services/limits.py", "src.modules.features.themis.model.ProgramedScan"):
         _PLAN_DIRECTION,
-    ("module-direction", "src/modules/infrastructure/engine.py", "src.modules.system.config_reading"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/shared/_crypto.py", "src.modules.system.config_reading"):
-        _PLAN_DIRECTION,
     ("module-direction", "src/modules/shared/_documents.py", "src.modules.system.taskqueue.TaskTrackingMixin"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/shared/_endpoints.py", "src.modules.system.config_reading"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.Role"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.require_oauth_token"):
-        _PLAN_DIRECTION,
-    ("module-direction", "src/modules/system/endpoints.py", "src.modules.users.require_role"):
         _PLAN_DIRECTION,
     ("module-direction", "src/modules/users/__init__.py", "src.modules.features.acheron.model.Vault"):
         _PLAN_DIRECTION,
@@ -1363,24 +1357,49 @@ def find_private_name_imports(source: SourceFile) -> set[tuple[str, str, str]]:
     }
 
 
+def is_authorized_direction(source: SourceFile, target: str, target_owner: str) -> bool:
+    """Indica si una dependencia hacia un rango mayor está autorizada por § 3.4.
+
+    Hay tres autorizaciones: ``config_reading`` → ``ScanType`` de Themis; cualquier
+    fichero → ``config_reading``; y un ``endpoints.py`` → la superficie de ``users``.
+
+    Args:
+        source: Fichero que importa.
+        target: Nombre absoluto importado (``src.modules.system.config_reading``).
+        target_owner: Módulo del convenio al que pertenece ``target``.
+
+    Returns:
+        bool: ``True`` si el import está autorizado aunque suba de rango.
+    """
+    if (source.path, target_owner) in _AUTHORIZED_DIRECTION_EXCEPTIONS:
+        return True
+    if target == _CONFIG_READING_MODULE or target.startswith(f"{_CONFIG_READING_MODULE}."):
+        return True
+    return source.path.endswith("/endpoints.py") and target_owner == _AUTHORIZATION_MODULE
+
+
 def find_reverse_dependencies(source: SourceFile) -> set[tuple[str, str, str]]:
     """Regla 5: imports hacia un módulo de rango mayor que el propio (§ 3.4).
+
+    Los ficheros de ``src/`` que no están en ningún módulo (hoy solo
+    ``src/__init__.py``) cuentan como rango 0: Python los ejecuta antes que
+    cualquier ``src.modules.x.y``, así que no pueden depender de nadie.
 
     Args:
         source: Fichero a revisar.
 
     Returns:
         set[tuple[str, str, str]]: Las violaciones, con el nombre importado como
-            símbolo; vacío si no hay ninguna. Los ficheros o destinos sin rango
+            símbolo; vacío si no hay ninguna. Los módulos o destinos sin rango
             no se evalúan (``test_every_module_has_a_rank`` los vigila).
     """
-    source_rank = rank_of(source.owner) if source.owner else None
+    source_rank = 0 if source.owner is None else rank_of(source.owner)
     if source_rank is None:
         return set()
     violations = set()
     for target, _ in iter_import_targets(source):
         target_owner = owner_module_of(target)
-        if target_owner is None or (source.path, target_owner) in _AUTHORIZED_DIRECTION_EXCEPTIONS:
+        if target_owner is None or is_authorized_direction(source, target, target_owner):
             continue
         target_rank = rank_of(target_owner)
         if target_rank is not None and target_rank > source_rank:
@@ -1604,8 +1623,23 @@ class TestDirectionDetector:
             (RULE_DIRECTION, source.path, "src.modules.features.acheron.Vault"),
         }
 
-    def test_ignores_downward_imports_and_authorized_exception(self):
-        """Importar hacia abajo vale, y ``config_reading`` → ``ScanType`` está autorizado."""
+    def test_detects_root_package_and_narrow_authorizations(self):
+        """``src/__init__.py`` es rango 0, y las autorizaciones no se extienden a sus vecinos."""
+        root_package = parse_source("src/__init__.py", "from src.modules.features.themis import NmapScanManager")
+        shared = parse_source("src/modules/shared/_documents.py", "from src.modules.system.taskqueue import Task")
+        system_manager = parse_source("src/modules/system/managers.py", "from src.modules.users import require_role")
+        assert find_reverse_dependencies(root_package) == {
+            (RULE_DIRECTION, root_package.path, "src.modules.features.themis.NmapScanManager"),
+        }
+        assert find_reverse_dependencies(shared) == {
+            (RULE_DIRECTION, shared.path, "src.modules.system.taskqueue.Task"),
+        }
+        assert find_reverse_dependencies(system_manager) == {
+            (RULE_DIRECTION, system_manager.path, "src.modules.users.require_role"),
+        }
+
+    def test_ignores_downward_imports_and_authorized_exceptions(self):
+        """Importar hacia abajo vale, igual que las tres dependencias autorizadas por § 3.4."""
         feature = parse_source(_MANAGER_PATH, """
             from src.modules.users import User
             from src.modules.shared import is_private_target
@@ -1614,5 +1648,14 @@ class TestDirectionDetector:
         config_reading = parse_source(
             "src/modules/system/config_reading.py", "from src.modules.features.themis.model import ScanType"
         )
+        shared = parse_source("src/modules/shared/_crypto.py", """
+            import src.modules.system.config_reading as CR
+            from src.modules.system import config_reading
+        """)
+        system_endpoints = parse_source(
+            "src/modules/system/endpoints.py", "from src.modules.users import Role, require_role"
+        )
         assert find_reverse_dependencies(feature) == set()
         assert find_reverse_dependencies(config_reading) == set()
+        assert find_reverse_dependencies(shared) == set()
+        assert find_reverse_dependencies(system_endpoints) == set()

--- a/API/tests/unit/test_system_import_isolation.py
+++ b/API/tests/unit/test_system_import_isolation.py
@@ -1,0 +1,54 @@
+"""Los módulos de mecanismo se importan sin arrastrar el dominio.
+
+``config_reading``, la TaskQueue, ``shared`` e ``infrastructure`` los importa casi
+todo el proyecto, y muy pronto. Si cargar cualquiera de ellos arrastra ``users``,
+``accounts`` o una feature, basta con que ese módulo de dominio vuelva a importar el
+mecanismo para cerrar un ciclo de imports. Y ese ciclo puede quedar escondido
+durante meses, porque solo explota con un orden de carga concreto.
+
+Leyendo un fichero suelto el ciclo no se ve, así que el test importa cada módulo en
+un **proceso limpio** —dentro de pytest, la suite ya ha cargado todo— y mira qué ha
+quedado en ``sys.modules``.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_API_ROOT = Path(__file__).resolve().parents[2]
+
+#: Prefijos de los módulos de dominio (rango 2 y 3 en CONVENCIONES.md § 3.4).
+_DOMAIN_PREFIXES = ("src.modules.users", "src.modules.accounts", "src.modules.features")
+
+_PROBE = """
+import importlib, json, sys
+importlib.import_module(sys.argv[1])
+print(json.dumps(sorted(sys.modules)))
+"""
+
+
+@pytest.mark.parametrize("module_name", [
+    "src.modules.system.config_reading",
+    "src.modules.system.taskqueue",
+    "src.modules.shared",
+    "src.modules.infrastructure",
+])
+def test_mechanism_module_imports_without_domain(module_name):
+    """Importar un módulo de mecanismo en un proceso limpio no carga ningún módulo de dominio."""
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE, module_name],
+        cwd=_API_ROOT, capture_output=True, text=True, timeout=120, check=False,
+    )
+    assert result.returncode == 0, f"importar {module_name} falla en un proceso limpio:\n{result.stderr}"
+
+    loaded_modules = json.loads(result.stdout.strip().splitlines()[-1])
+    domain_modules = [name for name in loaded_modules if name.startswith(_DOMAIN_PREFIXES)]
+    assert not domain_modules, (
+        f"importar {module_name} arrastra módulos de dominio (CONVENCIONES.md § 3.4): "
+        f"{domain_modules[:10]}"
+    )

--- a/CONVENCIONES.md
+++ b/CONVENCIONES.md
@@ -206,8 +206,21 @@ features/*  ──►  users, accounts  ──►  tools/*, system  ──►  s
   no importan nada del dominio; `users` y `accounts` no importan features.
 - Una feature puede usar a otra feature, siempre por su `__init__.py` (Aegis usa a Themis y a
   Hygeia así).
-- **Excepción autorizada:** `system/config_reading.py` importa `ScanType` de Themis, porque
-  `CR.THEMIS_SCANNERS` se deriva del enum a propósito (ver CLAUDE.md § Configuración).
+- **Excepciones autorizadas:**
+  - `system/config_reading.py` importa `ScanType` de Themis, porque `CR.THEMIS_SCANNERS` se
+    deriva del enum a propósito (ver CLAUDE.md § Configuración). El import ocurre la primera vez
+    que se pide la lista, nunca al cargar el módulo: cargar `themis/model.py` ejecuta antes
+    `features/themis/__init__.py`, que arrastra media aplicación.
+  - Cualquier módulo, también `shared/` e `infrastructure/`, puede leer `system/config_reading.py`.
+    Es una hoja: solo depende de la biblioteca estándar y de `shared._exceptions`.
+  - Un `endpoints.py` puede usar la superficie pública de `users` (los decoradores de permisos y
+    `Role`) aunque su módulo tenga un rango menor. Es un borde HTTP (§ 3.2) y la autenticación la
+    necesitan todos.
+- **Nada se importa en `src/__init__.py`.** Python lo ejecuta antes que cualquier
+  `src.modules.x.y`, así que lo que se importe ahí se carga en todos los imports del proyecto y
+  esconde los ciclos de imports. Por el mismo motivo, un `__init__.py` de mecanismo (`system`,
+  `shared`, `infrastructure`) no carga endpoints ni nada que dependa de `users`. Lo vigila
+  `tests/unit/test_system_import_isolation.py`, que importa esos módulos en un proceso limpio.
 - Cuando un módulo transversal necesita algo de todas las features —contar recursos para la
   cuota de un plan, borrar los datos de un usuario—, la dependencia se invierte con un registro:
   cada feature se da de alta en el transversal desde su propio `__init__.py`, igual que hace hoy
@@ -816,7 +829,6 @@ Cada prefijo tiene un significado fijo, para que el nombre diga qué esperar:
 **Imports que entran por dentro de otro módulo** (§ 3.3):
 - Hygeia importa `users.services.secrets`.
 - Una feature importa `accounts.services.entitlements`.
-- Otro import trae `Role` de `users.services.permissions`.
 - Las features importan `system.taskqueue.outbox_repository`, `.dispatcher` y `.outbox`.
   `TaskDispatchRepository` debería reexportarse en `system/taskqueue/__init__.py`.
 
@@ -824,7 +836,8 @@ Cada prefijo tiene un significado fijo, para que el nombre diga qué esperar:
 - `accounts/services/limits.py` y `users/services/account_deletion.py` importan modelos de todas
   las features.
 - `users/__init__.py` importa Acheron.
-- `shared/_exceptions.py` importa Themis.
+- `shared/_documents.py` importa la TaskQueue de `system`. Además usa la BD, así que no es código
+  puro y no le corresponde estar en `shared/` (§ 6.2).
 
 **Duplicados** (§ 6.2, § 9.1):
 - `iris/services/parsers.py::_is_private_ip` duplica `shared.is_private_target`.
@@ -860,6 +873,7 @@ la ruta:
 | `src/modules/features/<nombre>/…` | `features.<nombre>` |
 | `src/modules/tools/<nombre>/…` | `tools.<nombre>` |
 | `src/modules/<nombre>/…` (cualquier otro) | `<nombre>` |
+| `src/` fuera de `src/modules/` (hoy solo `src/__init__.py`) | ninguno; cuenta como rango 0 en la regla 5 |
 
 Los imports relativos (`from .x import y`) se resuelven a ruta absoluta antes de comparar.
 
@@ -914,8 +928,10 @@ hacerlo (§ 5.4).
 | `users`, `accounts` | 2 |
 | `features.*` | 3 |
 
-Es violación importar un módulo de rango **mayor** que el propio. Excepción autorizada:
-`system/config_reading.py` → `ScanType` de Themis (§ 3.4).
+Es violación importar un módulo de rango **mayor** que el propio. Los ficheros de `src/` que no
+están en ningún módulo cuentan como rango 0. Las tres excepciones autorizadas de § 3.4 no son
+violación: `system/config_reading.py` → `ScanType` de Themis, cualquier fichero →
+`system/config_reading.py`, y un `endpoints.py` → la superficie pública de `users`.
 
 #### La lista de excepciones que solo encoge
 


### PR DESCRIPTION
## Resumen

Hasta ahora, importar **cualquier** módulo del backend —aunque fuera solo la lectura de configuración (`config_reading`)— cargaba casi toda la aplicación: Themis, Acheron, `accounts` y `users`. Detrás había un **ciclo de imports** (A importa B, que acaba importando A mientras A todavía está a medio cargar). No explotaba de pura casualidad: `src/__init__.py`, un fichero de «alias de compatibilidad» que nadie usa, fijaba un orden de carga que lo esquivaba. Borrar ese fichero, que parece código muerto, rompía el arranque.

Esta PR rompe el ciclo en sus tres eslabones y deja tests que impiden que vuelva.

## Issue relacionado

Closes #582

## Implementación

Un commit por fase. Las fases 2 y 3 se aplicaron en orden inverso al del plan: con los alias quitados pero `system/__init__` todavía cargando su blueprint, la colección de tests fallaba con `ImportError: cannot import name 'generate_salt' from partially initialized module`. Primero hay que cortar el eslabón de `system` y después quitar los alias.

1. **`refactor(system)`: `THEMIS_SCANNERS` perezoso de verdad.** `config_reading` deriva la lista de escáneres del enum `ScanType` de Themis. El import estaba dentro de una función, pero una asignación a nivel de módulo la ejecutaba al cargar el fichero, y cargar `themis/model.py` ejecuta antes todo `features/themis/__init__.py`. Ahora la lista se calcula la primera vez que se pide (con caché), y un `__getattr__` de módulo mantiene `CR.THEMIS_SCANNERS` igual para quien lo lee.
2. **`refactor(system)`: `system/__init__` deja de importar su blueprint.** El blueprint de `/system` necesita los decoradores de permisos de `users`, así que cargarlo desde el `__init__` hacía que leer la configuración arrastrara `users`. `run.py`, su único consumidor, lo importa ahora de `system.endpoints`.
3. **`refactor(repo)`: `src/__init__.py` sin reexportaciones.** Queda solo con un docstring que explica por qué debe seguir vacío. Añade `tests/unit/test_system_import_isolation.py`, que importa `config_reading`, la TaskQueue, `shared` e `infrastructure` en un **proceso limpio** y comprueba que ninguno carga módulos de dominio. Tiene que ser un proceso aparte porque dentro de pytest la suite ya lo ha cargado todo, y un ciclo de imports no se ve leyendo un fichero suelto.
4. **`refactor(users)`: `Role` en la superficie pública de `users`.** Los endpoints de `accounts` y `system` lo importaban de `users.services.permissions` (las tripas del módulo) porque, con el ciclo, pedírselo al paquete fallaba. Ahora ya no falla.
5. **`test(repo)`: el convenio autoriza lo legítimo y vigila `src/__init__.py`.** En `CONVENCIONES.md` § 3.4 y en `test_code_conventions.py`:
   - cualquier módulo puede leer `config_reading`, que es una hoja (solo depende de la stdlib y de `shared._exceptions`);
   - un `endpoints.py` puede usar la superficie pública de `users`, porque es el borde HTTP y la autenticación la necesitan todos;
   - los ficheros de `src/` que no están en ningún módulo cuentan como rango 0, así que el test ya ve `src/__init__.py`;
   - se corrige § 11.1, que atribuía a `shared/_exceptions.py` un import de Themis que en realidad es un ejemplo dentro de un docstring.

## Validación

- `pytest` completo: 3095 passed y 50 skipped (los de PostgreSQL y el oráculo de Lybra, que se saltan sin su infraestructura).
- Cada fase se validó por separado antes de su commit (suite unitaria o completa, según lo que tocaba).
- `test_code_conventions.py` y `test_system_import_isolation.py` en verde. Se comprobó a mano que el primero falla tanto con una violación nueva como con una entrada obsoleta de `KNOWN_VIOLATIONS`.
- `pylint` (errores y avisos) sobre los ficheros de `src/` modificados: sin avisos nuevos. Los que salen (`TaskStatus` sin usar en `system/endpoints.py`, `W1203` en `accounts/endpoints.py` y el `E0401` de `config_reading`) ya existían.

## Notas

- **PR apilada.** Sale de `documentation/repo/code-conventions` (#581), que es donde viven `CONVENCIONES.md` y `test_code_conventions.py`, y apunta a esa rama. Cuando #581 se mergee en `v0.5`, esta pasa a apuntar a `v0.5`.
- **Fuera de alcance** (anotado en el issue):
  - `users/__init__.py` sigue importando `Vault` de Acheron;
  - `shared/_documents.py` usa BD y la TaskQueue y no debería estar en `shared/`;
  - los imports diferidos de `shared/_crypto.py`, `shared/_endpoints.py` e `infrastructure/engine.py` probablemente ya puedan ser imports normales, pero es otro cambio.
- No cambia nada visible para quien usa la API, así que el README no se toca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
