### PR TITLE
fix: la rama de la Fase 2 de Iris vuelve a arrancar y a cumplir CONVENCIONES.md

### DIFF
--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -25,11 +25,9 @@ from src.modules.users import (
     require_attributes,
     require_role,
     AttributeType,
+    Role,
     get_current_user,
 )
-# Role no está entre lo que reexporta el paquete users (mismo caso que en
-# accounts/endpoints.py), así que se pide a su módulo.
-from src.modules.users.services.permissions import Role
 from src.modules.shared import handle_exceptions, limiter
 from src.modules.shared.schemas import ErrorSchema
 from src.modules.shared._exceptions import DocumentError, DocumentNotReadyError

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -90,6 +90,51 @@ _VERDICT_SEVERITY = {v: i for i, v in enumerate(_VERDICT_ORDER)}
 
 
 
+def _rule_to_dict(rule: IrisRuleResult) -> Dict[str, Any]:
+    """Serializa una fila de regla con las claves camelCase de la API.
+
+    Args:
+        rule: Fila ``IrisRuleResult`` persistida.
+
+    Returns:
+        dict: ``ruleName``, ``category``, ``score``, ``verdict``,
+            ``details``, ``recommendation``, ``evidence`` (lista, vacía si
+            no hay) y ``evidenceUnavailableReason``.
+    """
+    return {
+        "ruleName": rule.rule_name,
+        "category": rule.category,
+        "score": rule.score,
+        "verdict": rule.verdict,
+        "details": rule.details,
+        "recommendation": rule.recommendation,
+        "evidence": rule.evidence or [],
+        "evidenceUnavailableReason": rule.evidence_unavailable_reason,
+    }
+
+
+def _winning_message_context(analysis: IrisAnalysis):
+    """Parsea el raw del análisis y devuelve el contexto que ganó.
+
+    Las vistas derivadas del raw (cadena Received, IOCs) tienen que
+    describir el mismo mensaje que el veredicto: en un reenvío cuyo
+    envoltorio fue más grave, el envoltorio.
+
+    Args:
+        analysis: Análisis ya cargado y con su propiedad comprobada.
+
+    Returns:
+        MessageContext: El contexto ganador (el interno si el análisis no
+            guardó ninguno).
+
+    Raises:
+        IrisRawMessagePurgedError: La retención ya purgó el raw.
+    """
+    if analysis.raw_headers is None:
+        raise IrisRawMessagePurgedError(analysis.id)
+    return context_of_type(parse_raw_message(analysis.raw_headers), analysis.winning_context)
+
+
 class IrisManager(TaskTrackingMixin):
     """Orchestrates the lifecycle of an Iris email-header analysis.
 
@@ -370,7 +415,7 @@ class IrisManager(TaskTrackingMixin):
         # Un análisis sin contexto ganador guardado solo tiene filas del
         # contexto que ganó, sin marcar: se leen todas, como siempre.
         rules = rule_repo.get_by_analysis(analysis_id, context_type=analysis.winning_context)
-        rules_data = [self._rule_to_dict(rule) for rule in rules]
+        rules_data = [_rule_to_dict(rule) for rule in rules]
 
         recommendations = [
             rule["recommendation"] for rule in rules_data
@@ -384,7 +429,7 @@ class IrisManager(TaskTrackingMixin):
             )
             secondary_context = {
                 **analysis.secondary_context,
-                "rules": [self._rule_to_dict(rule) for rule in secondary_rules],
+                "rules": [_rule_to_dict(rule) for rule in secondary_rules],
             }
 
         from src.modules.users import UserManager
@@ -439,29 +484,6 @@ class IrisManager(TaskTrackingMixin):
             "rules": rules_data,
             "recommendations": recommendations,
             "latestFeedback": latest_feedback,
-        }
-
-    @staticmethod
-    def _rule_to_dict(rule: IrisRuleResult) -> Dict[str, Any]:
-        """Serializa una fila de regla con las claves camelCase de la API.
-
-        Args:
-            rule: Fila ``IrisRuleResult`` persistida.
-
-        Returns:
-            dict: ``ruleName``, ``category``, ``score``, ``verdict``,
-                ``details``, ``recommendation``, ``evidence`` (lista, vacía si
-                no hay) y ``evidenceUnavailableReason``.
-        """
-        return {
-            "ruleName": rule.rule_name,
-            "category": rule.category,
-            "score": rule.score,
-            "verdict": rule.verdict,
-            "details": rule.details,
-            "recommendation": rule.recommendation,
-            "evidence": rule.evidence or [],
-            "evidenceUnavailableReason": rule.evidence_unavailable_reason,
         }
 
     @classmethod
@@ -537,34 +559,13 @@ class IrisManager(TaskTrackingMixin):
                 aquí no hay ningún raw que parsear, ni cabeceras.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
-        context = self._winning_message_context(analysis)
+        context = _winning_message_context(analysis)
         return {
             "analysisId": analysis.id,
             "contextType": analysis.winning_context,
             **build_path(context.received_headers),
         }
 
-    @staticmethod
-    def _winning_message_context(analysis: IrisAnalysis):
-        """Parsea el raw del análisis y devuelve el contexto que ganó.
-
-        Las vistas derivadas del raw (cadena Received, IOCs) tienen que
-        describir el mismo mensaje que el veredicto: en un reenvío cuyo
-        envoltorio fue más grave, el envoltorio.
-
-        Args:
-            analysis: Análisis ya cargado y con su propiedad comprobada.
-
-        Returns:
-            MessageContext: El contexto ganador (el interno si el análisis no
-                guardó ninguno).
-
-        Raises:
-            IrisRawMessagePurgedError: La retención ya purgó el raw.
-        """
-        if analysis.raw_headers is None:
-            raise IrisRawMessagePurgedError(analysis.id)
-        return context_of_type(parse_raw_message(analysis.raw_headers), analysis.winning_context)
 
     
 
@@ -594,7 +595,7 @@ class IrisManager(TaskTrackingMixin):
                 análisis.
         """
         analysis = self.assert_analysis_ownership(analysis_id, user_id)
-        context = self._winning_message_context(analysis)
+        context = _winning_message_context(analysis)
 
         domains: set[str] = set()
         emails: set[str] = set()

--- a/API/src/modules/features/iris/managers/replay.py
+++ b/API/src/modules/features/iris/managers/replay.py
@@ -48,6 +48,37 @@ def _invalid_input(text: str) -> IrisInvalidInputError:
     return IrisInvalidInputError(text, user_message=text)
 
 
+def _ad_hoc_samples(messages: List[Mapping[str, Any]]) -> List[ReplaySample]:
+    """Valida los mensajes pegados por el administrador y los prepara.
+
+    Args:
+        messages: Lista de ``{raw, label}``; ``label`` es opcional.
+
+    Returns:
+        List[ReplaySample]: Una muestra por mensaje, ``mensaje-1``,
+            ``mensaje-2``…
+
+    Raises:
+        IrisInvalidInputError: Si hay demasiados mensajes, alguno supera el
+            tamaño máximo o no es un correo analizable; el mensaje dice cuál.
+    """
+    if len(messages) > MAX_AD_HOC_MESSAGES:
+        raise _invalid_input(f"Como mucho {MAX_AD_HOC_MESSAGES} mensajes por simulación.")
+    max_bytes = CR.iris_config().max_message_bytes
+    samples = []
+    for index, message in enumerate(messages, start=1):
+        raw = message["raw"]
+        if len(raw.encode("utf-8")) > max_bytes:
+            raise _invalid_input(f"El mensaje {index} supera el tamaño máximo ({max_bytes} bytes).")
+        try:
+            IrisManager._validate_headers_pre(raw)  # pylint: disable=protected-access
+            IrisManager._validate_headers_parsed(parse_raw_message(raw).headers)  # pylint: disable=protected-access
+        except IrisInvalidInputError as e:
+            raise _invalid_input(f"El mensaje {index} no es un correo analizable: {e}") from e
+        samples.append(ReplaySample(f"mensaje-{index}", raw, message.get("label")))
+    return samples
+
+
 class IrisReplayManager:
     """Compara la política vigente (o una dada) con una candidata."""
 
@@ -96,37 +127,6 @@ class IrisReplayManager:
             )
         return policy
 
-    @staticmethod
-    def _ad_hoc_samples(messages: List[Mapping[str, Any]]) -> List[ReplaySample]:
-        """Valida los mensajes pegados por el administrador y los prepara.
-
-        Args:
-            messages: Lista de ``{raw, label}``; ``label`` es opcional.
-
-        Returns:
-            List[ReplaySample]: Una muestra por mensaje, ``mensaje-1``,
-                ``mensaje-2``…
-
-        Raises:
-            IrisInvalidInputError: Si hay demasiados mensajes, alguno supera el
-                tamaño máximo o no es un correo analizable; el mensaje dice cuál.
-        """
-        if len(messages) > MAX_AD_HOC_MESSAGES:
-            raise _invalid_input(f"Como mucho {MAX_AD_HOC_MESSAGES} mensajes por simulación.")
-        max_bytes = CR.iris_config().max_message_bytes
-        samples = []
-        for index, message in enumerate(messages, start=1):
-            raw = message["raw"]
-            if len(raw.encode("utf-8")) > max_bytes:
-                raise _invalid_input(f"El mensaje {index} supera el tamaño máximo ({max_bytes} bytes).")
-            try:
-                IrisManager._validate_headers_pre(raw)  # pylint: disable=protected-access
-                IrisManager._validate_headers_parsed(parse_raw_message(raw).headers)  # pylint: disable=protected-access
-            except IrisInvalidInputError as e:
-                raise _invalid_input(f"El mensaje {index} no es un correo analizable: {e}") from e
-            samples.append(ReplaySample(f"mensaje-{index}", raw, message.get("label")))
-        return samples
-
     def run(self, candidate_spec: Mapping[str, Any], baseline_spec: Optional[Mapping[str, Any]] = None,
             messages: Optional[List[Mapping[str, Any]]] = None, include_corpus: bool = True) -> Dict[str, Any]:
         """Ejecuta la simulación y devuelve el informe de replay.
@@ -154,7 +154,7 @@ class IrisReplayManager:
         samples: List[ReplaySample] = []
         if include_corpus:
             corpus_version, samples = load_corpus(CORPUS_DIRECTORY)
-        samples += self._ad_hoc_samples(list(messages or []))
+        samples += _ad_hoc_samples(list(messages or []))
         if not samples:
             raise _invalid_input("No hay nada que comparar: incluye el corpus o añade algún mensaje.")
 

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -51,6 +51,38 @@ def _extract_json_with_regex(raw: str) -> Optional[dict]:
     return None
 
 
+def _confidence_note(report: Dict[str, Any]) -> str:
+    """Aviso de confianza y cobertura que se añade al final del prompt.
+
+    Va anexado, igual que ``_degradation_note``, para no depender de que la
+    plantilla desplegada en ``SecOpsConfig.json`` tenga un marcador nuevo.
+    Le da al modelo la misma confianza ordinal y los mismos motivos que ve
+    el analista en la UI y en el PDF, y le prohíbe convertirla en un
+    porcentaje: el score no está calibrado y un número inventaría precisión.
+
+    Args:
+        report: Informe de ``IrisManager.get_analysis_results``; se leen
+            ``confidence``, ``coverage`` y ``uncertaintyReasons``.
+
+    Returns:
+        str: El aviso, o cadena vacía si el informe no trae confianza
+            (análisis anteriores a que se calculara).
+    """
+    label = _ANALYSIS_CONFIDENCE_LABELS.get(report.get("confidence") or "")
+    if label is None:
+        return ""
+    coverage = report.get("coverage") or {}
+    coverage_text = ("solo cabeceras (no se inspeccionó cuerpo ni adjuntos)"
+                     if coverage.get("mode") == "headers_only" else "mensaje completo")
+    reasons = report.get("uncertaintyReasons") or []
+    reasons_text = (" Motivos: " + " ".join(reasons)) if reasons else ""
+    return (
+        f"\n\nCONFIANZA DEL ANÁLISIS: {label}. Cobertura: {coverage_text}.{reasons_text} "
+        "Usa exactamente esta confianza en el campo \"confidence\", no la "
+        "expreses como porcentaje y no afirmes más certeza de la que indica."
+    )
+
+
 class IrisAIWriter:
     """Generates an executive narrative (summary, attacker intent,
     recommendations, confidence) from a finished Iris analysis report.
@@ -120,38 +152,6 @@ class IrisAIWriter:
             "ausencia de hallazgos."
         )
 
-    @staticmethod
-    def _confidence_note(report: Dict[str, Any]) -> str:
-        """Aviso de confianza y cobertura que se añade al final del prompt.
-
-        Va anexado, igual que ``_degradation_note``, para no depender de que la
-        plantilla desplegada en ``SecOpsConfig.json`` tenga un marcador nuevo.
-        Le da al modelo la misma confianza ordinal y los mismos motivos que ve
-        el analista en la UI y en el PDF, y le prohíbe convertirla en un
-        porcentaje: el score no está calibrado y un número inventaría precisión.
-
-        Args:
-            report: Informe de ``IrisManager.get_analysis_results``; se leen
-                ``confidence``, ``coverage`` y ``uncertaintyReasons``.
-
-        Returns:
-            str: El aviso, o cadena vacía si el informe no trae confianza
-                (análisis anteriores a que se calculara).
-        """
-        label = _ANALYSIS_CONFIDENCE_LABELS.get(report.get("confidence") or "")
-        if label is None:
-            return ""
-        coverage = report.get("coverage") or {}
-        coverage_text = ("solo cabeceras (no se inspeccionó cuerpo ni adjuntos)"
-                         if coverage.get("mode") == "headers_only" else "mensaje completo")
-        reasons = report.get("uncertaintyReasons") or []
-        reasons_text = (" Motivos: " + " ".join(reasons)) if reasons else ""
-        return (
-            f"\n\nCONFIANZA DEL ANÁLISIS: {label}. Cobertura: {coverage_text}.{reasons_text} "
-            "Usa exactamente esta confianza en el campo \"confidence\", no la "
-            "expreses como porcentaje y no afirmes más certeza de la que indica."
-        )
-
     def _build_user_prompt(self, report: Dict[str, Any]) -> str:
         failed_rules = [
             {
@@ -172,7 +172,7 @@ class IrisAIWriter:
             .replace("{{gate_reasons_json}}", json.dumps(report.get("gateReasons") or [], ensure_ascii=False))
             .replace("{{failed_rules_json}}", json.dumps(failed_rules, indent=2, ensure_ascii=False))
         )
-        return prompt + self._degradation_note(report) + self._confidence_note(report)
+        return prompt + self._degradation_note(report) + _confidence_note(report)
 
     def generate(self, report: Dict[str, Any]) -> dict:
         """Generate the AI narrative for a finished analysis report dict.

--- a/API/src/modules/infrastructure/unit_of_work.py
+++ b/API/src/modules/infrastructure/unit_of_work.py
@@ -47,6 +47,14 @@ from sqlalchemy.orm import Session
 
 # Re-exported for backward compatibility with the ~20 modules that import the
 # engine/session helpers from here. The definitions live in engine.py now.
+from .engine import (  # noqa: F401
+    ENGINE,
+    SESSION_FACTORY,
+    initialize,
+    get_session,
+    warmup,
+    close_all,
+)
 from .session import get_db_session
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## El problema

La rama de la Fase 2 del roadmap de Iris (`proyect/iris/roadmap/2`) no arrancaba. Tampoco podía integrarse en `v0.5` sin romper el CI. Había dos causas, y ninguna es de una iniciativa concreta de la fase:

1. **La aplicación no llegaba ni a importarse.** El commit `d932c3f4` («imports innecesarios borrados») quitó de `infrastructure/unit_of_work.py` seis nombres que ese fichero reexporta desde `engine.py`: `ENGINE`, `SESSION_FACTORY`, `initialize`, `get_session`, `warmup` y `close_all`. Un linter los marca como «importados y no usados» porque el fichero no los usa, pero existen para que otros los importen desde ahí: `scheduling.py`, `retry.py`, `job_context.py`, `worker.py`, `kb_sync.py`, `run.py` y una veintena de tests. Sin ellos, `import src.modules.infrastructure` lanza `ImportError` y con él cae la aplicación entera, y la suite no llega a recoger ningún test.

2. **El test de convenciones fallaba tras integrar `v0.5`.** `v0.5` trajo `CONVENCIONES.md` y `tests/unit/test_code_conventions.py`, un test que recorre el código y falla si aparece una violación del convenio que no esté en su inventario de excepciones conocidas. El código de M02, M05 y F16 se escribió antes de que existiera, y lo incumplía en dos puntos:
   - `iris/endpoints.py` importaba `Role` desde `users.services.permissions`, es decir, por dentro del módulo `users`. `v0.5` ya exporta `Role` en la superficie pública de `users`.
   - Cuatro métodos privados de clase no eran *ganchos*. El convenio solo permite un `_método` si una subclase lo redefine; si no, es un helper y va fuera de la clase como función de módulo. Son `IrisManager._rule_to_dict`, `IrisManager._winning_message_context`, `IrisReplayManager._ad_hoc_samples` e `IrisAIWriter._confidence_note`.

## Qué cambia

- Se revierte `d932c3f4`: `unit_of_work.py` vuelve a ser idéntico al de `v0.5`.
- `Role` se importa desde `src.modules.users`.
- Los cuatro métodos pasan a funciones de módulo con el mismo cuerpo y el mismo docstring. Solo los usaba su propia clase y ningún test los llamaba, así que fuera de esos ficheros no cambia nada.

No se añade nada al inventario de excepciones del test de convenciones: las violaciones se corrigen, no se registran.

## Validación

- Suite completa (`pytest`) sobre el revert: todo en verde salvo los dos casos de `test_code_conventions.py` que corrige el segundo commit.
- Después del segundo commit: `pytest -k "iris or conventions or caddy or import_isolation"` en verde.
- pylint no sirve de comprobación en este entorno Windows: al pasarle ficheros sueltos no resuelve los imports de `src` (`E0401`). Los avisos de longitud de línea que marca en estos ficheros ya estaban antes del cambio.

## Notas

Es un requisito previo para el resto de la Fase 2 (M03, M07, M12, F01 y F03). Sin él, ninguno de esos PRs puede pasar sus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
