### PR TITLE
feat(iris): excepciones de confianza por usuario, con caducidad y auditoría (M03)

### DIFF
--- a/API/alembic/versions/d4a8e2f6b1c7_add_iris_trusted_senders.py
+++ b/API/alembic/versions/d4a8e2f6b1c7_add_iris_trusted_senders.py
@@ -1,0 +1,51 @@
+"""iris: excepciones de confianza por usuario (IrisTrustedSender)
+
+Un falso positivo recurrente solo se podía quitar tocando la configuración
+global. Esta tabla guarda excepciones por usuario —remitente o dominio—, con
+motivo, caducidad y revocación sin borrado, y ``IrisAnalysis.trust_applied``
+deja en cada análisis el rastro de la excepción que se le aplicó.
+
+Revision ID: d4a8e2f6b1c7
+Revises: c1e5a9d3f7b2
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4a8e2f6b1c7'
+down_revision: Union[str, Sequence[str], None] = 'c1e5a9d3f7b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'IrisTrustedSender',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('kind', sa.String(length=16), nullable=False),
+        sa.Column('value', sa.String(length=320), nullable=False),
+        sa.Column('reason', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('revoked_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['User.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_iris_trusted_sender_user_id', 'IrisTrustedSender', ['user_id'])
+    op.add_column('IrisAnalysis', sa.Column('trust_applied',
+                                            postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('IrisAnalysis', 'trust_applied')
+    op.drop_index('ix_iris_trusted_sender_user_id', table_name='IrisTrustedSender')
+    op.drop_table('IrisTrustedSender')

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -36,7 +36,7 @@ import src.modules.system.config_reading as CR
 
 from .managers import (
     IrisFeedbackManager, IrisManager, IrisReportManager, IrisMailboxManager,
-    IrisNotificationPreferenceManager, IrisReplayManager,
+    IrisNotificationPreferenceManager, IrisReplayManager, IrisTrustPolicyManager,
 )
 from .exceptions import (
     IrisAnalysisNotFoundError,
@@ -44,6 +44,7 @@ from .exceptions import (
     IrisInvalidInputError,
     IrisMailboxConnectionNotFoundError,
     IrisMailboxOAuthStateError,
+    IrisTrustedSenderNotFoundError,
 )
 from .schemas import (
     AnalysisIdQuerySchema,
@@ -87,6 +88,10 @@ from .schemas import (
     IrisFeedbackMetricsResponseSchema,
     IrisReplayRequestSchema,
     IrisReplayResponseSchema,
+    IrisTrustedSenderItemSchema,
+    IrisTrustedSenderListResponseSchema,
+    IrisTrustedSenderRequestSchema,
+    IrisTrustedSendersQuerySchema,
 )
 
 
@@ -223,6 +228,59 @@ def get_feedback_metrics():
     """Precisión, recall, cobertura y desacuerdo del detector según tus correcciones"""
     user = get_current_user()
     return IrisFeedbackManager().get_metrics(user.id)
+
+
+@iris_blp.get("/trusted-senders")
+@iris_blp.arguments(IrisTrustedSendersQuerySchema, location="query")
+@iris_blp.response(200, IrisTrustedSenderListResponseSchema, description="Trusted-sender exceptions")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(logger=logger)
+def list_trusted_senders(args: dict):
+    """Excepciones de confianza del usuario (con includeInactive, también caducadas y revocadas)"""
+    user = get_current_user()
+    entries = IrisTrustPolicyManager().list_entries(user.id, args["includeInactive"])
+    return {"trustedSenders": entries, "total": len(entries)}
+
+
+@iris_blp.post("/trusted-senders")
+@iris_blp.arguments(IrisTrustedSenderRequestSchema)
+@iris_blp.response(201, IrisTrustedSenderItemSchema, description="Trusted-sender exception created")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Invalid value or duplicate exception")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_CREATE])
+@limiter.limit("60 per hour; 300 per day")
+@handle_exceptions(default_exception=IrisExecutionError, logger=logger)
+def create_trusted_sender(data):
+    """Declarar un remitente o dominio de confianza para los próximos análisis del usuario"""
+    user = get_current_user()
+    entry = IrisTrustPolicyManager().create_entry(
+        user.id, data["kind"], data["value"], data["reason"], data.get("expiresInDays"),
+    )
+    logger.info(f"Excepción de confianza {entry['trustedSenderId']} creada por {user.username}")
+    return entry
+
+
+@iris_blp.delete("/trusted-senders/<int:trusted_sender_id>")
+@iris_blp.response(200, IrisTrustedSenderItemSchema, description="Trusted-sender exception revoked")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Exception not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_DELETE])
+@limiter.limit("60 per hour; 300 per day")
+@handle_exceptions(default_exception=IrisTrustedSenderNotFoundError, logger=logger)
+def revoke_trusted_sender(trusted_sender_id: int):
+    """Revocar una excepción de confianza; no se borra, queda en la auditoría"""
+    user = get_current_user()
+    entry = IrisTrustPolicyManager().revoke_entry(trusted_sender_id, user.id)
+    logger.info(f"Excepción de confianza {trusted_sender_id} revocada por {user.username}")
+    return entry
 
 
 @iris_blp.get("/retention-policy")

--- a/API/src/modules/features/iris/exceptions.py
+++ b/API/src/modules/features/iris/exceptions.py
@@ -90,6 +90,17 @@ class IrisMailboxConnectionNotFoundError(EntityNotFoundError, IrisError):
     id_field = "connection_id"
 
 
+class IrisTrustedSenderNotFoundError(EntityNotFoundError, IrisError):
+    """La excepción de confianza no existe o no es del usuario.
+
+    El mismo error para los dos casos, como el resto de entidades de Iris,
+    para que no se puedan enumerar ids ajenos.
+    """
+    entity_label = "Excepción de confianza"
+    entity_is_feminine = True
+    id_field = "trusted_sender_id"
+
+
 class IrisMailboxInvalidProviderError(IrisError):
     """Raised when connecting to an unsupported mailbox provider."""
     default_code = ErrorCode.VALIDATION_ERROR

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -16,6 +16,8 @@ Managers del módulo Iris (análisis de correo).
   métricas del detector calculadas a partir de ellas.
 - ``IrisReplayManager`` (``replay.py``): simulador de reglas para
   administradores — compara políticas de puntuación sobre el corpus.
+- ``IrisTrustPolicyManager`` (``trust.py``): excepciones de confianza por
+  usuario (remitentes y dominios), con motivo, caducidad y revocación.
 
 Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el
@@ -36,9 +38,11 @@ from .mailbox import IrisMailboxManager
 from .notifications import IrisPhishingNotifyManager, IrisNotificationPreferenceManager
 from .feedback import IrisFeedbackManager
 from .replay import IrisReplayManager
+from .trust import IrisTrustPolicyManager
 
 __all__ = [
     "IrisManager",
+    "IrisTrustPolicyManager",
     "IrisFeedbackManager",
     "IrisReplayManager",
     "IrisReportManager",

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -71,7 +71,16 @@ from ..services.quality import (
     detector_version,
 )
 from ..services.ai_writer import IrisAIWriter
+from ..services.trust import (
+    TrustEntry,
+    apply_trust,
+    build_trust_record,
+    describe_trust_record,
+    find_matching_entry,
+    is_sender_authenticated,
+)
 from .notifications import IrisPhishingNotifyManager
+from .trust import IrisTrustPolicyManager
 
 
 logger = logging.getLogger(__name__)
@@ -484,6 +493,7 @@ class IrisManager(TaskTrackingMixin):
             "rules": rules_data,
             "recommendations": recommendations,
             "latestFeedback": latest_feedback,
+            "trustApplied": analysis.trust_applied,
         }
 
     @classmethod
@@ -1111,8 +1121,14 @@ class IrisManager(TaskTrackingMixin):
                 # La política se fija una vez por análisis y se guarda con él:
                 # un cambio de configuración a mitad no mezcla dos versiones.
                 policy = current_policy()
+                # Las excepciones de confianza del dueño se leen una vez por
+                # análisis, igual que la política: revocar una a mitad no
+                # mezcla dos criterios sobre el mismo mensaje.
+                owner = self.get_analysis(analysis_id)
+                trust_entries = IrisTrustPolicyManager.get_active_entries(owner.user_id) if owner else []
                 with CR.scoring_weight_overrides(policy.weight_overrides):
-                    evaluations = self._evaluate_contexts(analysis_id, context, job, rules_defs, policy)
+                    evaluations = self._evaluate_contexts(analysis_id, context, job, rules_defs, policy,
+                                                          trust_entries)
 
                 if evaluations is None:
                     return  # cancelado: no es un fallo, no hay nada que persistir
@@ -1230,7 +1246,8 @@ class IrisManager(TaskTrackingMixin):
         }
 
     def _evaluate_contexts(self, analysis_id: Optional[int], context, job, rules_defs: List[dict],
-                           policy: Optional[ScoringPolicy] = None) -> Optional[List[ContextEvaluation]]:
+                           policy: Optional[ScoringPolicy] = None,
+                           trust_entries: Optional[List[TrustEntry]] = None) -> Optional[List[ContextEvaluation]]:
         """Ejecuta el catálogo de reglas sobre cada contexto del mensaje.
 
         Vive aparte de :meth:`_run_analysis` para que el ``try`` de ciclo de
@@ -1248,6 +1265,9 @@ class IrisManager(TaskTrackingMixin):
                 progreso que informar.
             rules_defs: Catálogo de reglas, leído una sola vez por análisis.
             policy: Política con que se puntúa y decide. Por defecto ``None``: la vigente.
+            trust_entries: Excepciones de confianza activas del dueño del
+                análisis (ver ``services/trust.py``). Por defecto ``None``:
+                ninguna, que es lo que usan el replay y las comparaciones.
 
         Returns:
             Optional[List[ContextEvaluation]]: Una evaluación por contexto,
@@ -1311,6 +1331,20 @@ class IrisManager(TaskTrackingMixin):
                 if job is not None:
                     job.progress(int((completed_steps / total_steps) * 100))
 
+            # Una excepción de confianza del usuario solo se aplica si el
+            # mensaje demuestra venir de ese remitente, y solo neutraliza las
+            # reglas que cubre: se resuelve antes de puntuar y de los gates
+            # para que ni el score ni los gates de esas reglas la ignoren.
+            trust_record = None
+            trust_entry = find_matching_entry(evaluated_context.headers, trust_entries or [])
+            if trust_entry is not None:
+                is_applied = is_sender_authenticated(named_results)
+                modulated_rules: List[str] = []
+                if is_applied:
+                    results, modulated_rules = apply_trust(rules_defs, results, trust_entry)
+                    named_results = {rule_def["name"]: result for rule_def, result in zip(rules_defs, results)}
+                trust_record = build_trust_record(trust_entry, modulated_rules, is_applied)
+
             total_score = policy.aggregate(rules_defs, results)
             base_verdict = policy.verdict_for(total_score)
             verdict, gate_reasons = self._apply_verdict_gates(base_verdict, named_results)
@@ -1324,8 +1358,12 @@ class IrisManager(TaskTrackingMixin):
             verdict, quality_reasons = cap_verdict(verdict, quality)
             evaluations.append(ContextEvaluation(
                 context_type=context_type, verdict=verdict, total_score=total_score,
-                gate_reasons=gate_reasons + quality_reasons, results=results, quality=quality,
+                gate_reasons=gate_reasons + quality_reasons + (
+                    [describe_trust_record(trust_record)] if trust_record else []
+                ),
+                results=results, quality=quality,
                 coverage=assess_coverage(evaluated_context, rules_defs),
+                trust_applied=trust_record,
             ))
 
         return evaluations
@@ -1409,6 +1447,7 @@ class IrisManager(TaskTrackingMixin):
                 failed_rules=winner.quality.failed_rules or None, detector_version=detector,
                 winning_context=winner.context_type, winning_reason=winning_reason,
                 secondary_context=secondary_summary,
+                trust_applied=winner.trust_applied,
                 confidence=confidence.level if confidence else None,
                 coverage=winner.coverage or None,
                 uncertainty_reasons=confidence.reasons if confidence else None,

--- a/API/src/modules/features/iris/managers/trust.py
+++ b/API/src/modules/features/iris/managers/trust.py
@@ -1,0 +1,187 @@
+"""
+IrisTrustPolicyManager — excepciones de confianza por usuario.
+
+Permite a un usuario reducir un falso positivo recurrente sin tocar la
+configuración global: declara un remitente o un dominio de confianza, con
+motivo y caducidad. Las excepciones **no se borran**: revocar una la marca con
+``revoked_at`` y la deja en el listado, para que la auditoría conserve qué
+excepciones existieron, hasta cuándo y por qué. Cada análisis al que se aplica
+guarda además su propio rastro (``IrisAnalysis.trust_applied``).
+
+Qué hace una excepción al analizar un mensaje lo decide
+``services/trust.py``; este manager solo gestiona su ciclo de vida.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from src.modules.infrastructure import UnitOfWork, build_repository
+from src.modules.shared import assert_owned, isoformat_utc, utcnow_naive
+
+from ..exceptions import IrisInvalidInputError, IrisTrustedSenderNotFoundError
+from ..model import IrisTrustedSender, TrustKind
+from ..repositories import IrisTrustedSenderRepository
+from ..services.trust import (
+    DEFAULT_TRUST_EXPIRY_DAYS,
+    MAX_TRUST_EXPIRY_DAYS,
+    MAX_TRUST_REASON_LENGTH,
+    TrustEntry,
+    normalize_trust_value,
+)
+
+
+def _status_of(entry: IrisTrustedSender, now: datetime) -> str:
+    """Estado de una excepción en un instante dado.
+
+    Args:
+        entry: Fila ``IrisTrustedSender``.
+        now: Instante de referencia (UTC naive).
+
+    Returns:
+        str: ``revoked`` si se revocó (aunque además haya caducado),
+            ``expired`` si pasó su caducidad, o ``active``.
+    """
+    if entry.revoked_at is not None:
+        return "revoked"
+    if entry.expires_at <= now:
+        return "expired"
+    return "active"
+
+
+class IrisTrustPolicyManager:
+    """Alta, consulta y revocación de las excepciones de confianza de un usuario."""
+
+    @staticmethod
+    def entry_to_dict(entry: IrisTrustedSender, now: Optional[datetime] = None) -> Dict[str, Any]:
+        """Serializa una excepción con las claves camelCase de la API.
+
+        Args:
+            entry: Fila ``IrisTrustedSender``.
+            now: Instante con el que calcular ``status``. Por defecto ``None``:
+                el actual.
+
+        Returns:
+            dict: ``trustedSenderId``, ``kind``, ``value``, ``reason``,
+                ``status`` (``active``, ``expired`` o ``revoked``),
+                ``createdAt``, ``expiresAt`` y ``revokedAt``.
+        """
+        return {
+            "trustedSenderId": entry.id,
+            "kind": entry.kind,
+            "value": entry.value,
+            "reason": entry.reason,
+            "status": _status_of(entry, now or utcnow_naive()),
+            "createdAt": isoformat_utc(entry.created_at),
+            "expiresAt": isoformat_utc(entry.expires_at),
+            "revokedAt": isoformat_utc(entry.revoked_at),
+        }
+
+    def create_entry(self, user_id: int, kind: str, value: str, reason: str,
+                     expires_in_days: Optional[int] = None) -> Dict[str, Any]:
+        """Crea una excepción de confianza para un usuario.
+
+        Args:
+            user_id: Usuario al que se aplica; también es quien la crea.
+            kind: ``sender`` (una dirección exacta) o ``domain`` (el dominio
+                del ``From`` y sus subdominios).
+            value: Dirección o dominio; se normaliza con
+                ``services/trust.normalize_trust_value``.
+            reason: Por qué se confía en él. Obligatorio: sin motivo, la
+                auditoría no sirve para nada. Se recorta a
+                ``MAX_TRUST_REASON_LENGTH`` caracteres.
+            expires_in_days: Días hasta que caduca, entre 1 y
+                ``MAX_TRUST_EXPIRY_DAYS``. Por defecto ``None``:
+                ``DEFAULT_TRUST_EXPIRY_DAYS``.
+
+        Returns:
+            dict: La excepción creada (ver ``entry_to_dict``).
+
+        Raises:
+            IrisInvalidInputError: Si el tipo, el valor, el motivo o la
+                caducidad no son válidos, o si ya hay una excepción activa
+                para el mismo valor.
+        """
+        if kind not in {member.value for member in TrustKind}:
+            raise IrisInvalidInputError(f"Tipo de excepción desconocido: {kind!r}.")
+        try:
+            normalized = normalize_trust_value(kind, value)
+        except ValueError as e:
+            raise IrisInvalidInputError(str(e), user_message=str(e)) from e
+        cleaned_reason = (reason or "").strip()[:MAX_TRUST_REASON_LENGTH]
+        if not cleaned_reason:
+            raise IrisInvalidInputError("La excepción necesita un motivo.",
+                                        user_message="La excepción necesita un motivo.")
+        days = DEFAULT_TRUST_EXPIRY_DAYS if expires_in_days is None else expires_in_days
+        if not 1 <= days <= MAX_TRUST_EXPIRY_DAYS:
+            message = f"La caducidad debe estar entre 1 y {MAX_TRUST_EXPIRY_DAYS} días."
+            raise IrisInvalidInputError(message, user_message=message)
+
+        now = utcnow_naive()
+        with UnitOfWork() as uow:
+            repo = IrisTrustedSenderRepository(uow)
+            if repo.has_active(user_id, kind, normalized, now):
+                message = f"Ya tienes una excepción activa para {normalized}."
+                raise IrisInvalidInputError(message, user_message=message)
+            entry = repo.save(IrisTrustedSender(
+                user_id=user_id, kind=kind, value=normalized, reason=cleaned_reason,
+                created_at=now, expires_at=now + timedelta(days=days),
+            ))
+            return self.entry_to_dict(entry, now)
+
+    def list_entries(self, user_id: int, include_inactive: bool = False) -> List[Dict[str, Any]]:
+        """Excepciones de un usuario, de la más reciente a la más antigua.
+
+        Args:
+            user_id: Dueño de las excepciones.
+            include_inactive: Si ``True``, incluye también las caducadas y las
+                revocadas: es la vista de auditoría. Por defecto ``False``.
+
+        Returns:
+            List[dict]: Las excepciones (ver ``entry_to_dict``).
+        """
+        now = utcnow_naive()
+        entries = build_repository(IrisTrustedSenderRepository).get_by_user(user_id)
+        serialized = [self.entry_to_dict(entry, now) for entry in entries]
+        if include_inactive:
+            return serialized
+        return [entry for entry in serialized if entry["status"] == "active"]
+
+    def revoke_entry(self, entry_id: int, user_id: int) -> Dict[str, Any]:
+        """Revoca una excepción sin borrarla.
+
+        Revocar dos veces no es un error: la segunda vez devuelve la excepción
+        tal como quedó, con su fecha de revocación original.
+
+        Args:
+            entry_id: Excepción a revocar; debe ser del usuario.
+            user_id: Usuario que revoca.
+
+        Returns:
+            dict: La excepción ya revocada (ver ``entry_to_dict``).
+
+        Raises:
+            IrisTrustedSenderNotFoundError: Si no existe o no es suya.
+        """
+        with UnitOfWork() as uow:
+            entry = assert_owned(IrisTrustedSenderRepository, entry_id, user_id,
+                                 IrisTrustedSenderNotFoundError, uow=uow)
+            if entry.revoked_at is None:
+                entry.revoked_at = utcnow_naive()
+                IrisTrustedSenderRepository(uow).update(entry)
+            return self.entry_to_dict(entry)
+
+    @staticmethod
+    def get_active_entries(user_id: int) -> List[TrustEntry]:
+        """Excepciones que el motor de análisis debe tener en cuenta ahora.
+
+        Args:
+            user_id: Dueño del análisis.
+
+        Returns:
+            List[TrustEntry]: Las no revocadas y no caducadas; lista vacía si
+                no tiene ninguna.
+        """
+        rows = build_repository(IrisTrustedSenderRepository).get_active_for_user(user_id, utcnow_naive())
+        return [TrustEntry(id=row.id, kind=row.kind, value=row.value, reason=row.reason) for row in rows]

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -8,6 +8,7 @@ the output of every individual rule that was executed during the analysis.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Optional
 
 from sqlalchemy import (
@@ -93,6 +94,13 @@ class IrisAnalysis(Base):
                  (``contextType``, ``verdict``, ``totalScore``,
                  ``analysisQuality``); NULL cuando no hubo reenvío. Sus
                  reglas están en ``IrisRuleResult`` con su ``context_type``.
+        trust_applied: Rastro de la excepción de confianza del usuario que
+                 coincidió con el remitente del contexto ganador:
+                 ``entryId``, ``kind``, ``value``, ``reason``, ``applied``
+                 (``False`` si el mensaje no demostró venir de ese remitente)
+                 y ``modulatedRules``. Se guarda aunque la excepción se
+                 revoque después: es la auditoría de por qué este veredicto es
+                 el que es. NULL si ninguna excepción coincidió.
         failure_code: Why a ``failed`` analysis failed — "invalid_input"
                  (the submitted text is not an analysable message) or
                  "internal_error" (the pipeline broke). NULL for every
@@ -159,6 +167,7 @@ class IrisAnalysis(Base):
     winning_context = Column(String(16), nullable=True)
     winning_reason = Column(Text, nullable=True)
     secondary_context = Column(JSONB, nullable=True)
+    trust_applied = Column(JSONB, nullable=True)
     failure_code = Column(String(32), nullable=True)
     failure_reason = Column(Text, nullable=True)
     ai_summary = Column(JSONB, nullable=True)
@@ -672,3 +681,61 @@ class IrisNotificationPreference(Base):
     updated_at = Column(DateTime, nullable=False, default=utcnow_naive, onupdate=utcnow_naive)
 
     user = relationship("User")
+
+
+class TrustKind(StrEnum):
+    """Qué cubre una excepción de confianza (``IrisTrustedSender.kind``).
+
+    Attributes:
+        SENDER: Una dirección exacta del ``From``.
+        DOMAIN: El dominio del ``From`` y todos sus subdominios.
+    """
+    SENDER = "sender"
+    DOMAIN = "domain"
+
+
+class IrisTrustedSender(Base):
+    """Excepción de confianza de un usuario: un remitente o un dominio del que
+    no quiere seguir recibiendo el mismo falso positivo.
+
+    Es por usuario a propósito, no por organización: una organización comparte
+    plan y factura, no datos (ver ``Organization``), e Iris analiza correo
+    personal; una excepción declarada por el dueño cambiaría los veredictos del
+    correo de sus miembros.
+
+    No se borra al revocarse: ``revoked_at`` la desactiva y la fila queda para
+    la auditoría. Qué hace al analizar un mensaje lo decide
+    ``services/trust.py``: solo se aplica si el mensaje demuestra venir de ahí,
+    y solo neutraliza señales de redacción y de forma, nunca las de
+    autenticación, adjuntos o enlaces.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        user_id: FK al ``User`` dueño, que es también quien la creó;
+                 ``ondelete="CASCADE"``.
+        kind: ``TrustKind``: ``sender`` o ``domain``.
+        value: Dirección o dominio, normalizado en minúsculas (ver
+                 ``services/trust.normalize_trust_value``).
+        reason: Por qué se confía en él; obligatorio.
+        created_at: Cuándo se creó.
+        expires_at: Cuándo deja de aplicarse; como mucho
+                 ``services/trust.MAX_TRUST_EXPIRY_DAYS`` después de crearse.
+        revoked_at: Cuándo se revocó; NULL si no se ha revocado.
+        user: Relación al ``User`` dueño.
+    """
+    __tablename__ = "IrisTrustedSender"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("User.id", ondelete="CASCADE"), nullable=False)
+    kind = Column(String(16), nullable=False)
+    value = Column(String(320), nullable=False)
+    reason = Column(Text, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    expires_at = Column(DateTime, nullable=False)
+    revoked_at = Column(DateTime, nullable=True)
+
+    user = relationship("User")
+
+    __table_args__ = (
+        Index("ix_iris_trusted_sender_user_id", "user_id"),
+    )

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -19,7 +19,7 @@ from src.modules.shared import utcnow_naive
 from .model import (
     IrisAnalystFeedback,
     IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox, IrisNotificationPreference,
-    IrisRawMessage, IrisRuleResult, IrisDocument,
+    IrisRawMessage, IrisRuleResult, IrisDocument, IrisTrustedSender,
 )
 
 
@@ -641,6 +641,80 @@ class IrisNotificationPreferenceRepository(BaseRepository[IrisNotificationPrefer
             )
             .all()
         )
+
+
+class IrisTrustedSenderRepository(BaseRepository[IrisTrustedSender]):
+    """Acceso a las excepciones de confianza (``IrisTrustedSender``).
+
+    Las filas no se borran al revocarse: la auditoría necesita las caducadas y
+    las revocadas tanto como las activas.
+    """
+
+    _MODEL = IrisTrustedSender
+
+    def get_by_user(self, user_id: int) -> List[IrisTrustedSender]:
+        """Todas las excepciones de un usuario, de la más reciente a la más antigua.
+
+        Args:
+            user_id: Dueño de las excepciones.
+
+        Returns:
+            List[IrisTrustedSender]: Activas, caducadas y revocadas; lista
+                vacía si no tiene ninguna.
+        """
+        return (
+            self._session.query(IrisTrustedSender)
+            .filter(IrisTrustedSender.user_id == user_id)
+            .order_by(IrisTrustedSender.id.desc())
+            .all()
+        )
+
+    def get_active_for_user(self, user_id: int, now: datetime) -> List[IrisTrustedSender]:
+        """Excepciones de un usuario que siguen en vigor en un instante.
+
+        Args:
+            user_id: Dueño de las excepciones.
+            now: Instante de referencia (UTC naive).
+
+        Returns:
+            List[IrisTrustedSender]: Las no revocadas cuya caducidad es
+                posterior a ``now``.
+        """
+        return (
+            self._session.query(IrisTrustedSender)
+            .filter(
+                IrisTrustedSender.user_id == user_id,
+                IrisTrustedSender.revoked_at.is_(None),
+                IrisTrustedSender.expires_at > now,
+            )
+            .order_by(IrisTrustedSender.id.asc())
+            .all()
+        )
+
+    def has_active(self, user_id: int, kind: str, value: str, now: datetime) -> bool:
+        """Si el usuario ya tiene en vigor una excepción idéntica.
+
+        Args:
+            user_id: Dueño de las excepciones.
+            kind: ``sender`` o ``domain``.
+            value: Valor ya normalizado.
+            now: Instante de referencia (UTC naive).
+
+        Returns:
+            bool: ``True`` si hay una no revocada y no caducada con ese tipo y
+                valor.
+        """
+        return (
+            self._session.query(IrisTrustedSender.id)
+            .filter(
+                IrisTrustedSender.user_id == user_id,
+                IrisTrustedSender.kind == kind,
+                IrisTrustedSender.value == value,
+                IrisTrustedSender.revoked_at.is_(None),
+                IrisTrustedSender.expires_at > now,
+            )
+            .first()
+        ) is not None
 
 
 class IrisReportRepository(DocumentRepository[IrisDocument]):

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -11,7 +11,9 @@ import src.modules.system.config_reading as CR
 from src.modules.shared import UTCDateTime
 
 from .services.feedback_metrics import FEEDBACK_LABELS
+from .model import TrustKind
 from .services.scoring import PROFILE_THRESHOLD_OFFSETS
+from .services.trust import MAX_TRUST_EXPIRY_DAYS, MAX_TRUST_REASON_LENGTH
 
 
 class AnalyzeRequestSchema(Schema):
@@ -327,6 +329,7 @@ class AnalysisDetailResponseSchema(Schema):
     rules = fields.List(fields.Nested(RuleResultSchema))
     recommendations = fields.List(fields.String())
     latestFeedback = fields.Nested(IrisFeedbackItemSchema, load_default=None, allow_none=True)
+    trustApplied = fields.Dict(load_default=None, allow_none=True)
 
 
 class AnalysisListItemSchema(Schema):
@@ -753,3 +756,47 @@ class IrisReplayResponseSchema(Schema):
     policies = fields.Dict()
     samples = fields.List(fields.Dict())
     changedCount = fields.Integer()
+
+
+class IrisTrustedSenderRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/trusted-senders``.
+
+    ``kind`` es ``sender`` (una dirección exacta) o ``domain`` (el dominio del
+    ``From`` y sus subdominios). ``reason`` es obligatorio: queda en la
+    auditoría. ``expiresInDays`` va de 1 a 365; por defecto, 90.
+    """
+    kind = fields.String(required=True, validate=validate.OneOf([kind.value for kind in TrustKind]))
+    value = fields.String(required=True, validate=validate.Length(min=3, max=320))
+    reason = fields.String(required=True, validate=validate.Length(min=1, max=MAX_TRUST_REASON_LENGTH))
+    expiresInDays = fields.Integer(load_default=None, allow_none=True,
+                                   validate=validate.Range(min=1, max=MAX_TRUST_EXPIRY_DAYS))
+
+
+class IrisTrustedSendersQuerySchema(Schema):
+    """Parámetros de ``GET /iris/trusted-senders``.
+
+    Con ``includeInactive`` se listan también las caducadas y las revocadas
+    (vista de auditoría); por defecto solo las activas.
+    """
+    includeInactive = fields.Boolean(load_default=False)
+
+
+class IrisTrustedSenderItemSchema(Schema):
+    """Una excepción de confianza: qué cubre, por qué, y si sigue en vigor.
+
+    ``status`` es ``active``, ``expired`` o ``revoked``.
+    """
+    trustedSenderId = fields.Integer()
+    kind = fields.String()
+    value = fields.String()
+    reason = fields.String()
+    status = fields.String()
+    createdAt = fields.String()
+    expiresAt = fields.String()
+    revokedAt = fields.String(allow_none=True)
+
+
+class IrisTrustedSenderListResponseSchema(Schema):
+    """Excepciones de confianza del usuario, de la más reciente a la más antigua."""
+    trustedSenders = fields.List(fields.Nested(IrisTrustedSenderItemSchema))
+    total = fields.Integer()

--- a/API/src/modules/features/iris/services/contexts.py
+++ b/API/src/modules/features/iris/services/contexts.py
@@ -54,6 +54,10 @@ class ContextEvaluation:
         coverage: Cobertura de este contexto (``mode`` y ``uncoveredRules``,
             ver ``services/quality.assess_coverage``). Por defecto un dict
             vacío, que se lee como "sin información de cobertura".
+        trust_applied: Rastro de la excepción de confianza que coincidió con
+            el remitente de este contexto (ver
+            ``services/trust.build_trust_record``), se aplicara o no. Por
+            defecto ``None``: ninguna excepción coincidió.
     """
 
     context_type: str
@@ -63,6 +67,7 @@ class ContextEvaluation:
     results: List[Any]
     quality: Any
     coverage: Dict[str, Any] = field(default_factory=dict)
+    trust_applied: Dict[str, Any] | None = None
 
 
 def choose_winning_evaluation(

--- a/API/src/modules/features/iris/services/trust.py
+++ b/API/src/modules/features/iris/services/trust.py
@@ -1,0 +1,275 @@
+"""
+Excepciones de confianza por usuario: remitentes y dominios de confianza.
+
+Un falso positivo recurrente —el boletín de un proveedor que siempre usa un
+``Reply-To`` distinto, la alerta de un banco que siempre dice «urgente»— solo
+se podía quitar tocando la configuración global, que afecta a toda la
+instalación. Una excepción de confianza lo quita para **un** usuario, con
+motivo y caducidad, y deja rastro en cada análisis al que se aplica.
+
+Dos reglas de diseño que este módulo hace cumplir y que no se relajan:
+
+- **Solo se aplica a correo que demuestra venir de ese remitente.** Coincidir
+  con el ``From`` no basta: el ``From`` lo escribe cualquiera. Hace falta que
+  DMARC pase **y** que la cabecera ``Authentication-Results`` que lo afirma la
+  haya escrito un servidor por encima de la frontera de confianza de la cadena
+  ``Received`` (regla «Auth Results Provenance», ver ``services/auth_trust.py``).
+  Sin eso, la excepción se ignora y el análisis dice por qué.
+- **Solo modula las señales que cubre.** Una excepción dice «conozco a este
+  remitente y sé que escribe así»; responde a las heurísticas de lenguaje y de
+  forma que un remitente legítimo dispara (``TRUST_MODULATED_RULES``). Nunca
+  toca la autenticación, los adjuntos, los enlaces (incluidos los *cloaked* y
+  los QR), las suplantaciones de dominio ni las falsificaciones estructurales:
+  esas reglas no están en la lista, así que sus gates siguen disparando.
+
+Módulo puro: sin base de datos ni red. El manager le pasa las excepciones
+activas ya cargadas como ``TrustEntry``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .text import extract_domain
+
+#: Reglas cuya penalización puede neutralizar una excepción de confianza.
+#:
+#: Son las que un remitente legítimo conocido dispara por su forma de escribir
+#: o de enviar: lenguaje de urgencia, saludos genéricos, enlaces de
+#: seguimiento, un ``Reply-To`` o un ``Return-Path`` en otro dominio. Quedan
+#: fuera a propósito la familia ``auth``, la familia ``attachment``, la familia
+#: ``links`` (enlaces *cloaked*, QR, dominios comprometidos), las suplantaciones
+#: (dominios parecidos, marca en subdominio, dirección en el nombre visible),
+#: las evasiones Unicode y de *encoded-word*, las falsificaciones de hilo y de
+#: cadena ``Received``, y los patrones de fraude (BEC, TOAD): una cuenta de
+#: confianza comprometida es justo el caso en que esas señales importan.
+TRUST_MODULATED_RULES = frozenset({
+    "Alarming Keywords",
+    "Body Content",
+    "Generic Greeting",
+    "URL in Subject",
+    "External Login Link",
+    "External Image Tracking",
+    "Reply-To check",
+    "Reply-To Free Provider",
+    "Return-Path mismatch",
+    "From Reply-To Return-Path Triangulation",
+    "Display Name Email Mismatch",
+    "Suspicious TLD",
+    "Misspelled Brand Names",
+    "Message-ID Domain",
+    "Undisclosed Recipients",
+})
+
+#: ``verdict`` que recibe una regla neutralizada por una excepción. El
+#: veredicto y el score originales viajan en ``details["trustOverride"]``.
+TRUST_OVERRIDE_VERDICT = "trusted"
+
+#: Caducidad por defecto de una excepción, en días.
+DEFAULT_TRUST_EXPIRY_DAYS = 90
+
+#: Caducidad máxima de una excepción, en días. Es código y no configuración a
+#: propósito: una excepción sin fin es un bypass permanente que nadie vuelve a
+#: revisar, y esa garantía no debe poder rebajarse desde ``SecOpsConfig.json``.
+MAX_TRUST_EXPIRY_DAYS = 365
+
+#: Longitud máxima del motivo de una excepción.
+MAX_TRUST_REASON_LENGTH = 500
+
+_ANGLE_ADDRESS_RE = re.compile(r"<\s*([^<>@\s]+@[^<>\s]+?)\s*>")
+_BARE_ADDRESS_RE = re.compile(r"[\w.+'-]+@[\w-]+(?:\.[\w-]+)+")
+_DOMAIN_RE = re.compile(r"^(?=.{3,253}$)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$")
+
+
+@dataclass(frozen=True)
+class TrustEntry:
+    """Una excepción de confianza activa, reducida a lo que el motor necesita.
+
+    Attributes:
+        id: Primary key de la fila ``IrisTrustedSender``.
+        kind: ``sender`` (una dirección exacta) o ``domain`` (el dominio del
+            ``From`` y sus subdominios).
+        value: Dirección o dominio ya normalizado (ver
+            ``normalize_trust_value``).
+        reason: Motivo que escribió el usuario al crearla.
+    """
+
+    id: int
+    kind: str
+    value: str
+    reason: str
+
+
+def normalize_trust_value(kind: str, value: str) -> str:
+    """Normaliza y valida el valor de una excepción antes de guardarla.
+
+    Args:
+        kind: ``sender`` o ``domain``.
+        value: Lo que escribió el usuario. Para ``sender``, una dirección
+            (``nombre@dominio.tld``, admite ``Nombre <dir>``); para ``domain``,
+            un dominio (se quita un ``@`` inicial si lo trae).
+
+    Returns:
+        str: El valor en minúsculas y sin espacios: la dirección sola, o el
+            dominio sin punto final.
+
+    Raises:
+        ValueError: Si ``kind`` no es uno de los dos, o si el valor no tiene
+            forma de dirección o de dominio. El mensaje es apto para el usuario.
+    """
+    cleaned = (value or "").strip().lower()
+    if kind == "sender":
+        address = sender_address(cleaned)
+        if not address:
+            raise ValueError("El remitente debe ser una dirección de correo (nombre@dominio).")
+        return address
+    if kind == "domain":
+        domain = cleaned.lstrip("@").rstrip(".")
+        if not _DOMAIN_RE.match(domain):
+            raise ValueError("El dominio no es válido (ejemplo: proveedor.com).")
+        return domain
+    raise ValueError(f"Tipo de excepción desconocido: {kind!r}.")
+
+
+def sender_address(from_header: str) -> Optional[str]:
+    """Dirección de correo de un valor de cabecera ``From``.
+
+    Prefiere la dirección entre ángulos (``"Nombre" <dir>``) porque el nombre
+    visible puede contener otra dirección escrita a mano para engañar.
+
+    Args:
+        from_header: Valor crudo de la cabecera, o una dirección suelta.
+
+    Returns:
+        Optional[str]: La dirección en minúsculas, o ``None`` si no hay ninguna.
+    """
+    text = from_header or ""
+    match = _ANGLE_ADDRESS_RE.search(text) or _BARE_ADDRESS_RE.search(text)
+    return match.group(1 if match.re is _ANGLE_ADDRESS_RE else 0).lower() if match else None
+
+
+def find_matching_entry(headers: Mapping[str, Any], entries: Sequence[TrustEntry]) -> Optional[TrustEntry]:
+    """Excepción que cubre el remitente de un mensaje, si alguna lo hace.
+
+    Una excepción de dirección gana a una de dominio: es la más específica, y
+    su motivo describe mejor este mensaje.
+
+    Args:
+        headers: Cabeceras parseadas del mensaje evaluado (claves en minúscula).
+        entries: Excepciones activas del usuario.
+
+    Returns:
+        Optional[TrustEntry]: La que coincide con el ``From``, o ``None``.
+    """
+    address = sender_address(str(headers.get("from") or ""))
+    if not address:
+        return None
+    domain = extract_domain(address) or ""
+    by_address = [entry for entry in entries if entry.kind == "sender" and entry.value == address]
+    if by_address:
+        return by_address[0]
+    for entry in entries:
+        if entry.kind == "domain" and (domain == entry.value or domain.endswith("." + entry.value)):
+            return entry
+    return None
+
+
+def is_sender_authenticated(named_results: Mapping[str, Any]) -> bool:
+    """¿Demuestra el mensaje venir del dominio de su ``From``?
+
+    DMARC en ``pass`` ata SPF o DKIM al dominio visible; «Auth Results
+    Provenance» en ``pass`` garantiza que esa afirmación la escribió un
+    verificador por encima de la frontera de confianza y no el propio
+    remitente. Hacen falta las dos.
+
+    Args:
+        named_results: ``RuleResult`` por nombre de regla del contexto evaluado.
+
+    Returns:
+        bool: ``True`` solo si las dos reglas pasaron.
+    """
+    dmarc = named_results.get("DMARC")
+    provenance = named_results.get("Auth Results Provenance")
+    return (dmarc is not None and dmarc.verdict == "pass"
+            and provenance is not None and provenance.verdict == "pass")
+
+
+def apply_trust(rules_defs: Sequence[dict], results: Sequence[Any],
+                entry: TrustEntry) -> Tuple[List[Any], List[str]]:
+    """Neutraliza las penalizaciones que cubre una excepción de confianza.
+
+    Cada regla de ``TRUST_MODULATED_RULES`` que penalizó pasa a score ``0`` y
+    veredicto ``trusted``, así que ni resta puntos ni dispara su gate; su
+    veredicto y su score originales quedan en ``details["trustOverride"]`` para
+    que el informe diga qué se neutralizó y por qué. «Body Content» con texto
+    oculto no se toca: esconder texto es evasión, no un estilo de redacción.
+
+    Args:
+        rules_defs: Catálogo evaluado, emparejado por posición con ``results``.
+        results: Un ``RuleResult`` por regla.
+        entry: Excepción que se aplica.
+
+    Returns:
+        Tuple[List[RuleResult], List[str]]: Los resultados ya modulados (los
+            no afectados, tal cual) y los nombres de las reglas neutralizadas,
+            en el orden del catálogo; lista vacía si ninguna penalizaba.
+    """
+    modulated_results: List[Any] = []
+    modulated_names: List[str] = []
+    for rule_def, result in zip(rules_defs, results):
+        details = result.details or {}
+        is_covered = (rule_def["name"] in TRUST_MODULATED_RULES and result.score < 0
+                      and not details.get("hidden_text"))
+        if not is_covered:
+            modulated_results.append(result)
+            continue
+        modulated_names.append(rule_def["name"])
+        modulated_results.append(replace(
+            result, score=0.0, verdict=TRUST_OVERRIDE_VERDICT, recommendation=None,
+            details={**details, "trustOverride": {
+                "entryId": entry.id, "originalVerdict": result.verdict, "originalScore": result.score,
+            }},
+        ))
+    return modulated_results, modulated_names
+
+
+def build_trust_record(entry: TrustEntry, modulated_rules: List[str], is_applied: bool) -> Dict[str, Any]:
+    """Rastro de una excepción en el análisis al que se intentó aplicar.
+
+    Args:
+        entry: Excepción que coincidió con el remitente.
+        modulated_rules: Reglas que neutralizó; vacía si no se aplicó.
+        is_applied: ``False`` cuando coincidió pero el mensaje no demostró
+            venir de ese remitente.
+
+    Returns:
+        dict: ``entryId``, ``kind``, ``value``, ``reason``, ``applied`` y
+            ``modulatedRules``, con claves camelCase para guardarlo en JSONB y
+            devolverlo tal cual en el informe.
+    """
+    return {
+        "entryId": entry.id, "kind": entry.kind, "value": entry.value, "reason": entry.reason,
+        "applied": is_applied, "modulatedRules": modulated_rules,
+    }
+
+
+def describe_trust_record(record: Mapping[str, Any]) -> str:
+    """Frase legible del rastro de una excepción, para los motivos del veredicto.
+
+    Args:
+        record: Salida de ``build_trust_record``.
+
+    Returns:
+        str: Qué excepción se aplicó y cuántas reglas neutralizó, o por qué no
+            se aplicó.
+    """
+    target = f"{'el remitente' if record['kind'] == 'sender' else 'el dominio'} {record['value']}"
+    if not record["applied"]:
+        return (f"Hay una excepción de confianza para {target}, pero no se aplicó: el mensaje "
+                "no demuestra venir de ahí (DMARC no pasa o lo afirma un servidor no verificable).")
+    count = len(record["modulatedRules"])
+    return (f"Excepción de confianza aplicada a {target} ({record['reason']}): "
+            f"{count} {'regla neutralizada' if count == 1 else 'reglas neutralizadas'}. "
+            "Autenticación, adjuntos y enlaces se evaluaron sin excepción.")

--- a/API/src/modules/users/services/account_deletion.py
+++ b/API/src/modules/users/services/account_deletion.py
@@ -100,10 +100,10 @@ def _purge_aegis(uow: UnitOfWork, user_id: int) -> dict[str, int]:
 
 
 def _purge_iris(uow: UnitOfWork, user_id: int) -> dict[str, int]:
-    """Buzones conectados y excepciones de confianza. Los análisis cuelgan de ``User.analyses``."""
-    from src.modules.features.iris.model import IrisMailboxConnection, IrisTrustedSender
+    """Buzones conectados. Los análisis cuelgan de ``User.analyses``."""
+    from src.modules.features.iris.model import IrisMailboxConnection
 
-    return _delete_by_user(uow, user_id, [IrisMailboxConnection, IrisTrustedSender])
+    return _delete_by_user(uow, user_id, [IrisMailboxConnection])
 
 
 def _purge_hygeia(uow: UnitOfWork, user_id: int) -> dict[str, int]:

--- a/API/src/modules/users/services/account_deletion.py
+++ b/API/src/modules/users/services/account_deletion.py
@@ -100,10 +100,10 @@ def _purge_aegis(uow: UnitOfWork, user_id: int) -> dict[str, int]:
 
 
 def _purge_iris(uow: UnitOfWork, user_id: int) -> dict[str, int]:
-    """Buzones conectados. Los análisis cuelgan de ``User.analyses``."""
-    from src.modules.features.iris.model import IrisMailboxConnection
+    """Buzones conectados y excepciones de confianza. Los análisis cuelgan de ``User.analyses``."""
+    from src.modules.features.iris.model import IrisMailboxConnection, IrisTrustedSender
 
-    return _delete_by_user(uow, user_id, [IrisMailboxConnection])
+    return _delete_by_user(uow, user_id, [IrisMailboxConnection, IrisTrustedSender])
 
 
 def _purge_hygeia(uow: UnitOfWork, user_id: int) -> dict[str, int]:

--- a/API/tests/integration/test_iris_trusted_senders.py
+++ b/API/tests/integration/test_iris_trusted_senders.py
@@ -1,0 +1,244 @@
+"""Excepciones de confianza por usuario: reducir un falso positivo sin abrir un bypass.
+
+Cubre el criterio de cierre: el analista quita un falso positivo recurrente para
+sí mismo —no para toda la instalación—, la excepción caduca, se revoca sin
+borrarse y deja rastro en cada análisis. Y las dos reglas que no se relajan:
+solo se aplica a correo que demuestra venir de ese remitente, y nunca desactiva
+los gates de adjuntos peligrosos ni de autenticación forjada.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository, IrisTrustedSenderRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.shared import utcnow_naive
+from src.modules.users.services.permissions import AttributeType
+
+pytestmark = pytest.mark.integration
+
+_IRIS_ATTRIBUTES = [attribute.db_name for attribute in (
+    AttributeType.IRIS_READ, AttributeType.IRIS_CREATE,
+    AttributeType.IRIS_UPDATE, AttributeType.IRIS_DELETE,
+)]
+
+_RECEIVED_BY_OUR_MX = (
+    "Received: from mail.proveedor.com (mail.proveedor.com [203.0.113.10]) "
+    "by mx.example.com with ESMTPS id abc123; Mon, 07 Sep 2026 09:30:00 +0000"
+)
+_RECEIVED_BY_STRANGER = (
+    "Received: from mail.proveedor.com (mail.proveedor.com [203.0.113.10]) "
+    "by relay.otro.net with ESMTPS id abc123; Mon, 07 Sep 2026 09:30:00 +0000"
+)
+
+_EXE_ATTACHMENT = (
+    "--frontera\n"
+    "Content-Type: application/octet-stream; name=\"factura.exe\"\n"
+    "Content-Disposition: attachment; filename=\"factura.exe\"\n"
+    "Content-Transfer-Encoding: base64\n\n"
+    "TVqQAAMAAAAEAAAA//8AALgAAAAAAAAAQAAAAAAAAAA=\n"
+)
+
+
+def _message(*, received: str = _RECEIVED_BY_OUR_MX, attachment: str = "") -> str:
+    """Factura legítima de un proveedor que siempre responde desde Gmail.
+
+    El ``Reply-To`` en un webmail gratuito es el falso positivo recurrente que
+    la excepción debe poder quitar.
+    """
+    return (
+        f"{received}\n"
+        "Authentication-Results: mx.example.com; spf=pass smtp.mailfrom=proveedor.com; "
+        "dkim=pass header.d=proveedor.com; dmarc=pass\n"
+        'From: "Proveedor" <facturas@proveedor.com>\n'
+        "Reply-To: proveedor.facturas@gmail.com\n"
+        "Return-Path: <facturas@proveedor.com>\n"
+        "To: cliente@example.com\n"
+        "Subject: Factura de septiembre\n"
+        "Date: Mon, 07 Sep 2026 09:30:00 +0000\n"
+        "Message-ID: <factura-09@proveedor.com>\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: multipart/mixed; boundary=\"frontera\"\n\n"
+        "--frontera\n"
+        "Content-Type: text/plain; charset=utf-8\n\n"
+        "Hola Ana, te adjunto la factura de este mes. Un saludo, Luis.\n"
+        f"{attachment}"
+        "--frontera--\n"
+    )
+
+
+def _analyze(app, user_id: int, raw: str) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=raw, user_id=user_id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        IrisManager()._run_analysis(analysis_id, raw)
+    return analysis_id
+
+
+@pytest.fixture
+def analyst(make_user, auth_headers):
+    user = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    return user, auth_headers(user)
+
+
+def _trust(client, headers, **overrides):
+    body = {"kind": "domain", "value": "proveedor.com", "reason": "Proveedor habitual de facturación"}
+    body.update(overrides)
+    return client.post("/iris/trusted-senders", headers=headers, json=body)
+
+
+# ------------------------------------------------------------- ciclo de vida
+
+def test_an_analyst_declares_a_trusted_domain_with_reason_and_expiry(client, analyst):
+    _, headers = analyst
+
+    response = _trust(client, headers, value="@Proveedor.COM.", expiresInDays=30)
+
+    assert response.status_code == 201
+    entry = response.get_json()
+    assert entry["kind"] == "domain"
+    assert entry["value"] == "proveedor.com"
+    assert entry["reason"] == "Proveedor habitual de facturación"
+    assert entry["status"] == "active"
+    assert entry["expiresAt"] > entry["createdAt"]
+
+
+@pytest.mark.parametrize("overrides", [
+    {"reason": "   "},
+    {"value": "no es un dominio"},
+    {"kind": "sender", "value": "sin-arroba.com"},
+    {"expiresInDays": 400},
+    {"kind": "everything"},
+])
+def test_an_exception_without_reason_or_with_an_invalid_value_is_rejected(client, analyst, overrides):
+    _, headers = analyst
+
+    response = _trust(client, headers, **overrides)
+
+    assert response.status_code in (400, 422)
+
+
+def test_the_same_active_exception_cannot_be_declared_twice(client, analyst):
+    _, headers = analyst
+    assert _trust(client, headers).status_code == 201
+
+    assert _trust(client, headers).status_code == 400
+
+
+def test_revoking_keeps_the_exception_for_the_audit(client, analyst):
+    _, headers = analyst
+    entry_id = _trust(client, headers).get_json()["trustedSenderId"]
+
+    revoked = client.delete(f"/iris/trusted-senders/{entry_id}", headers=headers)
+
+    assert revoked.status_code == 200
+    assert revoked.get_json()["status"] == "revoked"
+    active = client.get("/iris/trusted-senders", headers=headers).get_json()
+    assert active["trustedSenders"] == []
+    audit = client.get("/iris/trusted-senders?includeInactive=true", headers=headers).get_json()
+    assert [(entry["trustedSenderId"], entry["status"]) for entry in audit["trustedSenders"]] == [
+        (entry_id, "revoked")
+    ]
+    assert audit["trustedSenders"][0]["revokedAt"]
+
+
+def test_an_exception_belongs_to_whoever_created_it(client, analyst, make_user, auth_headers):
+    _, headers = analyst
+    entry_id = _trust(client, headers).get_json()["trustedSenderId"]
+    stranger_headers = auth_headers(make_user(role="role_user", attributes=_IRIS_ATTRIBUTES))
+
+    assert client.delete(f"/iris/trusted-senders/{entry_id}", headers=stranger_headers).status_code == 404
+    assert client.get("/iris/trusted-senders", headers=stranger_headers).get_json()["trustedSenders"] == []
+
+
+# ------------------------------------------------------ efecto sobre el análisis
+
+def test_without_an_exception_the_free_webmail_reply_to_is_flagged(client, app, analyst):
+    user, headers = analyst
+
+    report = client.get(f"/iris/results/{_analyze(app, user.id, _message())}", headers=headers).get_json()
+
+    assert report["verdict"] != "Legitimate"
+    assert "reply target is free webmail" in report["gateReasons"]
+    assert report["trustApplied"] is None
+
+
+def test_a_trusted_and_authenticated_sender_loses_the_false_positive(client, app, analyst):
+    user, headers = analyst
+    entry_id = _trust(client, headers).get_json()["trustedSenderId"]
+
+    report = client.get(f"/iris/results/{_analyze(app, user.id, _message())}", headers=headers).get_json()
+
+    assert report["verdict"] == "Legitimate"
+    assert "reply target is free webmail" not in report["gateReasons"]
+    trust = report["trustApplied"]
+    assert trust["entryId"] == entry_id and trust["applied"] is True
+    assert "Reply-To Free Provider" in trust["modulatedRules"]
+    assert trust["reason"] == "Proveedor habitual de facturación"
+    assert any("Excepción de confianza aplicada" in reason for reason in report["gateReasons"])
+    rule = next(rule for rule in report["rules"] if rule["ruleName"] == "Reply-To Free Provider")
+    assert rule["verdict"] == "trusted" and rule["score"] == 0
+    assert rule["details"]["trustOverride"]["originalVerdict"] == "fail"
+
+
+def test_an_exception_never_disables_the_dangerous_attachment_gate(client, app, analyst):
+    user, headers = analyst
+    _trust(client, headers)
+
+    raw = _message(attachment=_EXE_ATTACHMENT)
+    report = client.get(f"/iris/results/{_analyze(app, user.id, raw)}", headers=headers).get_json()
+
+    assert report["verdict"] != "Legitimate"
+    assert "dangerous attachment" in report["gateReasons"]
+    assert report["trustApplied"]["applied"] is True
+
+
+def test_an_exception_is_ignored_when_the_authentication_cannot_be_verified(client, app, analyst):
+    """El ``dmarc=pass`` lo firma un servidor que no está en la cadena: pudo
+    escribirlo el propio remitente, así que no demuestra nada."""
+    user, headers = analyst
+    _trust(client, headers)
+
+    raw = _message(received=_RECEIVED_BY_STRANGER)
+    report = client.get(f"/iris/results/{_analyze(app, user.id, raw)}", headers=headers).get_json()
+
+    assert report["verdict"] != "Legitimate"
+    assert report["trustApplied"]["applied"] is False
+    assert report["trustApplied"]["modulatedRules"] == []
+    assert any("no se aplicó" in reason for reason in report["gateReasons"])
+
+
+def test_an_expired_exception_no_longer_applies(client, app, analyst):
+    user, headers = analyst
+    entry_id = _trust(client, headers).get_json()["trustedSenderId"]
+    with app.app_context():
+        with UnitOfWork() as uow:
+            repo = IrisTrustedSenderRepository(uow)
+            entry = repo.get_by_id(entry_id)
+            entry.expires_at = utcnow_naive() - timedelta(minutes=1)
+            repo.update(entry)
+
+    report = client.get(f"/iris/results/{_analyze(app, user.id, _message())}", headers=headers).get_json()
+
+    assert report["trustApplied"] is None
+    assert report["verdict"] != "Legitimate"
+    audit = client.get("/iris/trusted-senders?includeInactive=true", headers=headers).get_json()
+    assert audit["trustedSenders"][0]["status"] == "expired"
+
+
+def test_another_users_exception_does_not_apply(client, app, analyst, make_user, auth_headers):
+    user, headers = analyst
+    other_headers = auth_headers(make_user(role="role_user", attributes=_IRIS_ATTRIBUTES))
+    _trust(client, other_headers)
+
+    report = client.get(f"/iris/results/{_analyze(app, user.id, _message())}", headers=headers).get_json()
+
+    assert report["trustApplied"] is None
+    assert report["verdict"] != "Legitimate"

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -141,7 +141,7 @@ www.ellysia.es, http://localhost, http://127.0.0.1 {
 	# las continuaciones con `\` a un único espacio inicial, así que la
 	# alineación bonita no sobrevive al formateador. Una línea por matcher es
 	# lo que el formateador deja en paz.
-	@spa_bajo_prefijo_api path /themis/ /themis/escaneos /aegis/ /aegis/generador /iris/ /iris/analisis /iris/conexiones /acheron/ /acheron/boveda /hygeia/ /hygeia/activos /hygeia/etiquetas
+	@spa_bajo_prefijo_api path /themis/ /themis/escaneos /aegis/ /aegis/generador /iris/ /iris/analisis /iris/conexiones /iris/confianza /acheron/ /acheron/boveda /hygeia/ /hygeia/activos /hygeia/etiquetas
 	handle @spa_bajo_prefijo_api {
 		import spa
 	}

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -150,6 +150,37 @@
           por {{ reportData.latestFeedback.author }} · {{ formatDate(reportData.latestFeedback.createdAt) }}
           <template v-if="reportData.latestFeedback.note"> — «{{ reportData.latestFeedback.note }}»</template>
         </p>
+        <!-- Falso positivo recurrente: confiar en el remitente para los
+             próximos análisis. No toca este veredicto. -->
+        <button v-if="!trustFormOpen" type="button" class="feedback-option trust-open" @click="trustFormOpen = true">
+          Confiar en este remitente…
+        </button>
+        <IrisTrustForm
+          v-else
+          :from-header="reportData.previewHeaders?.from ?? ''"
+          cancellable
+          @saved="trustFormOpen = false"
+          @cancel="trustFormOpen = false"
+        />
+      </div>
+
+      <!-- Excepción de confianza que coincidió con el remitente: aplicada
+           (qué reglas neutralizó) o ignorada (el mensaje no demostró venir de
+           ahí). Es parte de la explicación del veredicto. -->
+      <div v-if="reportData.trustApplied" class="rv-trust" :class="{ 'rv-trust--ignored': !reportData.trustApplied.applied }">
+        <strong class="uncertainty-title">
+          {{ reportData.trustApplied.applied ? 'Excepción de confianza aplicada' : 'Excepción de confianza no aplicada' }}
+        </strong>
+        <p class="trust-detail">
+          {{ reportData.trustApplied.kind === 'domain' ? 'Dominio' : 'Remitente' }}
+          <code>{{ reportData.trustApplied.value }}</code> — «{{ reportData.trustApplied.reason }}».
+          <template v-if="reportData.trustApplied.applied">
+            Reglas neutralizadas: {{ reportData.trustApplied.modulatedRules.join(' · ') || 'ninguna penalizaba' }}.
+          </template>
+          <template v-else>
+            El mensaje no demuestra venir de ahí, así que se analizó sin la excepción.
+          </template>
+        </p>
       </div>
 
       <!-- Análisis degradado: alguna regla no llegó a ejecutarse, así que
@@ -360,6 +391,7 @@ import IrisDocumentsModal from '@/components/iris/IrisDocumentsModal.vue'
 import IrisRuleCard from '@/components/iris/IrisRuleCard.vue'
 import IrisIocsPanel from '@/components/iris/IrisIocsPanel.vue'
 import IrisVerdictHero from '@/components/iris/IrisVerdictHero.vue'
+import IrisTrustForm from '@/components/iris/IrisTrustForm.vue'
 
 const { formatDate } = useUtils()
 const irisStore = useIrisStore()
@@ -464,10 +496,13 @@ const FEEDBACK_LABELS = { malicious: 'malicioso', legitimate: 'legítimo', unkno
 const feedbackLabel = ref(null)
 const feedbackNote = ref('')
 const feedbackSaving = ref(false)
+// Formulario «Confiar en este remitente» (excepción de confianza).
+const trustFormOpen = ref(false)
 
 watch(() => props.reportData?.analysisId, () => {
   feedbackLabel.value = null
   feedbackNote.value = ''
+  trustFormOpen.value = false
 })
 
 async function saveFeedback() {
@@ -1109,6 +1144,25 @@ watch(
 .raw-line--hit {
   background: color-mix(in srgb, var(--accent) 22%, transparent);
   border-radius: 3px;
+}
+
+.trust-open { margin-top: 0.6rem; }
+
+.rv-trust {
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(96, 128, 224, 0.25);
+  border-radius: 10px;
+  background: var(--info-dim);
+}
+.rv-trust--ignored {
+  border-color: rgba(212, 160, 74, 0.3);
+  background: var(--warn-dim);
+}
+.trust-detail {
+  margin: 0.35rem 0 0;
+  font-size: var(--fs-md);
+  line-height: 1.5;
+  color: var(--text-dim);
 }
 
 .rv-gates {

--- a/web/app/src/components/iris/IrisRuleCard.vue
+++ b/web/app/src/components/iris/IrisRuleCard.vue
@@ -280,6 +280,8 @@ function formatDetailValue(v) {
   border: 1px solid rgba(217, 108, 108, 0.15);
 }
 
+/* Regla neutralizada por una excepción de confianza del usuario. */
+.verdict-chip--trusted,
 .verdict-chip--bestguess,
 .verdict-chip--policy {
   background: var(--info-dim);

--- a/web/app/src/components/iris/IrisTrustForm.vue
+++ b/web/app/src/components/iris/IrisTrustForm.vue
@@ -1,0 +1,132 @@
+<template>
+  <form class="trust-form" @submit.prevent="submit">
+    <div class="trust-row">
+      <label class="trust-field">
+        <span class="trust-label">Confiar en</span>
+        <select v-model="kind" class="trust-input">
+          <option value="domain">El dominio</option>
+          <option value="sender">Solo esta dirección</option>
+        </select>
+      </label>
+      <label class="trust-field trust-field--grow">
+        <span class="trust-label">{{ kind === 'domain' ? 'Dominio' : 'Dirección' }}</span>
+        <input
+          v-model="value"
+          class="trust-input"
+          type="text"
+          maxlength="320"
+          :placeholder="kind === 'domain' ? 'proveedor.com' : 'facturas@proveedor.com'"
+          required
+        />
+      </label>
+      <label class="trust-field">
+        <span class="trust-label">Caduca en</span>
+        <select v-model.number="expiresInDays" class="trust-input">
+          <option v-for="days in EXPIRY_OPTIONS" :key="days" :value="days">{{ days }} días</option>
+        </select>
+      </label>
+    </div>
+    <label class="trust-field">
+      <span class="trust-label">Motivo (obligatorio, queda en la auditoría)</span>
+      <input
+        v-model="reason"
+        class="trust-input"
+        type="text"
+        maxlength="500"
+        placeholder="Proveedor habitual: siempre responde desde otra dirección"
+        required
+      />
+    </label>
+    <p class="trust-hint">
+      Solo se aplica a correo que demuestra venir de ahí (DMARC verificado) y solo neutraliza
+      señales de redacción y de forma. Nunca desactiva los avisos de autenticación, adjuntos
+      peligrosos ni enlaces engañosos.
+    </p>
+    <div class="trust-actions">
+      <button type="submit" class="trust-save" :disabled="saving || !value.trim() || !reason.trim()">
+        {{ saving ? 'Guardando…' : 'Guardar excepción' }}
+      </button>
+      <button v-if="cancellable" type="button" class="trust-cancel" @click="$emit('cancel')">Cancelar</button>
+    </div>
+  </form>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useIrisStore } from '@/stores/irisStore'
+
+const props = defineProps({
+  // Cabecera From del informe del que se parte, para rellenar el valor.
+  fromHeader: { type: String, default: '' },
+  cancellable: { type: Boolean, default: false },
+})
+const emit = defineEmits(['saved', 'cancel'])
+
+const store = useIrisStore()
+const EXPIRY_OPTIONS = [30, 90, 180, 365]
+
+const kind = ref('domain')
+const value = ref('')
+const reason = ref('')
+const expiresInDays = ref(90)
+const saving = ref(false)
+
+/** Dirección de un valor de cabecera From: la de entre ángulos si la hay. */
+function addressOf(fromHeader) {
+  const match = /<\s*([^<>\s]+@[^<>\s]+)\s*>/.exec(fromHeader) || /[\w.+'-]+@[\w.-]+/.exec(fromHeader)
+  return match ? (match[1] ?? match[0]).toLowerCase() : ''
+}
+
+function prefill() {
+  const address = addressOf(props.fromHeader || '')
+  value.value = kind.value === 'domain' ? address.split('@')[1] ?? '' : address
+}
+
+watch(() => props.fromHeader, prefill, { immediate: true })
+watch(kind, prefill)
+
+async function submit() {
+  saving.value = true
+  const entry = await store.createTrustedSender({
+    kind: kind.value,
+    value: value.value.trim(),
+    reason: reason.value.trim(),
+    expiresInDays: expiresInDays.value,
+  })
+  saving.value = false
+  if (entry) {
+    reason.value = ''
+    emit('saved', entry)
+  }
+}
+</script>
+
+<style scoped>
+.trust-form { display: flex; flex-direction: column; gap: 0.6rem; }
+.trust-row { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.trust-field { display: flex; flex-direction: column; gap: 0.25rem; }
+.trust-field--grow { flex: 1; min-width: 12rem; }
+.trust-label { font-size: var(--fs-sm); color: var(--text-muted); }
+.trust-input {
+  padding: 0.45rem 0.6rem;
+  font-size: var(--fs-md);
+  background: var(--surface-2);
+  border: 1px solid var(--border-solid);
+  border-radius: 6px;
+  color: var(--text);
+}
+.trust-input:focus { outline: none; border-color: var(--accent); }
+.trust-hint { margin: 0; font-size: var(--fs-sm); color: var(--text-dim); line-height: 1.5; }
+.trust-actions { display: flex; gap: 0.5rem; }
+.trust-save,
+.trust-cancel {
+  padding: 0.4rem 0.9rem;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.trust-save { border: none; background: var(--accent); color: var(--on-accent); }
+.trust-save:disabled { opacity: 0.4; cursor: not-allowed; }
+.trust-cancel { border: 1px solid var(--border-med); background: transparent; color: var(--text-dim); }
+</style>

--- a/web/app/src/router/index.js
+++ b/web/app/src/router/index.js
@@ -79,6 +79,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/iris/confianza',
+    name: 'IrisTrust',
+    component: () => import('@/views/IrisTrustView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/acheron',
     name: 'AcheronHub',
     component: () => import('@/views/AcheronHubView.vue'),

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -419,6 +419,61 @@ export const useIrisStore = defineStore('iris', () => {
     return true
   }
 
+  /* ═══════════════════ EXCEPCIONES DE CONFIANZA ═══════════════════════ */
+
+  const trustedSenders = ref([])
+  const trustedSendersLoading = ref(false)
+
+  /**
+   * Carga las excepciones de confianza del usuario.
+   * @param {boolean} includeInactive Si se incluyen también las caducadas y
+   *   las revocadas (vista de auditoría).
+   */
+  async function fetchTrustedSenders(includeInactive = false) {
+    trustedSendersLoading.value = true
+    try {
+      const params = new URLSearchParams({ includeInactive: includeInactive ? 'true' : 'false' })
+      const res = await apiFetch(`/iris/trusted-senders?${params}`)
+      if (!res?.ok) { trustedSenders.value = []; return }
+      trustedSenders.value = (await res.json()).trustedSenders ?? []
+    } finally {
+      trustedSendersLoading.value = false
+    }
+  }
+
+  /**
+   * Declara un remitente o dominio de confianza.
+   * @param {{kind: 'sender'|'domain', value: string, reason: string, expiresInDays: number}} entry
+   * @returns {Promise<object|null>} La excepción creada, o null si falló.
+   */
+  async function createTrustedSender(entry) {
+    const res = await apiFetch('/iris/trusted-senders', {
+      method: 'POST',
+      body: JSON.stringify(entry),
+    })
+    if (!res?.ok) {
+      toast.show(await apiError(res, 'No se pudo guardar la excepción.'), 'error')
+      return null
+    }
+    toast.show('Excepción guardada. Se aplicará a los próximos análisis (reanaliza este para verla).', 'success')
+    return res.json()
+  }
+
+  /**
+   * Revoca una excepción. No la borra: sigue en la auditoría.
+   * @param {number} id Excepción a revocar.
+   * @returns {Promise<boolean>} true si se revocó.
+   */
+  async function revokeTrustedSender(id) {
+    const res = await apiFetch(`/iris/trusted-senders/${id}`, { method: 'DELETE' })
+    if (!res?.ok) {
+      toast.show(await apiError(res, 'No se pudo revocar la excepción.'), 'error')
+      return false
+    }
+    toast.show('Excepción revocada.', 'success')
+    return true
+  }
+
   /**
    * Solicita la narrativa ejecutiva IA (IA1) y sondea el informe hasta que
    * aparece `aiSummary` — no hay endpoint de estado propio, la narrativa es

--- a/web/app/src/views/IrisTrustView.vue
+++ b/web/app/src/views/IrisTrustView.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="trust-page" data-module="iris">
+    <StarBackground />
+    <Topbar title="Iris" badge="Remitentes de confianza" back-to="/iris/analisis" back-label="Análisis" />
+
+    <div class="trust-layout">
+      <section class="panel">
+        <p class="panel-eyebrow">Excepciones de confianza</p>
+        <h2 class="panel-title">Quitar un falso positivo que se repite</h2>
+        <p class="panel-sub">
+          Si un remitente que conoces dispara siempre la misma alerta —un proveedor que responde desde
+          otra dirección, un banco que escribe «urgente»—, declara aquí que confías en él. Solo te afecta
+          a ti, caduca sola y cada análisis en que se aplica lo dice.
+        </p>
+        <IrisTrustForm @saved="store.fetchTrustedSenders(showInactive)" />
+      </section>
+
+      <section class="panel">
+        <div class="list-header">
+          <h3 class="list-title">Tus excepciones</h3>
+          <label class="list-toggle">
+            <input v-model="showInactive" type="checkbox" @change="store.fetchTrustedSenders(showInactive)" />
+            Mostrar caducadas y revocadas
+          </label>
+        </div>
+
+        <p v-if="store.trustedSendersLoading" class="list-empty">Cargando…</p>
+        <p v-else-if="!store.trustedSenders.length" class="list-empty">No tienes ninguna excepción {{ showInactive ? '' : 'activa' }}.</p>
+        <ul v-else class="trust-list">
+          <li v-for="entry in store.trustedSenders" :key="entry.trustedSenderId" class="trust-item">
+            <div class="trust-main">
+              <span class="trust-value">{{ entry.value }}</span>
+              <span class="trust-kind">{{ entry.kind === 'domain' ? 'dominio' : 'dirección' }}</span>
+              <span class="trust-status" :class="`trust-status--${entry.status}`">{{ STATUS_LABELS[entry.status] }}</span>
+            </div>
+            <p class="trust-reason">«{{ entry.reason }}»</p>
+            <p class="trust-dates">
+              Creada {{ formatDate(entry.createdAt) }} ·
+              <template v-if="entry.revokedAt">revocada {{ formatDate(entry.revokedAt) }}</template>
+              <template v-else>caduca {{ formatDate(entry.expiresAt) }}</template>
+            </p>
+            <button
+              v-if="entry.status === 'active'"
+              type="button"
+              class="trust-revoke"
+              @click="pendingRevoke = entry"
+            >Revocar</button>
+          </li>
+        </ul>
+      </section>
+    </div>
+
+    <ConfirmModal
+      :show="pendingRevoke !== null"
+      title="Revocar excepción"
+      danger
+      confirm-label="Revocar"
+      :message="pendingRevoke ? `Los próximos correos de ${pendingRevoke.value} se analizarán sin excepción. La excepción seguirá en la auditoría.` : ''"
+      @confirm="confirmRevoke"
+      @cancel="pendingRevoke = null"
+    />
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import Topbar from '@/components/shared/Topbar.vue'
+import StarBackground from '@/components/shared/StarBackground.vue'
+import ConfirmModal from '@/components/shared/ConfirmModal.vue'
+import IrisTrustForm from '@/components/iris/IrisTrustForm.vue'
+import { useIrisStore } from '@/stores/irisStore'
+import { useUtils } from '@/composables/useUtils'
+
+const store = useIrisStore()
+const { formatDate } = useUtils()
+
+const STATUS_LABELS = { active: 'activa', expired: 'caducada', revoked: 'revocada' }
+const showInactive = ref(false)
+const pendingRevoke = ref(null)
+
+async function confirmRevoke() {
+  if (!pendingRevoke.value) return
+  await store.revokeTrustedSender(pendingRevoke.value.trustedSenderId)
+  pendingRevoke.value = null
+  await store.fetchTrustedSenders(showInactive.value)
+}
+
+onMounted(() => store.fetchTrustedSenders(false))
+</script>
+
+<style scoped>
+.trust-page { min-height: 100vh; background: var(--bg); padding-top: var(--topbar-h); position: relative; }
+.trust-layout {
+  position: relative; z-index: 1;
+  max-width: 820px; margin: 0 auto; padding: 2rem 1.25rem 3rem;
+  display: flex; flex-direction: column; gap: 1.75rem;
+}
+.panel { border: 1px solid var(--border); border-radius: 12px; background: var(--surface); padding: 1.4rem 1.6rem; }
+.panel-eyebrow {
+  margin: 0 0 0.3rem; font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
+  font-size: var(--fs-xs); letter-spacing: 0.28em; text-transform: uppercase; color: var(--accent);
+}
+.panel-title { margin: 0 0 0.5rem; font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-2xl); font-weight: 700; color: var(--text); }
+.panel-sub { margin: 0 0 1.2rem; font-size: var(--fs-md); line-height: 1.55; color: var(--text-dim); max-width: 62ch; }
+
+.list-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 0.9rem; }
+.list-title { margin: 0; font-size: var(--fs-lg); color: var(--text); }
+.list-toggle { display: flex; align-items: center; gap: 0.4rem; font-size: var(--fs-sm); color: var(--text-dim); }
+.list-empty { margin: 0; color: var(--text-muted); font-size: var(--fs-md); }
+
+.trust-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.6rem; }
+.trust-item { position: relative; padding: 0.75rem 0.9rem; border: 1px solid var(--border-med); border-radius: 8px; background: var(--surface-2); }
+.trust-main { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; padding-right: 5.5rem; }
+.trust-value { font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-size: var(--fs-md); color: var(--text); }
+.trust-kind { font-size: var(--fs-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.trust-status { font-size: var(--fs-xs); font-weight: 600; padding: 2px 8px; border-radius: 5px; text-transform: uppercase; }
+.trust-status--active { background: var(--success-dim); color: var(--success); }
+.trust-status--expired { background: rgba(100, 116, 139, 0.12); color: var(--text-muted); }
+.trust-status--revoked { background: var(--danger-dim); color: var(--danger); }
+.trust-reason { margin: 0.35rem 0 0; font-size: var(--fs-md); color: var(--text-dim); }
+.trust-dates { margin: 0.2rem 0 0; font-size: var(--fs-sm); color: var(--text-muted); }
+.trust-revoke {
+  position: absolute; top: 0.7rem; right: 0.8rem;
+  padding: 0.25rem 0.7rem; font-size: var(--fs-sm); font-weight: 600;
+  border: 1px solid var(--danger); border-radius: 6px; background: transparent; color: var(--danger); cursor: pointer;
+}
+.trust-revoke:hover { background: var(--danger); color: #fff; }
+</style>

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -63,6 +63,12 @@
         </svg>
         Conexiones de buzón
       </router-link>
+      <router-link to="/iris/confianza" class="back-link connections-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+        Remitentes de confianza
+      </router-link>
 
       <main class="iris-main">
         <IrisReportViewer


### PR DESCRIPTION
## El problema

Iris da un veredicto a cada correo (Legítimo, Sospechoso o Phishing) a partir de unas 48 reglas. Algunas son heurísticas de redacción y de forma: lenguaje de urgencia, un `Reply-To` que apunta a otro dominio, enlaces de seguimiento. Un remitente legítimo que el analista conoce bien puede dispararlas siempre. Pasa, por ejemplo, con el proveedor que factura desde su dominio pero pide que le respondan a una dirección de Gmail, o con el banco que escribe «urgente» en cada alerta.

Hasta ahora ese falso positivo solo se podía quitar tocando la configuración global (`SecOpsConfig.json`), que afecta a toda la instalación y no deja rastro de quién lo cambió ni por qué.

Cierra #224 (iniciativa `M03`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

**Excepciones de confianza por usuario.** Una tabla nueva, `IrisTrustedSender`, y tres endpoints:

- `POST /iris/trusted-senders` crea una excepción. Recibe `kind`, que es `sender` (una dirección exacta) o `domain` (el dominio del `From` y sus subdominios); `value`; `reason`, obligatorio porque es lo que se lee en la auditoría; y `expiresInDays`, de 1 a 365 (por defecto 90). El máximo de 365 días está en el código y no en la configuración a propósito: una excepción sin fin es un *bypass* permanente que nadie vuelve a revisar.
- `GET /iris/trusted-senders` lista las activas. Con `?includeInactive=true` lista también las caducadas y las revocadas: es la vista de auditoría.
- `DELETE /iris/trusted-senders/<id>` revoca una excepción. **No la borra**: queda marcada con `revokedAt` y sigue en la auditoría.

**Qué hace una excepción al analizar un correo.** Lo decide `services/trust.py`, con dos reglas que no se relajan:

1. **Solo se aplica si el correo demuestra venir de ese remitente.** Coincidir con el `From` no basta, porque el `From` lo puede escribir cualquiera. Hacen falta dos condiciones:
   - que DMARC pase (DMARC es el mecanismo que ata la autenticación SPF/DKIM al dominio visible del `From`);
   - que la cabecera `Authentication-Results` que lo afirma la haya escrito un servidor de confianza. La regla existente «Auth Results Provenance» comprueba que ese servidor aparece en la parte fiable de la cadena `Received`, es decir, la que no pudo fabricar el remitente.

   Si falla cualquiera de las dos, la excepción se ignora y el análisis lo dice.
2. **Solo neutraliza las señales que cubre.** Quien declara «conozco a este remitente y sé que escribe así» está respondiendo a las heurísticas de redacción y de forma: son las 15 reglas de `TRUST_MODULATED_RULES`. Nunca toca la autenticación, los adjuntos, los enlaces (incluidos los *cloaked*, donde el texto visible no coincide con el destino real, y los QR), las suplantaciones de dominio, las falsificaciones de hilo o de cadena `Received`, ni los patrones de fraude BEC y TOAD. Esas reglas no están en la lista, así que sus *gates* siguen disparando. Un *gate* es una señal de alta confianza que por sí sola sube el veredicto a Sospechoso o Phishing.

Una regla neutralizada pasa a score 0 y veredicto `trusted`. Su veredicto y su score originales quedan en `details.trustOverride`.

**Auditoría en cada análisis.** La columna nueva `IrisAnalysis.trust_applied` guarda qué excepción coincidió con el remitente, si se aplicó y qué reglas neutralizó. Se conserva aunque la excepción se revoque después. El informe (`GET /iris/results/<id>`) la devuelve como `trustApplied`, y entre los motivos del veredicto aparece una frase del tipo «Excepción de confianza aplicada al dominio proveedor.com (motivo): 2 reglas neutralizadas».

**Interfaz.**

- En el informe, «Confiar en este remitente…» abre un formulario con el dominio o la dirección del `From` ya rellenos.
- La vista nueva `/iris/confianza` (enlazada desde la de análisis) lista, crea y revoca excepciones.
- El informe explica la excepción que coincidió, y las reglas neutralizadas llevan la ficha «trusted».

## Decisiones que conviene revisar

- **Por usuario, no por organización.** El roadmap habla de políticas «por usuario, organización y proveedor». El modelo `Organization` fija que una organización comparte plan y factura, **no datos**, y que Iris analiza correo personal. Una excepción declarada por el dueño de la organización cambiaría los veredictos del correo de sus miembros, y eso es abrir una segunda excepción a esa regla. Se deja fuera hasta que haya una razón igual de concreta que la de Hygeia.
- **«Proveedor» se cubre con `domain`.** Un proveedor de servicios (el que te factura) es un dominio. Confiar en la infraestructura de envío (SendGrid, Mailchimp…) no se ofrece a propósito: equivaldría a confiar en todos sus clientes, incluidos los que envían phishing.
- **Borrado de cuentas.** `IrisTrustedSender.user_id` es `ON DELETE CASCADE`, así que la base de datos se lleva las excepciones con la cuenta. Añadirla a `users/services/account_deletion.py` habría obligado a `users` a importar un modelo de Iris, la dependencia en sentido contrario que `CONVENCIONES.md` prohíbe y `test_code_conventions.py` vigila.

## Validación

- `test_iris_trusted_senders.py` (nuevo, 15 casos):
  - **Ciclo de vida:** crear con motivo y caducidad; rechazar un motivo vacío, un dominio o una dirección inválidos, más de 365 días o un tipo desconocido; no duplicar una excepción activa; revocar sin borrar (sigue en la auditoría); ownership (otro usuario recibe `404` y no la ve).
  - **Efecto sobre el análisis**, con un correo real de proveedor que responde desde Gmail:
    - Sin excepción sale Sospechoso por el *gate* «reply target is free webmail».
    - Con excepción y autenticación verificable sale Legítimo, y el informe dice qué se neutralizó.
    - Con un adjunto `.exe`, el *gate* de adjunto peligroso sigue disparando aunque la excepción se aplique.
    - Con un `dmarc=pass` firmado por un servidor que no está en la cadena `Received`, la excepción no se aplica y el análisis explica por qué.
    - Una excepción caducada o de otro usuario no se aplica.
- Suite completa (`pytest`) en verde tras el último commit (el test de convenciones y el de borrado de cuentas, además, repetidos aparte).
- SPA: `IrisTrustForm.vue`, `IrisTrustView.vue`, `IrisReportViewer.vue`, `IrisView.vue` e `IrisRuleCard.vue` compilan con `@vue/compiler-sfc`. `npm run build` no se puede ejecutar en este entorno por el paquete privado `@projectellysia/acheron-core-web`.
- `test_caddy_api_routes.py` en verde con la ruta nueva en el matcher `@spa_bajo_prefijo_api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
