### PR TITLE
feat(iris): modo de análisis explícito, con lo que cubre cada modo y su aviso de sensibilidad (M07)

### DIFF
--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -63,7 +63,9 @@ from ..services.contexts import (
 )
 from ..services.scoring import ScoringPolicy, current_policy
 from ..services.quality import (
+    AnalysisMode,
     ConfidenceAssessment,
+    body_dependent_rule_names,
     assess_confidence,
     assess_coverage,
     assess_quality,
@@ -330,13 +332,30 @@ class IrisManager(TaskTrackingMixin):
         el módulo, para que un cambio vía ``PUT /system`` surta efecto sin
         reiniciar (mismo patrón que ``AnalyzeRequestSchema.validate_max_size``,
         que es la validación que este endpoint describe).
+
+        Publica también lo que la interfaz necesita para que el usuario elija
+        el modo sabiendo qué implica: qué reglas se quedan sin nada que mirar
+        en modo cabeceras y el aviso de que el modo completo puede incluir
+        datos sensibles.
+
+        Returns:
+            dict: ``maxMessageBytes``, ``minHeaders``, ``analysisModes``
+                (valores de ``AnalysisMode``), ``headersOnlyUncoveredRules``,
+                ``fullMessageNotice`` y ``verdictThresholds``.
         """
         config = CR.iris_config()
         policy = current_policy()
         return {
             "maxMessageBytes": config.max_message_bytes,
             "minHeaders": config.min_headers,
-            "analysisModes": ["headers", "message"],
+            "analysisModes": [mode.value for mode in AnalysisMode],
+            "headersOnlyUncoveredRules": body_dependent_rule_names(iris_rules.get_rules()),
+            "fullMessageNotice": (
+                "El mensaje completo incluye el cuerpo y los adjuntos, que pueden contener datos "
+                "sensibles: personales, confidenciales o de terceros. Iris lo guarda cifrado y "
+                f"purga ese contenido a los {config.raw_message_retention_days} días; el resultado "
+                "del análisis se conserva."
+            ),
             "verdictThresholds": {
                 "legitimate": policy.legitimate_threshold,
                 "suspicious": policy.suspicious_threshold,

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -5,31 +5,62 @@ Fields use camelCase for JSON keys as per the project convention.
 
 from __future__ import annotations
 
-from marshmallow import Schema, ValidationError, fields, validate, validates_schema
+from marshmallow import Schema, ValidationError, fields, post_load, validate, validates_schema
 
 import src.modules.system.config_reading as CR
 from src.modules.shared import UTCDateTime
 
 from .services.feedback_metrics import FEEDBACK_LABELS
 from .model import TrustKind
+from .services.quality import AnalysisMode
 from .services.scoring import PROFILE_THRESHOLD_OFFSETS
 from .services.trust import MAX_TRUST_EXPIRY_DAYS, MAX_TRUST_REASON_LENGTH
 
 
-class AnalyzeRequestSchema(Schema):
-    """Request body for ``POST /iris/analyze``.
+def _input_fields_in_use(data: dict) -> tuple[str, ...]:
+    """Campos de entrada que va a analizar una petición de ``POST /iris/analyze``.
 
-    Accepts either ``headers`` (a headers-only block, original behaviour)
-    or ``message`` (a full raw ``.eml`` message). At least one of
-    the two is required; if both are present, ``message`` takes priority
-    since it is a superset of the header information.
+    Args:
+        data: Cuerpo ya deserializado.
+
+    Returns:
+        tuple[str, ...]: ``("headers",)`` en modo cabeceras, ``("message",)`` en
+            modo completo, o los dos si la petición no trae ``mode``.
+    """
+    mode = data.get("mode")
+    if mode == AnalysisMode.HEADERS:
+        return ("headers",)
+    if mode == AnalysisMode.MESSAGE:
+        return ("message",)
+    return ("headers", "message")
+
+
+class AnalyzeRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/analyze``.
+
+    ``mode`` dice qué se analiza: ``headers`` (el bloque de cabeceras de
+    ``headers``) o ``message`` (el ``.eml`` completo de ``message``). Con
+    modo, solo se valida y se usa el campo de ese modo y el otro se descarta,
+    así que elegir solo cabeceras nunca falla por el tamaño de un mensaje que
+    no se va a analizar. Sin ``mode`` (clientes que no lo envían) basta con
+    cualquiera de los dos y, si vienen ambos, ``message`` tiene prioridad por
+    ser un superconjunto de las cabeceras.
     """
     title = fields.String(load_default=None, validate=validate.Length(max=120))
+    mode = fields.String(load_default=None, validate=validate.OneOf([mode.value for mode in AnalysisMode]))
     headers = fields.String(load_default=None, validate=validate.Length(min=10))
     message = fields.String(load_default=None, validate=validate.Length(min=10))
 
     @validates_schema
     def validate_has_input(self, data, **kwargs):
+        """Exige el campo que corresponde al modo, o al menos uno sin modo."""
+        mode = data.get("mode")
+        if mode == AnalysisMode.HEADERS and not data.get("headers"):
+            raise ValidationError("El modo 'headers' necesita el campo 'headers'.", field_name="headers")
+        if mode == AnalysisMode.MESSAGE and not data.get("message"):
+            raise ValidationError(
+                "El modo 'message' necesita el campo 'message' (el .eml completo).", field_name="message",
+            )
         if not data.get("headers") and not data.get("message"):
             raise ValidationError(
                 "Debe proporcionar 'headers' (cabeceras) o 'message' (mensaje completo .eml).",
@@ -38,21 +69,41 @@ class AnalyzeRequestSchema(Schema):
 
     @validates_schema
     def validate_max_size(self, data, **kwargs):
-        """Sin tope superior, un .eml de decenas de MB (adjuntos incluidos)
-        entraba entero a una columna Text y se re-parseaba completo (incluida
-        la decodificación base64) en cada lectura posterior. Leído con CR en
-        cada validación, no horneado al importar el módulo, para que un
-        cambio vía PUT /system surta efecto sin reiniciar la API (mismo
-        patrón que ``hygeia/schemas.py::validate_array_limits``).
+        """Rechaza la entrada que se va a analizar si supera ``iris.maxMessageBytes``.
+
+        Sin tope superior, un .eml de decenas de MB (adjuntos incluidos)
+        entraría entero a una columna Text y se re-parsearía completo (incluida
+        la decodificación base64) en cada lectura posterior. Solo se mira el
+        campo que usa el modo (``_input_fields_in_use``). Leído con CR en cada
+        validación, no horneado al importar el módulo, para que un cambio vía
+        PUT /system surta efecto sin reiniciar la API (mismo patrón que
+        ``hygeia/schemas.py::validate_array_limits``).
         """
         max_bytes = CR.iris_config().max_message_bytes
-        for field_name in ("headers", "message"):
+        for field_name in _input_fields_in_use(data):
             value = data.get(field_name)
             if value and len(value.encode("utf-8", errors="ignore")) > max_bytes:
                 raise ValidationError(
                     f"'{field_name}' excede el tamaño máximo permitido ({max_bytes} bytes).",
                     field_name=field_name,
                 )
+
+    @post_load
+    def drop_unused_input(self, data, **kwargs):
+        """Descarta el campo de entrada que el modo elegido no usa.
+
+        Así el endpoint y el manager siguen recibiendo ``headers`` y
+        ``message`` como siempre, y con modo solo llega relleno el que toca.
+
+        Returns:
+            dict: Los datos con ``message`` a ``None`` en modo cabeceras, o
+                ``headers`` a ``None`` en modo completo; sin modo, intactos.
+        """
+        in_use = _input_fields_in_use(data)
+        for field_name in ("headers", "message"):
+            if field_name not in in_use:
+                data[field_name] = None
+        return data
 
 
 class IrisCapabilitiesResponseSchema(Schema):
@@ -63,6 +114,11 @@ class IrisCapabilitiesResponseSchema(Schema):
     servidor, y el usuario se lleva el rechazo después de haber cargado el
     fichero entero en memoria.
 
+    ``headersOnlyUncoveredRules`` son las reglas que no tendrán nada que
+    inspeccionar en modo cabeceras, y ``fullMessageNotice`` el aviso de que el
+    modo completo puede incluir datos sensibles: la interfaz los enseña al
+    elegir el modo, antes de enviar.
+
     ``verdictThresholds`` viaja ya en la respuesta del listado; se repite aquí
     para que una vista que aún no ha listado nada pueda pintar la escala de
     riesgo sin pedir primero una página de resultados.
@@ -70,6 +126,8 @@ class IrisCapabilitiesResponseSchema(Schema):
     maxMessageBytes = fields.Integer()
     minHeaders = fields.Integer()
     analysisModes = fields.List(fields.String())
+    headersOnlyUncoveredRules = fields.List(fields.String())
+    fullMessageNotice = fields.String()
     verdictThresholds = fields.Nested(lambda: VerdictThresholdsSchema())
 
 

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any, Dict, List
 
 #: Valor de ``verdict`` con el que el motor marca una regla que lanzó una
@@ -155,12 +156,35 @@ def assess_coverage(context: Any, rules_defs: List[dict]) -> Dict[str, Any]:
     has_content = bool(context.body_text or context.body_html or context.attachments)
     if has_content:
         return {"mode": COVERAGE_FULL_MESSAGE, "uncoveredRules": []}
-    return {
-        "mode": COVERAGE_HEADERS_ONLY,
-        "uncoveredRules": [
-            rule_def["name"] for rule_def in rules_defs if rule_def.get("is_body_dependent")
-        ],
-    }
+    return {"mode": COVERAGE_HEADERS_ONLY, "uncoveredRules": body_dependent_rule_names(rules_defs)}
+
+
+class AnalysisMode(StrEnum):
+    """Qué parte del correo pide analizar el usuario (``POST /iris/analyze``, campo ``mode``).
+
+    Attributes:
+        HEADERS: Solo el bloque de cabeceras.
+        MESSAGE: El ``.eml`` completo, con cuerpo, enlaces y adjuntos.
+    """
+    HEADERS = "headers"
+    MESSAGE = "message"
+
+
+def body_dependent_rule_names(rules_defs: List[dict]) -> List[str]:
+    """Reglas que no tienen nada que inspeccionar en un análisis de solo cabeceras.
+
+    Es la misma lista que ``assess_coverage`` guarda en ``uncoveredRules`` de un
+    análisis de solo cabeceras, y la que ``GET /iris/capabilities`` publica
+    para que la interfaz la enseñe **antes** de enviar, al elegir el modo.
+
+    Args:
+        rules_defs: Catálogo de reglas; se usa el flag ``is_body_dependent``.
+
+    Returns:
+        List[str]: Nombres de las reglas de cuerpo, enlaces y adjuntos, en el
+            orden del catálogo.
+    """
+    return [rule_def["name"] for rule_def in rules_defs if rule_def.get("is_body_dependent")]
 
 
 @dataclass(frozen=True)

--- a/API/tests/integration/test_iris.py
+++ b/API/tests/integration/test_iris.py
@@ -103,15 +103,11 @@ def test_a_message_at_the_published_limit_is_accepted(client, regular_user, auth
     import src.modules.features.iris.schemas as schemas_mod
     import src.modules.features.iris.managers.analysis as analysis_mod
 
-    class _Limited:
-        max_message_bytes = 2048
-        min_headers = 2
-        legitimate_threshold = 80
-        suspicious_threshold = 55
-        sensitivity_profile = "balanced"
-
-    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
-    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+    # Un IrisConfig real con solo el límite cambiado: un doble escrito a mano
+    # se queda corto en cuanto el endpoint lee un campo más de la config.
+    limited = schemas_mod.CR.IrisConfig(max_message_bytes=2048)
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: limited)
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: limited)
 
     limit = client.get("/iris/capabilities",
                        headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]
@@ -135,15 +131,11 @@ def test_a_message_over_the_published_limit_is_rejected(client, regular_user, au
     import src.modules.features.iris.schemas as schemas_mod
     import src.modules.features.iris.managers.analysis as analysis_mod
 
-    class _Limited:
-        max_message_bytes = 2048
-        min_headers = 2
-        legitimate_threshold = 80
-        suspicious_threshold = 55
-        sensitivity_profile = "balanced"
-
-    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: _Limited())
-    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: _Limited())
+    # Un IrisConfig real con solo el límite cambiado: un doble escrito a mano
+    # se queda corto en cuanto el endpoint lee un campo más de la config.
+    limited = schemas_mod.CR.IrisConfig(max_message_bytes=2048)
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: limited)
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: limited)
 
     limit = client.get("/iris/capabilities",
                        headers=auth_headers(regular_user)).get_json()["maxMessageBytes"]

--- a/API/tests/integration/test_iris_analysis_modes.py
+++ b/API/tests/integration/test_iris_analysis_modes.py
@@ -1,0 +1,120 @@
+"""Modo de análisis explícito: solo cabeceras o mensaje completo.
+
+El modo se deducía de si el usuario había tocado el textarea después de
+arrastrar un ``.eml``: no era una elección, no estaba a la vista y podía
+acabar en un error contradictorio —pedir solo cabeceras y recibir un rechazo
+por el tamaño del mensaje completo—. Estos tests fijan el contrato: el modo
+viaja explícito, el servidor solo valida y usa el campo de ese modo, y
+publica qué reglas se quedan sin cobertura en modo cabeceras y el aviso de
+sensibilidad del modo completo.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+from unittest import mock
+
+import pytest
+
+from src.modules.features.iris.managers import analysis as analysis_mod
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.infrastructure import build_repository
+from src.modules.system.taskqueue import Task, TaskStatus
+
+pytestmark = pytest.mark.integration
+
+_HEADERS = "From: Ana <ana@example.com>\nTo: luis@example.com\nSubject: Hola\n"
+_MESSAGE = _HEADERS + "Content-Type: text/plain\n\nCuerpo del mensaje con un enlace https://example.com\n"
+
+
+class _NoopQueue:
+    """Cola que acepta el encolado y no ejecuta nada: aquí solo importa qué se guarda."""
+
+    def submit(self, func: Callable, *, name: str = "", category: str = "",
+               args: tuple = (), kwargs: Optional[dict] = None,
+               external_id: Optional[str] = None, timeout: int = 600) -> Task:
+        return Task(id=name or "job", name=name, category=category,
+                    external_id=external_id, status=TaskStatus.PENDING)
+
+    def get_task_by_external_id(self, external_id: str, category: Optional[str] = None): return None
+    def is_recoverable(self, external_id: str, category: Optional[str] = None) -> bool: return True
+    def cancel(self, task_id: str) -> bool: return True
+    def get_task(self, task_id: str): return None
+    def update_progress(self, task_id: str, progress: int) -> None: pass
+    def is_cancelled(self, task_id: str) -> bool: return False
+    def clear_cancel_signal(self, task_id: str) -> None: pass
+
+
+def _submit(client, headers, body):
+    with mock.patch.object(analysis_mod.TaskQueue, "get_instance", return_value=_NoopQueue()):
+        return client.post("/iris/analyze", headers=headers, json=body)
+
+
+def _stored_raw(app, analysis_id: int) -> str:
+    with app.app_context():
+        return build_repository(IrisAnalysisRepository).get_by_id(analysis_id).raw_headers
+
+
+def test_capabilities_list_the_rules_headers_mode_leaves_uncovered(client, user_headers):
+    body = client.get("/iris/capabilities", headers=user_headers).get_json()
+
+    expected = [rule["name"] for rule in iris_rules.get_rules() if rule.get("is_body_dependent")]
+    assert body["headersOnlyUncoveredRules"] == expected
+    assert "Suspicious Attachments" in body["headersOnlyUncoveredRules"]
+
+
+def test_capabilities_warn_that_the_full_message_can_contain_sensitive_data(client, user_headers):
+    body = client.get("/iris/capabilities", headers=user_headers).get_json()
+
+    assert "sensible" in body["fullMessageNotice"]
+
+
+def test_headers_mode_analyses_the_headers_even_when_a_message_travels_along(client, app, user_headers):
+    response = _submit(client, user_headers, {"mode": "headers", "headers": _HEADERS, "message": _MESSAGE})
+
+    assert response.status_code == 201, response.get_json()
+    assert _stored_raw(app, response.get_json()["analysisId"]) == _HEADERS
+
+
+def test_choosing_headers_mode_never_fails_for_the_size_of_the_unused_message(
+        client, user_headers, monkeypatch):
+    """El error contradictorio del issue: pedir solo cabeceras y recibir un
+    rechazo por el tamaño del ``.eml`` que no se iba a analizar."""
+    monkeypatch.setattr(analysis_mod.CR, "iris_config", lambda: analysis_mod.CR.IrisConfig(max_message_bytes=2048))
+    import src.modules.features.iris.schemas as schemas_mod
+    monkeypatch.setattr(schemas_mod.CR, "iris_config", lambda: schemas_mod.CR.IrisConfig(max_message_bytes=2048))
+
+    oversized = _HEADERS + "\n" + "x" * 5000
+    response = _submit(client, user_headers, {"mode": "headers", "headers": _HEADERS, "message": oversized})
+
+    assert response.status_code == 201, response.get_json()
+
+
+def test_message_mode_analyses_the_full_message(client, app, user_headers):
+    response = _submit(client, user_headers, {"mode": "message", "headers": _HEADERS, "message": _MESSAGE})
+
+    assert response.status_code == 201, response.get_json()
+    assert _stored_raw(app, response.get_json()["analysisId"]) == _MESSAGE
+
+
+def test_message_mode_without_a_message_says_so(client, user_headers):
+    response = _submit(client, user_headers, {"mode": "message", "headers": _HEADERS})
+
+    assert response.status_code == 422
+    assert "message" in str(response.get_json())
+
+
+def test_headers_mode_without_headers_says_so(client, user_headers):
+    response = _submit(client, user_headers, {"mode": "headers", "message": _MESSAGE})
+
+    assert response.status_code == 422
+    assert "headers" in str(response.get_json())
+
+
+def test_without_a_mode_the_full_message_still_takes_priority(client, app, user_headers):
+    """Quien no envía ``mode`` (clientes anteriores, la API a mano) sigue igual."""
+    response = _submit(client, user_headers, {"headers": _HEADERS, "message": _MESSAGE})
+
+    assert response.status_code == 201, response.get_json()
+    assert _stored_raw(app, response.get_json()["analysisId"]) == _MESSAGE

--- a/web/app/src/components/iris/IrisForm.vue
+++ b/web/app/src/components/iris/IrisForm.vue
@@ -3,8 +3,7 @@
     <div class="form-header">
       <h2>Nuevo Análisis</h2>
       <p class="form-hint">
-        Arrastra un archivo .eml para analizar el correo completo (cuerpo, enlaces y adjuntos),
-        o pega aquí solo las cabeceras.
+        Arrastra un archivo .eml o pega las cabeceras, y elige qué parte del correo quieres que Iris examine.
       </p>
     </div>
 
@@ -16,21 +15,60 @@
         maxlength="120"
         placeholder="Título opcional para identificar el análisis (ej: Correo sospechoso)"
       />
+
+      <!-- El modo es una elección explícita y reversible, no algo que se deduce
+           de si el usuario tocó el textarea. -->
+      <div class="mode-switch" role="radiogroup" aria-label="Qué se analiza">
+        <button
+          type="button"
+          role="radio"
+          class="mode-option"
+          :class="{ 'mode-option--active': mode === MODE_HEADERS }"
+          :aria-checked="mode === MODE_HEADERS"
+          @click="mode = MODE_HEADERS"
+        >
+          <span class="mode-name">Solo cabeceras</span>
+          <span class="mode-sub">Autenticación, remitente y ruta de entrega</span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          class="mode-option"
+          :class="{ 'mode-option--active': mode === MODE_MESSAGE }"
+          :aria-checked="mode === MODE_MESSAGE"
+          :disabled="!message"
+          @click="mode = MODE_MESSAGE"
+        >
+          <span class="mode-name">Mensaje completo (.eml)</span>
+          <span class="mode-sub">{{ message ? 'Añade cuerpo, enlaces y adjuntos' : 'Arrastra un .eml para activarlo' }}</span>
+        </button>
+      </div>
+
+      <p v-if="mode === MODE_MESSAGE" class="mode-notice mode-notice--warn">{{ fullMessageNotice }}</p>
+      <details v-else-if="uncoveredRules.length" class="mode-notice">
+        <summary>{{ uncoveredRules.length }} reglas no se evaluarán en este modo (necesitan cuerpo, enlaces o adjuntos)</summary>
+        <p class="mode-rules">{{ uncoveredRules.join(' · ') }}</p>
+      </details>
+
       <textarea
-        v-model="headers"
+        v-model="shownHeaders"
         class="form-textarea"
+        :readonly="mode === MODE_MESSAGE"
         placeholder="Received: from mail.example.com (209.85.220.41)&#10;DKIM-Signature: v=1; a=rsa-sha256; d=example.com;&#10;From: &quot;Usuario&quot; &lt;user@example.com&gt;&#10;Reply-To: user@example.com&#10;Return-Path: &lt;user@example.com&gt;&#10;Message-ID: &lt;20260607120000.abc123@mail.example.com&gt;&#10;Authentication-Results: mx.google.com;&#10;  spf=pass smtp.mailfrom=example.com;&#10;  dkim=pass header.i=@example.com;&#10;  dmarc=pass action=none;"
         rows="14"
         spellcheck="false"
       ></textarea>
+      <p v-if="mode === MODE_MESSAGE" class="form-subhint">
+        Se analiza el .eml tal como se cargó. Para editar las cabeceras, cambia a «Solo cabeceras».
+      </p>
     </div>
 
     <div class="form-footer">
-      <div class="char-count">{{ headers.length }} caracteres</div>
+      <div class="char-count">{{ shownHeaders.length }} caracteres</div>
       <button
         type="button"
         class="btn-analyze"
-        :disabled="headers.length < 10 || submitting"
+        :disabled="!canSubmit || submitting"
         @click="handleSubmit"
       >
         <span v-if="submitting" class="btn-spinner"></span>
@@ -39,14 +77,16 @@
           <polyline points="12 8 12 16"/>
           <line x1="8" y1="12" x2="16" y2="12"/>
         </svg>
-        {{ submitting ? 'Analizando…' : 'Analizar Cabeceras' }}
+        {{ submitting ? 'Analizando…' : (mode === MODE_MESSAGE ? 'Analizar mensaje completo' : 'Analizar cabeceras') }}
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useIrisStore } from '@/stores/irisStore'
+import { MODE_HEADERS, MODE_MESSAGE } from '@/components/iris/intake.js'
 
 const emit = defineEmits(['submit'])
 const props = defineProps({
@@ -55,33 +95,51 @@ const props = defineProps({
   prefill: { type: Object, default: null },
 })
 
-const headers = ref(props.prefill?.headers ?? '')
-const title = ref(props.prefill?.title ?? '')
-// Mensaje .eml completo, si el archivo arrastrado se cargó entero.
-const message = ref(props.prefill?.message ?? null)
-// Cabeceras tal como llegaron del prefill: si el usuario las edita, ya no
-// podemos garantizar que sigan correspondiendo al mensaje completo cargado,
-// así que dejamos de enviarlo y caemos de vuelta a solo-cabeceras.
-const loadedHeaders = ref(headers.value)
+const store = useIrisStore()
 
+// Respaldo mientras `/iris/capabilities` no ha respondido: el texto de verdad
+// lo publica el servidor, para que la UI y la API avisen de lo mismo.
+const FALLBACK_NOTICE = 'El mensaje completo incluye cuerpo y adjuntos, que pueden contener datos personales o confidenciales.'
+
+const title = ref('')
+// Cabeceras editables (modo solo cabeceras).
+const headers = ref('')
+// Mensaje .eml completo, si el archivo arrastrado se cargó entero.
+const message = ref(null)
+// Cabeceras tal como llegaron con el .eml: es lo que se ve en modo completo.
+const loadedHeaders = ref('')
+const mode = ref(MODE_HEADERS)
+
+function applyPrefill() {
+  headers.value = props.prefill?.headers ?? ''
+  title.value = props.prefill?.title ?? ''
+  message.value = props.prefill?.message ?? null
+  loadedHeaders.value = headers.value
+  mode.value = message.value ? MODE_MESSAGE : MODE_HEADERS
+}
+
+applyPrefill()
 // Cuando llega un nuevo .eml (token distinto), reemplaza el contenido del formulario.
-watch(
-  () => props.prefill?.token,
-  () => {
-    if (!props.prefill) return
-    headers.value = props.prefill.headers ?? ''
-    title.value = props.prefill.title ?? ''
-    message.value = props.prefill.message ?? null
-    loadedHeaders.value = headers.value
-  },
+watch(() => props.prefill?.token, () => { if (props.prefill) applyPrefill() })
+
+const shownHeaders = computed({
+  get: () => (mode.value === MODE_MESSAGE ? loadedHeaders.value : headers.value),
+  set: (value) => { headers.value = value },
+})
+
+const uncoveredRules = computed(() => store.capabilities?.headersOnlyUncoveredRules ?? [])
+const fullMessageNotice = computed(() => store.capabilities?.fullMessageNotice || FALLBACK_NOTICE)
+
+const canSubmit = computed(() =>
+  mode.value === MODE_MESSAGE ? !!message.value : headers.value.length >= 10
 )
 
 function handleSubmit() {
-  if (headers.value.length < 10 || props.submitting) return
-  const useFullMessage = message.value && headers.value === loadedHeaders.value
+  if (!canSubmit.value || props.submitting) return
   emit('submit', {
+    mode: mode.value,
     headers: headers.value,
-    message: useFullMessage ? message.value : undefined,
+    message: message.value,
     title: title.value || undefined,
   })
 }
@@ -91,7 +149,7 @@ function handleSubmit() {
 .iris-form {
   display: flex;
   flex-direction: column;
-    gap: 1.25rem;
+  gap: 1.25rem;
   max-width: 820px;
   width: 100%;
   margin: 0 auto;
@@ -142,6 +200,67 @@ function handleSubmit() {
   opacity: 0.4;
 }
 
+.mode-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.mode-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.65rem 0.85rem;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border-solid);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.mode-option--active {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.mode-option:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.mode-name {
+  font-size: var(--fs-md);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.mode-sub {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+.mode-notice {
+  margin: 0;
+  padding: 0.55rem 0.8rem;
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.mode-notice summary { cursor: pointer; }
+
+.mode-notice--warn {
+  color: var(--warn);
+  background: var(--warn-dim);
+  border-color: rgba(212, 160, 74, 0.25);
+}
+
+.mode-rules { margin: 0.4rem 0 0; color: var(--text-muted); }
+
 .form-textarea {
   width: 100%;
   min-height: 320px;
@@ -163,11 +282,21 @@ function handleSubmit() {
   box-shadow: 0 0 0 2px var(--accent-dim);
 }
 
+.form-textarea[readonly] {
+  color: var(--text-dim);
+}
+
 .form-textarea::placeholder {
   color: var(--text-muted);
   font-size: var(--fs-md);
   opacity: 0.35;
   font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
+}
+
+.form-subhint {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
 }
 
 .form-footer {
@@ -223,5 +352,9 @@ function handleSubmit() {
   border-top-color: var(--on-accent);
   border-radius: 50%;
   animation: seq-spin 0.6s linear infinite;
+}
+
+@media (max-width: 540px) {
+  .mode-switch { grid-template-columns: 1fr; }
 }
 </style>

--- a/web/app/src/components/iris/intake.js
+++ b/web/app/src/components/iris/intake.js
@@ -75,6 +75,30 @@ export function classifyIntake(file, capabilities) {
   }
 }
 
+/** Modos de análisis que acepta `POST /iris/analyze` en su campo `mode`. */
+export const MODE_HEADERS = 'headers'
+export const MODE_MESSAGE = 'message'
+
+/**
+ * Cuerpo de `POST /iris/analyze` para el modo que eligió el usuario.
+ *
+ * El modo viaja explícito y solo se envía el campo de ese modo: el servidor
+ * valida únicamente lo que va a analizar, así que elegir «solo cabeceras»
+ * sobre un `.eml` enorme no puede acabar en un rechazo por el tamaño de un
+ * mensaje que no se usa. El modo completo sin mensaje cargado cae a cabeceras
+ * en vez de enviar una petición que el servidor rechazaría.
+ *
+ * @param {{mode: string, headers: string, message?: string|null, title?: string}} input
+ * @returns {{mode: string, headers?: string, message?: string, title?: string}}
+ */
+export function buildSubmission({ mode, headers, message, title }) {
+  const body = mode === MODE_MESSAGE && message
+    ? { mode: MODE_MESSAGE, message }
+    : { mode: MODE_HEADERS, headers }
+  if (title) body.title = title
+  return body
+}
+
 /** Tamaño legible para el aviso que ve el usuario ("10 MB"). */
 export function formatByteLimit(bytes) {
   if (!Number.isFinite(bytes) || bytes <= 0) return ''

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -60,7 +60,10 @@ export const useIrisStore = defineStore('iris', () => {
   async function fetchCapabilities() {
     if (capabilities.value) return capabilities.value
     try {
-      capabilities.value = await apiFetch('/iris/capabilities')
+      // apiFetch devuelve la Response, no el cuerpo: sin el .json() la vista
+      // leía `maxMessageBytes` de la Response y caía siempre al respaldo.
+      const res = await apiFetch('/iris/capabilities')
+      capabilities.value = res?.ok ? await res.json() : null
     } catch {
       // Silencioso a propósito: no poder leer los límites no impide analizar
       // nada, solo hace que la interfaz use su respaldo. Un toast de error

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -4,6 +4,7 @@ import { useApi } from '@/composables/useApi'
 import { usePolling } from '@/composables/usePolling'
 import { useUtils } from '@/composables/useUtils'
 import { useToastStore } from '@/stores/toastStore'
+import { MODE_HEADERS, MODE_MESSAGE, buildSubmission } from '@/components/iris/intake.js'
 
 export const useIrisStore = defineStore('iris', () => {
   const { apiFetch, apiError } = useApi()
@@ -69,11 +70,18 @@ export const useIrisStore = defineStore('iris', () => {
     return capabilities.value
   }
 
-  async function submitAnalysis({ headers, message, title } = {}) {
+  /**
+   * Envía un correo a analizar en el modo que eligió el usuario.
+   * @param {{mode?: 'headers'|'message', headers: string, message?: string|null, title?: string}} submission
+   *   Sin `mode`, se usa el mensaje completo si lo hay y las cabeceras si no.
+   * @returns {Promise<number|null>} El id del análisis creado, o null si falló.
+   */
+  async function submitAnalysis({ mode, headers, message, title } = {}) {
     submitting.value = true
     try {
-      const body = message ? { message } : { headers }
-      if (title) body.title = title
+      const body = buildSubmission({
+        mode: mode ?? (message ? MODE_MESSAGE : MODE_HEADERS), headers, message, title,
+      })
 
       const res = await apiFetch('/iris/analyze', {
         method: 'POST',

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -242,8 +242,8 @@ onMounted(async () => {
   }
 })
 
-async function handleSubmit({ headers, message, title }) {
-  const id = await store.submitAnalysis({ headers, message, title })
+async function handleSubmit(submission) {
+  const id = await store.submitAnalysis(submission)
   if (id) {
     prefill.value = null
     formKey.value++

--- a/web/app/test/iris.intake.test.mjs
+++ b/web/app/test/iris.intake.test.mjs
@@ -15,6 +15,9 @@
 
 import {
   FALLBACK_MAX_MESSAGE_BYTES,
+  MODE_HEADERS,
+  MODE_MESSAGE,
+  buildSubmission,
   classifyIntake,
   formatByteLimit,
   isEmlFile,
@@ -97,6 +100,23 @@ eq('10 MB', formatByteLimit(10 * MB), '10 MB')
 eq('20 MB', formatByteLimit(20 * MB), '20 MB')
 eq('decimal por debajo de 10', formatByteLimit(2.5 * MB), '2.5 MB')
 eq('sin límite no hay texto', formatByteLimit(0), '')
+
+console.log('\nbuildSubmission — el modo viaja explícito')
+eq('modo cabeceras envía solo las cabeceras',
+  buildSubmission({ mode: MODE_HEADERS, headers: 'From: a', message: 'From: a\n\ncuerpo' }),
+  { mode: 'headers', headers: 'From: a' })
+eq('modo completo envía solo el mensaje',
+  buildSubmission({ mode: MODE_MESSAGE, headers: 'From: a', message: 'From: a\n\ncuerpo', title: 'T' }),
+  { mode: 'message', message: 'From: a\n\ncuerpo', title: 'T' })
+// Sin mensaje cargado (fichero truncado por tamaño o cabeceras pegadas a mano)
+// el modo completo no tiene nada que enviar: cae a cabeceras en vez de mandar
+// una petición que el servidor rechazaría.
+eq('modo completo sin mensaje cae a cabeceras',
+  buildSubmission({ mode: MODE_MESSAGE, headers: 'From: a', message: null }),
+  { mode: 'headers', headers: 'From: a' })
+eq('sin título no se envía la clave',
+  Object.keys(buildSubmission({ mode: MODE_HEADERS, headers: 'From: a', title: '' })),
+  ['mode', 'headers'])
 
 console.log(`\n${passed} pasados, ${failed} fallidos`)
 process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## El problema

Iris puede analizar un correo de dos formas: **solo las cabeceras** (quién lo envía, si se autentica, por dónde pasó) o el **mensaje completo** (`.eml`), que añade el cuerpo, los enlaces y los adjuntos. Hasta ahora el usuario no elegía entre las dos:

- El navegador *deducía* el modo: si el usuario había arrastrado un `.eml` y no había tocado el textarea, se enviaba el mensaje completo; si lo había tocado, solo las cabeceras. No se veía en ningún sitio ni se podía cambiar a propósito.
- El usuario no sabía qué dejaba de revisarse en modo cabeceras (unas 15 reglas de cuerpo, enlaces y adjuntos no tienen nada que mirar), ni que el modo completo sube a Iris contenido que puede ser sensible.
- El servidor validaba el tamaño de los dos campos aunque solo analizara uno. Elegir «solo cabeceras» sobre un `.eml` grande podía acabar en un rechazo por el tamaño del mensaje completo: un error contradictorio.

Además, el store del SPA guardaba la respuesta HTTP de `GET /iris/capabilities` en vez de su contenido. La interfaz nunca llegó a usar los límites que publica el servidor, siempre el valor de respaldo.

Cierra #214 (iniciativa `M07`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

**API.**

- `POST /iris/analyze` acepta un campo nuevo, `mode`, que vale `headers` o `message`. Con modo, el servidor exige, valida y usa **solo** el campo de ese modo y descarta el otro. Sin `mode` todo sigue como antes: basta con uno de los dos y, si vienen ambos, gana el mensaje completo. Así los clientes que no envían el campo no notan nada.
- `GET /iris/capabilities` publica dos datos más:
  - `headersOnlyUncoveredRules`: las reglas que no tendrán nada que inspeccionar en modo cabeceras. Sale del mismo helper con el que `assess_coverage` guarda esa lista en cada análisis, así que lo que avisa la interfaz antes de enviar y lo que registra el análisis después son la misma lista.
  - `fullMessageNotice`: el aviso de que el mensaje completo puede incluir datos sensibles, con los días de retención reales del raw.

**Interfaz.**

- El formulario muestra los dos modos como una elección visible y reversible. «Mensaje completo» solo se puede elegir si hay un `.eml` cargado, y es el modo por defecto al arrastrar uno.
- En modo cabeceras se puede desplegar la lista de reglas que no se evaluarán. En modo completo aparece el aviso de sensibilidad, y las cabeceras del `.eml` se ven en solo lectura para que no se desincronicen del mensaje que se envía.
- `buildSubmission` (en `intake.js`) construye el cuerpo de la petición con el modo explícito.
- `fetchCapabilities` lee el cuerpo JSON de la respuesta.

## Validación

- `test_iris_analysis_modes.py` (nuevo, 8 casos):
  - `capabilities` publica las reglas sin cobertura y el aviso.
  - En modo cabeceras se analizan las cabeceras aunque viaje el mensaje, y nunca se rechaza por el tamaño del mensaje que no se usa.
  - En modo completo se analiza el `.eml`.
  - Pedir un modo sin su campo da `422` indicando cuál falta.
  - Sin `mode`, el comportamiento anterior no cambia.
- `test_iris.py`: los dos tests de límite de tamaño sustituían la configuración por un doble escrito a mano, al que le faltaban campos. Ahora usan un `IrisConfig` real con solo el límite cambiado.
- `pytest -k "iris or conventions or caddy or import_isolation"` en verde.
- SPA: `node test/iris.intake.test.mjs` (27 casos, 4 nuevos de `buildSubmission`) en verde. `IrisForm.vue` e `IrisView.vue` compilan con `@vue/compiler-sfc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
