### PR TITLE
feat(iris): casos de analista con ciclo de vida, asignación, notas y timeline (F01)

### DIFF
--- a/API/alembic/versions/f6c1a4d8e3b9_add_iris_cases.py
+++ b/API/alembic/versions/f6c1a4d8e3b9_add_iris_cases.py
@@ -1,0 +1,84 @@
+"""iris: casos de analista (IrisCase, IrisCaseAnalysis, IrisCaseEvent)
+
+Un informe aislado no era trabajo operativo medible. Un caso agrupa uno o
+varios análisis —que siguen inmutables— y registra la decisión humana:
+estado, prioridad, asignación, etiquetas, notas y una timeline de todo lo que
+le pasó, con la razón de cierre.
+
+Revision ID: f6c1a4d8e3b9
+Revises: e5b9f3a7c2d8
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6c1a4d8e3b9'
+down_revision: Union[str, Sequence[str], None] = 'e5b9f3a7c2d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'IrisCase',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(length=120), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('priority', sa.String(length=16), nullable=False),
+        sa.Column('assignee_id', sa.Integer(), nullable=True),
+        sa.Column('tags', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('resolution_reason', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.Column('closed_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['User.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['assignee_id'], ['User.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_iris_case_user_id', 'IrisCase', ['user_id'])
+    op.create_index('ix_iris_case_status', 'IrisCase', ['status'])
+    op.create_table(
+        'IrisCaseAnalysis',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('case_id', sa.Integer(), nullable=False),
+        sa.Column('analysis_id', sa.Integer(), nullable=False),
+        sa.Column('added_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['case_id'], ['IrisCase.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['analysis_id'], ['IrisAnalysis.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('case_id', 'analysis_id', name='uq_iris_case_analysis_case_analysis'),
+    )
+    op.create_index('ix_iris_case_analysis_analysis_id', 'IrisCaseAnalysis', ['analysis_id'])
+    op.create_table(
+        'IrisCaseEvent',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('case_id', sa.Integer(), nullable=False),
+        sa.Column('actor_id', sa.Integer(), nullable=True),
+        sa.Column('kind', sa.String(length=24), nullable=False),
+        sa.Column('detail', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['case_id'], ['IrisCase.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['actor_id'], ['User.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_iris_case_event_case_id', 'IrisCaseEvent', ['case_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_iris_case_event_case_id', table_name='IrisCaseEvent')
+    op.drop_table('IrisCaseEvent')
+    op.drop_index('ix_iris_case_analysis_analysis_id', table_name='IrisCaseAnalysis')
+    op.drop_table('IrisCaseAnalysis')
+    op.drop_index('ix_iris_case_status', table_name='IrisCase')
+    op.drop_index('ix_iris_case_user_id', table_name='IrisCase')
+    op.drop_table('IrisCase')

--- a/API/src/modules/features/iris/endpoints.py
+++ b/API/src/modules/features/iris/endpoints.py
@@ -37,6 +37,7 @@ import src.modules.system.config_reading as CR
 from .managers import (
     IrisFeedbackManager, IrisManager, IrisReportManager, IrisMailboxManager,
     IrisNotificationPreferenceManager, IrisReplayManager, IrisTriageManager, IrisTrustPolicyManager,
+    IrisCaseManager,
 )
 from .exceptions import (
     IrisAnalysisNotFoundError,
@@ -44,6 +45,7 @@ from .exceptions import (
     IrisInvalidInputError,
     IrisMailboxConnectionNotFoundError,
     IrisMailboxOAuthStateError,
+    IrisCaseNotFoundError,
     IrisSavedViewNotFoundError,
     IrisTrustedSenderNotFoundError,
 )
@@ -100,6 +102,14 @@ from .schemas import (
     IrisSavedViewListResponseSchema,
     IrisSavedViewRequestSchema,
     IrisTagListResponseSchema,
+    IrisCaseCreateRequestSchema,
+    IrisCaseDetailSchema,
+    IrisCaseLinkRequestSchema,
+    IrisCaseListResponseSchema,
+    IrisCaseNoteRequestSchema,
+    IrisCaseStatusRequestSchema,
+    IrisCasesQuerySchema,
+    IrisCaseUpdateRequestSchema,
 )
 
 
@@ -367,6 +377,145 @@ def set_analysis_tags(data, analysis_id: int):
     user = get_current_user()
     tags = IrisTriageManager().set_tags(analysis_id, user.id, data["tags"])
     return {"analysisId": analysis_id, "tags": tags}
+
+
+# =============================================================================
+# Casos de analista
+# =============================================================================
+
+@iris_blp.post("/cases")
+@iris_blp.arguments(IrisCaseCreateRequestSchema)
+@iris_blp.response(201, IrisCaseDetailSchema, description="Case opened")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Invalid title, tags or too many analyses")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Analysis not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_CREATE])
+@limiter.limit("60 per hour; 300 per day")
+@handle_exceptions(default_exception=IrisExecutionError, logger=logger)
+def create_case(data):
+    """Abrir un caso de analista, opcionalmente con análisis ya vinculados"""
+    user = get_current_user()
+    case = IrisCaseManager().create_case(user.id, data["title"], data["priority"],
+                                         data["analysisIds"], data["tags"])
+    logger.info(f"Caso {case['caseId']} abierto por {user.username}")
+    return case
+
+
+@iris_blp.get("/cases")
+@iris_blp.arguments(IrisCasesQuerySchema, location="query")
+@iris_blp.response(200, IrisCaseListResponseSchema, description="Analyst cases and counts by status")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(logger=logger)
+def list_cases(args: dict):
+    """Casos del usuario, con cuántos tiene en cada estado"""
+    user = get_current_user()
+    return IrisCaseManager().list_cases(user.id, args["status"], args["priority"], args["assignedToMe"])
+
+
+@iris_blp.get("/cases/<int:case_id>")
+@iris_blp.response(200, IrisCaseDetailSchema, description="Case with its analyses and timeline")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_READ])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def get_case(case_id: int):
+    """Un caso con sus análisis y su timeline"""
+    return IrisCaseManager().get_case(case_id, get_current_user().id)
+
+
+@iris_blp.patch("/cases/<int:case_id>")
+@iris_blp.arguments(IrisCaseUpdateRequestSchema)
+@iris_blp.response(200, IrisCaseDetailSchema, description="Case updated")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Invalid value or assignee")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def update_case(data, case_id: int):
+    """Cambiar título, prioridad, etiquetas o asignación de un caso"""
+    # Solo se pasan los campos presentes: assigneeId a null (quitar la
+    # asignación) no es lo mismo que no enviarlo.
+    fields_by_key = {"title": "title", "priority": "priority", "tags": "tags", "assigneeId": "assignee_id"}
+    changes = {argument: data[key] for key, argument in fields_by_key.items() if key in data}
+    return IrisCaseManager().update_case(case_id, get_current_user().id, **changes)
+
+
+@iris_blp.post("/cases/<int:case_id>/status")
+@iris_blp.arguments(IrisCaseStatusRequestSchema)
+@iris_blp.response(200, IrisCaseDetailSchema, description="Case moved to a new status")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Transition not allowed or missing reason")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def change_case_status(data, case_id: int):
+    """Mover un caso por su ciclo de vida; cerrarlo exige una razón"""
+    user = get_current_user()
+    case = IrisCaseManager().change_status(case_id, user.id, data["status"], data.get("reason"))
+    logger.info(f"Caso {case_id} pasa a {data['status']} por {user.username}")
+    return case
+
+
+@iris_blp.post("/cases/<int:case_id>/notes")
+@iris_blp.arguments(IrisCaseNoteRequestSchema)
+@iris_blp.response(201, IrisCaseDetailSchema, description="Note added")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Empty note")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def add_case_note(data, case_id: int):
+    """Añadir una nota a la timeline de un caso"""
+    return IrisCaseManager().add_note(case_id, get_current_user().id, data["note"])
+
+
+@iris_blp.post("/cases/<int:case_id>/analyses")
+@iris_blp.arguments(IrisCaseLinkRequestSchema)
+@iris_blp.response(201, IrisCaseDetailSchema, description="Analysis linked")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Analysis already in the case")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case or analysis not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def link_case_analysis(data, case_id: int):
+    """Vincular un análisis a un caso (el análisis no cambia)"""
+    return IrisCaseManager().link_analysis(case_id, get_current_user().id, data["analysisId"])
+
+
+@iris_blp.delete("/cases/<int:case_id>/analyses/<int:analysis_id>")
+@iris_blp.response(200, IrisCaseDetailSchema, description="Analysis unlinked")
+@iris_blp.alt_response(400, schema=ErrorSchema, description="Analysis not in the case")
+@iris_blp.alt_response(401, schema=ErrorSchema, description="Not authenticated")
+@iris_blp.alt_response(403, schema=ErrorSchema, description="Insufficient permissions")
+@iris_blp.alt_response(404, schema=ErrorSchema, description="Case not found")
+@require_oauth_token
+@require_attributes(at_least_one=[AttributeType.IRIS_UPDATE])
+@limiter.limit("300 per hour; 2000 per day")
+@handle_exceptions(default_exception=IrisCaseNotFoundError, logger=logger)
+def unlink_case_analysis(case_id: int, analysis_id: int):
+    """Desvincular un análisis de un caso (el análisis no se borra)"""
+    return IrisCaseManager().unlink_analysis(case_id, get_current_user().id, analysis_id)
 
 
 @iris_blp.get("/retention-policy")

--- a/API/src/modules/features/iris/exceptions.py
+++ b/API/src/modules/features/iris/exceptions.py
@@ -108,6 +108,12 @@ class IrisSavedViewNotFoundError(EntityNotFoundError, IrisError):
     id_field = "view_id"
 
 
+class IrisCaseNotFoundError(EntityNotFoundError, IrisError):
+    """El caso no existe o no es del usuario (mismo error para los dos)."""
+    entity_label = "Caso"
+    id_field = "case_id"
+
+
 class IrisMailboxInvalidProviderError(IrisError):
     """Raised when connecting to an unsupported mailbox provider."""
     default_code = ErrorCode.VALIDATION_ERROR

--- a/API/src/modules/features/iris/managers/__init__.py
+++ b/API/src/modules/features/iris/managers/__init__.py
@@ -20,6 +20,8 @@ Managers del módulo Iris (análisis de correo).
   usuario (remitentes y dominios), con motivo, caducidad y revocación.
 - ``IrisTriageManager`` (``triage.py``): vistas guardadas y etiquetas del
   historial de triaje.
+- ``IrisCaseManager`` (``cases.py``): casos de analista con estado,
+  prioridad, asignación, notas y timeline sobre uno o varios análisis.
 
 Iris era el único módulo con
 **dos** ficheros de managers en la raíz — ``managers.py`` (64 KB, el
@@ -42,11 +44,13 @@ from .feedback import IrisFeedbackManager
 from .replay import IrisReplayManager
 from .trust import IrisTrustPolicyManager
 from .triage import IrisTriageManager
+from .cases import IrisCaseManager
 
 __all__ = [
     "IrisManager",
     "IrisTrustPolicyManager",
     "IrisTriageManager",
+    "IrisCaseManager",
     "IrisFeedbackManager",
     "IrisReplayManager",
     "IrisReportManager",

--- a/API/src/modules/features/iris/managers/cases.py
+++ b/API/src/modules/features/iris/managers/cases.py
@@ -1,0 +1,413 @@
+"""
+IrisCaseManager — casos de analista: la decisión humana encima de los análisis.
+
+Un análisis es el resultado inmutable de lo que decidió Iris. Un caso agrupa
+uno o varios análisis y registra lo que decidió una persona: estado,
+prioridad, asignación, etiquetas, notas y una timeline (``IrisCaseEvent``)
+con cada cambio, para que el trabajo operativo se pueda medir y auditar. Qué
+transiciones de estado son válidas lo decide ``services/cases.py``.
+
+Un caso es de un usuario, igual que sus análisis: una organización comparte
+plan y factura, no datos (ver ``Organization``), así que un caso solo se puede
+asignar a quien puede ver sus análisis, que es su dueño.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from src.modules.infrastructure import UnitOfWork, build_repository
+from src.modules.shared import assert_owned, isoformat_utc, utcnow_naive
+
+from ..exceptions import IrisCaseNotFoundError, IrisInvalidInputError
+from ..model import CasePriority, IrisCase, IrisCaseAnalysis, IrisCaseEvent
+from ..repositories import IrisCaseAnalysisRepository, IrisCaseEventRepository, IrisCaseRepository
+from ..services.cases import MAX_CASE_TEXT_LENGTH, validate_transition
+from ..services.tags import normalize_tags
+from .analysis import IrisManager
+
+#: Análisis que se pueden vincular a un caso al crearlo, en una sola petición.
+MAX_ANALYSES_ON_CREATE = 50
+
+#: Marca "no venía en la petición" en ``update_case``, distinta de ``None``
+#: (que en ``assignee_id`` significa "quitar la asignación").
+_UNSET = object()
+
+
+def _invalid_input(text: str) -> IrisInvalidInputError:
+    """Error de validación cuyo mensaje se enseña tal cual al usuario.
+
+    Args:
+        text: Qué falló, en castellano.
+
+    Returns:
+        IrisInvalidInputError: Con ``user_message`` igual a ``text``.
+    """
+    return IrisInvalidInputError(text, user_message=text)
+
+
+def _clean_tags(tags: Iterable[str]) -> List[str]:
+    """Normaliza las etiquetas de un caso con la misma regla que las de un análisis.
+
+    Args:
+        tags: Etiquetas tal como las escribió el usuario.
+
+    Returns:
+        List[str]: Etiquetas normalizadas (ver ``services/tags.normalize_tags``).
+
+    Raises:
+        IrisInvalidInputError: Si alguna es demasiado larga o son demasiadas.
+    """
+    try:
+        return normalize_tags(tags)
+    except ValueError as e:
+        raise _invalid_input(str(e)) from e
+
+
+def _record_event(uow: UnitOfWork, case: IrisCase, actor_id: int, kind: str,
+                  detail: Optional[Dict[str, Any]] = None, note: Optional[str] = None) -> None:
+    """Añade una entrada a la timeline del caso y marca su última modificación.
+
+    Args:
+        uow: Transacción en curso; el evento se confirma con el cambio que describe.
+        case: Caso al que pertenece el evento.
+        actor_id: Usuario que hizo el cambio.
+        kind: Qué pasó: ``created``, ``status_changed``, ``priority_changed``,
+            ``assigned``, ``title_changed``, ``tags_changed``, ``note``,
+            ``analysis_linked`` o ``analysis_unlinked``.
+        detail: Datos del cambio (``from``/``to``, ``analysisId``…). Por defecto ``None``.
+        note: Texto de una nota. Por defecto ``None``.
+    """
+    case.updated_at = utcnow_naive()
+    IrisCaseEventRepository(uow).save(IrisCaseEvent(
+        case_id=case.id, actor_id=actor_id, kind=kind, detail=detail, note=note,
+    ))
+
+
+def _assert_case(uow: UnitOfWork, case_id: int, user_id: int) -> IrisCase:
+    """Carga un caso dentro de la transacción y comprueba que es del usuario.
+
+    Args:
+        uow: Transacción en curso.
+        case_id: Caso pedido.
+        user_id: Usuario que lo pide.
+
+    Returns:
+        IrisCase: El caso.
+
+    Raises:
+        IrisCaseNotFoundError: Si no existe o no es suyo.
+    """
+    return assert_owned(IrisCaseRepository, case_id, user_id, IrisCaseNotFoundError, uow=uow)
+
+
+def _summary(case: IrisCase) -> Dict[str, Any]:
+    """Serializa lo que enseña el listado de casos.
+
+    Args:
+        case: Caso con sus vínculos cargados.
+
+    Returns:
+        dict: ``caseId``, ``title``, ``status``, ``priority``, ``assignee``,
+            ``tags``, ``analysisCount``, ``createdAt``, ``updatedAt`` y ``closedAt``.
+    """
+    return {
+        "caseId": case.id,
+        "title": case.title,
+        "status": case.status,
+        "priority": case.priority,
+        "assignee": case.assignee.username if case.assignee else None,
+        "tags": list(case.tags or []),
+        "analysisCount": len(case.links),
+        "createdAt": isoformat_utc(case.created_at),
+        "updatedAt": isoformat_utc(case.updated_at),
+        "closedAt": isoformat_utc(case.closed_at),
+    }
+
+
+def _detail(case: IrisCase) -> Dict[str, Any]:
+    """Serializa un caso entero: resumen, análisis vinculados y timeline.
+
+    Args:
+        case: Caso con sus vínculos y eventos cargados.
+
+    Returns:
+        dict: Lo de ``_summary`` más ``assigneeId``, ``resolutionReason``,
+            ``analyses`` (id, título, estado, veredicto, score, confianza y
+            cuándo se vinculó) y ``timeline`` (del evento más antiguo al más
+            reciente, con su autor).
+    """
+    return {
+        **_summary(case),
+        "assigneeId": case.assignee_id,
+        "resolutionReason": case.resolution_reason,
+        "analyses": [{
+            "analysisId": link.analysis.id,
+            "title": link.analysis.title,
+            "status": link.analysis.status,
+            "verdict": link.analysis.verdict,
+            "totalScore": link.analysis.total_score,
+            "confidence": link.analysis.confidence,
+            "addedAt": isoformat_utc(link.added_at),
+        } for link in case.links],
+        "timeline": [{
+            "eventId": event.id,
+            "kind": event.kind,
+            "detail": event.detail,
+            "note": event.note,
+            "actor": event.actor.username if event.actor else None,
+            "createdAt": isoformat_utc(event.created_at),
+        } for event in case.events],
+    }
+
+
+class IrisCaseManager:
+    """Alta, consulta y ciclo de vida de los casos de un usuario."""
+
+    def create_case(self, user_id: int, title: str, priority: str = CasePriority.MEDIUM.value,
+                    analysis_ids: Iterable[int] = (), tags: Iterable[str] = ()) -> Dict[str, Any]:
+        """Abre un caso, opcionalmente con análisis ya vinculados.
+
+        Args:
+            user_id: Dueño del caso, que es también quien lo abre.
+            title: Título visible; se recortan los espacios (hasta 120 caracteres).
+            priority: ``low``, ``medium``, ``high`` o ``critical``. Por defecto ``medium``.
+            analysis_ids: Análisis del usuario que se vinculan al abrirlo; se
+                ignoran los repetidos. Por defecto ninguno.
+            tags: Etiquetas del caso. Por defecto ninguna.
+
+        Returns:
+            dict: El caso abierto (ver ``_detail``), en estado ``new``.
+
+        Raises:
+            IrisInvalidInputError: Si el título está vacío, la prioridad no
+                existe, hay demasiados análisis o las etiquetas no son válidas.
+            IrisAnalysisNotFoundError: Si algún análisis no existe o no es suyo.
+        """
+        cleaned_title = (title or "").strip()[:120]
+        if not cleaned_title:
+            raise _invalid_input("El caso necesita un título.")
+        if priority not in {member.value for member in CasePriority}:
+            raise _invalid_input(f"Prioridad desconocida: {priority!r}.")
+        unique_ids = list(dict.fromkeys(analysis_ids))
+        if len(unique_ids) > MAX_ANALYSES_ON_CREATE:
+            raise _invalid_input(f"Como mucho {MAX_ANALYSES_ON_CREATE} análisis al abrir un caso.")
+        for analysis_id in unique_ids:
+            IrisManager.assert_analysis_ownership(analysis_id, user_id)
+        cleaned_tags = _clean_tags(tags)
+
+        with UnitOfWork() as uow:
+            case = IrisCaseRepository(uow).save(IrisCase(
+                user_id=user_id, title=cleaned_title, priority=priority, tags=cleaned_tags,
+            ))
+            link_repo = IrisCaseAnalysisRepository(uow)
+            for analysis_id in unique_ids:
+                link_repo.save(IrisCaseAnalysis(case_id=case.id, analysis_id=analysis_id))
+            _record_event(uow, case, user_id, "created", {"analysisIds": unique_ids, "priority": priority})
+            case_id = case.id
+        return self.get_case(case_id, user_id)
+
+    def list_cases(self, user_id: int, status: Optional[str] = None, priority: Optional[str] = None,
+                   assigned_to_me: bool = False) -> Dict[str, Any]:
+        """Casos de un usuario, del modificado más recientemente al más antiguo.
+
+        Args:
+            user_id: Dueño de los casos.
+            status: Solo los de este estado. Por defecto ``None``: todos.
+            priority: Solo los de esta prioridad. Por defecto ``None``: todas.
+            assigned_to_me: Solo los asignados al propio usuario. Por defecto ``False``.
+
+        Returns:
+            dict: ``cases`` (ver ``_summary``), ``total`` y ``countsByStatus``,
+                cuántos casos tiene en cada estado sin aplicar los filtros: es
+                la cola de trabajo de un vistazo.
+        """
+        repo = build_repository(IrisCaseRepository)
+        cases = repo.get_by_user_filtered(user_id, status=status, priority=priority,
+                                          assignee_id=user_id if assigned_to_me else None)
+        return {
+            "cases": [_summary(case) for case in cases],
+            "total": len(cases),
+            "countsByStatus": repo.count_by_status_for_user(user_id),
+        }
+
+    def get_case(self, case_id: int, user_id: int) -> Dict[str, Any]:
+        """Un caso entero, con sus análisis y su timeline.
+
+        Args:
+            case_id: Caso pedido.
+            user_id: Usuario que lo pide; debe ser el dueño.
+
+        Returns:
+            dict: Ver ``_detail``.
+
+        Raises:
+            IrisCaseNotFoundError: Si no existe o no es suyo.
+        """
+        case = assert_owned(IrisCaseRepository, case_id, user_id, IrisCaseNotFoundError)
+        return _detail(case)
+
+    def update_case(self, case_id: int, user_id: int, *, title: Any = _UNSET, priority: Any = _UNSET,
+                    tags: Any = _UNSET, assignee_id: Any = _UNSET) -> Dict[str, Any]:
+        """Cambia título, prioridad, etiquetas o asignación, dejando rastro de cada cambio.
+
+        Solo se toca lo que se pasa; un valor igual al actual no genera evento.
+
+        Args:
+            case_id: Caso a cambiar; debe ser del usuario.
+            user_id: Usuario que lo cambia.
+            title: Título nuevo. Por defecto sin cambios.
+            priority: ``low``, ``medium``, ``high`` o ``critical``. Por defecto sin cambios.
+            tags: Conjunto completo de etiquetas. Por defecto sin cambios.
+            assignee_id: A quién se asigna, o ``None`` para quitar la asignación.
+                Solo puede ser el dueño del caso: es el único que ve sus
+                análisis. Por defecto sin cambios.
+
+        Returns:
+            dict: El caso actualizado (ver ``_detail``).
+
+        Raises:
+            IrisCaseNotFoundError: Si no existe o no es suyo.
+            IrisInvalidInputError: Si algún valor no es válido.
+        """
+        with UnitOfWork() as uow:
+            case = _assert_case(uow, case_id, user_id)
+            if title is not _UNSET:
+                cleaned = (title or "").strip()[:120]
+                if not cleaned:
+                    raise _invalid_input("El caso necesita un título.")
+                if cleaned != case.title:
+                    _record_event(uow, case, user_id, "title_changed", {"from": case.title, "to": cleaned})
+                    case.title = cleaned
+            if priority is not _UNSET and priority != case.priority:
+                if priority not in {member.value for member in CasePriority}:
+                    raise _invalid_input(f"Prioridad desconocida: {priority!r}.")
+                _record_event(uow, case, user_id, "priority_changed", {"from": case.priority, "to": priority})
+                case.priority = priority
+            if tags is not _UNSET:
+                cleaned_tags = _clean_tags(tags)
+                if cleaned_tags != list(case.tags or []):
+                    _record_event(uow, case, user_id, "tags_changed", {"from": list(case.tags or []), "to": cleaned_tags})
+                    case.tags = cleaned_tags
+            if assignee_id is not _UNSET and assignee_id != case.assignee_id:
+                if assignee_id is not None and assignee_id != case.user_id:
+                    raise _invalid_input(
+                        "Un caso solo se puede asignar a quien puede ver sus análisis: su dueño."
+                    )
+                _record_event(uow, case, user_id, "assigned", {"from": case.assignee_id, "to": assignee_id})
+                case.assignee_id = assignee_id
+            IrisCaseRepository(uow).update(case)
+        return self.get_case(case_id, user_id)
+
+    def change_status(self, case_id: int, user_id: int, status: str,
+                      reason: Optional[str] = None) -> Dict[str, Any]:
+        """Mueve un caso por su ciclo de vida.
+
+        Cerrar (``resolved`` o ``false_positive``) exige una razón y fija la
+        fecha de cierre; reabrir (volver a ``triage``) las quita del caso, y
+        la timeline conserva las dos cosas.
+
+        Args:
+            case_id: Caso a mover; debe ser del usuario.
+            user_id: Usuario que lo mueve.
+            status: Estado de destino (ver ``services/cases.ALLOWED_TRANSITIONS``).
+            reason: Razón; obligatoria al cerrar. Por defecto ``None``.
+
+        Returns:
+            dict: El caso actualizado (ver ``_detail``).
+
+        Raises:
+            IrisCaseNotFoundError: Si no existe o no es suyo.
+            IrisInvalidInputError: Si la transición no está permitida o falta la razón.
+        """
+        with UnitOfWork() as uow:
+            case = _assert_case(uow, case_id, user_id)
+            try:
+                cleaned_reason = validate_transition(case.status, status, reason)
+            except ValueError as e:
+                raise _invalid_input(str(e)) from e
+            _record_event(uow, case, user_id, "status_changed",
+                          {"from": case.status, "to": status, "reason": cleaned_reason})
+            case.status = status
+            case.resolution_reason = cleaned_reason
+            case.closed_at = utcnow_naive() if cleaned_reason else None
+            IrisCaseRepository(uow).update(case)
+        return self.get_case(case_id, user_id)
+
+    def add_note(self, case_id: int, user_id: int, note: str) -> Dict[str, Any]:
+        """Añade una nota a la timeline del caso.
+
+        Args:
+            case_id: Caso anotado; debe ser del usuario.
+            user_id: Autor de la nota.
+            note: Texto; se recortan los espacios y se limita a
+                ``MAX_CASE_TEXT_LENGTH`` caracteres.
+
+        Returns:
+            dict: El caso actualizado (ver ``_detail``).
+
+        Raises:
+            IrisCaseNotFoundError: Si no existe o no es suyo.
+            IrisInvalidInputError: Si la nota está vacía.
+        """
+        cleaned = (note or "").strip()[:MAX_CASE_TEXT_LENGTH]
+        if not cleaned:
+            raise _invalid_input("La nota está vacía.")
+        with UnitOfWork() as uow:
+            case = _assert_case(uow, case_id, user_id)
+            _record_event(uow, case, user_id, "note", note=cleaned)
+            IrisCaseRepository(uow).update(case)
+        return self.get_case(case_id, user_id)
+
+    def link_analysis(self, case_id: int, user_id: int, analysis_id: int) -> Dict[str, Any]:
+        """Vincula un análisis del usuario a un caso. El análisis no cambia.
+
+        Args:
+            case_id: Caso; debe ser del usuario.
+            user_id: Usuario que vincula.
+            analysis_id: Análisis; debe ser del usuario.
+
+        Returns:
+            dict: El caso actualizado (ver ``_detail``).
+
+        Raises:
+            IrisCaseNotFoundError: Si el caso no existe o no es suyo.
+            IrisAnalysisNotFoundError: Si el análisis no existe o no es suyo.
+            IrisInvalidInputError: Si ya estaba vinculado.
+        """
+        IrisManager.assert_analysis_ownership(analysis_id, user_id)
+        with UnitOfWork() as uow:
+            case = _assert_case(uow, case_id, user_id)
+            link_repo = IrisCaseAnalysisRepository(uow)
+            if link_repo.get_link(case_id, analysis_id) is not None:
+                raise _invalid_input(f"El análisis {analysis_id} ya está en este caso.")
+            link_repo.save(IrisCaseAnalysis(case_id=case_id, analysis_id=analysis_id))
+            _record_event(uow, case, user_id, "analysis_linked", {"analysisId": analysis_id})
+            IrisCaseRepository(uow).update(case)
+        return self.get_case(case_id, user_id)
+
+    def unlink_analysis(self, case_id: int, user_id: int, analysis_id: int) -> Dict[str, Any]:
+        """Desvincula un análisis de un caso. El análisis no se borra.
+
+        Args:
+            case_id: Caso; debe ser del usuario.
+            user_id: Usuario que desvincula.
+            analysis_id: Análisis a quitar del caso.
+
+        Returns:
+            dict: El caso actualizado (ver ``_detail``).
+
+        Raises:
+            IrisCaseNotFoundError: Si el caso no existe o no es suyo.
+            IrisInvalidInputError: Si el análisis no estaba en el caso.
+        """
+        with UnitOfWork() as uow:
+            case = _assert_case(uow, case_id, user_id)
+            link_repo = IrisCaseAnalysisRepository(uow)
+            link = link_repo.get_link(case_id, analysis_id)
+            if link is None:
+                raise _invalid_input(f"El análisis {analysis_id} no está en este caso.")
+            link_repo.delete(link)
+            _record_event(uow, case, user_id, "analysis_unlinked", {"analysisId": analysis_id})
+            IrisCaseRepository(uow).update(case)
+        return self.get_case(case_id, user_id)

--- a/API/src/modules/features/iris/managers/cases.py
+++ b/API/src/modules/features/iris/managers/cases.py
@@ -132,13 +132,15 @@ def _detail(case: IrisCase) -> Dict[str, Any]:
         case: Caso con sus vínculos y eventos cargados.
 
     Returns:
-        dict: Lo de ``_summary`` más ``assigneeId``, ``resolutionReason``,
-            ``analyses`` (id, título, estado, veredicto, score, confianza y
-            cuándo se vinculó) y ``timeline`` (del evento más antiguo al más
-            reciente, con su autor).
+        dict: Lo de ``_summary`` más ``ownerId`` (el único usuario al que se
+            puede asignar), ``assigneeId``, ``resolutionReason``, ``analyses``
+            (id, título, estado, veredicto, score, confianza y cuándo se
+            vinculó) y ``timeline`` (del evento más antiguo al más reciente,
+            con su autor).
     """
     return {
         **_summary(case),
+        "ownerId": case.user_id,
         "assigneeId": case.assignee_id,
         "resolutionReason": case.resolution_reason,
         "analyses": [{

--- a/API/src/modules/features/iris/managers/triage.py
+++ b/API/src/modules/features/iris/managers/triage.py
@@ -21,16 +21,11 @@ from src.modules.shared import assert_owned, isoformat_utc
 from ..exceptions import IrisInvalidInputError, IrisSavedViewNotFoundError
 from ..model import IrisAnalysisTag, IrisSavedView
 from ..repositories import IrisAnalysisTagRepository, IrisSavedViewRepository
+from ..services.tags import normalize_tags
 from .analysis import IrisManager
 
 #: Vistas guardadas por usuario. Una lista más larga deja de ser un atajo.
 MAX_SAVED_VIEWS = 50
-
-#: Etiquetas por análisis.
-MAX_TAGS_PER_ANALYSIS = 10
-
-#: Longitud máxima de una etiqueta; coincide con la columna.
-MAX_TAG_LENGTH = 40
 
 #: Longitud máxima del nombre de una vista; coincide con la columna.
 MAX_VIEW_NAME_LENGTH = 60
@@ -46,33 +41,6 @@ def _invalid_input(text: str) -> IrisInvalidInputError:
         IrisInvalidInputError: Con ``user_message`` igual a ``text``.
     """
     return IrisInvalidInputError(text, user_message=text)
-
-
-def _normalize_tags(tags: Sequence[str]) -> List[str]:
-    """Limpia una lista de etiquetas antes de guardarla.
-
-    Args:
-        tags: Etiquetas tal como las escribió el usuario.
-
-    Returns:
-        List[str]: En minúsculas, con los espacios interiores colapsados, sin
-            vacías ni duplicadas, en el orden en que llegaron.
-
-    Raises:
-        IrisInvalidInputError: Si alguna supera ``MAX_TAG_LENGTH`` o si son
-            más de ``MAX_TAGS_PER_ANALYSIS``.
-    """
-    normalized: List[str] = []
-    for tag in tags:
-        cleaned = " ".join((tag or "").split()).lower()
-        if not cleaned or cleaned in normalized:
-            continue
-        if len(cleaned) > MAX_TAG_LENGTH:
-            raise _invalid_input(f"Una etiqueta no puede pasar de {MAX_TAG_LENGTH} caracteres.")
-        normalized.append(cleaned)
-    if len(normalized) > MAX_TAGS_PER_ANALYSIS:
-        raise _invalid_input(f"Como mucho {MAX_TAGS_PER_ANALYSIS} etiquetas por análisis.")
-    return normalized
 
 
 class IrisTriageManager:
@@ -160,7 +128,7 @@ class IrisTriageManager:
 
         Returns:
             List[str]: Las etiquetas que quedan, ya normalizadas (ver
-                ``_normalize_tags``).
+                ``services/tags.normalize_tags``).
 
         Raises:
             IrisAnalysisNotFoundError: Si el análisis no existe o no es suyo.
@@ -168,7 +136,10 @@ class IrisTriageManager:
                 demasiadas.
         """
         IrisManager.assert_analysis_ownership(analysis_id, user_id)
-        normalized = _normalize_tags(tags)
+        try:
+            normalized = normalize_tags(tags)
+        except ValueError as e:
+            raise _invalid_input(str(e)) from e
         with UnitOfWork() as uow:
             repo = IrisAnalysisTagRepository(uow)
             repo.delete_by_analysis(analysis_id)

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -139,6 +139,8 @@ class IrisAnalysis(Base):
                  Nunca modifican el veredicto de esta fila.
         tags: Etiquetas del analista (``IrisAnalysisTag``), por nombre.
                  Tampoco modifican el análisis.
+        case_links: Casos de analista en los que está este análisis
+                 (``IrisCaseAnalysis``); borrar el análisis lo saca de ellos.
         indicators: Índice de IOCs del contexto ganador (``IrisIndicator``).
                  Se rellena al terminar el análisis y sobrevive a la purga
                  del raw por retención.
@@ -217,6 +219,12 @@ class IrisAnalysis(Base):
     indicators = relationship(
         "IrisIndicator", back_populates="analysis",
         cascade="all, delete-orphan",
+    )
+    # "delete" y no "delete-orphan": el vínculo tiene dos padres (el caso y
+    # el análisis) y el que lo quita de un caso es el caso, no el análisis.
+    case_links = relationship(
+        "IrisCaseAnalysis", back_populates="analysis",
+        cascade="all, delete",
     )
 
     __table_args__ = (
@@ -848,4 +856,159 @@ class IrisIndicator(Base):
     __table_args__ = (
         Index("ix_iris_indicator_analysis_id", "analysis_id"),
         Index("ix_iris_indicator_value", "value"),
+    )
+
+
+class CaseStatus(StrEnum):
+    """Estado de un caso de analista (``IrisCase.status``).
+
+    Las transiciones válidas las fija ``services/cases.ALLOWED_TRANSITIONS``.
+
+    Attributes:
+        NEW: Recién abierto, nadie lo ha mirado.
+        TRIAGE: Alguien lo está investigando.
+        CONTAINED: La amenaza está controlada, pero el caso sigue abierto.
+        RESOLVED: Cerrado; era un incidente real y se trató.
+        FALSE_POSITIVE: Cerrado; no era una amenaza.
+    """
+    NEW = "new"
+    TRIAGE = "triage"
+    CONTAINED = "contained"
+    RESOLVED = "resolved"
+    FALSE_POSITIVE = "false_positive"
+
+
+class CasePriority(StrEnum):
+    """Prioridad de un caso de analista (``IrisCase.priority``).
+
+    Attributes:
+        LOW: Puede esperar.
+        MEDIUM: Por defecto.
+        HIGH: Pasa por delante de la cola.
+        CRITICAL: Incidente en curso.
+    """
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class IrisCase(Base):
+    """Caso de analista: la decisión humana sobre uno o varios análisis.
+
+    Los análisis que agrupa (``IrisCaseAnalysis``) no cambian: el caso es la
+    capa de decisión encima. Todo lo que le pasa queda en su timeline
+    (``IrisCaseEvent``).
+
+    Es de un usuario, igual que sus análisis: una organización comparte plan y
+    factura, no datos (ver ``Organization``), así que ``assignee_id`` solo puede
+    ser el propio dueño, el único que ve esos análisis.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        user_id: FK al ``User`` dueño; ``ondelete="CASCADE"``.
+        title: Título visible (hasta 120 caracteres).
+        status: ``CaseStatus``; empieza en ``new``.
+        priority: ``CasePriority``; por defecto ``medium``.
+        assignee_id: FK al ``User`` asignado; NULL si no está asignado.
+                 ``ondelete="SET NULL"``.
+        tags: Etiquetas normalizadas (ver ``services/tags.py``).
+        resolution_reason: Por qué se cerró; NULL mientras está abierto.
+        created_at: Cuándo se abrió.
+        updated_at: Último cambio (también las notas y los vínculos).
+        closed_at: Cuándo se cerró; NULL si está abierto (o se reabrió).
+        user / assignee: Relaciones a los ``User``.
+        links: Análisis vinculados, en el orden en que se añadieron.
+        events: Timeline, del evento más antiguo al más reciente.
+    """
+    __tablename__ = "IrisCase"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("User.id", ondelete="CASCADE"), nullable=False)
+    title = Column(String(120), nullable=False)
+    status = Column(String(20), nullable=False, default=CaseStatus.NEW.value)
+    priority = Column(String(16), nullable=False, default=CasePriority.MEDIUM.value)
+    assignee_id = Column(Integer, ForeignKey("User.id", ondelete="SET NULL"), nullable=True)
+    tags = Column(JSONB, nullable=False, default=list)
+    resolution_reason = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    updated_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    closed_at = Column(DateTime, nullable=True)
+
+    user = relationship("User", foreign_keys=[user_id])
+    assignee = relationship("User", foreign_keys=[assignee_id])
+    links = relationship(
+        "IrisCaseAnalysis", back_populates="case",
+        order_by="IrisCaseAnalysis.id",
+        cascade="all, delete-orphan",
+    )
+    events = relationship(
+        "IrisCaseEvent", back_populates="case",
+        order_by="IrisCaseEvent.id",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_iris_case_user_id", "user_id"),
+        Index("ix_iris_case_status", "status"),
+    )
+
+
+class IrisCaseAnalysis(Base):
+    """Vínculo entre un caso y uno de sus análisis.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        case_id: FK al ``IrisCase``; ``ondelete="CASCADE"``.
+        analysis_id: FK al ``IrisAnalysis``; ``ondelete="CASCADE"``.
+        added_at: Cuándo se vinculó.
+        case / analysis: Relaciones inversas.
+    """
+    __tablename__ = "IrisCaseAnalysis"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    case_id = Column(Integer, ForeignKey("IrisCase.id", ondelete="CASCADE"), nullable=False)
+    analysis_id = Column(Integer, ForeignKey("IrisAnalysis.id", ondelete="CASCADE"), nullable=False)
+    added_at = Column(DateTime, nullable=False, default=utcnow_naive)
+
+    case = relationship("IrisCase", back_populates="links")
+    analysis = relationship("IrisAnalysis", back_populates="case_links")
+
+    __table_args__ = (
+        UniqueConstraint("case_id", "analysis_id", name="uq_iris_case_analysis_case_analysis"),
+        Index("ix_iris_case_analysis_analysis_id", "analysis_id"),
+    )
+
+
+class IrisCaseEvent(Base):
+    """Una entrada de la timeline de un caso: un cambio o una nota.
+
+    Attributes:
+        id: Primary key, auto-incrementing integer.
+        case_id: FK al ``IrisCase``; ``ondelete="CASCADE"``.
+        actor_id: FK al ``User`` que hizo el cambio; ``ondelete="SET NULL"``.
+        kind: ``created``, ``status_changed``, ``priority_changed``,
+                 ``assigned``, ``title_changed``, ``tags_changed``, ``note``,
+                 ``analysis_linked`` o ``analysis_unlinked``.
+        detail: Datos del cambio (``from``/``to``, ``reason``, ``analysisId``…);
+                 NULL en las notas.
+        note: Texto de una nota; NULL en los demás eventos.
+        created_at: Cuándo pasó.
+        case / actor: Relaciones.
+    """
+    __tablename__ = "IrisCaseEvent"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    case_id = Column(Integer, ForeignKey("IrisCase.id", ondelete="CASCADE"), nullable=False)
+    actor_id = Column(Integer, ForeignKey("User.id", ondelete="SET NULL"), nullable=True)
+    kind = Column(String(24), nullable=False)
+    detail = Column(JSONB, nullable=True)
+    note = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+
+    case = relationship("IrisCase", back_populates="events")
+    actor = relationship("User")
+
+    __table_args__ = (
+        Index("ix_iris_case_event_case_id", "case_id"),
     )

--- a/API/src/modules/features/iris/repositories.py
+++ b/API/src/modules/features/iris/repositories.py
@@ -21,6 +21,7 @@ from .model import (
     IrisAnalysis, IrisMailboxConnection, IrisMailboxInbox, IrisNotificationPreference,
     IrisRawMessage, IrisRuleResult, IrisDocument, IrisTrustedSender,
     IrisAnalysisTag, IrisIndicator, IrisSavedView,
+    IrisCase, IrisCaseAnalysis, IrisCaseEvent,
 )
 
 
@@ -849,6 +850,88 @@ class IrisIndicatorRepository(BaseRepository[IrisIndicator]):
     """
 
     _MODEL = IrisIndicator
+
+
+class IrisCaseRepository(BaseRepository[IrisCase]):
+    """Acceso a los casos de analista (``IrisCase``)."""
+
+    _MODEL = IrisCase
+
+    def get_by_user_filtered(self, user_id: int, *, status: Optional[str] = None,
+                             priority: Optional[str] = None,
+                             assignee_id: Optional[int] = None) -> List[IrisCase]:
+        """Casos de un usuario, del modificado más recientemente al más antiguo.
+
+        Args:
+            user_id: Dueño de los casos.
+            status: Solo los de este estado. Por defecto ``None``: todos.
+            priority: Solo los de esta prioridad. Por defecto ``None``: todas.
+            assignee_id: Solo los asignados a este usuario. Por defecto
+                ``None``: sin filtro.
+
+        Returns:
+            List[IrisCase]: Los casos, con sus vínculos y su asignado cargados.
+        """
+        query = (
+            self._session.query(IrisCase)
+            .options(selectinload(IrisCase.links), joinedload(IrisCase.assignee))
+            .filter(IrisCase.user_id == user_id)
+        )
+        if status:
+            query = query.filter(IrisCase.status == status)
+        if priority:
+            query = query.filter(IrisCase.priority == priority)
+        if assignee_id is not None:
+            query = query.filter(IrisCase.assignee_id == assignee_id)
+        return query.order_by(IrisCase.updated_at.desc(), IrisCase.id.desc()).all()
+
+    def count_by_status_for_user(self, user_id: int) -> dict:
+        """Cuántos casos tiene un usuario en cada estado.
+
+        Args:
+            user_id: Dueño de los casos.
+
+        Returns:
+            dict: ``{estado: casos}``, solo con los estados que tienen alguno.
+        """
+        rows = (
+            self._session.query(IrisCase.status, func.count(IrisCase.id))
+            .filter(IrisCase.user_id == user_id)
+            .group_by(IrisCase.status)
+            .all()
+        )
+        return {status: total for status, total in rows}
+
+
+class IrisCaseAnalysisRepository(BaseRepository[IrisCaseAnalysis]):
+    """Acceso a los vínculos entre casos y análisis (``IrisCaseAnalysis``)."""
+
+    _MODEL = IrisCaseAnalysis
+
+    def get_link(self, case_id: int, analysis_id: int) -> Optional[IrisCaseAnalysis]:
+        """El vínculo entre un caso y un análisis, si existe.
+
+        Args:
+            case_id: Primary key del caso.
+            analysis_id: Primary key del análisis.
+
+        Returns:
+            Optional[IrisCaseAnalysis]: El vínculo, o ``None``.
+        """
+        return (
+            self._session.query(IrisCaseAnalysis)
+            .filter(IrisCaseAnalysis.case_id == case_id, IrisCaseAnalysis.analysis_id == analysis_id)
+            .first()
+        )
+
+
+class IrisCaseEventRepository(BaseRepository[IrisCaseEvent]):
+    """Acceso a la timeline de los casos (``IrisCaseEvent``).
+
+    Los eventos se leen a través de ``IrisCase.events``; aquí solo se guardan.
+    """
+
+    _MODEL = IrisCaseEvent
 
 
 class IrisReportRepository(DocumentRepository[IrisDocument]):

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -11,7 +11,7 @@ import src.modules.system.config_reading as CR
 from src.modules.shared import UTCDateTime
 
 from .services.feedback_metrics import FEEDBACK_LABELS
-from .model import TrustKind
+from .model import CasePriority, CaseStatus, TrustKind
 from .services.quality import AnalysisMode
 from .services.scoring import PROFILE_THRESHOLD_OFFSETS
 from .services.trust import MAX_TRUST_EXPIRY_DAYS, MAX_TRUST_REASON_LENGTH
@@ -925,3 +925,100 @@ class IrisTagCountSchema(Schema):
 class IrisTagListResponseSchema(Schema):
     """Etiquetas del usuario, de la más usada a la menos."""
     tags = fields.List(fields.Nested(IrisTagCountSchema))
+
+
+_CASE_STATUSES = [status.value for status in CaseStatus]
+_CASE_PRIORITIES = [priority.value for priority in CasePriority]
+
+
+class IrisCaseCreateRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/cases``: título, prioridad, análisis y etiquetas iniciales."""
+    title = fields.String(required=True, validate=validate.Length(min=1, max=200))
+    priority = fields.String(load_default=CasePriority.MEDIUM.value, validate=validate.OneOf(_CASE_PRIORITIES))
+    analysisIds = fields.List(fields.Integer(), load_default=list, validate=validate.Length(max=50))
+    tags = fields.List(fields.String(validate=validate.Length(max=200)), load_default=list,
+                       validate=validate.Length(max=50))
+
+
+class IrisCaseUpdateRequestSchema(Schema):
+    """Cuerpo de ``PATCH /iris/cases/<id>``: solo cambia lo que viene.
+
+    ``assigneeId`` a ``null`` quita la asignación; solo puede ser el dueño del caso.
+    """
+    title = fields.String(validate=validate.Length(min=1, max=200))
+    priority = fields.String(validate=validate.OneOf(_CASE_PRIORITIES))
+    tags = fields.List(fields.String(validate=validate.Length(max=200)), validate=validate.Length(max=50))
+    assigneeId = fields.Integer(allow_none=True)
+
+
+class IrisCaseStatusRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/cases/<id>/status``; ``reason`` es obligatoria al cerrar."""
+    status = fields.String(required=True, validate=validate.OneOf(_CASE_STATUSES))
+    reason = fields.String(load_default=None, allow_none=True, validate=validate.Length(max=4000))
+
+
+class IrisCaseNoteRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/cases/<id>/notes``."""
+    note = fields.String(required=True, validate=validate.Length(min=1, max=4000))
+
+
+class IrisCaseLinkRequestSchema(Schema):
+    """Cuerpo de ``POST /iris/cases/<id>/analyses``."""
+    analysisId = fields.Integer(required=True)
+
+
+class IrisCasesQuerySchema(Schema):
+    """Filtros de ``GET /iris/cases``; ninguno filtra por defecto."""
+    status = fields.String(load_default=None, validate=validate.OneOf(_CASE_STATUSES))
+    priority = fields.String(load_default=None, validate=validate.OneOf(_CASE_PRIORITIES))
+    assignedToMe = fields.Boolean(load_default=False)
+
+
+class IrisCaseAnalysisItemSchema(Schema):
+    """Un análisis de un caso, tal como es: el caso no lo modifica."""
+    analysisId = fields.Integer()
+    title = fields.String(allow_none=True)
+    status = fields.String()
+    verdict = fields.String(allow_none=True)
+    totalScore = fields.Float(allow_none=True)
+    confidence = fields.String(allow_none=True)
+    addedAt = fields.String()
+
+
+class IrisCaseEventSchema(Schema):
+    """Una entrada de la timeline: un cambio (``detail``) o una nota (``note``)."""
+    eventId = fields.Integer()
+    kind = fields.String()
+    detail = fields.Dict(allow_none=True)
+    note = fields.String(allow_none=True)
+    actor = fields.String(allow_none=True)
+    createdAt = fields.String()
+
+
+class IrisCaseSummarySchema(Schema):
+    """Lo que enseña el listado de casos."""
+    caseId = fields.Integer()
+    title = fields.String()
+    status = fields.String()
+    priority = fields.String()
+    assignee = fields.String(allow_none=True)
+    tags = fields.List(fields.String())
+    analysisCount = fields.Integer()
+    createdAt = fields.String()
+    updatedAt = fields.String()
+    closedAt = fields.String(allow_none=True)
+
+
+class IrisCaseDetailSchema(IrisCaseSummarySchema):
+    """Un caso entero: resumen, razón de cierre, análisis y timeline."""
+    assigneeId = fields.Integer(allow_none=True)
+    resolutionReason = fields.String(allow_none=True)
+    analyses = fields.List(fields.Nested(IrisCaseAnalysisItemSchema))
+    timeline = fields.List(fields.Nested(IrisCaseEventSchema))
+
+
+class IrisCaseListResponseSchema(Schema):
+    """Casos del usuario y cuántos tiene en cada estado (sin aplicar los filtros)."""
+    cases = fields.List(fields.Nested(IrisCaseSummarySchema))
+    total = fields.Integer()
+    countsByStatus = fields.Dict(keys=fields.String(), values=fields.Integer())

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -1010,7 +1010,11 @@ class IrisCaseSummarySchema(Schema):
 
 
 class IrisCaseDetailSchema(IrisCaseSummarySchema):
-    """Un caso entero: resumen, razón de cierre, análisis y timeline."""
+    """Un caso entero: resumen, razón de cierre, análisis y timeline.
+
+    ``ownerId`` es el dueño, el único al que se puede asignar el caso.
+    """
+    ownerId = fields.Integer()
     assigneeId = fields.Integer(allow_none=True)
     resolutionReason = fields.String(allow_none=True)
     analyses = fields.List(fields.Nested(IrisCaseAnalysisItemSchema))

--- a/API/src/modules/features/iris/services/cases.py
+++ b/API/src/modules/features/iris/services/cases.py
@@ -1,0 +1,68 @@
+"""
+Ciclo de vida de un caso de analista de Iris.
+
+Un análisis es el resultado inmutable de lo que decidió Iris; un caso es la
+decisión humana encima: se abre, se investiga, se contiene y se cierra con una
+razón. Este módulo fija qué transiciones de estado son válidas y qué exige
+cada una. Es puro: sin base de datos ni red.
+
+Estados (``CaseStatus`` en ``model.py``):
+
+- ``new``: recién abierto, nadie lo ha mirado.
+- ``triage``: alguien lo está investigando.
+- ``contained``: la amenaza está controlada (enlace bloqueado, buzón limpio)
+  pero el caso sigue abierto.
+- ``resolved``: cerrado; era un incidente real y se trató.
+- ``false_positive``: cerrado; no era una amenaza.
+
+Cerrar exige una razón. Reabrir un caso cerrado lo devuelve a ``triage``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+#: Estados que cierran un caso.
+CLOSED_STATUSES = frozenset({"resolved", "false_positive"})
+
+#: A qué estados se puede pasar desde cada uno. Un caso cerrado solo se
+#: reabre a ``triage``: volver a ``new`` borraría la señal de que ya se
+#: investigó una vez.
+ALLOWED_TRANSITIONS = {
+    "new": frozenset({"triage", "contained", "resolved", "false_positive"}),
+    "triage": frozenset({"contained", "resolved", "false_positive"}),
+    "contained": frozenset({"triage", "resolved", "false_positive"}),
+    "resolved": frozenset({"triage"}),
+    "false_positive": frozenset({"triage"}),
+}
+
+#: Longitud máxima de la razón de cierre y de una nota.
+MAX_CASE_TEXT_LENGTH = 4000
+
+
+def validate_transition(current: str, target: str, reason: Optional[str]) -> Optional[str]:
+    """Comprueba que un caso puede pasar de un estado a otro.
+
+    Args:
+        current: Estado actual del caso.
+        target: Estado al que se quiere pasar.
+        reason: Razón que da el analista. Obligatoria si ``target`` cierra el
+            caso (``CLOSED_STATUSES``); se ignora si no.
+
+    Returns:
+        Optional[str]: La razón limpia (sin espacios alrededor y recortada a
+            ``MAX_CASE_TEXT_LENGTH``) cuando se cierra; ``None`` en cualquier
+            otra transición.
+
+    Raises:
+        ValueError: Si la transición no está en ``ALLOWED_TRANSITIONS`` o si
+            falta la razón de cierre. El mensaje es apto para el usuario.
+    """
+    if target not in ALLOWED_TRANSITIONS.get(current, frozenset()):
+        raise ValueError(f"Un caso en estado «{current}» no puede pasar a «{target}».")
+    if target not in CLOSED_STATUSES:
+        return None
+    cleaned = (reason or "").strip()[:MAX_CASE_TEXT_LENGTH]
+    if not cleaned:
+        raise ValueError("Cerrar un caso exige explicar por qué.")
+    return cleaned

--- a/API/src/modules/features/iris/services/tags.py
+++ b/API/src/modules/features/iris/services/tags.py
@@ -1,0 +1,42 @@
+"""
+Etiquetas del analista: la misma regla para las de un análisis y las de un caso.
+
+Módulo puro: sin base de datos ni red.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+#: Etiquetas por análisis o por caso.
+MAX_TAGS = 10
+
+#: Longitud máxima de una etiqueta; coincide con ``IrisAnalysisTag.name``.
+MAX_TAG_LENGTH = 40
+
+
+def normalize_tags(tags: Iterable[str]) -> List[str]:
+    """Limpia una lista de etiquetas antes de guardarla.
+
+    Args:
+        tags: Etiquetas tal como las escribió el usuario.
+
+    Returns:
+        List[str]: En minúsculas, con los espacios interiores colapsados, sin
+            vacías ni duplicadas, en el orden en que llegaron.
+
+    Raises:
+        ValueError: Si alguna supera ``MAX_TAG_LENGTH`` o si son más de
+            ``MAX_TAGS``. El mensaje es apto para el usuario.
+    """
+    normalized: List[str] = []
+    for tag in tags:
+        cleaned = " ".join((tag or "").split()).lower()
+        if not cleaned or cleaned in normalized:
+            continue
+        if len(cleaned) > MAX_TAG_LENGTH:
+            raise ValueError(f"Una etiqueta no puede pasar de {MAX_TAG_LENGTH} caracteres.")
+        normalized.append(cleaned)
+    if len(normalized) > MAX_TAGS:
+        raise ValueError(f"Como mucho {MAX_TAGS} etiquetas.")
+    return normalized

--- a/API/tests/integration/test_iris_cases.py
+++ b/API/tests/integration/test_iris_cases.py
@@ -1,0 +1,227 @@
+"""Casos de analista: convertir informes aislados en trabajo operativo medible.
+
+Cubre el criterio de cierre: un caso se abre (con uno o varios análisis), se
+asigna, se anota y se cierra con una razón, todo queda en su timeline, y los
+análisis que agrupa no cambian nunca.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.infrastructure import UnitOfWork
+from src.modules.users.services.permissions import AttributeType
+
+pytestmark = pytest.mark.integration
+
+_IRIS_ATTRIBUTES = [attribute.db_name for attribute in (
+    AttributeType.IRIS_READ, AttributeType.IRIS_CREATE,
+    AttributeType.IRIS_UPDATE, AttributeType.IRIS_DELETE,
+)]
+
+
+def _analysis(app, user_id: int, verdict: str = "Phishing", score: float = 20.0) -> int:
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers="From: a@b.example\nSubject: x\n", user_id=user_id,
+                                    status="finished", verdict=verdict, total_score=score)
+            IrisAnalysisRepository(uow).save(analysis)
+            return analysis.id
+
+
+@pytest.fixture
+def analyst(make_user, auth_headers):
+    user = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    return user, auth_headers(user)
+
+
+def _open(client, headers, **body):
+    payload = {"title": "Campaña de facturas falsas"}
+    payload.update(body)
+    return client.post("/iris/cases", headers=headers, json=payload)
+
+
+def _status(client, headers, case_id, status, reason=None):
+    return client.post(f"/iris/cases/{case_id}/status", headers=headers,
+                       json={"status": status, "reason": reason})
+
+
+# -------------------------------------------------------------- apertura
+
+def test_a_case_groups_several_analyses_without_changing_them(client, app, analyst):
+    user, headers = analyst
+    first, second = _analysis(app, user.id), _analysis(app, user.id, "Suspicious", 60.0)
+
+    response = _open(client, headers, analysisIds=[first, second, first], priority="high", tags=["Facturas"])
+
+    assert response.status_code == 201, response.get_json()
+    case = response.get_json()
+    assert case["status"] == "new" and case["priority"] == "high" and case["tags"] == ["facturas"]
+    assert [entry["analysisId"] for entry in case["analyses"]] == [first, second]
+    assert [event["kind"] for event in case["timeline"]] == ["created"]
+    assert case["timeline"][0]["actor"] == user.username
+    report = client.get(f"/iris/results/{first}", headers=headers).get_json()
+    assert (report["verdict"], report["totalScore"]) == ("Phishing", 20.0)
+
+
+def test_a_case_needs_a_title_and_a_known_priority(client, analyst):
+    _, headers = analyst
+
+    assert _open(client, headers, title="   ").status_code == 400
+    assert _open(client, headers, priority="urgentísimo").status_code == 422
+
+
+def test_nobody_opens_a_case_with_someone_elses_analysis(client, app, analyst, make_user, auth_headers):
+    _, headers = analyst
+    stranger = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    foreign = _analysis(app, stranger.id)
+
+    assert _open(client, headers, analysisIds=[foreign]).status_code == 404
+
+
+# ------------------------------------------------------------ ciclo de vida
+
+def test_a_case_moves_through_its_lifecycle_and_closes_with_a_reason(client, analyst):
+    _, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+
+    assert _status(client, headers, case_id, "triage").status_code == 200
+    assert _status(client, headers, case_id, "contained").status_code == 200
+    assert _status(client, headers, case_id, "resolved").status_code == 400
+    closed = _status(client, headers, case_id, "resolved", "Enlaces bloqueados y buzones limpios.")
+
+    assert closed.status_code == 200
+    case = closed.get_json()
+    assert case["status"] == "resolved"
+    assert case["resolutionReason"] == "Enlaces bloqueados y buzones limpios."
+    assert case["closedAt"]
+    transitions = [(event["detail"]["from"], event["detail"]["to"])
+                   for event in case["timeline"] if event["kind"] == "status_changed"]
+    assert transitions == [("new", "triage"), ("triage", "contained"), ("contained", "resolved")]
+
+
+def test_a_closed_case_only_reopens_to_triage(client, analyst):
+    _, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+    _status(client, headers, case_id, "false_positive", "Newsletter legítima del proveedor.")
+
+    assert _status(client, headers, case_id, "contained").status_code == 400
+    reopened = _status(client, headers, case_id, "triage").get_json()
+
+    assert reopened["status"] == "triage"
+    assert reopened["closedAt"] is None and reopened["resolutionReason"] is None
+    reasons = [event["detail"]["reason"] for event in reopened["timeline"] if event["kind"] == "status_changed"]
+    assert reasons == ["Newsletter legítima del proveedor.", None]
+
+
+def test_an_unknown_status_is_rejected(client, analyst):
+    _, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+
+    assert _status(client, headers, case_id, "archived").status_code == 422
+
+
+# ------------------------------------------------- notas, asignación, cambios
+
+def test_notes_and_changes_land_in_the_timeline(client, analyst):
+    user, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+
+    client.post(f"/iris/cases/{case_id}/notes", headers=headers, json={"note": "  Tres usuarios hicieron clic. "})
+    case = client.patch(f"/iris/cases/{case_id}", headers=headers,
+                        json={"priority": "critical", "title": "Campaña Q3", "assigneeId": user.id}).get_json()
+
+    assert case["priority"] == "critical" and case["title"] == "Campaña Q3"
+    assert case["assignee"] == user.username
+    kinds = [event["kind"] for event in case["timeline"]]
+    assert kinds == ["created", "note", "title_changed", "priority_changed", "assigned"]
+    note = case["timeline"][1]
+    assert note["note"] == "Tres usuarios hicieron clic." and note["actor"] == user.username
+
+
+def test_an_empty_note_is_rejected(client, analyst):
+    _, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+
+    assert client.post(f"/iris/cases/{case_id}/notes", headers=headers, json={"note": "   "}).status_code == 400
+
+
+def test_a_case_is_only_assigned_to_whoever_can_see_its_analyses(client, analyst, make_user):
+    """Un caso muestra análisis de correo personal: asignarlo a otra persona le
+    daría acceso a ese correo, y una organización comparte plan, no datos."""
+    user, headers = analyst
+    other = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
+    case_id = _open(client, headers).get_json()["caseId"]
+
+    assert client.patch(f"/iris/cases/{case_id}", headers=headers, json={"assigneeId": other.id}).status_code == 400
+    assigned = client.patch(f"/iris/cases/{case_id}", headers=headers, json={"assigneeId": user.id}).get_json()
+    assert assigned["assigneeId"] == user.id
+    unassigned = client.patch(f"/iris/cases/{case_id}", headers=headers, json={"assigneeId": None}).get_json()
+    assert unassigned["assigneeId"] is None
+
+
+# ------------------------------------------------------------------ análisis
+
+def test_analyses_are_linked_and_unlinked(client, app, analyst):
+    user, headers = analyst
+    first, second = _analysis(app, user.id), _analysis(app, user.id)
+    case_id = _open(client, headers, analysisIds=[first]).get_json()["caseId"]
+
+    linked = client.post(f"/iris/cases/{case_id}/analyses", headers=headers, json={"analysisId": second})
+    assert [entry["analysisId"] for entry in linked.get_json()["analyses"]] == [first, second]
+    assert client.post(f"/iris/cases/{case_id}/analyses", headers=headers,
+                       json={"analysisId": second}).status_code == 400
+
+    unlinked = client.delete(f"/iris/cases/{case_id}/analyses/{first}", headers=headers).get_json()
+    assert [entry["analysisId"] for entry in unlinked["analyses"]] == [second]
+    assert client.get(f"/iris/results/{first}", headers=headers).status_code == 200
+    kinds = [event["kind"] for event in unlinked["timeline"]]
+    assert kinds == ["created", "analysis_linked", "analysis_unlinked"]
+
+
+def test_deleting_an_analysis_leaves_the_case(client, app, analyst):
+    user, headers = analyst
+    analysis_id = _analysis(app, user.id)
+    case_id = _open(client, headers, analysisIds=[analysis_id]).get_json()["caseId"]
+
+    assert client.delete(f"/iris/results/{analysis_id}", headers=headers).status_code == 200
+
+    case = client.get(f"/iris/cases/{case_id}", headers=headers).get_json()
+    assert case["analyses"] == []
+    assert [event["kind"] for event in case["timeline"]] == ["created"]
+
+
+# ----------------------------------------------------------- listado y dueño
+
+def test_the_list_counts_the_queue_by_status_and_filters(client, analyst):
+    user, headers = analyst
+    first = _open(client, headers, title="Uno").get_json()["caseId"]
+    _open(client, headers, title="Dos")
+    _status(client, headers, first, "triage")
+    client.patch(f"/iris/cases/{first}", headers=headers, json={"assigneeId": user.id})
+
+    everything = client.get("/iris/cases", headers=headers).get_json()
+    assert everything["total"] == 2
+    assert everything["countsByStatus"] == {"new": 1, "triage": 1}
+    triage = client.get("/iris/cases?status=triage", headers=headers).get_json()
+    assert [case["caseId"] for case in triage["cases"]] == [first]
+    mine = client.get("/iris/cases?assignedToMe=true", headers=headers).get_json()
+    assert [case["caseId"] for case in mine["cases"]] == [first]
+    assert mine["cases"][0]["analysisCount"] == 0
+
+
+def test_a_case_belongs_to_whoever_opened_it(client, app, analyst, make_user, auth_headers):
+    user, headers = analyst
+    case_id = _open(client, headers).get_json()["caseId"]
+    stranger = auth_headers(make_user(role="role_user", attributes=_IRIS_ATTRIBUTES))
+    mine = _analysis(app, user.id)
+
+    assert client.get(f"/iris/cases/{case_id}", headers=stranger).status_code == 404
+    assert _status(client, stranger, case_id, "triage").status_code == 404
+    assert client.post(f"/iris/cases/{case_id}/notes", headers=stranger, json={"note": "x"}).status_code == 404
+    assert client.get("/iris/cases", headers=stranger).get_json()["cases"] == []
+    stranger_case = _open(client, stranger).get_json()["caseId"]
+    assert client.post(f"/iris/cases/{stranger_case}/analyses", headers=stranger,
+                       json={"analysisId": mine}).status_code == 404

--- a/API/tests/integration/test_iris_cases.py
+++ b/API/tests/integration/test_iris_cases.py
@@ -153,7 +153,9 @@ def test_a_case_is_only_assigned_to_whoever_can_see_its_analyses(client, analyst
     daría acceso a ese correo, y una organización comparte plan, no datos."""
     user, headers = analyst
     other = make_user(role="role_user", attributes=_IRIS_ATTRIBUTES)
-    case_id = _open(client, headers).get_json()["caseId"]
+    case = _open(client, headers).get_json()
+    case_id = case["caseId"]
+    assert case["ownerId"] == user.id
 
     assert client.patch(f"/iris/cases/{case_id}", headers=headers, json={"assigneeId": other.id}).status_code == 400
     assigned = client.patch(f"/iris/cases/{case_id}", headers=headers, json={"assigneeId": user.id}).get_json()

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -141,7 +141,7 @@ www.ellysia.es, http://localhost, http://127.0.0.1 {
 	# las continuaciones con `\` a un único espacio inicial, así que la
 	# alineación bonita no sobrevive al formateador. Una línea por matcher es
 	# lo que el formateador deja en paz.
-	@spa_bajo_prefijo_api path /themis/ /themis/escaneos /aegis/ /aegis/generador /iris/ /iris/analisis /iris/conexiones /iris/confianza /acheron/ /acheron/boveda /hygeia/ /hygeia/activos /hygeia/etiquetas
+	@spa_bajo_prefijo_api path /themis/ /themis/escaneos /aegis/ /aegis/generador /iris/ /iris/analisis /iris/conexiones /iris/confianza /iris/casos /acheron/ /acheron/boveda /hygeia/ /hygeia/activos /hygeia/etiquetas
 	handle @spa_bajo_prefijo_api {
 		import spa
 	}

--- a/web/app/src/components/iris/IrisAddToCase.vue
+++ b/web/app/src/components/iris/IrisAddToCase.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="add-to-case">
+    <button v-if="!open" type="button" class="feedback-option" @click="openPicker">Añadir a un caso…</button>
+    <form v-else class="case-picker" @submit.prevent="submit">
+      <select v-model="target" class="case-select" aria-label="Caso de destino">
+        <option value="new">Nuevo caso con este análisis</option>
+        <option v-for="entry in openCases" :key="entry.caseId" :value="entry.caseId">
+          #{{ entry.caseId }} · {{ entry.title }} ({{ STATUS_LABELS[entry.status] }})
+        </option>
+      </select>
+      <button type="submit" class="case-save" :disabled="saving">{{ saving ? 'Guardando…' : 'Añadir' }}</button>
+      <button type="button" class="case-cancel" @click="open = false">Cancelar</button>
+      <router-link v-if="lastCaseId" to="/iris/casos" class="case-link">Ver el caso #{{ lastCaseId }}</router-link>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useIrisStore } from '@/stores/irisStore'
+
+const props = defineProps({
+  analysisId: { type: Number, required: true },
+  analysisTitle: { type: String, default: '' },
+})
+
+const store = useIrisStore()
+const STATUS_LABELS = { new: 'nuevo', triage: 'en triaje', contained: 'contenido', resolved: 'resuelto', false_positive: 'falso positivo' }
+const CLOSED = ['resolved', 'false_positive']
+
+const open = ref(false)
+const target = ref('new')
+const saving = ref(false)
+const lastCaseId = ref(null)
+
+// Solo los casos abiertos: añadir evidencia a uno cerrado es reabrirlo, y eso
+// se hace desde la vista de casos, con su razón.
+const openCases = computed(() => store.cases.items.filter(entry => !CLOSED.includes(entry.status)))
+
+watch(() => props.analysisId, () => { open.value = false; lastCaseId.value = null })
+
+async function openPicker() {
+  open.value = true
+  target.value = 'new'
+  await store.fetchCases()
+}
+
+async function submit() {
+  saving.value = true
+  const result = target.value === 'new'
+    ? await store.createCase({ title: props.analysisTitle || `Análisis #${props.analysisId}`, analysisIds: [props.analysisId] })
+    : await store.linkCaseAnalysis(target.value, props.analysisId)
+  saving.value = false
+  if (result) lastCaseId.value = result.caseId
+}
+</script>
+
+<style scoped>
+.add-to-case { margin-top: 0.6rem; }
+.case-picker { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; }
+.case-select {
+  min-width: 14rem; padding: 0.35rem 0.5rem; font-size: var(--fs-sm);
+  background: var(--surface-2); color: var(--text); border: 1px solid var(--border-med); border-radius: 6px;
+}
+.case-save, .case-cancel { padding: 0.35rem 0.8rem; font-size: var(--fs-sm); font-weight: 600; border-radius: 6px; cursor: pointer; }
+.case-save { border: none; background: var(--accent); color: var(--on-accent); }
+.case-save:disabled { opacity: 0.5; cursor: not-allowed; }
+.case-cancel { border: 1px solid var(--border-med); background: transparent; color: var(--text-dim); }
+.case-link { font-size: var(--fs-sm); color: var(--accent-bright); text-decoration: underline; }
+</style>

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -165,6 +165,8 @@
         </p>
         <!-- Falso positivo recurrente: confiar en el remitente para los
              próximos análisis. No toca este veredicto. -->
+        <!-- Convertir el informe en trabajo: añadirlo a un caso de analista. -->
+        <IrisAddToCase :analysis-id="reportData.analysisId" :analysis-title="reportData.title || ''" />
         <button v-if="!trustFormOpen" type="button" class="feedback-option trust-open" @click="trustFormOpen = true">
           Confiar en este remitente…
         </button>
@@ -405,6 +407,7 @@ import IrisRuleCard from '@/components/iris/IrisRuleCard.vue'
 import IrisIocsPanel from '@/components/iris/IrisIocsPanel.vue'
 import IrisVerdictHero from '@/components/iris/IrisVerdictHero.vue'
 import IrisTrustForm from '@/components/iris/IrisTrustForm.vue'
+import IrisAddToCase from '@/components/iris/IrisAddToCase.vue'
 
 const { formatDate } = useUtils()
 const irisStore = useIrisStore()

--- a/web/app/src/router/index.js
+++ b/web/app/src/router/index.js
@@ -85,6 +85,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/iris/casos',
+    name: 'IrisCases',
+    component: () => import('@/views/IrisCasesView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/acheron',
     name: 'AcheronHub',
     component: () => import('@/views/AcheronHubView.vue'),

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -802,6 +802,7 @@ export const useIrisStore = defineStore('iris', () => {
     fetchArchive, setArchiveFilters, resetArchiveFilters, setArchiveSort, goToArchivePage,
     savedViews, userTags, fetchSavedViews, saveArchiveView, applySavedView, deleteSavedView,
     fetchTags, setAnalysisTags, fetchReportById,
+    trustedSenders, trustedSendersLoading, fetchTrustedSenders, createTrustedSender, revokeTrustedSender,
     submitAnalysis, fetchResults, getReport, getStatus, pathFor, iocsFor,
     resolvedPathFor, isPathLoadingFor, resolvedIocsFor, isIocsLoadingFor,
     generateAiSummary, checkAiSummary,

--- a/web/app/src/stores/irisStore.js
+++ b/web/app/src/stores/irisStore.js
@@ -517,6 +517,99 @@ export const useIrisStore = defineStore('iris', () => {
     return true
   }
 
+  /* ═══════════════════════ CASOS DE ANALISTA ══════════════════════════ */
+
+  const cases = reactive({
+    items: [],
+    total: 0,
+    countsByStatus: {},
+    loading: false,
+    filters: { status: '', priority: '', assignedToMe: false },
+  })
+  const currentCase = ref(null)
+
+  /** Carga los casos del usuario con los filtros de `cases.filters`. */
+  async function fetchCases() {
+    cases.loading = true
+    try {
+      const params = new URLSearchParams()
+      if (cases.filters.status) params.set('status', cases.filters.status)
+      if (cases.filters.priority) params.set('priority', cases.filters.priority)
+      if (cases.filters.assignedToMe) params.set('assignedToMe', 'true')
+      const res = await apiFetch(`/iris/cases?${params}`)
+      if (!res?.ok) return
+      const data = await res.json()
+      cases.items = data.cases ?? []
+      cases.total = data.total ?? 0
+      cases.countsByStatus = data.countsByStatus ?? {}
+    } finally {
+      cases.loading = false
+    }
+  }
+
+  /** Carga un caso entero (análisis y timeline) en `currentCase`. */
+  async function fetchCase(id) {
+    const res = await apiFetch(`/iris/cases/${id}`)
+    currentCase.value = res?.ok ? await res.json() : null
+    return currentCase.value
+  }
+
+  /**
+   * Petición que devuelve el caso actualizado: lo deja en `currentCase` y
+   * refresca la lista. Si falla, avisa con el mensaje del servidor.
+   * @returns {Promise<object|null>} El caso, o null si falló.
+   */
+  async function _caseRequest(url, method, body, errorText) {
+    const res = await apiFetch(url, { method, body: body === undefined ? undefined : JSON.stringify(body) })
+    if (!res?.ok) {
+      toast.show(await apiError(res, errorText), 'error')
+      return null
+    }
+    currentCase.value = await res.json()
+    fetchCases()
+    return currentCase.value
+  }
+
+  /**
+   * Abre un caso.
+   * @param {{title: string, priority?: string, analysisIds?: number[], tags?: string[]}} data
+   * @returns {Promise<object|null>} El caso abierto, o null si falló.
+   */
+  async function createCase(data) {
+    const created = await _caseRequest('/iris/cases', 'POST', data, 'No se pudo abrir el caso.')
+    if (created) toast.show(`Caso #${created.caseId} abierto.`, 'success')
+    return created
+  }
+
+  /** Cambia título, prioridad, etiquetas o asignación (`assigneeId: null` la quita). */
+  function updateCase(id, changes) {
+    return _caseRequest(`/iris/cases/${id}`, 'PATCH', changes, 'No se pudo actualizar el caso.')
+  }
+
+  /** Mueve un caso de estado; cerrarlo exige `reason`. */
+  function changeCaseStatus(id, status, reason = null) {
+    return _caseRequest(`/iris/cases/${id}/status`, 'POST', { status, reason }, 'No se pudo cambiar el estado.')
+  }
+
+  /** Añade una nota a la timeline del caso. */
+  function addCaseNote(id, note) {
+    return _caseRequest(`/iris/cases/${id}/notes`, 'POST', { note }, 'No se pudo guardar la nota.')
+  }
+
+  /** Vincula un análisis a un caso. */
+  async function linkCaseAnalysis(id, analysisId) {
+    const updated = await _caseRequest(`/iris/cases/${id}/analyses`, 'POST', { analysisId },
+      'No se pudo añadir el análisis al caso.')
+    if (updated) toast.show(`Análisis #${analysisId} añadido al caso #${id}.`, 'success')
+    return updated
+  }
+
+  /** Desvincula un análisis de un caso (el análisis no se borra). */
+  function unlinkCaseAnalysis(id, analysisId) {
+    return _caseRequest(`/iris/cases/${id}/analyses/${analysisId}`, 'DELETE', undefined,
+      'No se pudo quitar el análisis del caso.')
+  }
+
   /* ═══════════════════ EXCEPCIONES DE CONFIANZA ═══════════════════════ */
 
   const trustedSenders = ref([])
@@ -778,6 +871,9 @@ export const useIrisStore = defineStore('iris', () => {
     archive.sort = { by: 'date', dir: 'desc' }
     savedViews.value = []
     userTags.value = []
+    Object.assign(cases, { items: [], total: 0, countsByStatus: {}, loading: false,
+      filters: { status: '', priority: '', assignedToMe: false } })
+    currentCase.value = null
 
     currentId.value = null
     Object.assign(currentReport, { loading: false, data: null })
@@ -802,6 +898,8 @@ export const useIrisStore = defineStore('iris', () => {
     fetchArchive, setArchiveFilters, resetArchiveFilters, setArchiveSort, goToArchivePage,
     savedViews, userTags, fetchSavedViews, saveArchiveView, applySavedView, deleteSavedView,
     fetchTags, setAnalysisTags, fetchReportById,
+    cases, currentCase, fetchCases, fetchCase, createCase, updateCase, changeCaseStatus,
+    addCaseNote, linkCaseAnalysis, unlinkCaseAnalysis,
     trustedSenders, trustedSendersLoading, fetchTrustedSenders, createTrustedSender, revokeTrustedSender,
     submitAnalysis, fetchResults, getReport, getStatus, pathFor, iocsFor,
     resolvedPathFor, isPathLoadingFor, resolvedIocsFor, isIocsLoadingFor,

--- a/web/app/src/views/IrisCasesView.vue
+++ b/web/app/src/views/IrisCasesView.vue
@@ -1,0 +1,303 @@
+<template>
+  <div class="cases-page" data-module="iris">
+    <StarBackground />
+    <Topbar title="Iris" badge="Casos" back-to="/iris/analisis" back-label="Análisis" />
+
+    <div class="cases-layout">
+      <!-- Cola de trabajo: cuántos casos hay en cada estado y cuáles. -->
+      <section class="panel list-panel">
+        <div class="status-pills" role="group" aria-label="Filtrar por estado">
+          <button type="button" class="pill" :class="{ active: !store.cases.filters.status }" @click="setStatusFilter('')">
+            Todos <span class="pill-count">{{ totalCases }}</span>
+          </button>
+          <button
+            v-for="status in STATUSES"
+            :key="status"
+            type="button"
+            class="pill"
+            :class="{ active: store.cases.filters.status === status }"
+            @click="setStatusFilter(status)"
+          >
+            {{ STATUS_LABELS[status] }} <span class="pill-count">{{ store.cases.countsByStatus[status] ?? 0 }}</span>
+          </button>
+        </div>
+        <label class="mine-toggle">
+          <input v-model="store.cases.filters.assignedToMe" type="checkbox" @change="store.fetchCases()" />
+          Solo los asignados a mí
+        </label>
+
+        <form class="new-case" @submit.prevent="openCase">
+          <input v-model="newTitle" type="text" maxlength="120" class="text-input" placeholder="Título del nuevo caso" aria-label="Título del nuevo caso" />
+          <select v-model="newPriority" class="text-input" aria-label="Prioridad">
+            <option v-for="priority in PRIORITIES" :key="priority" :value="priority">{{ PRIORITY_LABELS[priority] }}</option>
+          </select>
+          <button type="submit" class="primary-btn" :disabled="!newTitle.trim()">Abrir caso</button>
+        </form>
+
+        <p v-if="store.cases.loading && !store.cases.items.length" class="empty">Cargando…</p>
+        <p v-else-if="!store.cases.items.length" class="empty">No hay casos con estos filtros.</p>
+        <ul v-else class="case-list">
+          <li
+            v-for="entry in store.cases.items"
+            :key="entry.caseId"
+            class="case-row"
+            :class="{ 'case-row--active': store.currentCase?.caseId === entry.caseId }"
+            tabindex="0"
+            @click="store.fetchCase(entry.caseId)"
+            @keydown.enter="store.fetchCase(entry.caseId)"
+          >
+            <span class="case-title">#{{ entry.caseId }} · {{ entry.title }}</span>
+            <span class="case-meta">
+              <span class="chip" :class="`chip--${entry.status}`">{{ STATUS_LABELS[entry.status] }}</span>
+              <span class="chip" :class="`priority--${entry.priority}`">{{ PRIORITY_LABELS[entry.priority] }}</span>
+              {{ entry.analysisCount }} análisis · {{ formatDate(entry.updatedAt) }}
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Detalle del caso seleccionado. -->
+      <section class="panel detail-panel">
+        <p v-if="!detail" class="empty">Elige un caso para ver sus análisis, su estado y su timeline.</p>
+        <template v-else>
+          <header class="detail-header">
+            <h2 class="detail-title">#{{ detail.caseId }} · {{ detail.title }}</h2>
+            <span class="chip" :class="`chip--${detail.status}`">{{ STATUS_LABELS[detail.status] }}</span>
+          </header>
+          <p v-if="detail.resolutionReason" class="resolution">Cerrado: «{{ detail.resolutionReason }}» · {{ formatDate(detail.closedAt) }}</p>
+
+          <div class="controls">
+            <label class="control">
+              <span class="control-label">Prioridad</span>
+              <select class="text-input" :value="detail.priority" @change="store.updateCase(detail.caseId, { priority: $event.target.value })">
+                <option v-for="priority in PRIORITIES" :key="priority" :value="priority">{{ PRIORITY_LABELS[priority] }}</option>
+              </select>
+            </label>
+            <div class="control">
+              <span class="control-label">Asignado</span>
+              <button v-if="detail.assigneeId" type="button" class="ghost-btn" @click="store.updateCase(detail.caseId, { assigneeId: null })">
+                {{ detail.assignee }} · quitar
+              </button>
+              <!-- Solo el dueño ve el caso, así que asignárselo a uno mismo es
+                   asignarlo a su dueño. -->
+              <button v-else type="button" class="ghost-btn" @click="store.updateCase(detail.caseId, { assigneeId: detail.ownerId })">Asignármelo</button>
+            </div>
+            <label class="control control--grow">
+              <span class="control-label">Etiquetas (separadas por comas)</span>
+              <input
+                class="text-input"
+                :value="detail.tags.join(', ')"
+                @change="store.updateCase(detail.caseId, { tags: $event.target.value.split(',') })"
+              />
+            </label>
+          </div>
+
+          <div class="transitions">
+            <span class="control-label">Mover a</span>
+            <button
+              v-for="status in STATUSES.filter(candidate => candidate !== detail.status)"
+              :key="status"
+              type="button"
+              class="ghost-btn"
+              @click="requestStatus(status)"
+            >{{ STATUS_LABELS[status] }}</button>
+          </div>
+          <form v-if="pendingClose" class="close-form" @submit.prevent="confirmClose">
+            <textarea v-model="closeReason" class="text-input" rows="2" maxlength="4000"
+              :placeholder="`Por qué se cierra como «${STATUS_LABELS[pendingClose]}» (obligatorio)`"></textarea>
+            <button type="submit" class="primary-btn" :disabled="!closeReason.trim()">Cerrar caso</button>
+            <button type="button" class="ghost-btn" @click="pendingClose = null">Cancelar</button>
+          </form>
+
+          <h3 class="section-title">Análisis ({{ detail.analyses.length }})</h3>
+          <ul class="analysis-list">
+            <li v-for="analysis in detail.analyses" :key="analysis.analysisId" class="analysis-row">
+              <button type="button" class="link-btn" @click="openAnalysis(analysis.analysisId)">
+                #{{ analysis.analysisId }} · {{ analysis.title || '(sin título)' }}
+              </button>
+              <span class="case-meta">{{ analysis.verdict || analysis.status }} · {{ analysis.totalScore ?? '—' }}</span>
+              <button type="button" class="ghost-btn ghost-btn--small" @click="store.unlinkCaseAnalysis(detail.caseId, analysis.analysisId)">Quitar</button>
+            </li>
+          </ul>
+          <form class="inline-form" @submit.prevent="linkAnalysis">
+            <input v-model.number="analysisToLink" type="number" min="1" class="text-input" placeholder="Id de análisis" aria-label="Id del análisis a añadir" />
+            <button type="submit" class="ghost-btn" :disabled="!analysisToLink">Añadir análisis</button>
+          </form>
+
+          <h3 class="section-title">Timeline</h3>
+          <form class="inline-form" @submit.prevent="addNote">
+            <textarea v-model="note" class="text-input" rows="2" maxlength="4000" placeholder="Añadir una nota"></textarea>
+            <button type="submit" class="primary-btn" :disabled="!note.trim()">Anotar</button>
+          </form>
+          <ol class="timeline">
+            <li v-for="event in [...detail.timeline].reverse()" :key="event.eventId" class="timeline-item">
+              <span class="timeline-when">{{ formatDate(event.createdAt) }} · {{ event.actor || '—' }}</span>
+              <span class="timeline-what">{{ describeEvent(event) }}</span>
+            </li>
+          </ol>
+        </template>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import Topbar from '@/components/shared/Topbar.vue'
+import StarBackground from '@/components/shared/StarBackground.vue'
+import { useIrisStore } from '@/stores/irisStore'
+import { useUtils } from '@/composables/useUtils'
+
+const store = useIrisStore()
+const router = useRouter()
+const { formatDate } = useUtils()
+
+const STATUSES = ['new', 'triage', 'contained', 'resolved', 'false_positive']
+const CLOSED = ['resolved', 'false_positive']
+const STATUS_LABELS = { new: 'Nuevo', triage: 'En triaje', contained: 'Contenido', resolved: 'Resuelto', false_positive: 'Falso positivo' }
+const PRIORITIES = ['low', 'medium', 'high', 'critical']
+const PRIORITY_LABELS = { low: 'Baja', medium: 'Media', high: 'Alta', critical: 'Crítica' }
+
+const newTitle = ref('')
+const newPriority = ref('medium')
+const note = ref('')
+const analysisToLink = ref(null)
+const pendingClose = ref(null)
+const closeReason = ref('')
+
+const detail = computed(() => store.currentCase)
+const totalCases = computed(() => Object.values(store.cases.countsByStatus).reduce((sum, count) => sum + count, 0))
+
+function setStatusFilter(status) {
+  store.cases.filters.status = status
+  store.fetchCases()
+}
+
+async function openCase() {
+  const created = await store.createCase({ title: newTitle.value.trim(), priority: newPriority.value })
+  if (created) newTitle.value = ''
+}
+
+// Cerrar pide la razón antes de enviar; el resto de transiciones van directas
+// y, si no están permitidas, el servidor explica por qué.
+function requestStatus(status) {
+  if (CLOSED.includes(status)) {
+    pendingClose.value = status
+    closeReason.value = ''
+    return
+  }
+  pendingClose.value = null
+  store.changeCaseStatus(detail.value.caseId, status)
+}
+
+async function confirmClose() {
+  const updated = await store.changeCaseStatus(detail.value.caseId, pendingClose.value, closeReason.value.trim())
+  if (updated) pendingClose.value = null
+}
+
+async function addNote() {
+  const updated = await store.addCaseNote(detail.value.caseId, note.value.trim())
+  if (updated) note.value = ''
+}
+
+async function linkAnalysis() {
+  const updated = await store.linkCaseAnalysis(detail.value.caseId, analysisToLink.value)
+  if (updated) analysisToLink.value = null
+}
+
+function openAnalysis(analysisId) {
+  store.selectAnalysis(analysisId)
+  router.push('/iris/analisis')
+}
+
+const EVENT_LABELS = {
+  created: 'Caso abierto',
+  status_changed: 'Cambio de estado',
+  priority_changed: 'Cambio de prioridad',
+  assigned: 'Cambio de asignación',
+  title_changed: 'Cambio de título',
+  tags_changed: 'Cambio de etiquetas',
+  note: 'Nota',
+  analysis_linked: 'Análisis añadido',
+  analysis_unlinked: 'Análisis quitado',
+}
+
+/** Frase de una entrada de la timeline a partir de su tipo y su detalle. */
+function describeEvent(event) {
+  const detailData = event.detail ?? {}
+  if (event.kind === 'note') return `Nota: ${event.note}`
+  if (event.kind === 'status_changed') {
+    const reason = detailData.reason ? ` — «${detailData.reason}»` : ''
+    return `${STATUS_LABELS[detailData.from] ?? detailData.from} → ${STATUS_LABELS[detailData.to] ?? detailData.to}${reason}`
+  }
+  if (event.kind === 'priority_changed') return `Prioridad: ${PRIORITY_LABELS[detailData.from]} → ${PRIORITY_LABELS[detailData.to]}`
+  if (event.kind === 'analysis_linked' || event.kind === 'analysis_unlinked') {
+    return `${EVENT_LABELS[event.kind]}: #${detailData.analysisId}`
+  }
+  if (event.kind === 'created' && detailData.analysisIds?.length) {
+    return `Caso abierto con ${detailData.analysisIds.length} análisis`
+  }
+  return EVENT_LABELS[event.kind] ?? event.kind
+}
+
+onMounted(() => store.fetchCases())
+</script>
+
+<style scoped>
+.cases-page { min-height: 100vh; background: var(--bg); padding-top: var(--topbar-h); position: relative; }
+.cases-layout {
+  position: relative; z-index: 1;
+  max-width: 1200px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem;
+  display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 3fr); gap: 1.25rem; align-items: start;
+}
+.panel { border: 1px solid var(--border); border-radius: 12px; background: var(--surface); padding: 1.1rem 1.25rem; min-width: 0; }
+.status-pills { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.pill {
+  padding: 0.25rem 0.65rem; font-size: var(--fs-sm); border-radius: 999px; cursor: pointer;
+  border: 1px solid var(--border-med); background: transparent; color: var(--text-dim);
+}
+.pill.active { border-color: var(--accent); color: var(--accent-bright); background: var(--accent-dim); }
+.pill-count { margin-left: 0.2rem; font-weight: 700; }
+.mine-toggle { display: flex; align-items: center; gap: 0.4rem; margin: 0.7rem 0; font-size: var(--fs-sm); color: var(--text-dim); }
+.new-case, .inline-form, .close-form { display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0.6rem 0; }
+.new-case .text-input:first-child, .inline-form textarea, .close-form textarea { flex: 1; min-width: 10rem; }
+.text-input {
+  padding: 0.4rem 0.55rem; font-size: var(--fs-sm);
+  background: var(--surface-2); color: var(--text); border: 1px solid var(--border-med); border-radius: 6px;
+}
+.primary-btn, .ghost-btn { padding: 0.35rem 0.8rem; font-size: var(--fs-sm); font-weight: 600; border-radius: 6px; cursor: pointer; }
+.primary-btn { border: none; background: var(--accent); color: var(--on-accent); }
+.primary-btn:disabled, .ghost-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.ghost-btn { border: 1px solid var(--border-med); background: transparent; color: var(--text-dim); }
+.ghost-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent-bright); }
+.ghost-btn--small { padding: 0.15rem 0.5rem; font-weight: 500; }
+.empty { color: var(--text-muted); font-size: var(--fs-md); }
+.case-list, .analysis-list, .timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.case-row { padding: 0.55rem 0.7rem; border: 1px solid var(--border); border-radius: 8px; cursor: pointer; display: flex; flex-direction: column; gap: 0.2rem; }
+.case-row:hover, .case-row:focus-visible { border-color: var(--border-med); background: var(--surface-2); outline: none; }
+.case-row--active { border-color: var(--accent); background: var(--accent-dim); }
+.case-title { font-weight: 600; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.case-meta { font-size: var(--fs-sm); color: var(--text-muted); display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem; }
+.chip { padding: 0 0.45rem; font-size: var(--fs-xs); font-weight: 600; border-radius: 999px; text-transform: uppercase; background: var(--surface-2); color: var(--text-dim); }
+.chip--new { background: var(--info-dim); color: var(--info); }
+.chip--triage { background: var(--warn-dim); color: var(--warn); }
+.chip--contained { background: var(--accent-dim); color: var(--accent-bright); }
+.chip--resolved { background: var(--success-dim); color: var(--success); }
+.priority--high, .priority--critical { background: var(--danger-dim); color: var(--danger); }
+.detail-header { display: flex; align-items: center; gap: 0.6rem; }
+.detail-title { margin: 0; font-family: var(--font-display); font-size-adjust: var(--fsa-display); font-size: var(--fs-xl); color: var(--text); }
+.resolution { margin: 0.4rem 0 0; font-size: var(--fs-sm); color: var(--text-dim); }
+.controls { display: flex; flex-wrap: wrap; gap: 0.8rem; margin: 0.9rem 0 0.6rem; }
+.control { display: flex; flex-direction: column; gap: 0.25rem; }
+.control--grow { flex: 1; min-width: 12rem; }
+.control-label { font-size: var(--fs-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); }
+.transitions { display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem; }
+.section-title { margin: 1.1rem 0 0.5rem; font-size: var(--fs-md); color: var(--text); }
+.analysis-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+.link-btn { border: none; background: none; padding: 0; color: var(--accent-bright); cursor: pointer; font-size: var(--fs-md); text-align: left; }
+.timeline-item { display: flex; flex-direction: column; padding-left: 0.7rem; border-left: 2px solid var(--border-med); }
+.timeline-when { font-size: var(--fs-xs); color: var(--text-muted); }
+.timeline-what { font-size: var(--fs-sm); color: var(--text-dim); overflow-wrap: anywhere; }
+@media (max-width: 900px) { .cases-layout { grid-template-columns: 1fr; } }
+</style>

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -69,6 +69,12 @@
         </svg>
         Remitentes de confianza
       </router-link>
+      <router-link to="/iris/casos" class="back-link connections-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <rect x="3" y="7" width="18" height="13" rx="2" /><path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
+        </svg>
+        Casos
+      </router-link>
 
       <main class="iris-main">
         <IrisReportViewer


### PR DESCRIPTION
## El problema

Iris produce informes: cada análisis dice qué se decidió sobre un correo y por qué. Pero un informe aislado no es trabajo operativo. No hay dónde apuntar que alguien lo está investigando, que la amenaza ya se contuvo, que diez correos son la misma campaña o por qué se cerró. Tampoco se puede medir cuántos incidentes hay abiertos ni en qué estado.

Cierra #242 (iniciativa `F01`, Fase 2 del roadmap de Iris, #202).

## Qué cambia

**Casos de analista.** Un caso (`IrisCase`) agrupa uno o varios análisis y registra la **decisión humana** encima de ellos. Los análisis no cambian nunca: siguen diciendo lo que decidió Iris, igual que con el feedback de `M04`.

- **Estado**, con un ciclo de vida fijo que decide `services/cases.py`:
  - `new` (nadie lo ha mirado) pasa a `triage` (alguien lo investiga), luego a `contained` (la amenaza está controlada pero sigue abierto) y termina en `resolved` (era un incidente real y se trató) o en `false_positive` (no era una amenaza).
  - **Cerrar exige una razón.**
  - Un caso cerrado solo se reabre a `triage`: volver a `new` borraría la señal de que ya se investigó una vez.
- **Prioridad** (`low`, `medium`, `high`, `critical`), **etiquetas** y **asignación**.
- **Timeline** (`IrisCaseEvent`): cada cambio deja un evento con autor, fecha y el antes y el después: apertura, estado con su razón, prioridad, título, etiquetas, asignación, análisis añadido o quitado. **Las notas son eventos de la timeline.**

**API.**

- `POST /iris/cases` abre un caso, opcionalmente con análisis vinculados.
- `GET /iris/cases` lista los casos con filtros por estado, prioridad y «asignados a mí». Además devuelve `countsByStatus`, la cola de trabajo de un vistazo y la base de las métricas de operación.
- `GET` y `PATCH /iris/cases/<id>`.
- `POST /iris/cases/<id>/status` y `POST /iris/cases/<id>/notes`.
- `POST /iris/cases/<id>/analyses` y `DELETE /iris/cases/<id>/analyses/<analysisId>`.

Borrar un análisis lo saca de sus casos, y la timeline conserva que estuvo.

**Interfaz.**

- La vista nueva `/iris/casos` (enlazada desde Análisis) muestra la lista con recuento por estado, filtros y alta de casos. El detalle permite cambiar prioridad, etiquetas y asignación, mover el caso de estado (cerrarlo pide la razón antes de enviar), añadir y quitar análisis, anotar y leer la timeline.
- En el informe, «Añadir a un caso…» lleva el análisis a un caso abierto o abre uno nuevo con él.

## Decisiones que conviene revisar

- **La asignación solo admite al dueño del caso.** El roadmap habla de asignar casos. Un caso enseña análisis de correo personal, y asignarlo a otra persona le daría acceso a ese correo. El modelo `Organization` fija que una organización comparte plan y factura, **no datos**, con una única excepción documentada (el inventario de Hygeia). Abrir una segunda para Iris es una decisión de producto, no de este PR. Hoy `assigneeId` sirve para marcar «me lo quedo» frente a «sin asignar» y deja el campo listo por si esa decisión llega. El detalle expone `ownerId` para que la interfaz pueda ofrecer «Asignármelo».
- **Una sola tabla para notas y timeline.** El roadmap proponía `IrisCaseNote` aparte. Una nota es un evento más de la timeline, y separarla obligaría a mezclar dos listas para enseñar la historia en orden.
- **Etiquetas.** La normalización pasa de `managers/triage.py` (`M12`) a `services/tags.py`, porque ahora la usan dos managers.

## También en este PR

`fix(web)`: el store de Iris definía las acciones de remitentes de confianza de `M03` (#585) pero no las devolvía, así que el formulario del informe y la vista `/iris/confianza` llamaban a funciones que no existían. Va en su propio commit.

## Validación

- `test_iris_cases.py` (nuevo, 13 casos):
  - un caso con varios análisis, que no cambian;
  - título y prioridad obligatorios;
  - ningún caso con análisis ajenos;
  - el ciclo de vida completo, con la razón de cierre;
  - un caso cerrado solo se reabre a `triage`;
  - un estado desconocido da `422`;
  - notas y cambios en la timeline, y una nota vacía se rechaza;
  - la asignación solo al dueño;
  - vincular y desvincular análisis;
  - borrar un análisis deja el caso;
  - listado con recuentos y filtros;
  - ownership en todos los endpoints.
- Suite completa (`pytest`): 3237 pasados, 50 saltados (los de `tests/postgres`), 0 fallos. Después, con `ownerId`: `pytest -k "cases or conventions or caddy or import_isolation"` en verde.
- SPA: `IrisCasesView.vue`, `IrisAddToCase.vue`, `IrisReportViewer.vue` e `IrisView.vue` compilan con `@vue/compiler-sfc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
