### PR TITLE
fix(iris): Public Suffix List y confusables Unicode — un IDN legítimo deja de ser phishing (M06)

### DIFF
--- a/API/SecOpsConfig.json
+++ b/API/SecOpsConfig.json
@@ -1049,22 +1049,6 @@
           ".ppam",
           ".sldm"
         ],
-        "multi_level_tlds": [
-          "co.uk",
-          "org.uk",
-          "gov.uk",
-          "ac.uk",
-          "co.jp",
-          "com.mx",
-          "com.br",
-          "com.ar",
-          "com.au",
-          "com.es",
-          "co.in",
-          "co.nz",
-          "com.tr",
-          "com.co"
-        ],
         "redirect_params": [
           "url",
           "u",

--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -16,6 +16,12 @@ reportlab>=4.0.7
 # transitiva de reportlab.
 Pillow>=11.0.0
 
+# Iris: dominio registrable según la Public Suffix List (empaquetada; no se
+# descarga en ejecución) y tabla de confusables de Unicode para distinguir un
+# dominio internacionalizado legítimo de un homógrafo.
+publicsuffixlist>=1.0.2
+confusable-homoglyphs>=3.3.1
+
 # QR code decoding (Iris quishing detection, D1)
 opencv-python-headless>=4.10.0
 

--- a/API/src/modules/features/iris/services/idn.py
+++ b/API/src/modules/features/iris/services/idn.py
@@ -1,0 +1,219 @@
+"""
+Dominios internacionalizados (IDN): cuándo son legítimos y cuándo un homógrafo.
+
+Un dominio con caracteres no ASCII viaja en punycode (``xn--mnchen-3ya.de`` es
+``münchen.de``). Hasta ahora cualquier etiqueta ``xn--`` se trataba como
+sospechosa, lo que penalizaba a todo remitente legítimo de un idioma con
+tildes, cirílico, griego o escrituras asiáticas. Lo sospechoso no es el IDN en
+sí, sino dos cosas concretas:
+
+- **Mezcla de alfabetos** en una misma etiqueta (``pаypal`` con una ``а``
+  cirílica entre letras latinas): ningún idioma la produce, salvo las
+  combinaciones que Unicode admite para el japonés, el coreano y el chino
+  (perfil *highly restrictive* de UTS #39).
+- **Homógrafo de una marca**: el *esqueleto* visual de una etiqueta —cada
+  carácter sustituido por la letra latina con la que se confunde, según la
+  tabla oficial de confusables de Unicode, y sin tildes— coincide con una
+  marca conocida aunque la etiqueta no sea la marca.
+
+Un IDN de un solo alfabeto cuyo esqueleto no es una marca es un dominio
+internacionalizado válido y no se penaliza.
+
+Módulo puro: sin base de datos ni red. Los datos de confusables vienen del
+paquete ``confusable_homoglyphs``, que empaqueta la tabla de Unicode.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import lru_cache
+from typing import Iterable, Optional, Tuple
+
+from confusable_homoglyphs import categories, confusables
+
+#: Alfabetos que no cuentan para decidir si una etiqueta mezcla escrituras:
+#: dígitos, guion y marcas combinantes son comunes a todas.
+_NEUTRAL_SCRIPTS = frozenset({"COMMON", "INHERITED"})
+
+#: Combinaciones de alfabetos que un idioma real usa en una misma palabra
+#: (UTS #39, perfil *highly restrictive*): japonés, coreano y chino con latín.
+_ALLOWED_SCRIPT_COMBINATIONS = (
+    frozenset({"LATIN", "HAN", "HIRAGANA", "KATAKANA"}),
+    frozenset({"LATIN", "HAN", "HANGUL"}),
+    frozenset({"LATIN", "HAN", "BOPOMOFO"}),
+)
+
+
+class IdnVerdict(StrEnum):
+    """Qué es un dominio desde el punto de vista de la suplantación visual.
+
+    Attributes:
+        ASCII: Solo ASCII; no hay nada internacionalizado que evaluar.
+        VALID_IDN: Internacionalizado legítimo: un solo alfabeto (o una
+            combinación admitida) y ningún homógrafo de marca.
+        MIXED_SCRIPT: Alguna etiqueta mezcla alfabetos que ningún idioma
+            combina.
+        BRAND_HOMOGRAPH: Alguna etiqueta es visualmente una marca conocida
+            sin serlo.
+    """
+    ASCII = "ascii"
+    VALID_IDN = "valid_idn"
+    MIXED_SCRIPT = "mixed_script"
+    BRAND_HOMOGRAPH = "brand_homograph"
+
+
+@dataclass(frozen=True)
+class IdnAssessment:
+    """Resultado de evaluar un dominio.
+
+    Attributes:
+        verdict: ``IdnVerdict``.
+        unicode_domain: El dominio con las etiquetas punycode decodificadas.
+        label: La etiqueta que decidió el veredicto (en Unicode); ``None`` en
+            ``ASCII`` y ``VALID_IDN``.
+        scripts: Alfabetos de esa etiqueta, ordenados; vacío si no aplica.
+        brand: La marca que imita, en ``BRAND_HOMOGRAPH``; ``None`` si no.
+    """
+    verdict: IdnVerdict
+    unicode_domain: str
+    label: Optional[str] = None
+    scripts: Tuple[str, ...] = ()
+    brand: Optional[str] = None
+
+    @property
+    def is_suspicious(self) -> bool:
+        """``True`` en mezcla de alfabetos y en homógrafo de marca."""
+        return self.verdict in (IdnVerdict.MIXED_SCRIPT, IdnVerdict.BRAND_HOMOGRAPH)
+
+
+def to_unicode(domain: str) -> str:
+    """Decodifica las etiquetas punycode (``xn--``) de un dominio.
+
+    Args:
+        domain: Dominio tal como aparece en una cabecera o una URL.
+
+    Returns:
+        str: El dominio en minúsculas con cada etiqueta ``xn--`` decodificada;
+            una etiqueta que no decodifica se deja tal cual.
+    """
+    labels = []
+    for label in (domain or "").strip(".").lower().split("."):
+        if label.startswith("xn--"):
+            try:
+                label = label.encode("ascii").decode("idna")
+            except UnicodeError:
+                pass
+        labels.append(label)
+    return ".".join(labels)
+
+
+def label_scripts(label: str) -> frozenset[str]:
+    """Alfabetos de una etiqueta, sin contar los comunes (dígitos, guion).
+
+    Args:
+        label: Una etiqueta de dominio en Unicode.
+
+    Returns:
+        frozenset[str]: Nombres Unicode de los alfabetos (``LATIN``,
+            ``CYRILLIC``, ``HAN``…); vacío si solo hay caracteres comunes.
+    """
+    return frozenset(categories.unique_aliases(label)) - _NEUTRAL_SCRIPTS
+
+
+def is_mixed_script(label: str) -> bool:
+    """Si una etiqueta mezcla alfabetos que ningún idioma combina.
+
+    Args:
+        label: Una etiqueta de dominio en Unicode.
+
+    Returns:
+        bool: ``True`` si tiene dos o más alfabetos y no son una de las
+            combinaciones de ``_ALLOWED_SCRIPT_COMBINATIONS``.
+    """
+    scripts = label_scripts(label)
+    if len(scripts) <= 1:
+        return False
+    return not any(scripts <= allowed for allowed in _ALLOWED_SCRIPT_COMBINATIONS)
+
+
+@lru_cache(maxsize=4096)
+def _skeleton_char(char: str) -> str:
+    """Letra latina con la que se confunde visualmente un carácter.
+
+    Args:
+        char: Un carácter.
+
+    Returns:
+        str: El carácter ASCII equivalente (sin tildes, sin anchura completa,
+            sin variantes matemáticas, o su confusable latino según Unicode);
+            el propio carácter si no se parece a ninguno.
+    """
+    if char.isascii():
+        return char
+    decomposed = "".join(c for c in unicodedata.normalize("NFKD", char) if not unicodedata.combining(c))
+    if decomposed and decomposed.isascii():
+        return decomposed.lower()
+    matches = confusables.is_confusable(char, preferred_aliases=["latin"]) or []
+    for match in matches:
+        for homoglyph in match.get("homoglyphs", []):
+            candidate = homoglyph.get("c", "")
+            if len(candidate) == 1 and candidate.isascii() and candidate.isalnum():
+                return candidate.lower()
+    return char
+
+
+def skeleton(text: str) -> str:
+    """Esqueleto visual de un texto: cómo lo lee un humano, en ASCII.
+
+    ``pаypаl`` (con ``а`` cirílicas) -> ``paypal``; ``gööglé`` -> ``google``;
+    ``ｇｏｏｇｌｅ`` (anchura completa) -> ``google``.
+
+    Args:
+        text: Texto en cualquier escritura.
+
+    Returns:
+        str: El texto en minúsculas con cada carácter sustituido por su
+            equivalente latino cuando lo tiene.
+    """
+    return "".join(_skeleton_char(char) for char in (text or "").lower())
+
+
+def assess_domain(domain: str, brands: Iterable[str]) -> IdnAssessment:
+    """Decide si un dominio internacionalizado es legítimo o una suplantación.
+
+    Se evalúan todas las etiquetas, no solo la registrable: un homógrafo de
+    marca en un subdominio (``pаypal.ejemplo.com``) engaña igual.
+
+    Args:
+        domain: Dominio en punycode o en Unicode.
+        brands: Marcas conocidas (``wordlists.canonical_brands``).
+
+    Returns:
+        IdnAssessment: ``ASCII`` si no hay nada internacionalizado;
+            ``BRAND_HOMOGRAPH`` si alguna etiqueta no ASCII tiene por esqueleto
+            una marca; si no, ``MIXED_SCRIPT`` si alguna mezcla alfabetos; y
+            ``VALID_IDN`` en el resto.
+    """
+    unicode_domain = to_unicode(domain)
+    if unicode_domain.isascii():
+        return IdnAssessment(IdnVerdict.ASCII, unicode_domain)
+
+    brand_set = frozenset(brands)
+    labels = [label for label in unicode_domain.split(".") if not label.isascii()]
+    for label in labels:
+        # Un homógrafo es una marca escrita con caracteres que no lo son: la
+        # palabra tiene que cambiar al leerla. «paypal» tal cual dentro de
+        # «paypal-segurídad» no es un homógrafo sino un dominio primo, y de
+        # eso se encarga el análisis normal de la regla sobre el esqueleto.
+        for token in [label, *label.split("-")]:
+            visual = skeleton(token)
+            if visual in brand_set and visual != token:
+                return IdnAssessment(IdnVerdict.BRAND_HOMOGRAPH, unicode_domain, label,
+                                     tuple(sorted(label_scripts(label))), visual)
+    for label in labels:
+        if is_mixed_script(label):
+            return IdnAssessment(IdnVerdict.MIXED_SCRIPT, unicode_domain, label,
+                                 tuple(sorted(label_scripts(label))))
+    return IdnAssessment(IdnVerdict.VALID_IDN, unicode_domain)

--- a/API/src/modules/features/iris/services/rules/sender_identity_rules.py
+++ b/API/src/modules/features/iris/services/rules/sender_identity_rules.py
@@ -31,14 +31,15 @@ import re
 import src.modules.system.config_reading as CR
 from ..registry import iris_rules, RuleResult
 from ..wordlists import (
-    brand_trusted_domains, canonical_brands, multi_level_tlds,
+    brand_trusted_domains, canonical_brands,
     subdomain_action_words, suspicious_tlds,
 )
 from ..text import (
     extract_display_name, extract_domain, is_free_provider,
     is_plausible_typo, levenshtein, normalize_homoglyphs,
-    registrable_domain, registrable_label,
+    public_suffix, registrable_domain, registrable_label,
 )
+from ..idn import IdnVerdict, assess_domain, skeleton, to_unicode
 from ..parsers import decode_mime_words
 
 
@@ -264,19 +265,32 @@ def check_lookalike_domain(headers: dict) -> RuleResult:
             recommendation=None,
         )
 
-    # Punycode / IDN homograph — any xn-- label is inherently suspicious.
-    if any(label.startswith("xn--") for label in domain.split(".")):
+    # Un IDN (``xn--``) solo es sospechoso si imita una marca o mezcla
+    # alfabetos; uno legítimo de un solo alfabeto sigue el análisis normal,
+    # sobre su esqueleto visual.
+    idn = assess_domain(domain, canonical_brands())
+    if idn.is_suspicious:
+        is_homograph = idn.verdict == IdnVerdict.BRAND_HOMOGRAPH
         return RuleResult(
             score=CR.get_iris_scoring_weight("lookalike_domain.punycode", -15), verdict="fail",
-            details={"domain": domain, "type": "punycode"},
+            details={
+                "domain": domain, "unicode_domain": idn.unicode_domain,
+                "type": "idn_homograph" if is_homograph else "idn_mixed_script",
+                "label": idn.label, "scripts": list(idn.scripts), "brand": idn.brand,
+            },
             recommendation=(
-                f"El dominio del remitente ({domain}) usa codificación punycode (IDN, 'xn--'). "
-                "Es una técnica habitual para registrar dominios que parecen marcas conocidas "
-                "usando caracteres Unicode visualmente idénticos. Trátalo como phishing."
+                f"El dominio del remitente ({domain}, que se lee «{idn.unicode_domain}») "
+                + (f"usa caracteres de otro alfabeto que se ven igual que «{idn.brand}». "
+                   if is_homograph else
+                   f"mezcla alfabetos en una misma palabra ({', '.join(idn.scripts)}), algo que "
+                   "ningún idioma hace. ")
+                + "Es la técnica de homógrafos IDN para suplantar dominios. Trátalo como phishing."
             ),
         )
 
     label = registrable_label(domain)
+    if idn.verdict == IdnVerdict.VALID_IDN:
+        label = skeleton(to_unicode(label))
     if not label:
         return RuleResult(score=1, verdict="pass", details={"domain": domain}, recommendation=None)
 
@@ -346,13 +360,15 @@ def check_subdomain_impersonation(headers: dict) -> RuleResult:
     if _is_trusted_brand_domain(domain):
         return RuleResult(score=1, verdict="pass", details={"domain": domain}, recommendation=None)
 
-    if "xn--" in domain:
+    idn = assess_domain(domain, canonical_brands())
+    if idn.is_suspicious:
         return RuleResult(
             score=CR.get_iris_scoring_weight("subdomain_impersonation.punycode", -10), verdict="fail",
-            details={"domain": domain, "type": "punycode_in_subdomain"},
+            details={"domain": domain, "unicode_domain": idn.unicode_domain,
+                     "type": "punycode_in_subdomain", "idn_verdict": idn.verdict.value, "brand": idn.brand},
             recommendation=(
-                f"El dominio {domain} usa codificación punycode. Combinado con la "
-                "imposible coincidencia con un subdominio, es muy probable phishing."
+                f"El dominio {domain} (se lee «{idn.unicode_domain}») usa caracteres Unicode "
+                "que imitan otro nombre o mezclan alfabetos. Es muy probable phishing."
             ),
         )
 
@@ -364,8 +380,10 @@ def check_subdomain_impersonation(headers: dict) -> RuleResult:
     if reg_label in brands:
         return RuleResult(score=0, verdict="neutral", details={"domain": domain}, recommendation=None)
 
-    pre_labels = [label for label in labels[:-2] if label] if ".".join(labels[-2:]) in multi_level_tlds() \
-        else [label for label in labels[:-1] if label]
+    # Todas las etiquetas salvo el sufijo público: los subdominios más la
+    # registrable.
+    suffix_length = len(public_suffix(domain).split("."))
+    pre_labels = [label for label in labels[:-suffix_length] if label]
 
     findings: list[dict] = []
 

--- a/API/src/modules/features/iris/services/text.py
+++ b/API/src/modules/features/iris/services/text.py
@@ -15,16 +15,20 @@ utilidad, vive aquí; si necesitan un dataset, vive en ``wordlists.py``.
 
 from __future__ import annotations
 
+import ipaddress
 import re
+from functools import lru_cache
 from typing import Optional
 from urllib.parse import urlparse
 
+from publicsuffixlist import PublicSuffixList
+
+from .idn import assess_domain, skeleton
 from .wordlists import (
     canonical_brands,
     esp_tracker_domains,
     free_provider_domains,
     homoglyph_table,
-    multi_level_tlds,
     multitenant_hosting_domains,
     shortener_domains,
     url_phishing_keywords,
@@ -44,35 +48,93 @@ def extract_domain(email: str) -> Optional[str]:
     return match.group(1).lower() if match else None
 
 
+@lru_cache(maxsize=1)
+def _public_suffix_list() -> PublicSuffixList:
+    """Public Suffix List empaquetada, solo la sección ICANN.
+
+    Solo ICANN a propósito: la sección privada declara sufijos como
+    ``github.io`` o ``blogspot.com``, y con ella cada inquilino de un servicio
+    compartido sería una «organización» distinta del servicio. Eso es lo que
+    necesitaría una cookie, no la comparación de alineamiento organizativo que
+    hacen estas reglas; los servicios multiinquilino se tratan aparte
+    (``wordlists.multitenant_hosting_domains``). La lista viene dentro del
+    paquete ``publicsuffixlist``: nunca se descarga en ejecución.
+
+    Returns:
+        PublicSuffixList: Instancia compartida.
+    """
+    return PublicSuffixList(only_icann=True)
+
+
+def _normalize_host(domain: Optional[str]) -> str:
+    """Host en minúsculas y sin puntos al principio ni al final."""
+    return (domain or "").strip().strip(".").lower()
+
+
+def _is_ip_literal(host: str) -> bool:
+    """Si un host es una dirección IP (una IP no tiene dominio registrable)."""
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return False
+    return True
+
+
+def public_suffix(domain: Optional[str]) -> str:
+    """Sufijo público de un host según la Public Suffix List (ICANN).
+
+    ``mail.hacienda.gob.es`` -> ``gob.es``; ``shop.example.app`` -> ``app``.
+
+    Args:
+        domain: Host en ASCII (punycode) o en Unicode.
+
+    Returns:
+        str: El sufijo; cadena vacía si no hay host o si es una IP. Un TLD
+            que la lista no conoce se trata como sufijo de un nivel.
+    """
+    host = _normalize_host(domain)
+    if not host or _is_ip_literal(host):
+        return ""
+    return _public_suffix_list().publicsuffix(host) or host.rsplit(".", 1)[-1]
+
+
 def registrable_domain(domain: Optional[str]) -> Optional[str]:
-    """Reduce a hostname to its registrable domain (best-effort, no PSL).
+    """Dominio registrable de un host, según la Public Suffix List (ICANN).
 
     ``mail.corp.paypal.com`` -> ``paypal.com``; ``a.b.example.co.uk`` ->
-    ``example.co.uk``.  Good enough to compare organisational alignment.
+    ``example.co.uk``; ``mail.hacienda.gob.es`` -> ``hacienda.gob.es``. Es la
+    unidad con la que se compara si dos dominios son de la misma organización.
+
+    Args:
+        domain: Host en ASCII (punycode) o en Unicode.
+
+    Returns:
+        Optional[str]: El dominio registrable; el propio host si es una IP o
+            no tiene sufijo por delante (``localhost``); ``None`` si no hay host.
     """
-    if not domain:
+    host = _normalize_host(domain)
+    if not host:
         return None
-    labels = domain.strip(".").lower().split(".")
-    if len(labels) < 2:
-        return domain.lower()
-    last_two = ".".join(labels[-2:])
-    if last_two in multi_level_tlds() and len(labels) >= 3:
-        return ".".join(labels[-3:])
-    return last_two
+    if _is_ip_literal(host):
+        return host
+    return _public_suffix_list().privatesuffix(host) or host
 
 
 def registrable_label(domain: str) -> str:
-    """Return the owner-identifying label of the registrable domain.
+    """Etiqueta que identifica al dueño del dominio registrable.
 
-    ``mail.paypal.com`` -> ``paypal``; ``a.example.co.uk`` -> ``example``.
+    ``mail.paypal.com`` -> ``paypal``; ``a.example.co.uk`` -> ``example``;
+    ``mail.hacienda.gob.es`` -> ``hacienda``.
+
+    Args:
+        domain: Host en ASCII (punycode) o en Unicode.
+
+    Returns:
+        str: La primera etiqueta del dominio registrable; cadena vacía si no
+            hay host.
     """
-    labels = domain.strip(".").lower().split(".")
-    if len(labels) < 2:
-        return labels[0] if labels else ""
-    last_two = ".".join(labels[-2:])
-    if last_two in multi_level_tlds() and len(labels) >= 3:
-        return labels[-3]
-    return labels[-2]
+    registrable = registrable_domain(domain)
+    return registrable.split(".")[0] if registrable else ""
 
 
 def extract_display_name(from_header: str) -> str:
@@ -201,8 +263,20 @@ def is_plausible_typo(a: str, b: str) -> bool:
 
 
 def normalize_homoglyphs(text: str) -> str:
-    """Sustituye homóglifos comunes (0->o, 1->l, $->s…) y pasa a minúsculas."""
-    return text.lower().translate(homoglyph_table())
+    """Lee un texto como lo leería un humano, para compararlo con marcas.
+
+    Primero el esqueleto visual de Unicode (cirílico, griego, tildes,
+    anchura completa… -> su letra latina, ver ``services/idn.skeleton``) y
+    después la tabla de sustituciones ASCII de la configuración (0->o,
+    1->l, $->s…).
+
+    Args:
+        text: Texto en cualquier escritura.
+
+    Returns:
+        str: El texto normalizado, en minúsculas.
+    """
+    return skeleton(text).translate(homoglyph_table())
 
 
 def find_brand_in_subdomain(domain: str) -> Optional[dict]:
@@ -222,9 +296,8 @@ def find_brand_in_subdomain(domain: str) -> Optional[dict]:
     brands = canonical_brands()
     if registrable_label(domain) in brands:
         return None  # genuinely the brand's own domain (e.g. mail.github.com)
-    pre_labels = (
-        labels[:-3] if ".".join(labels[-2:]) in multi_level_tlds() else labels[:-2]
-    )
+    # Todo lo que queda a la izquierda del dominio registrable.
+    pre_labels = labels[:-len(registrable_domain(domain).split("."))]
     for lbl in pre_labels:
         for token in re.split(r"[^a-z0-9]+", lbl):
             if token in brands:
@@ -335,8 +408,14 @@ def analyze_url(href: str, sender_domain: Optional[str] = None,
         })
         score -= 20
 
-    if any(label.startswith("xn--") for label in host.split(".")):
-        findings.append({"type": "punycode", "href": href})
+    # Un IDN legítimo (un solo alfabeto, sin imitar una marca) no penaliza:
+    # lo sospechoso es la mezcla de alfabetos o el homógrafo de una marca.
+    idn = assess_domain(host, brands)
+    if idn.is_suspicious:
+        findings.append({
+            "type": "punycode", "href": href, "unicode_host": idn.unicode_domain,
+            "idn_verdict": idn.verdict.value, "imitates": idn.brand,
+        })
         score -= 8
 
     if _URL_IP_HOST_RE.match(host) or is_obfuscated_ip_host(host):

--- a/API/src/modules/features/iris/services/wordlists.py
+++ b/API/src/modules/features/iris/services/wordlists.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import re
 from functools import lru_cache
+from importlib.metadata import version
 from typing import Any
 
 import src.modules.system.config_reading as CR
@@ -30,13 +31,6 @@ import src.modules.system.config_reading as CR
 # =============================================================================
 
 _DEFAULTS: dict[str, Any] = {
-    # Public-suffix de segundo nivel que requieren conservar dos labels
-    # (lista pequeña y pragmática — un PSL completo es excesivo aquí).
-    "multi_level_tlds": [
-        "co.uk", "org.uk", "gov.uk", "ac.uk", "co.jp", "com.mx", "com.br",
-        "com.ar", "com.au", "com.es", "co.in", "co.nz", "com.tr", "com.co",
-    ],
-
     # Marcas canónicas usadas por lookalike/typosquat/subdomain checks.
     "canonical_brands": [
         "microsoft", "paypal", "netflix", "amazon", "google", "apple",
@@ -468,6 +462,9 @@ def _tuple_of(key: str) -> tuple[str, ...]:
     return _cached_tuple(CR.config_version(), key)
 
 
+#: Paquetes cuyos datos empaquetados deciden igual que un dataset.
+_FINGERPRINT_PACKAGES = ("publicsuffixlist", "confusable-homoglyphs")
+
 #: Datasets que viven solo en la configuración (sin default en ``_DEFAULTS``)
 #: y que también cambian el resultado de un análisis.
 _FINGERPRINT_EXTRA_KEYS = ("trusted_authserv_ids",)
@@ -487,6 +484,9 @@ def _datasets_fingerprint(config_version: tuple) -> str:
     effective = {key: _data(key) for key in sorted(_DEFAULTS)}
     for key in _FINGERPRINT_EXTRA_KEYS:
         effective.setdefault(key, CR.get_iris_data(key))
+    # La Public Suffix List y la tabla de confusables también deciden: una
+    # versión nueva de cualquiera de las dos puede cambiar un veredicto.
+    effective["_packages"] = {package: version(package) for package in _FINGERPRINT_PACKAGES}
     material = json.dumps(effective, sort_keys=True, ensure_ascii=False, default=list)
     return "iris-data:" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
 
@@ -507,9 +507,6 @@ def datasets_fingerprint() -> str:
 
 
 # --- Accessors públicos (uno por dataset) ------------------------------------
-
-def multi_level_tlds() -> frozenset[str]:
-    return _set_of("multi_level_tlds")
 
 def canonical_brands() -> frozenset[str]:
     return _set_of("canonical_brands")

--- a/API/tests/unit/test_iris_idn_psl.py
+++ b/API/tests/unit/test_iris_idn_psl.py
@@ -1,0 +1,189 @@
+"""Public Suffix List y confusables IDN: menos falsos positivos, los mismos homógrafos.
+
+Cubre el criterio de cierre: ``co.uk``, TLDs nuevos, punycode, cirílico y
+dominios multilingües no producen regresiones en remitentes legítimos, y los
+homógrafos de marca y la mezcla de alfabetos se siguen detectando.
+
+Los dominios internacionalizados se escriben en Unicode y se convierten con
+el codec ``idna`` de la biblioteca estándar, para que el test diga qué
+dominio es sin tener que descifrar el punycode a mano.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from email.utils import format_datetime
+
+import pytest
+
+from src.modules.features.iris.managers import IrisManager
+from src.modules.features.iris.services.idn import IdnVerdict, assess_domain, skeleton
+from src.modules.features.iris.services.parsers import parse_raw_message
+from src.modules.features.iris.services.rules import iris_rules
+from src.modules.features.iris.services.rules.sender_identity_rules import (
+    check_lookalike_domain,
+    check_subdomain_impersonation,
+)
+from src.modules.features.iris.services.text import (
+    analyze_url,
+    normalize_homoglyphs,
+    public_suffix,
+    registrable_domain,
+    registrable_label,
+)
+from src.modules.features.iris.services.wordlists import canonical_brands
+
+pytestmark = pytest.mark.unit
+
+
+def _puny(domain: str) -> str:
+    return domain.encode("idna").decode("ascii")
+
+
+# --------------------------------------------------------- dominio registrable
+
+@pytest.mark.parametrize("host, expected", [
+    ("a.b.example.co.uk", "example.co.uk"),
+    ("mail.paypal.com", "paypal.com"),
+    ("shop.example.com.br", "example.com.br"),
+    # Antes gob.es no era un sufijo conocido: todo el sector público español
+    # contaba como una sola organización, «gob.es».
+    ("mail.hacienda.gob.es", "hacienda.gob.es"),
+    ("login.example.ac.jp", "example.ac.jp"),
+    ("news.example.app", "example.app"),
+    ("email.mango", "email.mango"),
+    ("Mail.Example.COM.", "example.com"),
+    ("localhost", "localhost"),
+    ("192.168.1.10", "192.168.1.10"),
+])
+def test_registrable_domain_follows_the_public_suffix_list(host, expected):
+    assert registrable_domain(host) == expected
+
+
+def test_registrable_label_and_public_suffix():
+    assert registrable_label("mail.hacienda.gob.es") == "hacienda"
+    assert public_suffix("mail.hacienda.gob.es") == "gob.es"
+    assert registrable_domain(_puny("correo.пример.рф")) == _puny("пример.рф")
+    assert registrable_domain(None) is None
+
+
+# --------------------------------------------------------------- IDN y esqueleto
+
+def test_the_visual_skeleton_reads_like_a_human():
+    assert skeleton("pаypаl") == "paypal"          # а cirílicas
+    assert skeleton("gööglé") == "google"          # tildes latinas
+    assert skeleton("ｇｏｏｇｌｅ") == "google"      # anchura completa
+    assert skeleton("münchen") == "munchen"
+    assert normalize_homoglyphs("PаYPа1") == "paypal"
+
+
+@pytest.mark.parametrize("domain, verdict", [
+    ("example.com", IdnVerdict.ASCII),
+    (_puny("münchen.de"), IdnVerdict.VALID_IDN),
+    (_puny("пример.рф"), IdnVerdict.VALID_IDN),
+    (_puny("日本語.jp"), IdnVerdict.VALID_IDN),
+    (_puny("ひらがなカタカナ漢字.jp"), IdnVerdict.VALID_IDN),
+    (_puny("ελληνικά.gr"), IdnVerdict.VALID_IDN),
+    ("xn--pypal-4ve.com", IdnVerdict.BRAND_HOMOGRAPH),   # pаypal
+    (_puny("gооgle.com"), IdnVerdict.BRAND_HOMOGRAPH),   # о cirílicas
+    (_puny("gööglé.com"), IdnVerdict.BRAND_HOMOGRAPH),   # latín con tildes
+    (_puny("bаnco.com"), IdnVerdict.MIXED_SCRIPT),        # latín + cirílico, sin marca
+    (_puny("pаypal.ejemplo.com"), IdnVerdict.BRAND_HOMOGRAPH),
+])
+def test_an_idn_is_only_suspicious_when_it_imitates_or_mixes(domain, verdict):
+    assert assess_domain(domain, canonical_brands()).verdict == verdict
+
+
+# ------------------------------------------------------------ reglas afectadas
+
+@pytest.mark.parametrize("domain", [
+    _puny("münchen.de"), _puny("пример.рф"), _puny("日本語.jp"), _puny("correos-españa.es"),
+])
+def test_a_legitimate_international_sender_is_not_a_lookalike(domain):
+    assert check_lookalike_domain({"from": f"info@{domain}"}).verdict == "pass"
+    assert check_subdomain_impersonation({"from": f"info@{domain}"}).verdict != "fail"
+
+
+def test_a_homograph_of_a_brand_is_still_flagged():
+    result = check_lookalike_domain({"from": f"seguridad@{_puny('gооgle.com')}"})
+
+    assert result.verdict == "fail"
+    assert result.details["type"] == "idn_homograph"
+    assert result.details["brand"] == "google"
+    assert result.details["unicode_domain"] == "gооgle.com"
+
+
+def test_a_mixed_script_sender_is_flagged_even_without_a_brand():
+    result = check_lookalike_domain({"from": f"avisos@{_puny('bаnco.com')}"})
+
+    assert result.verdict == "fail"
+    assert result.details["type"] == "idn_mixed_script"
+
+
+def test_a_cousin_domain_written_with_accents_is_still_a_cousin():
+    """Un IDN válido sigue el análisis normal sobre su esqueleto:
+    «paypal-segurídad» contiene la marca aunque lleve tildes."""
+    result = check_lookalike_domain({"from": f"x@{_puny('paypal-segurídad.com')}"})
+
+    assert result.verdict == "fail"
+    assert result.details["findings"][0]["type"] == "cousin"
+
+
+def test_a_brand_in_a_subdomain_of_a_government_suffix_is_detected():
+    """Con la lista corta, ``gob.es`` no era un sufijo y la etiqueta
+    registrable salía mal; con la PSL, «paypal» queda como subdominio."""
+    result = check_subdomain_impersonation({"from": "x@paypal.fraude.gob.es"})
+
+    assert result.verdict == "fail"
+    assert result.details["findings"][0]["type"] == "brand_in_subdomain"
+
+
+def test_body_links_only_flag_suspicious_idn_hosts():
+    legit, _ = analyze_url(f"https://{_puny('münchen.de')}/rathaus")
+    homograph, score = analyze_url("https://xn--pypal-4ve.com/login")
+
+    assert not any(finding["type"] == "punycode" for finding in legit)
+    punycode = [finding for finding in homograph if finding["type"] == "punycode"]
+    assert punycode and punycode[0]["imitates"] == "paypal"
+    assert score < 0
+
+
+# ------------------------------------------------ remitente legítimo de principio a fin
+
+def _run_engine(raw: str):
+    context = parse_raw_message(raw)
+    rules_defs = iris_rules.get_rules()
+    results, named_results = [], {}
+    for rule_def in rules_defs:
+        result = rule_def["func"](context if rule_def.get("needs_context") else context.headers)
+        result = replace(result, score=min(0.0, float(result.score)))
+        results.append(result)
+        named_results[rule_def["name"]] = result
+    total_score = IrisManager._aggregate_score(rules_defs, results)
+    verdict, gate_reasons = IrisManager._apply_verdict_gates(
+        IrisManager()._determine_verdict(total_score), named_results)
+    return verdict, total_score, gate_reasons
+
+
+def test_an_authenticated_newsletter_from_an_idn_domain_is_legitimate():
+    domain = _puny("münchen.de")
+    date = format_datetime(datetime.now(timezone.utc))
+    raw = (
+        f"Received: from mail.{domain} (mail.{domain} [203.0.113.5]) by mx.example.com "
+        f"with ESMTPS id q1; {date}\r\n"
+        f"Authentication-Results: mx.example.com; spf=pass smtp.mailfrom={domain}; "
+        f"dkim=pass header.d={domain}; dmarc=pass header.from={domain}\r\n"
+        f"From: Stadt München <newsletter@{domain}>\r\n"
+        f"Return-Path: <newsletter@{domain}>\r\n"
+        "To: vecino@example.com\r\n"
+        "Subject: Agenda cultural de septiembre\r\n"
+        f"Date: {date}\r\n"
+        f"Message-ID: <agenda-09@{domain}>\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+        "Hola, te enviamos la agenda cultural de este mes. Un saludo.\r\n"
+    )
+
+    verdict, _, gate_reasons = _run_engine(raw)
+
+    assert verdict == "Legitimate", gate_reasons

--- a/API/tests/unit/test_iris_rules.py
+++ b/API/tests/unit/test_iris_rules.py
@@ -301,9 +301,11 @@ def test_lookalike_cousin_domain_is_flagged():
 
 
 def test_lookalike_punycode_domain_is_flagged():
+    """``xn--pypal-4ve`` es «pаypal» con una ``а`` cirílica: homógrafo de marca."""
     result = check_lookalike_domain({"from": "a@xn--pypal-4ve.com"})
     assert result.verdict == "fail"
-    assert result.details["type"] == "punycode"
+    assert result.details["type"] == "idn_homograph"
+    assert result.details["brand"] == "paypal"
 
 
 def test_lookalike_legitimate_brand_domain_passes():


### PR DESCRIPTION
## El problema

Muchas reglas de Iris comparan dominios: ¿el `Reply-To` es de la misma organización que el `From`? ¿El enlace lleva al dominio del remitente o a otro? ¿Este dominio imita a `paypal.com`? Para eso reducen cada host a su **dominio registrable**, la parte que registra una organización (`mail.corp.paypal.com` → `paypal.com`). Había dos fallos de base.

**1. El dominio registrable salía de una lista corta de 14 sufijos.** Para saber dónde acaba el dominio de una organización hace falta conocer los *sufijos públicos*: `com`, pero también `co.uk`, `com.br` o `gob.es`, bajo los que cualquiera registra. La lista oficial es la [Public Suffix List](https://publicsuffix.org/) (PSL), con miles de entradas. Iris usaba 14. Con ella, `mail.hacienda.gob.es` se reducía a `gob.es`, así que todo el sector público español contaba como una sola organización, y lo mismo pasaba con cualquier sufijo de dos niveles fuera de la lista.

**2. Cualquier dominio internacionalizado se trataba como phishing.** Un dominio con caracteres no ASCII (tildes, cirílico, griego, japonés…) viaja codificado en *punycode*, con etiquetas que empiezan por `xn--`: `münchen.de` es `xn--mnchen-3ya.de`. Tres sitios penalizaban cualquier `xn--`:

- «Lookalike Sender Domain», con −15;
- «Subdomain Impersonation», con −10;
- el análisis de enlaces del cuerpo, con −8.

Un ayuntamiento alemán, una tienda rusa o una empresa japonesa escribiendo desde su propio dominio recibían el mismo trato que un *homógrafo*: un dominio que imita a otro con letras de otro alfabeto que se ven igual (`pаypal.com`, con una `а` cirílica).

Cierra #213 (iniciativa `M06`, Fase 3 del roadmap de Iris, #203).

## Qué cambia

**Public Suffix List.** `registrable_domain()` y `registrable_label()`, y el nuevo `public_suffix()`, usan la PSL mediante el paquete `publicsuffixlist` (MPL-2.0).

- La lista viene **dentro del paquete**: nunca se descarga en ejecución, lo que también mantiene la suite sellada contra la red.
- Se usa solo la sección ICANN. La sección privada declara sufijos como `github.io`, y con ella cada usuario de un servicio compartido sería una organización distinta del propio servicio. Eso es lo que necesita una cookie, no la comparación de organizaciones que hacen estas reglas; los servicios compartidos ya tienen su propia lista (`multitenant_hosting_domains`).
- Una IP es su propio «dominio» (antes, `192.168.1.10` se reducía a `1.10`).
- Desaparece el dataset `multi_level_tlds` de `SecOpsConfig.json`.

**Cuándo un dominio internacionalizado es sospechoso.** El módulo nuevo `services/idn.py` decodifica el punycode y distingue cuatro casos:

- **ASCII**: no hay nada que evaluar.
- **IDN válido**: cada etiqueta usa un solo alfabeto, o una de las combinaciones que Unicode admite para el japonés, el coreano y el chino (latín con kanji/kana, hangul o bopomofo). `münchen.de`, `пример.рф`, `日本語.jp` o `ελληνικά.gr` son válidos.
- **Mezcla de alfabetos**: una etiqueta combina alfabetos que ningún idioma usa juntos en una palabra, como latín y cirílico en `bаnco`.
- **Homógrafo de marca**: el *esqueleto visual* de una etiqueta coincide con una marca conocida sin ser la marca. El esqueleto es cómo la lee un humano: cada carácter se sustituye por la letra latina con la que se confunde, según la tabla oficial de confusables de Unicode (paquete `confusable-homoglyphs`, MIT), y se quitan tildes, anchura completa y variantes matemáticas. Así, `pаypal` (cirílica), `gööglé` (tildes) o `ｇｏｏｇｌｅ` (anchura completa) se leen como `paypal` o `google`.

Las tres reglas anteriores **solo penalizan los dos últimos casos**. Un IDN válido sigue el análisis normal de la regla sobre su esqueleto, así que un dominio primo con tildes (`paypal-segurídad.com`, la marca más una palabra) se sigue detectando como tal. La recomendación del informe enseña cómo se lee el dominio (`xn--pypal-4ve.com`, «pаypal.com») y qué marca imita.

`normalize_homoglyphs()`, que usan las reglas de marcas mal escritas y la de dominio parecido al del destinatario, aplica también el esqueleto de Unicode antes de la tabla de sustituciones ASCII de la configuración (`0`→`o`, `1`→`l`…).

**Trazabilidad.** Cada análisis guarda desde `M05` la huella de los datasets con que se decidió. La huella incluye ahora las versiones de los dos paquetes: una PSL o una tabla de confusables nuevas pueden cambiar un veredicto, igual que cambiar una lista de marcas.

## Efecto medido con el replay

El roadmap pedía hacer este cambio después de `M05` para poder medirlo, porque la PSL puede mover la tasa de falsos positivos en cualquier dirección. Evalué el corpus etiquetado con el motor real antes y después del cambio: **las siete muestras dan exactamente el mismo veredicto y el mismo score.** Las cuatro legítimas salen Legítimo con 100 y las tres maliciosas, Phishing con 45, 89 y 30. El corpus no tiene dominios internacionalizados ni sufijos raros, así que el efecto de la PSL y del IDN lo cubren los tests nuevos.

## Validación

- `test_iris_idn_psl.py` (nuevo, 34 casos):
  - **Dominio registrable con la PSL:** `co.uk`, `com.br`, `gob.es`, `ac.jp`, un gTLD nuevo (`.app`), un gTLD de marca (`email.mango`), mayúsculas y punto final, `localhost`, una IP y dominios en Unicode.
  - **Esqueleto visual:** cirílico, tildes, anchura completa.
  - **Clasificación de IDN:** alemán, ruso, japonés (kanji, y kana con kanji), griego, tres homógrafos de marca (cirílico, cirílico en un subdominio y latín con tildes) y una mezcla de alfabetos sin marca.
  - **Reglas afectadas:** cuatro remitentes internacionales legítimos no son «lookalike» ni «subdomain impersonation»; el homógrafo y la mezcla de alfabetos se siguen marcando; el dominio primo con tildes sigue siendo primo; una marca como subdominio de `gob.es` se detecta; los enlaces solo marcan IDN sospechosos.
  - **De principio a fin:** un boletín autenticado desde `münchen.de` sale Legítimo con el motor completo.
- `test_iris_rules.py`: el test del punycode `xn--pypal-4ve.com` sigue marcándolo, ahora como `idn_homograph` de `paypal`.
- `pytest -k "iris or conventions or config_shape or config_view or caddy or import_isolation"`: 1035 pasados.
- Suite completa (`pytest`): 3284 pasados, 50 saltados (los de `tests/postgres`), 0 fallos.

## Notas

- **Dependencias nuevas** en `requirements.txt`: `publicsuffixlist` (MPL-2.0) y `confusable-homoglyphs` (MIT). Las dos son Python puro y no necesitan nada en el Dockerfile. Actualizar la PSL es actualizar el paquete.
- La regla «Unicode Evasion» mantiene su propia detección de mezcla de alfabetos para el asunto y el nombre visible, que no son dominios. Unificarla con `services/idn.py` no hace falta para este issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
