### PR TITLE
Iris: taxonomía estable de reglas con severidad y MITRE ATT&CK

### DIFF
--- a/API/alembic/versions/b8e3c6f1a5d2_add_iris_rule_taxonomy.py
+++ b/API/alembic/versions/b8e3c6f1a5d2_add_iris_rule_taxonomy.py
@@ -1,0 +1,43 @@
+"""iris: taxonomía estable de cada hallazgo (rule_id, severity, mitre_techniques)
+
+El identificador de una regla era su nombre humano, que es lo que se muestra y
+lo que se puede traducir o corregir: un hallazgo no se podía reutilizar en el
+PDF, la API, un panel o una exportación sin atarse a esa cadena. Cada fila de
+IrisRuleResult guarda ahora el id estable de su regla, su severidad (separada
+del score) y las técnicas MITRE ATT&CK que le corresponden, tal como estaban
+en el catálogo cuando se analizó. Las filas anteriores quedan a NULL.
+
+Revision ID: b8e3c6f1a5d2
+Revises: a7d2b5e9f4c0
+Create Date: 2026-09-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8e3c6f1a5d2'
+down_revision: Union[str, Sequence[str], None] = 'a7d2b5e9f4c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('IrisRuleResult', sa.Column('rule_id', sa.String(length=64), nullable=True))
+    op.add_column('IrisRuleResult', sa.Column('severity', sa.String(length=16), nullable=True))
+    op.add_column('IrisRuleResult', sa.Column('mitre_techniques',
+                                              postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.create_index('ix_iris_rule_result_rule_id', 'IrisRuleResult', ['rule_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_iris_rule_result_rule_id', table_name='IrisRuleResult')
+    op.drop_column('IrisRuleResult', 'mitre_techniques')
+    op.drop_column('IrisRuleResult', 'severity')
+    op.drop_column('IrisRuleResult', 'rule_id')

--- a/API/src/modules/features/iris/managers/analysis.py
+++ b/API/src/modules/features/iris/managers/analysis.py
@@ -115,12 +115,17 @@ def _rule_to_dict(rule: IrisRuleResult) -> Dict[str, Any]:
         rule: Fila ``IrisRuleResult`` persistida.
 
     Returns:
-        dict: ``ruleName``, ``category``, ``score``, ``verdict``,
-            ``details``, ``recommendation``, ``evidence`` (lista, vacía si
-            no hay) y ``evidenceUnavailableReason``.
+        dict: ``ruleId`` (estable; ``None`` en filas anteriores a la
+            taxonomía), ``ruleName`` (visible), ``severity``,
+            ``mitreTechniques`` (lista, vacía si no hay), ``category``,
+            ``score``, ``verdict``, ``details``, ``recommendation``,
+            ``evidence`` (lista, vacía si no hay) y ``evidenceUnavailableReason``.
     """
     return {
+        "ruleId": rule.rule_id,
         "ruleName": rule.rule_name,
+        "severity": rule.severity,
+        "mitreTechniques": rule.mitre_techniques or [],
         "category": rule.category,
         "score": rule.score,
         "verdict": rule.verdict,
@@ -540,6 +545,7 @@ class IrisManager(TaskTrackingMixin):
         negative.sort(key=lambda pair: pair[1]["score"])
         return [
             {
+                "ruleId": r.get("ruleId"),
                 "ruleName": r["ruleName"],
                 "category": r.get("category"),
                 "score": r["score"],
@@ -1422,6 +1428,9 @@ class IrisManager(TaskTrackingMixin):
                     rule_repo.save(IrisRuleResult(
                         analysis_id=analysis_id,
                         rule_name=rule_def["name"],
+                        rule_id=rule_def.get("rule_id") or None,
+                        severity=rule_def.get("severity") or None,
+                        mitre_techniques=list(rule_def.get("mitre_techniques") or ()) or None,
                         category=rule_def["category"],
                         score=rule_result.score,
                         verdict=rule_result.verdict,

--- a/API/src/modules/features/iris/model.py
+++ b/API/src/modules/features/iris/model.py
@@ -548,6 +548,15 @@ class IrisRuleResult(Base):
                         o no pudo anclarse.
         evidence_unavailable_reason: Por qué un hallazgo no se puede anclar;
                         NULL si tiene evidencia o si la regla no penalizó.
+        rule_id: Identificador estable de la regla (``iris.<grupo>.<nombre>``),
+                        independiente de ``rule_name``, que es visible y puede
+                        cambiar. NULL en filas anteriores a la taxonomía.
+        severity: Gravedad del hallazgo (``low``, ``medium``, ``high`` o
+                        ``critical``), separada del score; la del catálogo
+                        cuando se analizó. NULL en filas anteriores.
+        mitre_techniques: Técnicas MITRE ATT&CK de la regla cuando se analizó
+                        (``["T1566.002"]``); NULL si no tiene o en filas
+                        anteriores.
         analysis: SQLAlchemy back-reference to the parent IrisAnalysis.
     """
     __tablename__ = "IrisRuleResult"
@@ -564,11 +573,15 @@ class IrisRuleResult(Base):
     context_type = Column(String(16), nullable=True)
     evidence = Column(JSONB, nullable=True)
     evidence_unavailable_reason = Column(Text, nullable=True)
+    rule_id = Column(String(64), nullable=True)
+    severity = Column(String(16), nullable=True)
+    mitre_techniques = Column(JSONB, nullable=True)
 
     analysis = relationship("IrisAnalysis", back_populates="rule_results")
 
     __table_args__ = (
         Index("ix_iris_rule_result_analysis_id", "analysis_id"),
+        Index("ix_iris_rule_result_rule_id", "rule_id"),
     )
 
 

--- a/API/src/modules/features/iris/schemas.py
+++ b/API/src/modules/features/iris/schemas.py
@@ -213,8 +213,16 @@ class RuleResultSchema(Schema):
 
     Una regla que penaliza trae ``evidence`` o, si su hallazgo no se puede
     anclar a un fragmento del mensaje, ``evidenceUnavailableReason``.
+
+    ``ruleId`` es el identificador estable del hallazgo (``ruleName`` es el
+    nombre visible y puede cambiar); ``severity`` es su gravedad, separada del
+    score, y ``mitreTechniques`` sus técnicas ATT&CK. Los tres valen ``null``
+    (o lista vacía) en análisis anteriores a la taxonomía.
     """
+    ruleId = fields.String(load_default=None, allow_none=True)
     ruleName = fields.String()
+    severity = fields.String(load_default=None, allow_none=True)
+    mitreTechniques = fields.List(fields.String(), load_default=list)
     category = fields.String(load_default=None)
     score = fields.Float()
     verdict = fields.String()
@@ -226,6 +234,7 @@ class RuleResultSchema(Schema):
 
 class TopSignalSchema(Schema):
     """One of the highest-penalty rules for a finished analysis."""
+    ruleId = fields.String(load_default=None, allow_none=True)
     ruleName = fields.String()
     category = fields.String(load_default=None)
     score = fields.Float()
@@ -248,6 +257,7 @@ class FailedRuleSchema(Schema):
     parte del mensaje se quedó sin inspeccionar.
     """
     name = fields.String()
+    ruleId = fields.String(load_default=None, allow_none=True)
     family = fields.String(load_default=None, allow_none=True)
     category = fields.String(load_default=None, allow_none=True)
 

--- a/API/src/modules/features/iris/services/ai_writer.py
+++ b/API/src/modules/features/iris/services/ai_writer.py
@@ -156,6 +156,7 @@ class IrisAIWriter:
         failed_rules = [
             {
                 "name": rule.get("ruleName"),
+                "ruleId": rule.get("ruleId"),
                 "category": rule.get("category"),
                 "score": rule.get("score"),
                 "recommendation": rule.get("recommendation"),

--- a/API/src/modules/features/iris/services/quality.py
+++ b/API/src/modules/features/iris/services/quality.py
@@ -86,6 +86,7 @@ def assess_quality(rules_defs: List[dict], results: List[Any]) -> AnalysisQualit
     failed_rules = [
         {
             "name": rule_def["name"],
+            "ruleId": rule_def.get("rule_id") or None,
             "family": rule_def.get("family") or None,
             "category": rule_def.get("category") or None,
         }

--- a/API/src/modules/features/iris/services/registry.py
+++ b/API/src/modules/features/iris/services/registry.py
@@ -13,10 +13,38 @@ contiene el mecanismo de registro.
 from __future__ import annotations
 
 import functools
+import re
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from .evidence import anchor_result
+
+#: Forma de un ``rule_id``: ``iris.<grupo>.<nombre>``, en minúsculas. Es un
+#: identificador estable: no cambia aunque cambie el nombre visible de la regla.
+_RULE_ID_RE = re.compile(r"^iris\.[a-z_]+\.[a-z0-9_]+$")
+
+#: Técnica o subtécnica de MITRE ATT&CK (``T1566`` o ``T1566.002``).
+_MITRE_TECHNIQUE_RE = re.compile(r"^T\d{4}(\.\d{3})?$")
+
+
+class RuleSeverity(StrEnum):
+    """Gravedad de un hallazgo de la regla, separada de su score.
+
+    El score mide cuánto pesa la señal en el veredicto; la severidad dice
+    cuánto importa el hecho si es cierto (una suplantación de dominio es
+    crítica aunque la regla pese poco en un mensaje concreto).
+
+    Attributes:
+        LOW: Indicio débil o frecuente en correo legítimo.
+        MEDIUM: Anomalía que merece revisión.
+        HIGH: Indicador fuerte de phishing.
+        CRITICAL: Suplantación deliberada de una identidad.
+    """
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
 
 
 @dataclass
@@ -68,7 +96,8 @@ class RuleRegistry:
                  description: str = "", needs_context: bool = False,
                  family: str = "", is_body_dependent: bool = False,
                  evidence_headers: Sequence[str] = (), is_self_anchoring: bool = False,
-                 unanchorable_reason: str = ""):
+                 unanchorable_reason: str = "", rule_id: str = "", severity: str = "",
+                 mitre_techniques: Sequence[str] = ()):
         """Decorator that registers a function as an analysis rule.
 
         La regla se guarda envuelta: tras ejecutarla, el envoltorio garantiza
@@ -108,7 +137,18 @@ class RuleRegistry:
                 el que los hallazgos de la regla no se pueden anclar a un
                 fragmento concreto. Por defecto vacío.
 
-            Toda regla declara al menos una de las tres últimas: el catálogo no
+            rule_id: Identificador estable (``iris.<grupo>.<nombre>``). Es lo
+                que usan el PDF, la API y las exportaciones para referirse al
+                hallazgo; el nombre visible puede cambiar sin tocarlo.
+                Obligatorio y único en el catálogo.
+            severity: ``RuleSeverity`` del hallazgo, separada del score.
+                Obligatoria.
+            mitre_techniques: Técnicas MITRE ATT&CK (``T1566.002``) que
+                corresponden al hallazgo, solo si encajan de verdad: la mayoría
+                de heurísticas no son una técnica. Por defecto ninguna.
+
+            Toda regla declara al menos una de ``evidence_headers``,
+            ``is_self_anchoring`` o ``unanchorable_reason``: el catálogo no
             admite reglas cuyos hallazgos no digan dónde están ni por qué no.
 
         Returns:
@@ -116,13 +156,26 @@ class RuleRegistry:
 
         Raises:
             ValueError: Si la regla no declara ni ``evidence_headers``, ni
-                ``is_self_anchoring``, ni ``unanchorable_reason``.
+                ``is_self_anchoring``, ni ``unanchorable_reason``; si su
+                ``rule_id`` falta, no tiene la forma ``iris.<grupo>.<nombre>`` o
+                ya existe; si la severidad no es una de ``RuleSeverity``; o si
+                alguna técnica no tiene forma de técnica ATT&CK.
         """
         if not (evidence_headers or is_self_anchoring or unanchorable_reason):
             raise ValueError(
                 f"La regla '{name}' debe declarar cómo ancla su evidencia: "
                 "evidence_headers, is_self_anchoring o unanchorable_reason."
             )
+        if not _RULE_ID_RE.match(rule_id or ""):
+            raise ValueError(f"La regla '{name}' necesita un rule_id con forma iris.<grupo>.<nombre>.")
+        if any(rule["rule_id"] == rule_id for rule in self._rules):
+            raise ValueError(f"El rule_id '{rule_id}' ya está registrado.")
+        if severity not in {member.value for member in RuleSeverity}:
+            raise ValueError(f"La regla '{name}' tiene una severidad desconocida: {severity!r}.")
+        techniques = tuple(mitre_techniques)
+        invalid = [technique for technique in techniques if not _MITRE_TECHNIQUE_RE.match(technique)]
+        if invalid:
+            raise ValueError(f"La regla '{name}' declara técnicas ATT&CK no válidas: {invalid}.")
         header_names = tuple(evidence_headers)
 
         def decorator(func: Callable) -> Callable:
@@ -142,6 +195,9 @@ class RuleRegistry:
                 "evidence_headers": header_names,
                 "is_self_anchoring": is_self_anchoring,
                 "unanchorable_reason": unanchorable_reason,
+                "rule_id": rule_id,
+                "severity": severity,
+                "mitre_techniques": techniques,
             })
             return func
         return decorator

--- a/API/src/modules/features/iris/services/reports.py
+++ b/API/src/modules/features/iris/services/reports.py
@@ -217,6 +217,40 @@ class IrisReportTheme:
         return [pill_wrapper, title_wrapper, divider_wrapper]
 
 
+def _rule_cell(rule: Dict[str, Any]) -> str:
+    """Celda de la tabla de reglas: nombre visible y, debajo, el id estable.
+
+    Args:
+        rule: Regla serializada del informe.
+
+    Returns:
+        str: Marcado de reportlab, con el texto ya escapado.
+    """
+    text = _esc(rule.get("ruleName", ""))
+    if rule.get("ruleId"):
+        text += f"<br/><font size='7' color='#6b7280'>{_esc(rule['ruleId'])}</font>"
+    return text
+
+
+def _rule_reference(rule: Dict[str, Any]) -> str:
+    """Referencia estable de un hallazgo para el detalle: id y técnicas ATT&CK.
+
+    Args:
+        rule: Regla serializada del informe.
+
+    Returns:
+        str: `` (<id> · ATT&CK T1566.002)`` ya escapado; cadena vacía si la
+            regla no tiene id (análisis anteriores a la taxonomía).
+    """
+    if not rule.get("ruleId"):
+        return ""
+    reference = f"<font face='Courier'>{_esc(rule['ruleId'])}</font>"
+    techniques = rule.get("mitreTechniques") or []
+    if techniques:
+        reference += " · ATT&amp;CK " + ", ".join(_esc(technique) for technique in techniques)
+    return f" ({reference})"
+
+
 class IrisPDFCreator:
     """Builds a complete PDF report from an Iris analysis report dict.
 
@@ -623,7 +657,7 @@ class IrisPDFCreator:
             score = rule.get("score", 0)
             sign = "+" if score > 0 else ""
             rule_data.append([
-                Paragraph(_esc(rule.get("ruleName", "")), theme.cell_left),
+                Paragraph(_rule_cell(rule), theme.cell_left),
                 Paragraph(_esc(rule.get("category") or "-"), theme.cell_left),
                 Paragraph(f"{sign}{score}", theme.cell_center),
                 Paragraph(_esc(rule.get("verdict", "")), theme.cell_center),
@@ -655,7 +689,8 @@ class IrisPDFCreator:
             elements.append(Paragraph("Detalle de hallazgos", theme.subtitle))
             elements.append(Spacer(1, 0.08 * inch))
             for flagged_rule in flagged:
-                text = f"<b>{_esc(flagged_rule.get('ruleName'))}:</b> {_esc(flagged_rule.get('recommendation'))}"
+                text = (f"<b>{_esc(flagged_rule.get('ruleName'))}</b>{_rule_reference(flagged_rule)}: "
+                        f"{_esc(flagged_rule.get('recommendation'))}")
                 # El extracto ya viene desactivado (hxxp, [.], [@]): el PDF sale
                 # del panel autenticado y no debe llevar enlaces vivos.
                 evidence = flagged_rule.get("evidence") or []

--- a/API/src/modules/features/iris/services/rules/attachment_media_rules.py
+++ b/API/src/modules/features/iris/services/rules/attachment_media_rules.py
@@ -37,7 +37,7 @@ _IMG_SRC_RE = re.compile(r'<img\b[^>]*src\s*=\s*["\']([^"\']+)["\']',
 
 
 @iris_rules.register(
-    name="External Image Tracking", unanchorable_reason=(
+    name="External Image Tracking", rule_id="iris.attachment.external_image_tracking", severity="low", unanchorable_reason=(
         "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
     ), is_body_dependent=True,
     category="content_analysis", family="attachment",
@@ -119,7 +119,7 @@ _SRC_RE = re.compile(r'src\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE)
 
 
 @iris_rules.register(
-    name="Image-Only Email", unanchorable_reason=(
+    name="Image-Only Email", rule_id="iris.attachment.image_only_email", severity="medium", unanchorable_reason=(
         "La señal es la proporción entre imágenes y texto de todo el cuerpo, no un fragmento concreto."
     ), is_body_dependent=True,
     category="content_analysis", family="attachment",
@@ -339,7 +339,7 @@ def _check_headers_fallback(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Suspicious Attachments", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="attachment",
+    name="Suspicious Attachments", rule_id="iris.attachment.suspicious_attachments", severity="high", mitre_techniques=("T1566.001",), is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="attachment",
     description=(
         "Inspecciona los adjuntos MIME reales (extensiones peligrosas, doble "
         "extensión, macros, HTML smuggling, ZIP con ejecutables); recurre a la "

--- a/API/src/modules/features/iris/services/rules/auth_rules.py
+++ b/API/src/modules/features/iris/services/rules/auth_rules.py
@@ -60,7 +60,7 @@ def _dmarc_is_conclusive(auth_lower: str) -> bool:
 
 
 @iris_rules.register(
-    name="SPF", evidence_headers=("received-spf", "authentication-results"), category="authentication", family="auth",
+    name="SPF", rule_id="iris.auth.spf", severity="medium", evidence_headers=("received-spf", "authentication-results"), category="authentication", family="auth",
     description="Verifica que el servidor remitente esté autorizado por el SPF del dominio",
 )
 def check_spf(headers: dict) -> RuleResult:
@@ -157,7 +157,7 @@ def check_spf(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="DKIM", evidence_headers=("authentication-results", "dkim-signature"), category="authentication", family="auth",
+    name="DKIM", rule_id="iris.auth.dkim", severity="medium", evidence_headers=("authentication-results", "dkim-signature"), category="authentication", family="auth",
     description="Verifica la firma DKIM del correo",
 )
 def check_dkim(headers: dict) -> RuleResult:
@@ -208,7 +208,7 @@ def check_dkim(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="DMARC", evidence_headers=("authentication-results",), category="authentication", family="auth",
+    name="DMARC", rule_id="iris.auth.dmarc", severity="high", evidence_headers=("authentication-results",), category="authentication", family="auth",
     description="Verifica la política DMARC del dominio remitente",
 )
 def check_dmarc(headers: dict) -> RuleResult:
@@ -297,7 +297,7 @@ def _spf_mailfrom_domain(headers: dict) -> str | None:
 
 
 @iris_rules.register(
-    name="Domain Alignment", evidence_headers=("from", "authentication-results"), category="authentication", family="auth",
+    name="Domain Alignment", rule_id="iris.auth.domain_alignment", severity="medium", evidence_headers=("from", "authentication-results"), category="authentication", family="auth",
     description="Comprueba que el dominio autenticado por SPF/DKIM coincide con el dominio del remitente (alineación DMARC)",
 )
 def check_domain_alignment(headers: dict) -> RuleResult:
@@ -394,7 +394,7 @@ _ARC_CV_RE = re.compile(r"\bcv=(\w+)", re.IGNORECASE)
 
 
 @iris_rules.register(
-    name="ARC Chain", evidence_headers=("arc-seal", "arc-authentication-results"), category="authentication",
+    name="ARC Chain", rule_id="iris.auth.arc_chain", severity="low", evidence_headers=("arc-seal", "arc-authentication-results"), category="authentication",
     description=(
         "Evalúa la validez declarada (cv=) de la cadena ARC (Authenticated "
         "Received Chain, RFC 8617) y si la validó un verificador de confianza"
@@ -501,7 +501,7 @@ _AUTHSERV_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*\.[a-z]{2,}$")
 
 
 @iris_rules.register(
-    name="Auth Results Provenance", evidence_headers=("authentication-results",), category="authentication", family="auth",
+    name="Auth Results Provenance", rule_id="iris.auth.auth_results_provenance", severity="high", evidence_headers=("authentication-results",), category="authentication", family="auth",
     description=(
         "Comprueba que el authserv-id de Authentication-Results pertenezca a "
         "algún host `by` de la propia cadena Received del mensaje -- una "

--- a/API/src/modules/features/iris/services/rules/body_content_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_content_rules.py
@@ -62,7 +62,7 @@ def _score_by_weight(weight: int) -> tuple[float, str, str | None]:
 
 
 @iris_rules.register(
-    name="Alarming Keywords", evidence_headers=("subject", "from"), category="content_analysis", family="content",
+    name="Alarming Keywords", rule_id="iris.content.alarming_keywords", severity="low", evidence_headers=("subject", "from"), category="content_analysis", family="content",
     description="Detecta palabras y frases alarmantes en el asunto y nombre del remitente (inglés/español)",
 )
 def check_alarming_keywords(headers: dict) -> RuleResult:
@@ -180,7 +180,7 @@ def _has_evasive_hidden_text(body_html: str) -> bool:
 
 
 @iris_rules.register(
-    name="Body Content", unanchorable_reason=(
+    name="Body Content", rule_id="iris.content.body_content", severity="medium", unanchorable_reason=(
         "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
     ), is_body_dependent=True, category="content_analysis", family="content",
     description=(
@@ -232,7 +232,7 @@ def check_body_content(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="BEC Wire Transfer Pattern", unanchorable_reason=(
+    name="BEC Wire Transfer Pattern", rule_id="iris.content.bec_wire_transfer", severity="high", mitre_techniques=("T1656",), unanchorable_reason=(
         "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
     ), is_body_dependent=True,
     category="content_analysis", family="content",
@@ -311,7 +311,7 @@ def check_bec_wire_pattern(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Generic Greeting", unanchorable_reason=(
+    name="Generic Greeting", rule_id="iris.content.generic_greeting", severity="low", unanchorable_reason=(
         "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
     ), is_body_dependent=True,
     category="content_analysis", family="content",
@@ -386,7 +386,7 @@ def _contains_url(text: str) -> list[str]:
 
 
 @iris_rules.register(
-    name="URL in Subject", evidence_headers=("subject",), category="content_analysis", family="content",
+    name="URL in Subject", rule_id="iris.content.url_in_subject", severity="low", evidence_headers=("subject",), category="content_analysis", family="content",
     description="Detecta si el asunto del correo contiene URLs (común en phishing)",
 )
 def check_url_in_subject(headers: dict) -> RuleResult:
@@ -470,7 +470,7 @@ def _mixed_script(text: str) -> str | None:
 
 
 @iris_rules.register(
-    name="Unicode Evasion", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="content",
+    name="Unicode Evasion", rule_id="iris.content.unicode_evasion", severity="high", mitre_techniques=("T1036.002",), is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="content",
     description=(
         "Detecta caracteres de control bidireccional (RLO/LRO - spoofing de "
         "extension de archivo) y mezcla de scripts confusables (cirilico/"
@@ -615,7 +615,7 @@ def _encoded_word_finding_scores() -> dict[str, float]:
 
 
 @iris_rules.register(
-    name="Encoded-Word Abuse", evidence_headers=("subject", "from"), category="content_analysis", family="content",
+    name="Encoded-Word Abuse", rule_id="iris.content.encoded_word_abuse", severity="medium", mitre_techniques=("T1027",), evidence_headers=("subject", "from"), category="content_analysis", family="content",
     description=(
         "Detecta abuso de encoded-words RFC 2047 en Subject/From: bloques "
         "encadenados para evadir filtros de keywords, charsets exoticos "
@@ -654,7 +654,7 @@ _PHONE_RE = re.compile(r"(?:\+\d{1,3}[\s.-]?)?\(?\d{2,4}\)?[\s.-]?\d{3,4}[\s.-]?
 
 
 @iris_rules.register(
-    name="TOAD Callback Pattern", unanchorable_reason=(
+    name="TOAD Callback Pattern", rule_id="iris.content.toad_callback", severity="high", mitre_techniques=("T1566.004",), unanchorable_reason=(
         "La regla evalúa el cuerpo en conjunto y no registra la posición exacta de lo que encuentra, así que no hay un fragmento concreto que señalar."
     ), is_body_dependent=True,
     category="content_analysis", family="content",

--- a/API/src/modules/features/iris/services/rules/body_links_rules.py
+++ b/API/src/modules/features/iris/services/rules/body_links_rules.py
@@ -41,7 +41,7 @@ def _max_score_floor() -> float:
 
 
 @iris_rules.register(
-    name="Body Links", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
+    name="Body Links", rule_id="iris.links.body_links", severity="high", mitre_techniques=("T1566.002",), is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Analiza los enlaces reales del cuerpo: texto visible vs href, "
         "punycode/IDN, IPs literales, acortadores de URL, credenciales en la "
@@ -113,7 +113,7 @@ def _decode_qr_urls(image_bytes: bytes) -> list[str]:
 
 
 @iris_rules.register(
-    name="QR Code Links", is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
+    name="QR Code Links", rule_id="iris.links.qr_code_links", severity="high", mitre_techniques=("T1566.002",), is_self_anchoring=True, is_body_dependent=True, category="content_analysis", family="links",
     description=(
         "Decodifica códigos QR en imágenes inline/adjuntas y analiza la URL "
         "resultante con la misma batería de chequeos que Body Links "
@@ -187,7 +187,7 @@ def _looks_opaque_path(path: str) -> bool:
 
 
 @iris_rules.register(
-    name="Compromised Legitimate Domain", is_self_anchoring=True, is_body_dependent=True,
+    name="Compromised Legitimate Domain", rule_id="iris.links.compromised_legitimate_domain", severity="medium", mitre_techniques=("T1566.002",), is_self_anchoring=True, is_body_dependent=True,
     category="content_analysis", family="links",
     description=(
         "Detecta enlaces a dominios legítimos que probablemente han sido "
@@ -261,7 +261,7 @@ def check_compromised_legitimate_domain(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="External Login Link", unanchorable_reason=(
+    name="External Login Link", rule_id="iris.links.external_login_link", severity="medium", mitre_techniques=("T1598.003",), unanchorable_reason=(
         "Señal informativa que no resta puntos: resume los dominios externos de todos los enlaces en conjunto."
     ), is_body_dependent=True,
     category="content_analysis",

--- a/API/src/modules/features/iris/services/rules/content_trust_rules.py
+++ b/API/src/modules/features/iris/services/rules/content_trust_rules.py
@@ -18,7 +18,7 @@ from ..registry import iris_rules, RuleResult
 
 
 @iris_rules.register(
-    name="List-Unsubscribe", evidence_headers=("list-unsubscribe",), category="header_analysis",
+    name="List-Unsubscribe", rule_id="iris.content.list_unsubscribe", severity="low", evidence_headers=("list-unsubscribe",), category="header_analysis",
     description="Detecta un mecanismo de baja (List-Unsubscribe) válido como señal débil de legitimidad de correo masivo",
 )
 def check_list_unsubscribe(headers: dict) -> RuleResult:

--- a/API/src/modules/features/iris/services/rules/received_timing_rules.py
+++ b/API/src/modules/features/iris/services/rules/received_timing_rules.py
@@ -39,7 +39,7 @@ CLOCK_SKEW_TOLERANCE_SECONDS = 300
 
 
 @iris_rules.register(
-    name="Date Header Anomaly", evidence_headers=("date",), category="header_analysis", family="received",
+    name="Date Header Anomaly", rule_id="iris.received.date_header_anomaly", severity="low", evidence_headers=("date",), category="header_analysis", family="received",
     description="Detecta si la cabecera Date está ausente, en el futuro lejano o en el pasado remoto",
 )
 def check_date_anomaly(headers: dict) -> RuleResult:
@@ -108,7 +108,7 @@ def check_date_anomaly(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Received Chain", evidence_headers=("received",), category="header_analysis", family="received",
+    name="Received Chain", rule_id="iris.received.received_chain", severity="medium", evidence_headers=("received",), category="header_analysis", family="received",
     description=(
         "Analiza la cadena completa de cabeceras Received: número de saltos y "
         "consistencia temporal con Date. La IP interna del salto de origen se "
@@ -182,7 +182,7 @@ def check_received_chain(context) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Received Chain Temporal Inconsistency", is_self_anchoring=True,
+    name="Received Chain Temporal Inconsistency", rule_id="iris.received.temporal_inconsistency", severity="medium", is_self_anchoring=True,
     category="header_analysis", family="received",
     description=(
         "Detecta cadenas Received: con marcas de tiempo no monótonamente "
@@ -276,7 +276,7 @@ MISSING_TS_MIN_HOPS = 3
 
 
 @iris_rules.register(
-    name="Received Path Anomaly", evidence_headers=("received",),
+    name="Received Path Anomaly", rule_id="iris.received.path_anomaly", severity="medium", evidence_headers=("received",),
     category="header_analysis", family="received",
     description=(
         "Evalúa el recorrido Received: del correo — número de saltos, "
@@ -404,7 +404,7 @@ _HOSTNAME_RE = re.compile(r"[a-zA-Z0-9][\w.-]*\.[a-zA-Z]{2,}")
 
 
 @iris_rules.register(
-    name="Origin HELO Coherence", evidence_headers=("received",),
+    name="Origin HELO Coherence", rule_id="iris.received.origin_helo_coherence", severity="low", evidence_headers=("received",),
     category="header_analysis", family="received",
     description=(
         "Aproximación offline (Iris no resuelve DNS/PTR real) de coherencia "

--- a/API/src/modules/features/iris/services/rules/recipient_rules.py
+++ b/API/src/modules/features/iris/services/rules/recipient_rules.py
@@ -15,7 +15,7 @@ from ..wordlists import undisclosed_patterns
 
 
 @iris_rules.register(
-    name="Undisclosed Recipients", evidence_headers=("to", "cc"), category="header_analysis",
+    name="Undisclosed Recipients", rule_id="iris.recipient.undisclosed_recipients", severity="low", evidence_headers=("to", "cc"), category="header_analysis",
     description="Detecta si el campo To está vacío o contiene destinatarios no revelados (BCC)",
 )
 def check_undisclosed_recipients(headers: dict) -> RuleResult:

--- a/API/src/modules/features/iris/services/rules/reply_path_rules.py
+++ b/API/src/modules/features/iris/services/rules/reply_path_rules.py
@@ -46,7 +46,7 @@ def _is_esp_domain(domain: str | None) -> bool:
 
 
 @iris_rules.register(
-    name="Reply-To check", evidence_headers=("from", "reply-to"), category="header_analysis", family="reply_path",
+    name="Reply-To check", rule_id="iris.reply_path.reply_to_mismatch", severity="medium", evidence_headers=("from", "reply-to"), category="header_analysis", family="reply_path",
     description="Detecta si Reply-To difiere del remitente real",
 )
 def check_reply_to(headers: dict) -> RuleResult:
@@ -129,7 +129,7 @@ def check_reply_to(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Reply-To Free Provider", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="reply_path",
+    name="Reply-To Free Provider", rule_id="iris.reply_path.reply_to_free_provider", severity="medium", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="reply_path",
     description="Detecta el patrón BEC: remitente con dominio corporativo pero Reply-To/Return-Path apuntando a un correo gratuito",
 )
 def check_reply_to_free_provider(headers: dict) -> RuleResult:
@@ -170,7 +170,7 @@ def check_reply_to_free_provider(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Return-Path mismatch", evidence_headers=("return-path", "from"), category="header_analysis", family="reply_path",
+    name="Return-Path mismatch", rule_id="iris.reply_path.return_path_mismatch", severity="low", evidence_headers=("return-path", "from"), category="header_analysis", family="reply_path",
     description="Detecta si el dominio en Return-Path difiere del remitente visible",
 )
 def check_return_path(headers: dict) -> RuleResult:
@@ -263,7 +263,7 @@ def _triangulation_would_fire(headers: dict) -> bool:
 
 
 @iris_rules.register(
-    name="From Reply-To Return-Path Triangulation", evidence_headers=("from", "reply-to", "return-path"),
+    name="From Reply-To Return-Path Triangulation", rule_id="iris.reply_path.triangulation", severity="medium", evidence_headers=("from", "reply-to", "return-path"),
     category="header_analysis", family="reply_path",
     description=(
         "Detecta mensajes donde From, Reply-To y Return-Path apuntan a tres "

--- a/API/src/modules/features/iris/services/rules/sender_identity_rules.py
+++ b/API/src/modules/features/iris/services/rules/sender_identity_rules.py
@@ -44,7 +44,7 @@ from ..parsers import decode_mime_words
 
 
 @iris_rules.register(
-    name="From header check", evidence_headers=("from",), category="header_analysis", family="identity",
+    name="From header check", rule_id="iris.identity.from_header", severity="low", evidence_headers=("from",), category="header_analysis", family="identity",
     description="Verifica que la cabecera From esté presente y no esté vacía",
 )
 def check_from_header(headers: dict) -> RuleResult:
@@ -79,7 +79,7 @@ def _domain_matches_trusted(domain: str, trusted_domains: tuple[str, ...]) -> bo
 
 
 @iris_rules.register(
-    name="Display Name Spoofing", evidence_headers=("from",), category="header_analysis", family="identity",
+    name="Display Name Spoofing", rule_id="iris.identity.display_name_spoofing", severity="high", mitre_techniques=("T1656",), evidence_headers=("from",), category="header_analysis", family="identity",
     description="Detecta si el nombre del remitente suplanta a una marca conocida pero el dominio del correo no pertenece a ella",
 )
 def check_display_name_spoof(headers: dict) -> RuleResult:
@@ -199,7 +199,7 @@ def _is_random_local(local: str) -> bool:
 
 
 @iris_rules.register(
-    name="Display Name Email Mismatch", evidence_headers=("from",),
+    name="Display Name Email Mismatch", rule_id="iris.identity.display_name_email_mismatch", severity="medium", mitre_techniques=("T1656",), evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el display name suplanta a una organización pero "
@@ -246,7 +246,7 @@ def check_display_name_email_mismatch(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Lookalike Sender Domain", evidence_headers=("from",), category="header_analysis", family="identity",
+    name="Lookalike Sender Domain", rule_id="iris.identity.lookalike_sender_domain", severity="critical", mitre_techniques=("T1583.001", "T1656",), evidence_headers=("from",), category="header_analysis", family="identity",
     description="Detecta si el dominio real del remitente imita a una marca conocida (typosquatting, homóglifos, cousin domain o punycode/IDN)",
 )
 def check_lookalike_domain(headers: dict) -> RuleResult:
@@ -340,7 +340,7 @@ def _is_trusted_brand_domain(domain: str) -> bool:
 
 
 @iris_rules.register(
-    name="Subdomain Impersonation", evidence_headers=("from",),
+    name="Subdomain Impersonation", rule_id="iris.identity.subdomain_impersonation", severity="high", mitre_techniques=("T1583.001",), evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta trucos de subdominio donde un nombre de marca conocido aparece "
@@ -486,7 +486,7 @@ def _find_typosquats(text: str) -> list[dict]:
 
 
 @iris_rules.register(
-    name="Misspelled Brand Names", evidence_headers=("from", "subject"), category="content_analysis", family="identity",
+    name="Misspelled Brand Names", rule_id="iris.identity.misspelled_brand_names", severity="medium", mitre_techniques=("T1656",), evidence_headers=("from", "subject"), category="content_analysis", family="identity",
     description="Detecta homóglifos y errores tipográficos de marcas conocidas en el asunto y nombre del remitente",
 )
 def check_misspelled_brands(headers: dict) -> RuleResult:
@@ -536,7 +536,7 @@ def check_misspelled_brands(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Suspicious TLD", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="identity",
+    name="Suspicious TLD", rule_id="iris.identity.suspicious_tld", severity="low", evidence_headers=("from", "reply-to", "return-path"), category="header_analysis", family="identity",
     description="Detecta si el dominio del remitente usa TLDs frecuentemente asociados con phishing",
 )
 def check_suspicious_tld(headers: dict) -> RuleResult:
@@ -618,7 +618,7 @@ def _recipient_domain(headers: dict) -> str | None:
 
 
 @iris_rules.register(
-    name="Recipient Domain Lookalike", evidence_headers=("from", "to"),
+    name="Recipient Domain Lookalike", rule_id="iris.identity.recipient_domain_lookalike", severity="critical", mitre_techniques=("T1583.001", "T1656",), evidence_headers=("from", "to"),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el dominio del remitente es un typosquat/homoglifo "
@@ -689,7 +689,7 @@ _EMAIL_LIKE_RE = re.compile(r"[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}")
 
 
 @iris_rules.register(
-    name="Display Name Foreign Address", evidence_headers=("from",),
+    name="Display Name Foreign Address", rule_id="iris.identity.display_name_foreign_address", severity="high", mitre_techniques=("T1656",), evidence_headers=("from",),
     category="header_analysis", family="identity",
     description=(
         "Detecta cuando el display name del remitente ES una dirección de "

--- a/API/src/modules/features/iris/services/rules/thread_rules.py
+++ b/API/src/modules/features/iris/services/rules/thread_rules.py
@@ -40,7 +40,7 @@ REPLY_PREFIX_PATTERN = re.compile(
 
 
 @iris_rules.register(
-    name="Fake Reply Chain", evidence_headers=("subject", "in-reply-to", "references"), category="header_analysis",
+    name="Fake Reply Chain", rule_id="iris.thread.fake_reply_chain", severity="medium", evidence_headers=("subject", "in-reply-to", "references"), category="header_analysis",
     description="Detecta si el asunto imita una respuesta o reenvío sin los cabeceras In-Reply-To o References",
 )
 def check_fake_reply_chain(headers: dict) -> RuleResult:
@@ -121,7 +121,7 @@ def _strip_brackets(value: str) -> str:
 
 
 @iris_rules.register(
-    name="Self-Referencing In-Reply-To", evidence_headers=("in-reply-to", "message-id"),
+    name="Self-Referencing In-Reply-To", rule_id="iris.thread.self_referencing_in_reply_to", severity="medium", evidence_headers=("in-reply-to", "message-id"),
     category="header_analysis",
     description=(
         "Detecta cuando In-Reply-To (o el primer References) apunta al "
@@ -185,7 +185,7 @@ def check_self_referencing_in_reply_to(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID check", evidence_headers=("message-id",), category="header_analysis",
+    name="Message-ID check", rule_id="iris.thread.message_id", severity="low", evidence_headers=("message-id",), category="header_analysis",
     description="Verifica que el Message-ID esté presente y tenga una longitud razonable",
 )
 def check_message_id(headers: dict) -> RuleResult:
@@ -210,7 +210,7 @@ def check_message_id(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID Domain", evidence_headers=("message-id", "from"), category="header_analysis",
+    name="Message-ID Domain", rule_id="iris.thread.message_id_domain", severity="low", evidence_headers=("message-id", "from"), category="header_analysis",
     description="Compara el dominio del Message-ID con el dominio del remitente",
 )
 def check_msgid_domain(headers: dict) -> RuleResult:
@@ -263,7 +263,7 @@ def check_msgid_domain(headers: dict) -> RuleResult:
 
 
 @iris_rules.register(
-    name="Message-ID Received Correlation", evidence_headers=("message-id", "received"),
+    name="Message-ID Received Correlation", rule_id="iris.thread.message_id_received_correlation", severity="low", evidence_headers=("message-id", "received"),
     category="header_analysis",
     description=(
         "Comprueba que el dominio del Message-ID aparezca en algún host "

--- a/API/tests/integration/test_iris_rule_taxonomy_api.py
+++ b/API/tests/integration/test_iris_rule_taxonomy_api.py
@@ -1,0 +1,31 @@
+"""La taxonomía estable viaja con cada análisis real, de la base de datos a la API."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.model import IrisAnalysis
+from src.modules.features.iris.repositories import IrisAnalysisRepository
+from src.modules.features.iris.services.replay import CORPUS_DIRECTORY
+from src.modules.infrastructure import UnitOfWork
+
+pytestmark = pytest.mark.integration
+
+_PHISH = (CORPUS_DIRECTORY / "phish_ip_link_executable.eml").read_text(encoding="utf-8")
+
+
+def test_every_finding_of_an_analysis_carries_its_stable_reference(client, app, root_user, root_headers):
+    with app.app_context():
+        with UnitOfWork() as uow:
+            analysis = IrisAnalysis(raw_headers=_PHISH, user_id=root_user.id, status="pending")
+            IrisAnalysisRepository(uow).save(analysis)
+            analysis_id = analysis.id
+        IrisManager()._run_analysis(analysis_id, _PHISH)
+
+    report = client.get(f"/iris/results/{analysis_id}", headers=root_headers).get_json()
+
+    assert all(rule["ruleId"] and rule["severity"] for rule in report["rules"])
+    assert all(signal["ruleId"] for signal in report["topSignals"])
+    attachments = next(rule for rule in report["rules"] if rule["ruleId"] == "iris.attachment.suspicious_attachments")
+    assert attachments["mitreTechniques"] == ["T1566.001"]

--- a/API/tests/unit/test_iris_evidence.py
+++ b/API/tests/unit/test_iris_evidence.py
@@ -137,13 +137,13 @@ def test_invalid_self_provided_evidence_is_rejected():
 
 def test_a_rule_that_declares_nothing_cannot_be_registered():
     with pytest.raises(ValueError):
-        RuleRegistry().register(name="Sin declarar")
+        RuleRegistry().register(name="Sin declarar", rule_id="iris.test.sin_declarar", severity="low")
 
 
 def test_the_registry_anchors_through_its_wrapper_but_returns_the_original():
     registry = RuleRegistry()
 
-    @registry.register(name="Falsa", evidence_headers=("from",))
+    @registry.register(name="Falsa", evidence_headers=("from",), rule_id="iris.test.falsa", severity="low")
     def fake_rule(headers):
         return RuleResult(score=-5, verdict="fail")
 

--- a/API/tests/unit/test_iris_quality.py
+++ b/API/tests/unit/test_iris_quality.py
@@ -54,8 +54,10 @@ def test_a_broken_rule_degrades_and_is_recorded():
     quality = assess_quality(rules, [_ok(), _errored()])
 
     assert quality.quality == QUALITY_DEGRADED
+    # La regla sintética no declara rule_id; las del catálogo sí (ver
+    # test_iris_rule_taxonomy.py).
     assert quality.failed_rules == [
-        {"name": "Body Links", "family": "links", "category": "header_analysis"}
+        {"name": "Body Links", "ruleId": None, "family": "links", "category": "header_analysis"}
     ]
 
 

--- a/API/tests/unit/test_iris_rule_taxonomy.py
+++ b/API/tests/unit/test_iris_rule_taxonomy.py
@@ -1,0 +1,178 @@
+"""Taxonomía estable de los hallazgos de Iris: rule_id, severidad y MITRE ATT&CK.
+
+Cubre el criterio de cierre: un hallazgo se identifica por un id estable que
+no depende del nombre visible (que se puede traducir o corregir), lleva una
+severidad separada del score y, cuando encaja, sus técnicas ATT&CK; y el PDF lo
+enseña.
+
+``EXPECTED_RULE_IDS`` congela los ids a propósito: son un contrato con quien
+exporte o agrupe hallazgos, así que cambiar uno tiene que ser una decisión
+explícita, no un efecto secundario de renombrar una regla.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from reportlab.lib.styles import getSampleStyleSheet
+
+from src.modules.features.iris.managers.analysis import _rule_to_dict
+from src.modules.features.iris.model import IrisRuleResult
+from src.modules.features.iris.services.quality import assess_quality
+from src.modules.features.iris.services.registry import RuleRegistry, RuleResult, RuleSeverity
+from src.modules.features.iris.services.reports import IrisPDFCreator, IrisReportTheme, PALETTE
+from src.modules.features.iris.services.rules import iris_rules
+
+pytestmark = pytest.mark.unit
+
+EXPECTED_RULE_IDS = frozenset({
+    "iris.attachment.external_image_tracking", "iris.attachment.image_only_email",
+    "iris.attachment.suspicious_attachments",
+    "iris.auth.spf", "iris.auth.dkim", "iris.auth.dmarc", "iris.auth.domain_alignment",
+    "iris.auth.arc_chain", "iris.auth.auth_results_provenance",
+    "iris.content.alarming_keywords", "iris.content.body_content", "iris.content.bec_wire_transfer",
+    "iris.content.generic_greeting", "iris.content.url_in_subject", "iris.content.unicode_evasion",
+    "iris.content.encoded_word_abuse", "iris.content.toad_callback", "iris.content.list_unsubscribe",
+    "iris.links.body_links", "iris.links.qr_code_links", "iris.links.compromised_legitimate_domain",
+    "iris.links.external_login_link",
+    "iris.received.date_header_anomaly", "iris.received.received_chain",
+    "iris.received.temporal_inconsistency", "iris.received.path_anomaly",
+    "iris.received.origin_helo_coherence",
+    "iris.recipient.undisclosed_recipients",
+    "iris.reply_path.reply_to_mismatch", "iris.reply_path.reply_to_free_provider",
+    "iris.reply_path.return_path_mismatch", "iris.reply_path.triangulation",
+    "iris.identity.from_header", "iris.identity.display_name_spoofing",
+    "iris.identity.display_name_email_mismatch", "iris.identity.lookalike_sender_domain",
+    "iris.identity.subdomain_impersonation", "iris.identity.misspelled_brand_names",
+    "iris.identity.suspicious_tld", "iris.identity.recipient_domain_lookalike",
+    "iris.identity.display_name_foreign_address",
+    "iris.thread.fake_reply_chain", "iris.thread.self_referencing_in_reply_to",
+    "iris.thread.message_id", "iris.thread.message_id_domain",
+    "iris.thread.message_id_received_correlation",
+})
+
+
+# ------------------------------------------------------------------ catálogo
+
+def test_every_rule_has_a_frozen_stable_id():
+    ids = [rule_def["rule_id"] for rule_def in iris_rules.get_rules()]
+
+    assert len(ids) == len(set(ids)), "hay rule_id repetidos"
+    assert set(ids) == EXPECTED_RULE_IDS
+
+
+def test_every_rule_has_a_severity_and_well_formed_techniques():
+    severities = {member.value for member in RuleSeverity}
+    for rule_def in iris_rules.get_rules():
+        assert rule_def["severity"] in severities, rule_def["name"]
+        for technique in rule_def["mitre_techniques"]:
+            assert re.match(r"^T\d{4}(\.\d{3})?$", technique), (rule_def["name"], technique)
+
+
+def test_attack_techniques_are_only_declared_where_they_fit():
+    """Adjunto -> T1566.001, enlace -> T1566.002, y la mayoría sin técnica:
+    una heurística de cabeceras no es una técnica de ATT&CK."""
+    by_id = {rule_def["rule_id"]: rule_def for rule_def in iris_rules.get_rules()}
+
+    assert by_id["iris.attachment.suspicious_attachments"]["mitre_techniques"] == ("T1566.001",)
+    assert by_id["iris.links.body_links"]["mitre_techniques"] == ("T1566.002",)
+    assert by_id["iris.auth.spf"]["mitre_techniques"] == ()
+    without = sum(1 for rule_def in by_id.values() if not rule_def["mitre_techniques"])
+    assert without > len(by_id) / 2
+
+
+# ---------------------------------------------------------------- registro
+
+def _register(**overrides):
+    fields = dict(name="Prueba", evidence_headers=("from",), rule_id="iris.test.prueba", severity="low")
+    fields.update(overrides)
+    registry = RuleRegistry()
+    registry.register(**fields)(lambda headers: RuleResult(score=0, verdict="pass"))
+    return registry
+
+
+@pytest.mark.parametrize("overrides", [
+    {"rule_id": ""},
+    {"rule_id": "Prueba"},
+    {"rule_id": "iris.Test.prueba"},
+    {"severity": ""},
+    {"severity": "extreme"},
+    {"mitre_techniques": ("phishing",)},
+    {"mitre_techniques": ("T1566.2",)},
+])
+def test_the_registry_rejects_an_incomplete_or_malformed_taxonomy(overrides):
+    with pytest.raises(ValueError):
+        _register(**overrides)
+
+
+def test_the_registry_rejects_a_duplicate_id():
+    registry = _register()
+
+    with pytest.raises(ValueError):
+        registry.register(name="Otra", evidence_headers=("from",), rule_id="iris.test.prueba", severity="low")
+
+
+def test_the_registry_keeps_the_taxonomy_with_the_rule():
+    rule_def = _register(mitre_techniques=["T1566.002"]).get_rules()[0]
+
+    assert (rule_def["rule_id"], rule_def["severity"], rule_def["mitre_techniques"]) == (
+        "iris.test.prueba", "low", ("T1566.002",))
+
+
+# ------------------------------------------------------------ serialización
+
+def test_a_finding_is_serialized_with_its_stable_reference():
+    row = IrisRuleResult(rule_name="Enlaces del cuerpo", rule_id="iris.links.body_links", severity="high",
+                         mitre_techniques=["T1566.002"], category="content_analysis", score=-20.0,
+                         verdict="fail")
+
+    serialized = _rule_to_dict(row)
+
+    assert serialized["ruleId"] == "iris.links.body_links"
+    assert serialized["ruleName"] == "Enlaces del cuerpo"
+    assert serialized["severity"] == "high"
+    assert serialized["mitreTechniques"] == ["T1566.002"]
+
+
+def test_a_finding_from_before_the_taxonomy_still_serializes():
+    row = IrisRuleResult(rule_name="SPF", category="authentication", score=0.0, verdict="pass")
+
+    serialized = _rule_to_dict(row)
+
+    assert serialized["ruleId"] is None
+    assert serialized["mitreTechniques"] == []
+
+
+def test_a_rule_that_could_not_run_is_reported_with_its_id():
+    rules_defs = [rule_def for rule_def in iris_rules.get_rules() if rule_def["rule_id"] == "iris.auth.dmarc"]
+
+    quality = assess_quality(rules_defs, [RuleResult(score=0, verdict="error")])
+
+    assert quality.failed_rules[0]["ruleId"] == "iris.auth.dmarc"
+
+
+# ------------------------------------------------------------------- PDF
+
+def test_the_pdf_shows_the_stable_id_and_the_attack_technique(tmp_path, monkeypatch):
+    import src.modules.features.iris.services.reports as reports_mod
+    monkeypatch.setattr(reports_mod.CR, "get_directory_of", lambda *_args, **_kwargs: str(tmp_path))
+    report = {
+        "analysisId": 1, "status": "finished", "verdict": "Phishing", "totalScore": 20,
+        "rules": [{
+            "ruleId": "iris.links.body_links", "ruleName": "Body Links", "category": "content_analysis",
+            "score": -20, "verdict": "fail", "details": {}, "mitreTechniques": ["T1566.002"],
+            "recommendation": "No hagas clic.", "evidence": [],
+        }],
+    }
+    elements: list = []
+
+    IrisPDFCreator(report=report).append_rules(elements, IrisReportTheme(getSampleStyleSheet(), PALETTE))
+
+    texts = " ".join(getattr(element, "text", "") for element in elements)
+    table_cells = " ".join(
+        cell.text for element in elements if hasattr(element, "_cellvalues")
+        for row in element._cellvalues for cell in row if hasattr(cell, "text")
+    )
+    assert "iris.links.body_links" in table_cells
+    assert "iris.links.body_links" in texts and "T1566.002" in texts

--- a/web/app/src/components/iris/IrisRuleCard.vue
+++ b/web/app/src/components/iris/IrisRuleCard.vue
@@ -4,6 +4,7 @@
       <div class="rule-left">
         <span class="rule-name">{{ rule.ruleName }}</span>
         <span class="rule-category" v-if="rule.category">{{ rule.category }}</span>
+        <span v-if="rule.severity" class="rule-severity" :class="`rule-severity--${rule.severity}`">{{ SEVERITY_LABELS[rule.severity] || rule.severity }}</span>
       </div>
       <div class="rule-right">
         <span class="rule-score" :class="scoreClass(rule.score, rule.verdict)">{{ sign(rule.score) }}{{ rule.score }}</span>
@@ -13,6 +14,19 @@
     </button>
     <Transition name="rule-detail">
       <div v-if="expanded" class="rule-detail">
+        <!-- Referencia estable del hallazgo: el id no cambia aunque cambie el
+             nombre visible, y las técnicas enlazan a MITRE ATT&CK. -->
+        <p v-if="rule.ruleId" class="rule-reference">
+          <code class="rule-id">{{ rule.ruleId }}</code>
+          <a
+            v-for="technique in rule.mitreTechniques || []"
+            :key="technique"
+            class="rule-technique"
+            :href="attackUrl(technique)"
+            target="_blank"
+            rel="noopener noreferrer"
+          >ATT&amp;CK {{ technique }}</a>
+        </p>
         <div v-if="rule.details && Object.keys(rule.details).length" class="rule-details">
           <div v-for="(v, k) in rule.details" :key="k" class="detail-row">
             <span class="detail-key">{{ k }}</span>
@@ -60,6 +74,13 @@ defineProps({
 })
 
 defineEmits(['toggle', 'jump-evidence'])
+
+const SEVERITY_LABELS = { low: 'baja', medium: 'media', high: 'alta', critical: 'crítica' }
+
+/** Página de MITRE ATT&CK de una técnica: T1566.002 -> /techniques/T1566/002/. */
+function attackUrl(technique) {
+  return `https://attack.mitre.org/techniques/${technique.replace('.', '/')}/`
+}
 
 /** Etiqueta corta de un elemento de evidencia (ver services/evidence.py en la API). */
 function evidenceLabel(item) {
@@ -238,6 +259,21 @@ function formatDetailValue(v) {
 .score--pos { color: var(--success); }
 .score--neg { color: var(--danger); }
 .score--neutral { color: var(--text-muted); }
+
+.rule-severity {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  background: rgba(100, 116, 139, 0.12);
+  color: var(--text-muted);
+}
+.rule-severity--high { background: var(--warn-dim); color: var(--warn); }
+.rule-severity--critical { background: var(--danger-dim); color: var(--danger); }
+.rule-reference { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin: 0 0 0.6rem; }
+.rule-id { font-size: var(--fs-sm); color: var(--text-muted); }
+.rule-technique { font-size: var(--fs-sm); color: var(--accent-bright); text-decoration: underline; }
 
 .rule-verdict {
   font-size: var(--fs-md);

--- a/web/app/src/components/iris/compare.js
+++ b/web/app/src/components/iris/compare.js
@@ -4,7 +4,9 @@
  * Vive fuera del componente para poder probarla con `node` a secas (ver
  * `test/iris.compare.test.mjs`), igual que `intake.js`. Recibe los informes tal
  * como los devuelve `GET /iris/results/<id>` y no reinterpreta nada: solo
- * empareja reglas por nombre y señala qué cambia.
+ * empareja reglas y señala qué cambia. Empareja por `ruleId`, que es estable
+ * aunque el nombre visible cambie entre dos versiones del catálogo, y por
+ * `ruleName` en análisis anteriores a que existiera el id.
  */
 
 /**
@@ -19,16 +21,17 @@
  *   reglas que cambian van primero; dentro de cada grupo, por nombre.
  */
 export function compareReports(left, right) {
-  const byName = new Map()
+  const byKey = new Map()
   for (const [side, report] of [['left', left], ['right', right]]) {
     for (const rule of report?.rules ?? []) {
-      const entry = byName.get(rule.ruleName) ?? { ruleName: rule.ruleName, left: null, right: null }
+      const key = rule.ruleId || rule.ruleName
+      const entry = byKey.get(key) ?? { ruleId: rule.ruleId ?? null, ruleName: rule.ruleName, left: null, right: null }
       entry[side] = { score: rule.score, verdict: rule.verdict }
-      byName.set(rule.ruleName, entry)
+      byKey.set(key, entry)
     }
   }
 
-  const rules = [...byName.values()].map(entry => ({
+  const rules = [...byKey.values()].map(entry => ({
     ...entry,
     changed: entry.left?.verdict !== entry.right?.verdict || entry.left?.score !== entry.right?.score,
   }))

--- a/web/app/test/iris.compare.test.mjs
+++ b/web/app/test/iris.compare.test.mjs
@@ -49,5 +49,13 @@ check('un informe comparado consigo mismo no cambia', !same.verdictChanged && sa
 eq('sin score en un lado no hay diferencia', compareReports({ ...left, totalScore: null }, right).scoreDelta, null)
 eq('sin informes no revienta', compareReports(null, undefined).rules, [])
 
+console.log('\ncompareReports — el id estable manda sobre el nombre')
+const renamed = compareReports(
+  { verdict: 'Phishing', totalScore: 30, rules: [{ ruleId: 'iris.links.body_links', ruleName: 'Body Links', score: -20, verdict: 'fail' }] },
+  { verdict: 'Phishing', totalScore: 30, rules: [{ ruleId: 'iris.links.body_links', ruleName: 'Enlaces del cuerpo', score: -20, verdict: 'fail' }] },
+)
+eq('una regla renombrada sigue emparejada por su id', renamed.rules.length, 1)
+check('y no cuenta como cambio', renamed.changedCount === 0)
+
 console.log(`\n${passed} pasados, ${failed} fallidos`)
 process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## El problema

Cada hallazgo de Iris procede de una regla: «Body Links», «Lookalike Sender Domain», «SPF»… Hasta ahora ese **nombre visible** era también el identificador de la regla: es lo que se guardaba en cada fila de resultado (`IrisRuleResult.rule_name`) y lo que viajaba en la API, el PDF y la exportación.

Un nombre visible no sirve de identificador, porque se puede traducir, corregir o reformular. Si mañana «Body Links» pasa a llamarse «Enlaces del cuerpo», todo lo que se hubiera construido sobre los hallazgos deja de encajar: un panel, una exportación STIX/MISP (`F10`, Fase 4) o la agrupación de campañas (`F02`, Fase 4). Faltaban además dos cosas:

- **Una severidad separada del score.** El score dice cuánto pesa una señal en el veredicto de un mensaje concreto; la severidad dice cuánto importa el hecho si es cierto. Una suplantación de dominio es grave aunque en un mensaje concreto su regla pese poco.
- **El vínculo con MITRE ATT&CK**, el catálogo de técnicas de ataque con el que trabajan los equipos de seguridad. Por ejemplo, `T1566.001` es phishing con adjunto y `T1566.002`, phishing con enlace.

Cierra #233 (iniciativa `M11`, Fase 3 del roadmap de Iris, #203).

## Qué cambia

**Cada regla declara su taxonomía al registrarse** (`services/registry.py`):

- `rule_id`: identificador estable con la forma `iris.<grupo>.<nombre>` (`iris.links.body_links`). Es obligatorio, y el registro rechaza al arrancar uno que falte, esté mal formado o se repita.
- `severity`: `low`, `medium`, `high` o `critical` (`RuleSeverity`). Es obligatoria.
- `mitre_techniques`: técnicas ATT&CK, solo donde encajan de verdad. El issue pedía expresamente «no pretender que cada heurística sea una técnica», así que 30 de las 46 reglas no declaran ninguna. Las que sí:

| Técnica | Qué es | Reglas |
|---|---|---|
| `T1566.001` | Phishing con adjunto | Suspicious Attachments |
| `T1566.002` | Phishing con enlace | Body Links, QR Code Links, Compromised Legitimate Domain |
| `T1566.004` | Phishing por voz | TOAD Callback Pattern (el correo empuja a llamar a un teléfono) |
| `T1598.003` | Phishing para robar información, con enlace | External Login Link |
| `T1656` | Suplantación de identidad | Display Name Spoofing / Email Mismatch / Foreign Address, Misspelled Brand Names, BEC Wire Transfer Pattern, y los dos dominios parecidos |
| `T1583.001` | Registrar dominios para el ataque | Lookalike Sender Domain, Subdomain Impersonation, Recipient Domain Lookalike |
| `T1036.002` | Engaño con el carácter de inversión de texto (RTLO) | Unicode Evasion |
| `T1027` | Ofuscación | Encoded-Word Abuse |

**Cada hallazgo guarda su taxonomía.** `IrisRuleResult` gana `rule_id`, `severity` y `mitre_techniques` (migración `b8e3c6f1a5d2`, con índice por `rule_id` para la agrupación futura). Se guardan tal como estaban en el catálogo cuando se analizó el correo, así que un hallazgo histórico no cambia de severidad si el catálogo cambia después. Las filas anteriores quedan a `NULL` y se sirven igual.

**Salidas:**

- **API:** cada regla del informe trae `ruleId`, `severity` y `mitreTechniques`. También las «señales principales» y la lista de reglas que no se pudieron ejecutar llevan `ruleId`. La exportación JSON lo hereda del informe.
- **PDF:** la tabla de reglas muestra el id bajo el nombre, y el detalle de cada hallazgo lleva su id y sus técnicas ATT&CK.
- **Resumen de IA:** el modelo recibe el `ruleId` de cada regla.
- **SPA:** la ficha de regla enseña la severidad y, al desplegarla, el id y enlaces a la página de cada técnica en MITRE ATT&CK. La comparación de dos análisis (`M12`) empareja las reglas por `ruleId`, así que una regla renombrada entre dos versiones del catálogo sigue apareciendo como la misma.

## Notas

- **El catálogo tiene 46 reglas, no 48** como decía el issue: el recuento del issue estaba desactualizado.
- Las métricas de feedback (`M04`) y el replay (`M05`, `F16`) siguen agrupando por nombre internamente; el cambio visible de este PR es la referencia estable en todas las salidas.

## Validación

- `test_iris_rule_taxonomy.py` (nuevo, 16 casos):
  - **Catálogo:** la lista de ids está congelada a propósito, porque es un contrato con quien exporte o agrupe hallazgos y cambiar un id tiene que ser deliberado. No hay ids repetidos, toda regla tiene severidad y técnicas bien formadas, y la mayoría de reglas no declaran técnica.
  - **Registro:** rechaza un id que falta o tiene mala forma, una severidad desconocida, una técnica mal escrita y un id repetido.
  - **Salidas:** serialización con y sin taxonomía (filas antiguas), la lista de reglas que no se ejecutaron con su id, y el PDF con el id y la técnica.
- `test_iris_rule_taxonomy_api.py` (nuevo): un análisis real del corpus devuelve `ruleId` y `severity` en todas sus reglas y señales, y `T1566.001` en la de adjuntos.
- `test_iris_evidence.py` y `test_iris_quality.py`: actualizados al contrato nuevo (los registros de prueba declaran id; la regla que no se ejecutó lleva `ruleId`).
- `pytest -k "iris or conventions or config_shape or caddy or import_isolation"`: 1046 pasados.
- Suite completa (`pytest`): 3301 pasados, 50 omitidos.
- SPA: `node test/iris.compare.test.mjs` (10 casos, 2 nuevos) en verde; `IrisRuleCard.vue` compila con `@vue/compiler-sfc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
