### PR TITLE
Iris: analizar .msg de Outlook convirtiéndolos a .eml

### DIFF
--- a/API/requirements.txt
+++ b/API/requirements.txt
@@ -59,3 +59,6 @@ croniter>=2.0
 redis>=5.0.0
 rq>=1.16.0
 
+# Iris: lectura de .msg de Outlook (contenedor OLE/CFB), licencia BSD
+olefile>=0.46
+

--- a/API/src/modules/features/iris/services/batch.py
+++ b/API/src/modules/features/iris/services/batch.py
@@ -1,10 +1,15 @@
 """
 Análisis por lotes: qué entra en un lote y qué se queda fuera.
 
-Un lote llega como varios ``.eml`` o como un ZIP que los contiene. Este módulo
-lo convierte en una lista de entradas, una por mensaje, y decide las que no se
-pueden analizar —no son ``.eml``, pasan del tamaño máximo, están cifradas o
-son un ZIP dentro de otro— sin que eso tumbe el resto del lote.
+Un lote llega como varios ``.eml`` o ``.msg`` de Outlook, o como un ZIP que
+los contiene. Este módulo lo convierte en una lista de entradas, una por
+mensaje, y decide las que no se pueden analizar —no son un correo, pasan del
+tamaño máximo, están cifradas, son un ZIP dentro de otro o un ``.msg`` dañado—
+sin que eso tumbe el resto del lote.
+
+Un ``.msg`` se convierte aquí a ``.eml`` (``msg_converter``), así que lo que
+sale de este módulo son siempre mensajes RFC 5322 y el resto de Iris no
+distingue de qué formato vino cada uno.
 
 Los límites de lote (cuántos mensajes y cuántos bytes en total) sí lo tumban
 entero, y antes de crear nada: un lote que no cabe se rechaza con un motivo
@@ -26,8 +31,12 @@ import zipfile
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
+from .msg_converter import MsgConversionError, convert_msg_to_eml
+
 _EML_SUFFIX = ".eml"
+_MSG_SUFFIX = ".msg"
 _ZIP_SUFFIX = ".zip"
+_NOT_A_MESSAGE = "No es un fichero .eml ni .msg."
 
 
 class BatchLimitError(ValueError):
@@ -48,9 +57,38 @@ class BatchEntry:
     rejection: Optional[str] = None
 
 
-def _is_eml(filename: str) -> bool:
-    """Si un nombre de fichero es un ``.eml`` (sin distinguir mayúsculas)."""
-    return filename.lower().endswith(_EML_SUFFIX)
+def _is_message_file(filename: str) -> bool:
+    """Si un nombre de fichero es un ``.eml`` o un ``.msg`` (sin distinguir mayúsculas)."""
+    return filename.lower().endswith((_EML_SUFFIX, _MSG_SUFFIX))
+
+
+def _message_entry(name: str, data: bytes, max_message_bytes: int) -> BatchEntry:
+    """Entrada de un mensaje, suelto o sacado de un ZIP.
+
+    Un ``.eml`` pasa tal cual; un ``.msg`` se convierte a ``.eml``. El tope se
+    aplica al fichero recibido y, en un ``.msg``, también al resultado: la
+    conversión pasa los adjuntos a base64, que ocupa un tercio más.
+
+    Args:
+        name: Nombre del fichero (dentro de un ZIP, ``zip/ruta``).
+        data: Sus bytes.
+        max_message_bytes: Tamaño máximo de un mensaje.
+
+    Returns:
+        BatchEntry: Con el ``.eml`` en ``content``, o con el motivo de rechazo
+            si pasa del tamaño o es un ``.msg`` que no se puede convertir.
+    """
+    too_big = f"Supera el tamaño máximo ({max_message_bytes} bytes)."
+    if len(data) > max_message_bytes:
+        return BatchEntry(name, rejection=too_big)
+    if name.lower().endswith(_MSG_SUFFIX):
+        try:
+            data = convert_msg_to_eml(data).encode("utf-8")
+        except MsgConversionError as e:
+            return BatchEntry(name, rejection=str(e))
+        if len(data) > max_message_bytes:
+            return BatchEntry(name, rejection=f"Convertido a .eml, supera el tamaño máximo ({max_message_bytes} bytes).")
+    return BatchEntry(name, content=data)
 
 
 def _expand_zip(filename: str, data: bytes, max_message_bytes: int) -> List[BatchEntry]:
@@ -80,17 +118,13 @@ def _expand_zip(filename: str, data: bytes, max_message_bytes: int) -> List[Batc
                 entries.append(BatchEntry(name, rejection="Está cifrado dentro del ZIP."))
             elif info.filename.lower().endswith(_ZIP_SUFFIX):
                 entries.append(BatchEntry(name, rejection="No se admiten ZIP dentro de un ZIP."))
-            elif not _is_eml(info.filename):
-                entries.append(BatchEntry(name, rejection="No es un fichero .eml."))
+            elif not _is_message_file(info.filename):
+                entries.append(BatchEntry(name, rejection=_NOT_A_MESSAGE))
             elif info.file_size > max_message_bytes:
                 entries.append(BatchEntry(name, rejection=f"Supera el tamaño máximo ({max_message_bytes} bytes)."))
             else:
                 with archive.open(info) as handle:
-                    content = handle.read(max_message_bytes + 1)
-                if len(content) > max_message_bytes:
-                    entries.append(BatchEntry(name, rejection=f"Supera el tamaño máximo ({max_message_bytes} bytes)."))
-                else:
-                    entries.append(BatchEntry(name, content=content))
+                    entries.append(_message_entry(name, handle.read(max_message_bytes + 1), max_message_bytes))
     return entries
 
 
@@ -99,8 +133,8 @@ def expand_uploads(uploads: Sequence[Tuple[str, bytes]], *, max_items: int,
     """Convierte los ficheros subidos en las entradas del lote.
 
     Args:
-        uploads: Pares ``(nombre, bytes)`` tal como llegaron: ``.eml`` sueltos
-            y/o ZIP.
+        uploads: Pares ``(nombre, bytes)`` tal como llegaron: ``.eml`` y
+            ``.msg`` sueltos y/o ZIP.
         max_items: Mensajes como máximo en el lote, contando los rechazados.
         max_message_bytes: Tamaño máximo de un mensaje.
         max_total_bytes: Suma máxima de los mensajes que se van a analizar.
@@ -115,18 +149,16 @@ def expand_uploads(uploads: Sequence[Tuple[str, bytes]], *, max_items: int,
             ``max_total_bytes``.
     """
     if not uploads:
-        raise BatchLimitError("El lote está vacío: adjunta ficheros .eml o un ZIP que los contenga.")
+        raise BatchLimitError("El lote está vacío: adjunta ficheros .eml o .msg, o un ZIP que los contenga.")
     entries: List[BatchEntry] = []
     for filename, data in uploads:
         name = filename or "sin-nombre"
         if name.lower().endswith(_ZIP_SUFFIX):
             entries.extend(_expand_zip(name, data, max_message_bytes))
-        elif not _is_eml(name):
-            entries.append(BatchEntry(name, rejection="No es un fichero .eml."))
-        elif len(data) > max_message_bytes:
-            entries.append(BatchEntry(name, rejection=f"Supera el tamaño máximo ({max_message_bytes} bytes)."))
+        elif not _is_message_file(name):
+            entries.append(BatchEntry(name, rejection=_NOT_A_MESSAGE))
         else:
-            entries.append(BatchEntry(name, content=data))
+            entries.append(_message_entry(name, data, max_message_bytes))
         if len(entries) > max_items:
             raise BatchLimitError(f"Un lote admite como mucho {max_items} mensajes.")
 

--- a/API/src/modules/features/iris/services/msg_converter.py
+++ b/API/src/modules/features/iris/services/msg_converter.py
@@ -1,0 +1,490 @@
+"""
+Conversor de ``.msg`` de Outlook a un ``.eml`` canónico.
+
+Outlook exporta los correos en ``.msg``: un fichero *Compound File Binary*
+(el contenedor OLE de Microsoft) con una propiedad MAPI por flujo, no texto
+RFC 5322. Iris analiza ``.eml``, así que este módulo lee las propiedades del
+``.msg`` y reconstruye el mensaje en MIME; a partir de ahí todo sigue igual —el
+parser, las reglas, la evidencia anclada, el reanálisis— porque lo que se guarda
+y se analiza es ese ``.eml``.
+
+Qué se conserva:
+
+- **Las cabeceras originales** cuando el ``.msg`` es de un correo recibido:
+  Outlook guarda el bloque de cabeceras de Internet tal como llegó
+  (``PR_TRANSPORT_MESSAGE_HEADERS``), con ``Received``,
+  ``Authentication-Results``, DKIM y ``Message-ID``. Sin él (un borrador o un
+  enviado), las cabeceras básicas se reconstruyen desde las propiedades.
+- **Los cuerpos**: texto, HTML y, si solo hay RTF comprimido, su texto.
+- **Los adjuntos**, con nombre Unicode, tipo y ``Content-ID`` de los que van en
+  línea, y los **mensajes incrustados** (el «reenviar como adjunto» de
+  Outlook), que pasan a ser una parte ``message/rfc822``.
+
+Nunca se ejecuta ni se interpreta el contenido de un adjunto: sus bytes se
+copian tal cual. Se usa ``olefile`` (BSD) para leer el contenedor; la
+descompresión del RTF (MS-OXRTFCP) está implementada aquí.
+
+Módulo puro: sin base de datos ni red.
+"""
+
+from __future__ import annotations
+
+import io
+import mimetypes
+import re
+import struct
+from datetime import datetime, timedelta, timezone
+from email import encoders
+from email.header import Header
+from email.mime.base import MIMEBase
+from email.mime.message import MIMEMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.parser import Parser
+from email.utils import format_datetime, formataddr
+from typing import Dict, List, Optional, Tuple
+
+import olefile
+
+#: Firma de un Compound File Binary (``.msg``, y también ``.doc``/``.xls``).
+OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+
+#: Adjuntos como máximo por mensaje (contando los de los incrustados).
+MAX_ATTACHMENTS = 100
+
+#: Profundidad máxima de mensajes incrustados (un reenvío de un reenvío…).
+MAX_EMBEDDING_DEPTH = 3
+
+#: Tamaño máximo del RTF descomprimido: el tamaño declarado en la cabecera del
+#: RTF puede mentir, así que la descompresión se corta aquí pase lo que pase.
+MAX_RTF_BYTES = 4 * 1024 * 1024
+
+#: Cabeceras que describen la estructura MIME original del correo. No se
+#: copian: el cuerpo se reconstruye, y con él su propia estructura.
+_MIME_STRUCTURE_HEADERS = frozenset({"content-type", "content-transfer-encoding", "mime-version"})
+
+# Propiedades MAPI (id de 4 hexadecimales).
+_PR_SUBJECT = "0037"
+_PR_MESSAGE_CLASS = "001A"
+_PR_TRANSPORT_MESSAGE_HEADERS = "007D"
+_PR_SENDER_NAME = "0C1A"
+_PR_SENDER_EMAIL = "0C1F"
+_PR_SENDER_SMTP = "5D01"
+_PR_DISPLAY_TO = "0E04"
+_PR_DISPLAY_CC = "0E03"
+_PR_BODY = "1000"
+_PR_RTF_COMPRESSED = "1009"
+_PR_HTML = "1013"
+_PR_INTERNET_MESSAGE_ID = "1035"
+_PR_ATTACH_DATA = "3701"
+_PR_ATTACH_FILENAME = "3704"
+_PR_ATTACH_LONG_FILENAME = "3707"
+_PR_ATTACH_MIME_TAG = "370E"
+_PR_ATTACH_CONTENT_ID = "3712"
+_TAG_CLIENT_SUBMIT_TIME = 0x00390040
+_TAG_MESSAGE_CODEPAGE = 0x3FFD0003
+_TAG_INTERNET_CPID = 0x3FDE0003
+
+# Cabecera del flujo de propiedades según el objeto (MS-OXMSG §2.4).
+_PROPERTIES_STREAM = "__properties_version1.0"
+_TOP_LEVEL_HEADER_SIZE = 32
+_EMBEDDED_HEADER_SIZE = 24
+_ATTACHMENT_HEADER_SIZE = 8
+
+_ATTACHMENT_STORAGE_PREFIX = "__attach_version1.0_"
+_EMBEDDED_MESSAGE_STORAGE = "__substg1.0_3701000D"
+
+# Diccionario inicial del RTF comprimido (MS-OXRTFCP §3.1.3.1).
+_RTF_PREBUFFER = (
+    b"{\\rtf1\\ansi\\mac\\deff0\\deftab720{\\fonttbl;}{\\f0\\fnil \\froman \\fswiss "
+    b"\\fmodern \\fscript \\fdecor MS Sans SerifSymbolArialTimes New RomanCourier"
+    b"{\\colortbl\\red0\\green0\\blue0\r\n\\par \\pard\\plain\\f0\\fs20\\b\\i\\u\\tab\\tx"
+)
+_RTF_COMPRESSED = 0x75465A4C    # "LZFu"
+_RTF_UNCOMPRESSED = 0x414C454D  # "MELA"
+_RTF_DICTIONARY_SIZE = 4096
+
+_FILETIME_EPOCH = datetime(1601, 1, 1, tzinfo=timezone.utc)
+
+
+class MsgConversionError(ValueError):
+    """El fichero no es un ``.msg`` de Outlook que se pueda convertir.
+
+    El mensaje es apto para el usuario.
+    """
+
+
+def is_msg(data: bytes) -> bool:
+    """Si unos bytes empiezan por la firma de un Compound File Binary.
+
+    Args:
+        data: Contenido del fichero (basta con los 8 primeros bytes).
+
+    Returns:
+        bool: ``True`` si puede ser un ``.msg`` (la conversión confirma que lo es).
+    """
+    return data[:8] == OLE_MAGIC
+
+
+def decompress_rtf(data: bytes, max_bytes: int = MAX_RTF_BYTES) -> bytes:
+    """Descomprime el RTF de ``PR_RTF_COMPRESSED`` (MS-OXRTFCP).
+
+    Args:
+        data: El valor de la propiedad: cabecera de 16 bytes y contenido.
+        max_bytes: Tope de la salida, pase lo que diga la cabecera. Por
+            defecto ``MAX_RTF_BYTES``.
+
+    Returns:
+        bytes: El RTF sin comprimir (recortado a ``max_bytes``).
+
+    Raises:
+        MsgConversionError: Si la cabecera no es de RTF comprimido.
+    """
+    if len(data) < 16:
+        raise MsgConversionError("El cuerpo RTF del .msg está incompleto.")
+    compressed_size, raw_size, compression_type, _crc = struct.unpack("<IIII", data[:16])
+    if compression_type == _RTF_UNCOMPRESSED:
+        return data[16:16 + min(raw_size, max_bytes)]
+    if compression_type != _RTF_COMPRESSED:
+        raise MsgConversionError("El cuerpo RTF del .msg tiene un formato desconocido.")
+
+    dictionary = bytearray(_RTF_DICTIONARY_SIZE)
+    dictionary[:len(_RTF_PREBUFFER)] = _RTF_PREBUFFER
+    write_position = len(_RTF_PREBUFFER)
+    output = bytearray()
+    position, end = 16, min(len(data), compressed_size + 4)
+    while position < end and len(output) < max_bytes:
+        control = data[position]
+        position += 1
+        for bit in range(8):
+            if position >= end or len(output) >= max_bytes:
+                break
+            if control & (1 << bit):
+                if position + 1 >= end:
+                    return bytes(output)
+                token = (data[position] << 8) | data[position + 1]
+                position += 2
+                offset, length = token >> 4, (token & 0x0F) + 2
+                if offset == write_position:
+                    return bytes(output[:max_bytes])
+                for index in range(length):
+                    byte = dictionary[(offset + index) % _RTF_DICTIONARY_SIZE]
+                    output.append(byte)
+                    dictionary[write_position] = byte
+                    write_position = (write_position + 1) % _RTF_DICTIONARY_SIZE
+            else:
+                byte = data[position]
+                position += 1
+                output.append(byte)
+                dictionary[write_position] = byte
+                write_position = (write_position + 1) % _RTF_DICTIONARY_SIZE
+    return bytes(output[:max_bytes])
+
+
+_RTF_TOKEN_RE = re.compile(
+    rb"\\([a-z]+)(-?\d+)? ?|\\'([0-9a-f]{2})|\\([\\{}])|(\\\*)|([{}])|\r?\n|([^\\{}\r\n]+)", re.IGNORECASE,
+)
+_RTF_HIDDEN_DESTINATIONS = (b"fonttbl", b"colortbl", b"stylesheet", b"info", b"pict")
+
+
+def rtf_to_text(rtf: bytes) -> str:
+    """Texto legible de un RTF: suficiente para las reglas de contenido.
+
+    Descarta los grupos que no se muestran (``{\\*…}``, tablas de fuentes y
+    colores) y traduce los saltos, tabuladores, escapes ``\\'hh`` (Windows-1252)
+    y caracteres ``\\uN``.
+
+    Args:
+        rtf: RTF sin comprimir.
+
+    Returns:
+        str: El texto, sin marcado.
+    """
+    parts: List[str] = []
+    # Profundidad del grupo oculto que se está saltando; un grupo oculto dentro
+    # de otro ya queda cubierto por el de fuera.
+    skip_depth: Optional[int] = None
+    depth = 0
+    skip_next = 0
+    for match in _RTF_TOKEN_RE.finditer(rtf):
+        word, number, hex_value, escaped, star, brace, text = match.groups()
+        if brace == b"{":
+            depth += 1
+            continue
+        if brace == b"}":
+            if skip_depth == depth:
+                skip_depth = None
+            depth -= 1
+            continue
+        if star is not None or (word is not None and word.lower() in _RTF_HIDDEN_DESTINATIONS):
+            if skip_depth is None:
+                skip_depth = depth
+            continue
+        if skip_depth is not None:
+            continue
+        if skip_next and (text or hex_value):
+            skip_next -= 1
+            if text and len(text) > 1:
+                parts.append(text[1:].decode("cp1252", errors="replace"))
+            continue
+        if word is not None:
+            lowered = word.lower()
+            if lowered in (b"par", b"line"):
+                parts.append("\n")
+            elif lowered == b"tab":
+                parts.append("\t")
+            elif lowered == b"u" and number is not None:
+                parts.append(chr(int(number) % 0x10000))
+                skip_next = 1
+        elif hex_value is not None:
+            parts.append(bytes([int(hex_value, 16)]).decode("cp1252", errors="replace"))
+        elif escaped is not None:
+            parts.append(escaped.decode("ascii"))
+        elif text is not None:
+            parts.append(text.decode("cp1252", errors="replace"))
+    return re.sub(r"\n{3,}", "\n\n", "".join(parts)).strip()
+
+
+def _fixed_properties(ole: olefile.OleFileIO, prefix: str, header_size: int) -> Dict[int, bytes]:
+    """Propiedades de tamaño fijo de un objeto, por etiqueta MAPI.
+
+    Args:
+        ole: Contenedor abierto.
+        prefix: Ruta del objeto (``""`` para el mensaje raíz).
+        header_size: Bytes de cabecera del flujo según el tipo de objeto.
+
+    Returns:
+        Dict[int, bytes]: Etiqueta (id << 16 | tipo) -> 8 bytes de valor; vacío
+            si el objeto no tiene flujo de propiedades.
+    """
+    path = prefix + _PROPERTIES_STREAM
+    if not ole.exists(path):
+        return {}
+    raw = ole.openstream(path).read()
+    properties: Dict[int, bytes] = {}
+    for offset in range(header_size, len(raw) - 15, 16):
+        tag = struct.unpack("<I", raw[offset:offset + 4])[0]
+        properties[tag] = raw[offset + 8:offset + 16]
+    return properties
+
+
+def _codec_for(codepage: Optional[int], fallback: str = "cp1252") -> str:
+    """Codec de Python para una página de códigos de Windows."""
+    if not codepage:
+        return fallback
+    if codepage == 65001:
+        return "utf-8"
+    codec = f"cp{codepage}"
+    try:
+        "".encode(codec)
+    except LookupError:
+        return fallback
+    return codec
+
+
+def _read_string(ole: olefile.OleFileIO, prefix: str, property_id: str, codec: str) -> Optional[str]:
+    """Valor de texto de una propiedad, en Unicode o en la página de códigos del mensaje."""
+    for suffix, encoding in (("001F", "utf-16-le"), ("001E", codec)):
+        path = f"{prefix}__substg1.0_{property_id}{suffix}"
+        if ole.exists(path):
+            return ole.openstream(path).read().decode(encoding, errors="replace").rstrip("\x00")
+    return None
+
+
+def _read_binary(ole: olefile.OleFileIO, prefix: str, property_id: str) -> Optional[bytes]:
+    """Valor binario de una propiedad, o ``None`` si no está."""
+    path = f"{prefix}__substg1.0_{property_id}0102"
+    return ole.openstream(path).read() if ole.exists(path) else None
+
+
+def _long(properties: Dict[int, bytes], tag: int) -> Optional[int]:
+    value = properties.get(tag)
+    return struct.unpack("<i", value[:4])[0] if value else None
+
+
+def _systime(properties: Dict[int, bytes], tag: int) -> Optional[datetime]:
+    value = properties.get(tag)
+    if not value:
+        return None
+    filetime = struct.unpack("<Q", value)[0]
+    return _FILETIME_EPOCH + timedelta(microseconds=filetime // 10) if filetime else None
+
+
+def _attachment_storages(ole: olefile.OleFileIO, prefix: str) -> List[str]:
+    """Rutas de los adjuntos directos de un objeto, en su orden."""
+    depth = prefix.count("/")
+    names = set()
+    for entry in ole.listdir(streams=False, storages=True):
+        if len(entry) == depth + 1 and "/".join(entry[:-1]) + ("/" if depth else "") == prefix \
+                and entry[-1].startswith(_ATTACHMENT_STORAGE_PREFIX):
+            names.add(entry[-1])
+    return [f"{prefix}{name}/" for name in sorted(names)]
+
+
+def _headers_block(ole: olefile.OleFileIO, prefix: str, properties: Dict[int, bytes], codec: str) -> str:
+    """Bloque de cabeceras RFC 5322 del mensaje, sin las de estructura MIME.
+
+    Returns:
+        str: Las cabeceras de transporte originales si el ``.msg`` las guarda;
+            si no, las básicas reconstruidas. Termina en salto de línea.
+    """
+    transport = _read_string(ole, prefix, _PR_TRANSPORT_MESSAGE_HEADERS, codec)
+    if transport and transport.strip():
+        parsed = Parser().parsestr(transport.strip() + "\n\n", headersonly=True)
+        lines = [f"{name}: {value}" for name, value in parsed.items()
+                 if name.lower() not in _MIME_STRUCTURE_HEADERS]
+        return "\n".join(lines) + "\n"
+
+    sender_address = (_read_string(ole, prefix, _PR_SENDER_SMTP, codec)
+                      or _read_string(ole, prefix, _PR_SENDER_EMAIL, codec) or "")
+    sender_name = _read_string(ole, prefix, _PR_SENDER_NAME, codec) or ""
+    headers = []
+    if sender_address or sender_name:
+        headers.append(("From", formataddr((sender_name, sender_address), charset="utf-8")))
+    for header_name, property_id in (("To", _PR_DISPLAY_TO), ("Cc", _PR_DISPLAY_CC)):
+        value = _read_string(ole, prefix, property_id, codec)
+        if value:
+            headers.append((header_name, Header(value, "utf-8").encode()))
+    subject = _read_string(ole, prefix, _PR_SUBJECT, codec)
+    if subject:
+        headers.append(("Subject", Header(subject, "utf-8").encode()))
+    submitted = _systime(properties, _TAG_CLIENT_SUBMIT_TIME)
+    if submitted:
+        headers.append(("Date", format_datetime(submitted)))
+    message_id = _read_string(ole, prefix, _PR_INTERNET_MESSAGE_ID, codec)
+    if message_id:
+        headers.append(("Message-ID", message_id))
+    return "".join(f"{name}: {value}\n" for name, value in headers)
+
+
+def _body_part(ole: olefile.OleFileIO, prefix: str, properties: Dict[int, bytes], codec: str):
+    """Parte MIME con el cuerpo del mensaje (texto, HTML o los dos)."""
+    text = _read_string(ole, prefix, _PR_BODY, codec)
+    html_bytes = _read_binary(ole, prefix, _PR_HTML)
+    html = None
+    if html_bytes:
+        html = html_bytes.decode(_codec_for(_long(properties, _TAG_INTERNET_CPID), "utf-8"), errors="replace")
+    if not text and not html:
+        rtf = _read_binary(ole, prefix, _PR_RTF_COMPRESSED)
+        if rtf:
+            text = rtf_to_text(decompress_rtf(rtf))
+    parts = []
+    if text:
+        parts.append(MIMEText(text, "plain", "utf-8"))
+    if html:
+        parts.append(MIMEText(html, "html", "utf-8"))
+    if not parts:
+        return MIMEText("", "plain", "utf-8")
+    if len(parts) == 1:
+        return parts[0]
+    alternative = MIMEMultipart("alternative")
+    for part in parts:
+        alternative.attach(part)
+    return alternative
+
+
+def _is_embedded_message(ole: olefile.OleFileIO, storage: str, codec: str) -> bool:
+    """Si una carpeta ``3701000D`` es un mensaje (y no un documento OLE incrustado)."""
+    message_class = _read_string(ole, storage, _PR_MESSAGE_CLASS, codec) or ""
+    return message_class.upper().startswith("IPM") or ole.exists(storage + _PROPERTIES_STREAM)
+
+
+def _build_message(ole: olefile.OleFileIO, prefix: str, header_size: int, depth: int,
+                   attachment_count: List[int]) -> str:
+    """Reconstruye un mensaje (el raíz o uno incrustado) como texto ``.eml``.
+
+    Args:
+        ole: Contenedor abierto.
+        prefix: Ruta del mensaje dentro del contenedor.
+        header_size: Cabecera de su flujo de propiedades.
+        depth: Nivel de incrustación (0 es el raíz).
+        attachment_count: Contador compartido de adjuntos, en una lista para
+            poder sumarlo desde los mensajes incrustados.
+
+    Returns:
+        str: El mensaje en RFC 5322 / MIME.
+
+    Raises:
+        MsgConversionError: Si se superan ``MAX_ATTACHMENTS`` o
+            ``MAX_EMBEDDING_DEPTH``.
+    """
+    properties = _fixed_properties(ole, prefix, header_size)
+    codec = _codec_for(_long(properties, _TAG_MESSAGE_CODEPAGE))
+    headers = _headers_block(ole, prefix, properties, codec)
+    body = _body_part(ole, prefix, properties, codec)
+
+    attachments = []
+    for storage in _attachment_storages(ole, prefix):
+        attachment_count[0] += 1
+        if attachment_count[0] > MAX_ATTACHMENTS:
+            raise MsgConversionError(f"El .msg tiene más de {MAX_ATTACHMENTS} adjuntos.")
+        filename = (_read_string(ole, storage, _PR_ATTACH_LONG_FILENAME, codec)
+                    or _read_string(ole, storage, _PR_ATTACH_FILENAME, codec) or "adjunto")
+        embedded = storage + _EMBEDDED_MESSAGE_STORAGE + "/"
+        if ole.exists(storage + _EMBEDDED_MESSAGE_STORAGE) and _is_embedded_message(ole, embedded, codec):
+            if depth + 1 > MAX_EMBEDDING_DEPTH:
+                raise MsgConversionError(
+                    f"El .msg anida más de {MAX_EMBEDDING_DEPTH} mensajes incrustados.")
+            nested = _build_message(ole, embedded, _EMBEDDED_HEADER_SIZE, depth + 1, attachment_count)
+            part = MIMEMessage(Parser().parsestr(nested))
+            part.add_header("Content-Disposition", "attachment", filename=("utf-8", "", filename + ".eml"))
+            attachments.append(part)
+            continue
+        data = _read_binary(ole, storage, _PR_ATTACH_DATA)
+        if data is None:
+            continue  # objeto OLE incrustado sin datos que copiar
+        mime_type = (_read_string(ole, storage, _PR_ATTACH_MIME_TAG, codec)
+                     or mimetypes.guess_type(filename)[0] or "application/octet-stream")
+        maintype, _, subtype = mime_type.partition("/")
+        part = MIMEBase(maintype or "application", subtype or "octet-stream")
+        part.set_payload(data)
+        encoders.encode_base64(part)
+        content_id = _read_string(ole, storage, _PR_ATTACH_CONTENT_ID, codec)
+        part.add_header("Content-Disposition", "inline" if content_id else "attachment",
+                        filename=("utf-8", "", filename))
+        if content_id:
+            part.add_header("Content-ID", f"<{content_id.strip('<>')}>")
+        attachments.append(part)
+
+    if attachments:
+        root = MIMEMultipart("mixed")
+        root.attach(body)
+        for part in attachments:
+            root.attach(part)
+    else:
+        root = body
+    return headers + root.as_string()
+
+
+def convert_msg_to_eml(data: bytes) -> str:
+    """Convierte un ``.msg`` de Outlook en un ``.eml`` que Iris analiza como cualquier otro.
+
+    Args:
+        data: Contenido completo del ``.msg``. El llamante ya ha comprobado su
+            tamaño contra ``iris.maxMessageBytes``.
+
+    Returns:
+        str: El mensaje en RFC 5322 / MIME, con la cabecera
+            ``X-Iris-Source-Format: outlook-msg`` al final del bloque para que
+            el analista sepa que viene de una conversión.
+
+    Raises:
+        MsgConversionError: Si no es un ``.msg`` válido, o si supera
+            ``MAX_ATTACHMENTS`` o ``MAX_EMBEDDING_DEPTH``.
+    """
+    if not is_msg(data):
+        raise MsgConversionError("No es un fichero .msg de Outlook.")
+    try:
+        ole = olefile.OleFileIO(io.BytesIO(data))
+    except (OSError, ValueError, struct.error) as e:
+        raise MsgConversionError("El fichero .msg está dañado y no se puede leer.") from e
+    with ole:
+        if not ole.exists(_PROPERTIES_STREAM):
+            raise MsgConversionError("El fichero no es un mensaje de Outlook (.msg).")
+        try:
+            converted = _build_message(ole, "", _TOP_LEVEL_HEADER_SIZE, 0, [0])
+        except (OSError, struct.error) as e:
+            raise MsgConversionError("El fichero .msg está dañado y no se puede leer.") from e
+    header_end = converted.find("\n\n")
+    marker = "X-Iris-Source-Format: outlook-msg\n"
+    return converted[:header_end + 1] + marker + converted[header_end + 1:] if header_end >= 0 else marker + converted

--- a/API/tests/_iris_msg_fixtures.py
+++ b/API/tests/_iris_msg_fixtures.py
@@ -1,0 +1,205 @@
+"""Generador de ficheros ``.msg`` de Outlook para los tests del conversor.
+
+``olefile`` solo lee, así que para probar el conversor con muestras
+controladas (sin ficheros binarios de origen dudoso en el repositorio) se
+escribe aquí un *Compound File Binary* mínimo: versión 3, sectores de 512
+bytes, los flujos de menos de 4096 bytes en el *mini stream* (sectores de 64
+bytes, como manda el formato) y los demás en la FAT normal. El único atajo es
+el árbol de directorio: cada hermano cuelga del anterior en vez de formar un
+árbol rojo-negro equilibrado, algo que los lectores aceptan.
+
+No es un test: pytest no lo recoge (no empieza por ``test_``). Vive en
+``tests/`` porque el conftest de ahí pone el directorio en ``sys.path`` y así
+lo importan igual los tests unitarios y los de integración.
+"""
+
+from __future__ import annotations
+
+import struct
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Sequence, Tuple
+
+_SECTOR = 512
+_MINI_SECTOR = 64
+_MINI_CUTOFF = 4096
+_FREE, _END, _FAT = 0xFFFFFFFF, 0xFFFFFFFE, 0xFFFFFFFD
+_NO_STREAM = 0xFFFFFFFF
+
+
+def _entry(name: str, kind: int, child: int, right: int, start: int, size: int) -> bytes:
+    encoded = (name + "\x00").encode("utf-16-le")
+    return (encoded.ljust(64, b"\x00") + struct.pack("<HBB", len(encoded), kind, 1)
+            + struct.pack("<III", _NO_STREAM, right, child) + b"\x00" * 16 + b"\x00" * 4
+            + b"\x00" * 16 + struct.pack("<IQ", start, size))
+
+
+def build_cfb(streams: Dict[str, bytes]) -> bytes:
+    """Contenedor CFB con los flujos dados; las carpetas se crean solas.
+
+    Args:
+        streams: Ruta (``"a/b/flujo"``) -> contenido.
+
+    Returns:
+        bytes: El fichero completo.
+    """
+    storages = {""}
+    for path in streams:
+        parts = path.split("/")
+        for index in range(1, len(parts)):
+            storages.add("/".join(parts[:index]))
+    nodes = sorted(storages | set(streams), key=lambda path: (path.count("/"), path))
+    children: Dict[str, List[str]] = {node: [] for node in storages}
+    for node in nodes:
+        if node:
+            children[node.rsplit("/", 1)[0] if "/" in node else ""].append(node)
+
+    def order(path: str) -> Tuple[int, str]:
+        name = path.rsplit("/", 1)[-1]
+        return len(name), name.upper()
+
+    for key in children:
+        children[key].sort(key=order)
+    index_of = {node: position for position, node in enumerate(nodes)}
+
+    sectors: List[bytes] = []
+    fat: List[int] = []
+
+    def put(data: bytes, padding: bytes = b"\x00") -> int:
+        """Escribe una cadena de sectores normales y devuelve el primero."""
+        start, count = len(sectors), -(-len(data) // _SECTOR)
+        for chunk in range(count):
+            sectors.append(data[chunk * _SECTOR:(chunk + 1) * _SECTOR].ljust(_SECTOR, padding))
+            fat.append(len(sectors) if chunk < count - 1 else _END)
+        return start
+
+    mini_stream = bytearray()
+    mini_fat: List[int] = []
+    starts: Dict[str, int] = {}
+    for path in nodes:
+        data = streams.get(path) if path not in storages else None
+        if not data:
+            continue
+        if len(data) >= _MINI_CUTOFF:
+            starts[path] = put(data)
+            continue
+        starts[path] = len(mini_stream) // _MINI_SECTOR
+        count = -(-len(data) // _MINI_SECTOR)
+        for chunk in range(count):
+            mini_fat.append(len(mini_fat) + 1 if chunk < count - 1 else _END)
+        mini_stream += data.ljust(count * _MINI_SECTOR, b"\x00")
+    root_start = put(bytes(mini_stream)) if mini_stream else _END
+    first_mini_fat = put(struct.pack(f"<{len(mini_fat)}I", *mini_fat), b"\xff") if mini_fat else _END
+    mini_fat_sectors = -(-len(mini_fat) * 4 // _SECTOR)
+
+    directory = b""
+    for path in nodes:
+        siblings = children[path.rsplit("/", 1)[0] if "/" in path else ""] if path else []
+        right = index_of[siblings[siblings.index(path) + 1]] if path and siblings.index(path) + 1 < len(siblings) else _NO_STREAM
+        child = index_of[children[path][0]] if path in storages and children[path] else _NO_STREAM
+        if path == "":
+            directory += _entry("Root Entry", 5, child, _NO_STREAM, root_start, len(mini_stream))
+        elif path in storages:
+            directory += _entry(path.rsplit("/", 1)[-1], 1, child, right, _END, 0)
+        else:
+            data = streams[path]
+            directory += _entry(path.rsplit("/", 1)[-1], 2, _NO_STREAM, right,
+                                starts.get(path, _END), len(data))
+    first_directory = put(directory)
+
+    fat_sectors = 1
+    while (len(sectors) + fat_sectors) > fat_sectors * (_SECTOR // 4):
+        fat_sectors += 1
+    first_fat = len(sectors)
+    fat.extend([_FAT] * fat_sectors)
+    fat.extend([_FREE] * (fat_sectors * (_SECTOR // 4) - len(fat)))
+    fat_bytes = struct.pack(f"<{len(fat)}I", *fat)
+    for chunk in range(fat_sectors):
+        sectors.append(fat_bytes[chunk * _SECTOR:(chunk + 1) * _SECTOR])
+
+    difat = [first_fat + chunk for chunk in range(fat_sectors)] + [_FREE] * (109 - fat_sectors)
+    header = (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 16
+              + struct.pack("<HHHHH", 0x3E, 3, 0xFFFE, 9, 6) + b"\x00" * 6
+              + struct.pack("<IIIIIIIII", 0, fat_sectors, first_directory, 0, _MINI_CUTOFF,
+                            first_mini_fat, mini_fat_sectors, _END, 0)
+              + struct.pack("<109I", *difat))
+    return header + b"".join(sectors)
+
+
+def compress_rtf(raw: bytes) -> bytes:
+    """RTF comprimido válido (MS-OXRTFCP) formado solo por literales."""
+    tokens: List[bytes] = [bytes([byte]) for byte in raw]
+    end_position = (207 + len(raw)) % 4096
+    tokens.append(bytes([(end_position >> 4) & 0xFF, (end_position << 4) & 0xF0]))
+    body = bytearray()
+    for start in range(0, len(tokens), 8):
+        group = tokens[start:start + 8]
+        control = sum(1 << bit for bit, token in enumerate(group) if len(token) == 2)
+        body.append(control)
+        for token in group:
+            body += token
+    return struct.pack("<IIII", len(body) + 12, len(raw), 0x75465A4C, 0) + bytes(body)
+
+
+def _utf16(value: str) -> bytes:
+    return value.encode("utf-16-le")
+
+
+def _properties(header_size: int, submitted: Optional[datetime] = None, cpid: Optional[int] = None) -> bytes:
+    stream = b"\x00" * header_size
+    if submitted is not None:
+        filetime = int((submitted - datetime(1601, 1, 1, tzinfo=timezone.utc)).total_seconds() * 10_000_000)
+        stream += struct.pack("<IIQ", 0x00390040, 6, filetime)
+    if cpid is not None:
+        stream += struct.pack("<IIi", 0x3FDE0003, 6, cpid) + b"\x00" * 4
+    return stream
+
+
+def msg_streams(*, prefix: str = "", header_size: int = 32, subject: Optional[str] = None,
+                sender_name: Optional[str] = None, sender_email: Optional[str] = None,
+                transport_headers: Optional[str] = None, body: Optional[str] = None,
+                html: Optional[str] = None, rtf: Optional[bytes] = None,
+                submitted: Optional[datetime] = None, message_id: Optional[str] = None,
+                attachments: Sequence[dict] = (), embedded: Optional[dict] = None) -> Dict[str, bytes]:
+    """Flujos de un mensaje de Outlook (el raíz, o uno incrustado con ``prefix``).
+
+    ``attachments`` son dicts con ``filename``, ``data`` y, opcionales,
+    ``mime`` y ``content_id``. ``embedded`` son los argumentos de otro mensaje,
+    que se añade como adjunto incrustado (el «reenviar como adjunto» de Outlook).
+    """
+    streams = {prefix + "__properties_version1.0": _properties(header_size, submitted, 65001 if html else None),
+               prefix + "__substg1.0_001A001F": _utf16("IPM.Note")}
+
+    def put(property_id: str, value: Optional[str]) -> None:
+        if value is not None:
+            streams[f"{prefix}__substg1.0_{property_id}001F"] = _utf16(value)
+
+    put("0037", subject)
+    put("0C1A", sender_name)
+    put("5D01", sender_email)
+    put("007D", transport_headers)
+    put("1000", body)
+    put("1035", message_id)
+    if html is not None:
+        streams[prefix + "__substg1.0_10130102"] = html.encode("utf-8")
+    if rtf is not None:
+        streams[prefix + "__substg1.0_10090102"] = compress_rtf(rtf)
+    for index, attachment in enumerate(attachments):
+        storage = f"{prefix}__attach_version1.0_#{index:08X}/"
+        streams[storage + "__properties_version1.0"] = b"\x00" * 8
+        streams[storage + "__substg1.0_3707001F"] = _utf16(attachment["filename"])
+        streams[storage + "__substg1.0_37010102"] = attachment["data"]
+        if attachment.get("mime"):
+            streams[storage + "__substg1.0_370E001F"] = _utf16(attachment["mime"])
+        if attachment.get("content_id"):
+            streams[storage + "__substg1.0_3712001F"] = _utf16(attachment["content_id"])
+    if embedded is not None:
+        storage = f"{prefix}__attach_version1.0_#{len(attachments):08X}/"
+        streams[storage + "__properties_version1.0"] = b"\x00" * 8
+        streams[storage + "__substg1.0_3707001F"] = _utf16(embedded.get("subject") or "reenviado")
+        streams.update(msg_streams(prefix=storage + "__substg1.0_3701000D/", header_size=24, **embedded))
+    return streams
+
+
+def build_msg(**fields) -> bytes:
+    """Un ``.msg`` completo; los argumentos son los de ``msg_streams``."""
+    return build_cfb(msg_streams(**fields))

--- a/API/tests/integration/test_iris_batch.py
+++ b/API/tests/integration/test_iris_batch.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional
 from unittest import mock
 
 import pytest
+from _iris_msg_fixtures import build_msg
 
 import src.modules.system.config_reading as CR
 from src.modules.features.iris.managers import analysis as analysis_mod
@@ -88,6 +89,31 @@ def _statuses(batch) -> list:
     return [(item["filename"], item["status"]) for item in batch["items"]]
 
 
+# ---------------------------------------------------- .msg de Outlook
+
+def test_outlook_msg_files_are_converted_and_analysed(client, app, analyst):
+    """Un .msg entra en el lote como un .eml más, suelto o dentro de un ZIP, y
+    lo que se guarda es el .eml convertido: el reanálisis no vuelve a pasar por
+    el conversor. Uno dañado se rechaza con su motivo sin tumbar el resto."""
+    user, headers = analyst
+    loose = build_msg(subject="Aviso", sender_email="alertas@evil.example", body="Entre ya.",
+                      message_id="<aviso@evil.example>")
+    zipped = build_msg(subject="Otro", sender_email="otro@evil.example", body="Hola.")
+    broken = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 100
+
+    batch = _upload(client, headers, [("aviso.msg", loose), ("roto.msg", broken),
+                                      ("buzon.zip", _zip({"dentro.MSG": zipped}))]).get_json()
+
+    assert _statuses(batch) == [("aviso.msg", "created"), ("roto.msg", "rejected"),
+                                ("buzon.zip/dentro.MSG", "created")]
+    assert "dañado" in batch["items"][1]["error"]
+    with app.app_context():
+        stored = build_repository(IrisAnalysisRepository).get_by_id(batch["items"][0]["analysisId"])
+        assert stored.user_id == user.id
+        assert stored.raw_headers.startswith("From: alertas@evil.example")
+        assert "X-Iris-Source-Format: outlook-msg" in stored.raw_headers
+
+
 # -------------------------------------------------------------- resumen
 
 def test_a_batch_returns_a_summary_and_a_link_per_message(client, app, analyst):
@@ -100,7 +126,7 @@ def test_a_batch_returns_a_summary_and_a_link_per_message(client, app, analyst):
     batch = response.get_json()
     assert batch["counts"] == {"created": 2, "duplicate": 0, "rejected": 1, "failed": 0}
     assert _statuses(batch) == [("uno.eml", "created"), ("dos.eml", "created"), ("notas.txt", "rejected")]
-    assert batch["items"][2]["error"] == "No es un fichero .eml."
+    assert batch["items"][2]["error"] == "No es un fichero .eml ni .msg."
     with app.app_context():
         repo = build_repository(IrisAnalysisRepository)
         created = [repo.get_by_id(item["analysisId"]) for item in batch["items"][:2]]

--- a/API/tests/unit/test_iris_msg_converter.py
+++ b/API/tests/unit/test_iris_msg_converter.py
@@ -1,0 +1,178 @@
+"""Conversor de ``.msg`` de Outlook: la evidencia sobrevive a la conversión.
+
+Cubre el criterio de cierre: muestras de Outlook con cuerpo RTF, HTML,
+adjuntos en línea y Unicode conservan evidencia equivalente a un ``.eml``.
+Las muestras se generan aquí (``tests/_iris_msg_fixtures.py``) en vez de guardarse como
+binarios, para que cada test diga qué contiene su ``.msg``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.modules.features.iris.managers.analysis import IrisManager
+from src.modules.features.iris.services.msg_converter import (
+    MAX_EMBEDDING_DEPTH,
+    MsgConversionError,
+    convert_msg_to_eml,
+    decompress_rtf,
+    is_msg,
+    rtf_to_text,
+)
+from src.modules.features.iris.services.parsers import parse_raw_message
+
+from _iris_msg_fixtures import build_cfb, build_msg, compress_rtf
+
+pytestmark = pytest.mark.unit
+
+_TRANSPORT_HEADERS = (
+    "Received: from mail.evil.example (mail.evil.example [198.51.100.7]) by mx.example.com "
+    "with ESMTPS id x1; Mon, 07 Sep 2026 09:30:00 +0000\r\n"
+    "Authentication-Results: mx.example.com; spf=fail smtp.mailfrom=evil.example; dmarc=fail\r\n"
+    'From: "Banco Ejemplo" <alertas@evil.example>\r\n'
+    "To: cliente@example.com\r\n"
+    "Subject: =?utf-8?q?Verificaci=C3=B3n_urgente?=\r\n"
+    "Date: Mon, 07 Sep 2026 09:30:00 +0000\r\n"
+    "Message-ID: <x1@evil.example>\r\n"
+    "MIME-Version: 1.0\r\n"
+    'Content-Type: multipart/alternative; boundary="original"\r\n'
+)
+_HTML = ('<html><body><p>Su cuenta será bloqueada. Verifique aquí: '
+         '<a href="https://login.evil.example/verify">https://banco.example</a></p>'
+         '<img src="cid:logo123"></body></html>')
+
+
+# ------------------------------------------------------------- RTF
+
+def test_rtf_decompression_round_trips_and_honours_the_uncompressed_variant():
+    raw = b"{\\rtf1\\ansi Hola mundo\\par}"
+
+    assert decompress_rtf(compress_rtf(raw)) == raw
+    mela = b"".join([(len(raw) + 12).to_bytes(4, "little"), len(raw).to_bytes(4, "little"),
+                     b"MELA", b"\x00" * 4, raw])
+    assert decompress_rtf(mela) == raw
+
+
+def test_rtf_decompression_is_capped_whatever_the_header_says():
+    raw = b"A" * 5000
+
+    assert len(decompress_rtf(compress_rtf(raw), max_bytes=1000)) == 1000
+
+
+def test_rtf_to_text_keeps_the_readable_text():
+    rtf = (b"{\\rtf1\\ansi{\\fonttbl{\\f0 Arial;}}{\\*\\generator Word;}"
+           b"Pulse aqu\\'ed: https://evil.example/login\\par Caf\\u233? y m\\'e1s}")
+
+    text = rtf_to_text(rtf)
+
+    assert "Pulse aquí: https://evil.example/login" in text
+    assert "Café y más" in text
+    assert "Arial" not in text and "Word" not in text
+
+
+# ------------------------------------------------------ correo recibido
+
+def test_a_received_msg_keeps_its_original_transport_headers_and_bodies():
+    data = build_msg(
+        subject="Verificación urgente", transport_headers=_TRANSPORT_HEADERS,
+        body="Su cuenta será bloqueada. Verifique aquí: https://login.evil.example/verify",
+        html=_HTML,
+        attachments=[
+            {"filename": "logo.png", "data": b"\x89PNG\r\n\x1a\nfake", "mime": "image/png", "content_id": "logo123"},
+            {"filename": "factura_ñ.pdf", "data": b"%PDF-1.4 fake", "mime": "application/pdf"},
+        ],
+    )
+
+    eml = convert_msg_to_eml(data)
+    context = parse_raw_message(eml)
+
+    assert context.headers["from"] == '"Banco Ejemplo" <alertas@evil.example>'
+    assert "dmarc=fail" in context.headers["authentication-results"]
+    assert len(context.received_headers) == 1
+    assert "X-Iris-Source-Format: outlook-msg" in eml
+    assert "boundary=\"original\"" not in eml
+    assert [link.href for link in context.links] == ["https://login.evil.example/verify"]
+    assert "bloqueada" in context.body_text
+    by_name = {attachment.filename: attachment for attachment in context.attachments}
+    assert by_name["factura_ñ.pdf"].content == b"%PDF-1.4 fake"
+    assert by_name["logo.png"].content_type == "image/png"
+    assert "Content-ID: <logo123>" in eml
+
+
+def test_the_converted_msg_is_judged_like_the_equivalent_eml():
+    """La prueba de equivalencia: el mismo correo, como .eml y como .msg,
+    recibe el mismo veredicto y el mismo score del motor completo."""
+    eml = (_TRANSPORT_HEADERS.replace('multipart/alternative; boundary="original"', "text/html; charset=utf-8")
+           + "\r\n" + _HTML + "\r\n")
+    msg = build_msg(transport_headers=_TRANSPORT_HEADERS, html=_HTML)
+
+    direct = IrisManager.evaluate_raw(eml)
+    converted = IrisManager.evaluate_raw(convert_msg_to_eml(msg))
+
+    assert (converted["verdict"], converted["totalScore"]) == (direct["verdict"], direct["totalScore"])
+    assert converted["gateReasons"] == direct["gateReasons"]
+
+
+# ---------------------------------------------------- borrador o enviado
+
+def test_without_transport_headers_the_basic_headers_are_rebuilt():
+    data = build_msg(subject="Reunión mañana", sender_name="Ana Pérez", sender_email="ana@example.org",
+                     body="Nos vemos a las diez.", message_id="<m1@example.org>",
+                     submitted=datetime(2026, 9, 7, 9, 30, tzinfo=timezone.utc))
+
+    context = parse_raw_message(convert_msg_to_eml(data))
+
+    assert "ana@example.org" in context.headers["from"]
+    assert context.headers["message-id"] == "<m1@example.org>"
+    assert "07 Sep 2026 09:30:00" in context.headers["date"]
+    assert context.body_text.strip() == "Nos vemos a las diez."
+
+
+def test_an_rtf_only_body_is_turned_into_text():
+    data = build_msg(subject="Aviso", sender_email="x@evil.example",
+                     rtf=b"{\\rtf1\\ansi Entre en https://evil.example/login ahora\\par}")
+
+    context = parse_raw_message(convert_msg_to_eml(data))
+
+    assert "https://evil.example/login" in context.body_text
+    assert [link.href for link in context.links] == ["https://evil.example/login"]
+
+
+# ------------------------------------------------------------ reenvíos
+
+def test_an_embedded_message_becomes_a_forward_the_parser_unwraps():
+    """El «reenviar como adjunto» de Outlook incrusta el .msg original: tiene
+    que llegar al parser como message/rfc822 para que se analicen los dos."""
+    data = build_msg(
+        subject="Fwd: sospechoso", sender_email="empleado@example.com", body="Mira esto.",
+        embedded={"transport_headers": _TRANSPORT_HEADERS, "html": _HTML, "subject": "Verificación urgente"},
+    )
+
+    context = parse_raw_message(convert_msg_to_eml(data))
+
+    assert context.unwrapped_from_forward
+    assert context.headers["from"] == '"Banco Ejemplo" <alertas@evil.example>'
+    assert context.wrapper_context is not None
+
+
+def test_nesting_is_limited():
+    embedded = {"subject": "nivel", "body": "x"}
+    for _ in range(MAX_EMBEDDING_DEPTH):
+        embedded = {"subject": "nivel", "body": "x", "embedded": embedded}
+
+    with pytest.raises(MsgConversionError):
+        convert_msg_to_eml(build_msg(subject="raíz", body="x", embedded=embedded))
+
+
+# -------------------------------------------------------------- errores
+
+def test_what_is_not_a_msg_is_rejected_with_a_clear_message():
+    assert not is_msg(b"From: a@b.example\n")
+    with pytest.raises(MsgConversionError):
+        convert_msg_to_eml(b"From: a@b.example\nSubject: x\n\nhola")
+    with pytest.raises(MsgConversionError):
+        convert_msg_to_eml(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"\x00" * 100)
+    with pytest.raises(MsgConversionError, match="no es un mensaje"):
+        convert_msg_to_eml(build_cfb({"WordDocument": b"doc"}))

--- a/web/app/src/components/iris/IrisForm.vue
+++ b/web/app/src/components/iris/IrisForm.vue
@@ -4,10 +4,10 @@
       <h2>Nuevo Análisis</h2>
       <p class="form-hint">
         Arrastra un archivo .eml o pega las cabeceras, y elige qué parte del correo quieres que Iris examine.
-        Para varios correos a la vez, suelta varios .eml o un ZIP, o
+        Para varios correos a la vez o para un .msg de Outlook, suelta los ficheros o un ZIP, o
         <label class="batch-link">
           elige un lote
-          <input type="file" accept=".eml,.zip,message/rfc822,application/zip" multiple class="batch-input" @change="pickBatch" />
+          <input type="file" accept=".eml,.msg,.zip,message/rfc822,application/vnd.ms-outlook,application/zip" multiple class="batch-input" @change="pickBatch" />
         </label>.
       </p>
     </div>

--- a/web/app/src/components/iris/intake.js
+++ b/web/app/src/components/iris/intake.js
@@ -105,15 +105,26 @@ export function isZipFile(file) {
   return /\.zip$/i.test(file.name ?? '') || ['application/zip', 'application/x-zip-compressed'].includes(file.type)
 }
 
+/** ¿Es un `.msg` de Outlook? Por extensión o por el tipo MIME que le ponen
+ *  algunos sistemas (`application/vnd.ms-outlook`). */
+export function isMsgFile(file) {
+  if (!file) return false
+  return /\.msg$/i.test(file.name ?? '') || file.type === 'application/vnd.ms-outlook'
+}
+
 /**
- * ¿Se analiza como lote? Sí si llega más de un fichero o algún ZIP: un `.eml`
- * suelto sigue el camino de siempre (se carga en el formulario para elegir el
- * modo), y lo demás va a `POST /iris/analyze/batch`, que es quien decide qué
- * entra y qué se rechaza.
+ * ¿Se analiza como lote? Sí si llega más de un fichero, algún ZIP o algún
+ * `.msg`: un `.eml` suelto sigue el camino de siempre (se carga en el
+ * formulario para elegir el modo), y lo demás va a `POST /iris/analyze/batch`,
+ * que es quien decide qué entra y qué se rechaza.
+ *
+ * Un `.msg` va siempre a lote aunque llegue solo porque es un fichero binario
+ * de Outlook: el navegador no puede sacar de él las cabeceras para el
+ * formulario, y el servidor sí sabe convertirlo a `.eml`.
  */
 export function isBatchDrop(files) {
   const list = Array.from(files ?? [])
-  return list.length > 1 || list.some(isZipFile)
+  return list.length > 1 || list.some((file) => isZipFile(file) || isMsgFile(file))
 }
 
 /** Tamaño legible para el aviso que ve el usuario ("10 MB"). */

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -29,9 +29,9 @@
 
           <p class="intake-eyebrow">{{ rejecting ? 'Formato no válido' : 'Intake de evidencia' }}</p>
           <h2 class="intake-title">
-            {{ rejecting ? 'Solo se admiten archivos .eml o un ZIP' : 'Suelta el correo (o varios) para examinarlo' }}
+            {{ rejecting ? 'Solo se admiten archivos .eml, .msg o un ZIP' : 'Suelta el correo (o varios) para examinarlo' }}
           </h2>
-          <span class="intake-chip">.eml · .zip</span>
+          <span class="intake-chip">.eml · .msg · .zip</span>
         </div>
       </div>
     </Transition>
@@ -177,7 +177,7 @@ async function onDrop(e) {
   dragDepth.value = 0
 
   const files = Array.from(e.dataTransfer?.files ?? [])
-  // Varios ficheros o un ZIP van a lote: el servidor decide qué entra.
+  // Varios ficheros, un ZIP o un .msg van a lote: el servidor decide qué entra.
   if (isBatchDrop(files)) {
     await handleBatch(files)
     return
@@ -189,7 +189,7 @@ async function onDrop(e) {
   const intake = classifyIntake(file, capabilities)
   if (!intake.accepted) {
     flashReject()
-    toast.show('Solo se aceptan archivos .eml', 'error')
+    toast.show('Solo se aceptan archivos .eml, .msg o un ZIP', 'error')
     return
   }
 
@@ -267,7 +267,7 @@ async function handleSubmit(submission) {
   }
 }
 
-/** Envía un lote de .eml o ZIP y deja el panel del lote a la vista. */
+/** Envía un lote de .eml, .msg o ZIP y deja el panel del lote a la vista. */
 async function handleBatch(files) {
   if (store.batchSubmitting) return
   await store.submitBatch(files)

--- a/web/app/test/iris.intake.test.mjs
+++ b/web/app/test/iris.intake.test.mjs
@@ -23,6 +23,7 @@ import {
   isZipFile,
   formatByteLimit,
   isEmlFile,
+  isMsgFile,
   resolveMaxMessageBytes,
 } from '../src/components/iris/intake.js'
 
@@ -126,6 +127,11 @@ check('dos .eml son lote', isBatchDrop([file('a.eml', 10), file('b.eml', 10)]))
 check('un ZIP suelto es lote', isBatchDrop([file('buzon.zip', 10)]))
 check('un ZIP sin extensión se reconoce por tipo', isZipFile(file('buzon', 10, 'application/zip')))
 check('nada no es lote', !isBatchDrop([]))
+// El navegador no puede leer un .msg (es binario): lo convierte el servidor.
+check('un .msg suelto va a lote', isBatchDrop([file('aviso.msg', 10)]))
+check('un .msg en mayúsculas también', isBatchDrop([file('AVISO.MSG', 10)]))
+check('un .msg sin extensión se reconoce por tipo', isMsgFile(file('aviso', 10, 'application/vnd.ms-outlook')))
+check('un .eml no es un .msg', !isMsgFile(file('a.eml', 10)))
 
 console.log(`\n${passed} pasados, ${failed} fallidos`)
 process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## El problema

Iris analiza correos en formato `.eml`, el texto estándar de un correo (RFC 5322): cabeceras, una línea en blanco y el cuerpo en MIME. Pero quien usa Outlook, al guardar un correo desde el cliente, obtiene un `.msg`, que es otra cosa: un fichero binario de Microsoft (*Compound File Binary*, el mismo contenedor OLE que usaban los `.doc` antiguos), con una «propiedad MAPI» por flujo interno: el asunto en un flujo, el cuerpo en otro, cada adjunto en su propia carpeta… Hasta ahora ese fichero no se podía analizar sin convertirlo antes a mano.

Cierra #237 (iniciativa `F04`, Fase 3 del roadmap de Iris, #203).

## Qué cambia

**Nuevo conversor `services/msg_converter.py`.** Lee el `.msg` y reconstruye un `.eml` canónico. Desde ese punto no cambia nada del resto de Iris (parser, 46 reglas, evidencia anclada, reanálisis, exportación), porque lo que se guarda y se analiza es el `.eml`. La conversión conserva:

- **Las cabeceras originales de un correo recibido.** Outlook guarda el bloque de cabeceras de Internet tal como llegó, con `Received`, `Authentication-Results`, DKIM, `Message-ID` y `Date`, así que las reglas de autenticación y de ruta ven exactamente lo mismo que con el `.eml`. Solo se descartan las cabeceras que describían la estructura MIME original (`Content-Type` y compañía), porque el cuerpo se reconstruye con la suya. Un `.msg` sin ese bloque (un borrador o un correo enviado) recupera `From`, `To`, `Cc`, `Subject`, `Date` y `Message-ID` desde sus propiedades.
- **Los cuerpos:** texto, HTML y, cuando solo hay RTF (el formato de texto enriquecido de Microsoft, que Outlook guarda comprimido), su texto legible. La descompresión del RTF (algoritmo MS-OXRTFCP) está implementada en el propio conversor, con un tope de 4 MB de salida pase lo que pase: la cabecera del RTF declara su tamaño, y ese dato lo controla el atacante.
- **Los adjuntos,** con su nombre Unicode, su tipo y el `Content-ID` de los que van en línea (los logos que el HTML referencia con `cid:`).
- **Los mensajes incrustados.** El «reenviar como adjunto» de Outlook mete el `.msg` original dentro del otro. Ese mensaje se reconstruye como parte `message/rfc822`, que es justo lo que el parser ya sabe desenvolver, así que un reenvío de un `.msg` sospechoso se analiza como uno de `.eml`.

El `.eml` convertido lleva la cabecera `X-Iris-Source-Format: outlook-msg`, para que el analista sepa que viene de una conversión.

**Seguridad.** Nunca se ejecuta ni se interpreta el contenido de un adjunto: sus bytes se copian tal cual al `.eml`. Hay topes de 100 adjuntos y de 3 niveles de mensajes incrustados, y un `.msg` dañado se rechaza con un mensaje claro.

**Entrada: el análisis por lotes.** El issue proponía un `POST /iris/analyze/upload` nuevo o «extender explícitamente el endpoint actual». Ya existe una subida multipart de ficheros, `POST /iris/analyze/batch`, que analiza varios `.eml` o un ZIP, y es la que se extiende:

- acepta `.msg`, sueltos o dentro de un ZIP;
- el tope de tamaño se aplica al `.msg` recibido y también al `.eml` resultante, porque al pasar los adjuntos a base64 el `.eml` ocupa un tercio más;
- un `.msg` que no se puede convertir queda como elemento rechazado del lote, con su motivo, sin tumbar el resto.

Un endpoint aparte habría duplicado la lectura acotada, los límites, los duplicados y el freno de análisis en curso que el lote ya resuelve. Un `.msg` suelto es simplemente un lote de uno.

**SPA:**

- el arrastre y el selector de ficheros aceptan `.msg`;
- un `.msg` va siempre por la vía del lote aunque llegue solo: al ser binario, el navegador no puede sacar de él las cabeceras para rellenar el formulario (que es lo que hace con un `.eml`), y el servidor sí sabe convertirlo;
- los textos de la vista mencionan el nuevo formato.

## Notas

- **Dependencia: `olefile` (licencia BSD)**, para leer el contenedor CFB. El issue sugería `extract-msg`, pero su licencia es GPL, incompatible con distribuirlo dentro del producto. Además, lo que hace falta de él cabe en un módulo: leer propiedades MAPI y descomprimir el RTF.
- **`F13`** (el botón «reportar phishing», Fase 4) necesitará un endpoint de subida. Lo natural es que reutilice la misma pieza: `expand_uploads` ya acepta `.eml` y `.msg` y devuelve siempre `.eml`.

## Validación

- `test_iris_msg_converter.py` (nuevo, 10 casos). Las muestras de Outlook se generan en el propio test con `tests/_iris_msg_fixtures.py`, un escritor mínimo de CFB, en vez de guardarse como binarios en el repositorio. Así cada test dice qué lleva su `.msg`. Cubren el criterio de cierre:
  - **RTF:** descompresión de ida y vuelta, la variante sin comprimir, el tope de salida y un RTF con fuentes, grupos ocultos, escapes Windows-1252 y caracteres `\u`, del que solo queda el texto visible.
  - **HTML, adjuntos en línea y Unicode:** un `.msg` recibido conserva cabeceras de transporte, enlaces del HTML, el adjunto `factura_ñ.pdf` byte a byte y el `Content-ID` del logo.
  - **Equivalencia con `.eml`:** el mismo correo, como `.eml` y como `.msg`, recibe el mismo veredicto, la misma puntuación y los mismos motivos del motor completo.
  - **Otros casos:** el borrador sin cabeceras de transporte, el cuerpo que solo trae RTF, el reenvío incrustado que el parser desenvuelve, el tope de anidamiento y el rechazo de lo que no es un `.msg` (texto, un CFB vacío, un documento de Word).
- `test_iris_batch.py`: un `.msg` suelto y otro dentro de un ZIP se analizan, uno dañado se rechaza con su motivo, y lo guardado es el `.eml` convertido con su marca de origen.
- `test_code_conventions.py` en verde.
- Suite completa (`pytest`): 3312 pasados, 50 omitidos.
- SPA: `node test/iris.intake.test.mjs` (36 casos, 4 nuevos) en verde; `IrisForm.vue` e `IrisView.vue` compilan con `@vue/compiler-sfc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
