### PR TITLE
Iris: accesos a subpáginas en una barra horizontal y transiciones en el panel de análisis

### DIFF
--- a/web/app/src/components/iris/IrisBatchPanel.vue
+++ b/web/app/src/components/iris/IrisBatchPanel.vue
@@ -1,4 +1,5 @@
 <template>
+  <Transition name="batch-slide">
   <section v-if="batch" class="batch-panel" aria-live="polite">
     <header class="batch-header">
       <div>
@@ -40,6 +41,7 @@
       </table>
     </div>
   </section>
+  </Transition>
 </template>
 
 <script setup>
@@ -82,4 +84,14 @@ const finishedCount = computed(() => tracked.value.filter(item => TERMINAL.inclu
 .item-error { display: block; margin-top: 0.2rem; color: var(--text-muted); }
 .link-btn { border: none; background: none; padding: 0; color: var(--accent-bright); cursor: pointer; font-size: var(--fs-sm); }
 .muted { color: var(--text-muted); }
+
+/* El panel empuja el informe hacia abajo: entra y sale deslizándose para que
+   ese salto no ocurra de golpe. */
+.batch-slide-enter-active { transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.22, 1, 0.36, 1); }
+.batch-slide-leave-active { transition: opacity 0.15s ease, transform 0.15s ease; }
+.batch-slide-enter-from, .batch-slide-leave-to { opacity: 0; transform: translateY(-6px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .batch-slide-enter-active, .batch-slide-leave-active { transition: none; }
+}
 </style>

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="report-viewer">
 
+    <!-- Un fundido entre estados: sin él, Vue cambia formulario, carga e
+         informe en el mismo fotograma y todo aparece de golpe. -->
+    <Transition name="rv-swap" mode="out-in">
     <!-- EMPTY -- no selection, show form -->
     <div v-if="!reportId && !reportData && !reportLoading" class="rv-empty">
       <slot name="form" />
@@ -46,7 +49,8 @@
     </div>
 
     <!-- FINISHED REPORT -->
-    <div v-else-if="reportData && reportData.status === 'finished'" class="rv-report">
+    <!-- La key hace que pasar de un informe terminado a otro también se anime. -->
+    <div v-else-if="reportData && reportData.status === 'finished'" :key="reportData.analysisId" class="rv-report">
       <div class="rv-report-header">
         <div class="rv-report-id">
           <span v-if="reportData.title" class="report-title">{{ reportData.title }}</span>
@@ -380,6 +384,7 @@
       </div>
 
     </div>
+    </Transition>
 
     <!-- Informes PDF (modal, fuera del flujo de scroll del informe) -->
     <IrisDocumentsModal
@@ -1411,5 +1416,41 @@ watch(
 .btn-export-csv svg {
   width: 16px;
   height: 16px;
+}
+
+/* Fundido entre estados del visor (formulario, carga, en curso, informe). */
+.rv-swap-enter-active {
+  transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.rv-swap-leave-active {
+  transition: opacity 0.15s ease;
+}
+.rv-swap-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+.rv-swap-leave-to {
+  opacity: 0;
+}
+
+/* Entrada escalonada de las secciones del informe, con la misma animación
+   que la tira de historial. De la novena en adelante comparten retraso: al
+   abrir quedan por debajo del pliegue y hacerlas esperar más no aporta. */
+.rv-report > * {
+  animation: seq-fade-up 0.35s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+}
+.rv-report > :nth-child(2) { animation-delay: 0.04s; }
+.rv-report > :nth-child(3) { animation-delay: 0.08s; }
+.rv-report > :nth-child(4) { animation-delay: 0.12s; }
+.rv-report > :nth-child(5) { animation-delay: 0.16s; }
+.rv-report > :nth-child(6) { animation-delay: 0.2s; }
+.rv-report > :nth-child(7) { animation-delay: 0.24s; }
+.rv-report > :nth-child(8) { animation-delay: 0.28s; }
+.rv-report > :nth-child(n+9) { animation-delay: 0.32s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rv-swap-enter-active, .rv-swap-leave-active { transition: none; }
+  .rv-swap-enter-from { transform: none; }
+  .rv-report > * { animation: none; }
 }
 </style>

--- a/web/app/src/views/IrisView.vue
+++ b/web/app/src/views/IrisView.vue
@@ -58,25 +58,29 @@
         @select="store.selectAnalysis"
       />
 
-      <router-link to="/iris/conexiones" class="back-link connections-link">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <rect x="2" y="4" width="20" height="16" rx="2" />
-          <path d="m2 7 10 6 10-6" />
-        </svg>
-        Conexiones de buzón
-      </router-link>
-      <router-link to="/iris/confianza" class="back-link connections-link">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-        </svg>
-        Remitentes de confianza
-      </router-link>
-      <router-link to="/iris/casos" class="back-link connections-link">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-          <rect x="3" y="7" width="18" height="13" rx="2" /><path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
-        </svg>
-        Casos
-      </router-link>
+      <!-- Accesos a las subpáginas de Iris: una sola fila, no un hijo suelto
+           por enlace de la columna flex de .iris-layout. -->
+      <nav class="iris-subnav" aria-label="Secciones de Iris">
+        <router-link to="/iris/conexiones" class="back-link">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="2" y="4" width="20" height="16" rx="2" />
+            <path d="m2 7 10 6 10-6" />
+          </svg>
+          Conexiones de buzón
+        </router-link>
+        <router-link to="/iris/confianza" class="back-link">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+          Remitentes de confianza
+        </router-link>
+        <router-link to="/iris/casos" class="back-link">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="7" width="18" height="13" rx="2" /><path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
+          </svg>
+          Casos
+        </router-link>
+      </nav>
 
       <main class="iris-main">
         <IrisReportViewer
@@ -301,9 +305,12 @@ async function handleDelete(id) {
 }
 
 /* .back-link ya trae tipografía/color/hover del sistema de diseño
-   (assets/css/shared.css) — solo se ajusta la posición dentro del layout. */
-.connections-link {
-  align-self: flex-end;
+   (assets/css/shared.css) — la barra solo los coloca en fila. */
+.iris-subnav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.25rem;
   margin: 0.5rem 1rem 0;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Resumen

Dos arreglos de presentación en la vista de análisis de Iris (`/iris/analisis`), la pantalla donde se pega o arrastra un correo y se lee su informe de phishing:

1. **Los accesos a las subpáginas ya no se apilan.** Los enlaces a «Conexiones de buzón», «Remitentes de confianza» y «Casos» ocupaban tres filas sueltas, pegadas a la derecha, entre la tira de historial y el informe. Ahora forman una sola barra horizontal.
2. **El panel principal anima sus cambios.** Al elegir un correo en la tira superior, al lanzar un análisis o al terminar uno, el contenido aparecía de golpe. Ahora cada cambio es un fundido corto y las secciones del informe entran escalonadas, como ya hacían otras partes de Iris.

## Issue relacionado

Closes #600

## Implementación

**1. Barra de accesos (`IrisView.vue`).** El contenedor de la vista es una columna flex: apila la tira de historial, el panel de lote y el informe. Los tres enlaces eran hijos directos de esa columna y cada uno llevaba `align-self: flex-end`, heredado de cuando solo existía el de «Conexiones», así que cada enlace ocupaba su propia fila. Ahora van dentro de un `<nav aria-label="Secciones de Iris">` en fila, alineado a la derecha y con salto de línea en pantallas estrechas. Los enlaces conservan la clase compartida `back-link`, así que su tipografía y su hover no cambian.

**2. Transiciones del visor (`IrisReportViewer.vue`).** El visor elige qué enseñar con una cadena de `v-if` (formulario → cargando → en análisis → fallido → cancelado → informe). Sin transición, Vue sustituye un bloque por otro en el mismo fotograma.
- La cadena va envuelta en un `<Transition mode="out-in">`: el estado anterior se desvanece (150 ms) antes de que entre el nuevo (250 ms, con un desplazamiento vertical de 6 px).
- El bloque del informe lleva `:key` por análisis. Sin ella, pasar de un informe terminado a otro reutilizaría el mismo elemento y no habría nada que animar.
- Las secciones del informe entran escalonadas cada 40 ms con la animación compartida `seq-fade-up`, la misma que usan la tira de historial y las tarjetas de buzón. De la novena sección en adelante comparten retraso: al abrir el informe quedan por debajo del pliegue, y hacerlas esperar más no aporta nada.

**3. Panel de lote (`IrisBatchPanel.vue`).** El panel que sigue el progreso de un lote de correos empujaba el informe hacia abajo de golpe al aparecer. Ahora entra y sale con un fundido y un deslizamiento corto.

Las tres animaciones se desactivan con `prefers-reduced-motion`, así que quien tenga las animaciones apagadas en el sistema no las ve.

## Validación

- **Suites del SPA:** pasan las ocho que no dependen de Acheron (`test:hygeia`, `polling`, `element-width`, `toast`, `quiz`, `logs`, `iris`, `themis`).
- **Comprobación en el navegador:** con el servidor de desarrollo de Vite y las respuestas de la API simuladas en la página.
  - Escritorio: los tres enlaces quedan en una fila.
  - Móvil (375 px): la barra pasa a dos líneas, sin scroll horizontal.
  - Al pasar de un informe a otro, se registró la secuencia de clases de `<Transition>` (sale el informe, entra y sale el spinner, entra el nuevo informe) y el estado final queda limpio.
  - Los retrasos escalonados de las secciones van de 0 s a 0,32 s.
  - El panel de lote entra y sale con sus clases de transición.

### Lo que no se pudo ejecutar

`npm run build` y `npm test` completos fallan en esta máquina por un problema de entorno ajeno al cambio: el paquete `@projectellysia/acheron-core-web`, declarado en `package.json` (2.0.0), no está instalado en `node_modules`. Lo importan `LoginView.vue` y el test de Acheron. La compilación de Vite sí transforma los 324 módulos, y los tres componentes tocados compilan en el servidor de desarrollo. El CI, que instala las dependencias, debería cubrirlo.

## Notas

- **Fuera de alcance, a propósito:**
  - Rediseñar la tira de historial o el formulario.
  - Sustituir el spinner de carga por un esqueleto: el único esqueleto que existe es local a Acheron.
  - La posición fija de la flecha derecha de la tira (`right: 150px`), que depende del ancho del botón «Archivo».
- **Visto de paso en móvil, sin tocar:** la insignia «Análisis de cabeceras» de la barra superior se parte en tres líneas, y la cabecera del informe se aprieta. Son anteriores a este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
