### PR TITLE
La interfaz habla el idioma del usuario: fuera «cubos», «host_down», heartbeats y veredictos en inglés

### DIFF
--- a/CONVENCIONES.md
+++ b/CONVENCIONES.md
@@ -1,7 +1,8 @@
 # Convenciones de código — Ellysia
 
 Este documento responde a una sola pregunta: **si tengo que crear esto, ¿dónde lo creo, cómo lo creo
-y qué entidad le doy?** Cubre el backend (`API/`), que es donde vive casi todo el código.
+y qué entidad le doy?** Cubre el backend (`API/`), que es donde vive casi todo el código; los textos
+que el SPA pone delante del usuario tienen su propia sección ([§ 12](#12-textos-de-la-interfaz)).
 
 Lo operativo —comandos, arquitectura, configuración, «cosas que muerden»— sigue en
 [`CLAUDE.md`](CLAUDE.md). La regla de docstrings también vive allí (§ *Documentación de funciones,
@@ -26,6 +27,7 @@ lista, se adapta en el mismo cambio.
 9. [Constantes y configuración](#9-constantes-y-configuración)
 10. [Nombres](#10-nombres)
 11. [Estado actual y cumplimiento](#11-estado-actual-y-cumplimiento)
+12. [Textos de la interfaz](#12-textos-de-la-interfaz)
 
 ---
 
@@ -49,6 +51,7 @@ lista, se adapta en el mismo cambio.
 | Una excepción de dominio | clase `<Algo>Error` | `<módulo>/exceptions.py` |
 | Hablar con un proveedor de IA o de correo | estrategia | `tools/scribe/` o `tools/herald/` |
 | Un módulo de feature nuevo | paquete completo ([§ 3.1](#31-anatomía-de-un-módulo)) | `features/<nombre>/` + blueprint en `run.py` + `web/Caddyfile` + `web/app/vite.config.js` |
+| Un texto que ve el usuario (etiqueta, aviso, estado vacío, tooltip) | lenguaje del usuario; los enums, por un rótulo compartido | el `.vue` + `web/app/src/components/<módulo>/<tema>.js` ([§ 12](#12-textos-de-la-interfaz)) |
 
 ---
 
@@ -971,3 +974,72 @@ comprueba los dos sentidos:
 - que detecta un caso que debe detectar, como un `uow.session.add(x)` dentro de un manager;
 - que no detecta uno que no debe, como la misma llamada dentro de un `FooRepository`, o un
   `_método` abstracto.
+
+---
+
+## 12. Textos de la interfaz
+
+La única sección que no trata del backend. Rige todo lo que el SPA (`web/app/`) pone delante del
+usuario: etiquetas, leyendas, avisos, estados vacíos, tooltips, toasts y el texto accesible
+(`aria-label`, `.sr-only`).
+
+La interfaz la usan personas técnicas y no técnicas. Enseñarles cómo funciona Ellysia por dentro no
+ayuda a ninguna de las dos: a quien no es técnico le confunde, y a quien lo es le añade ruido visual
+sin darle ninguna decisión que tomar.
+
+### 12.1 La pregunta que decide
+
+**¿Esto describe algo del usuario —su equipo, su correo, su escaneo— o describe cómo funciona
+Ellysia?**
+
+- **Del usuario** → se muestra, con su nombre estándar. CPU, swap, kernel, el PID de un proceso, un
+  puerto abierto, SPF o una CVE son hechos de lo que el usuario vigila, y un técnico los busca por
+  ese nombre. No se rebajan.
+- **De Ellysia** → no llega a la pantalla.
+
+| Vocabulario de implementación | Así no | Así sí |
+|---|---|---|
+| Cómo se agregan o se muestrean los datos | «235 cubos», «cubos de 5 min» | nada: la gráfica ya enseña el periodo |
+| Cómo viajan los datos | «Último heartbeat hace 4 s» | «Última señal hace 4 s» |
+| Valores de enum y claves internas | `host_down`, `cpu.usagePct`, `content_analysis` | su rótulo: «caída detectada», «Contenido» |
+| Estados y códigos en inglés | `running`, `Suspicious` | «En análisis», «Sospechoso» |
+| Ids internos que el usuario no usa para nada | «Análisis iniciado (escaneo 1234)» | «Análisis iniciado» |
+| Motores y piezas internas fuera de la pantalla que los presenta | «Analizar con Lybra» en Hygeia, «el motor está pesando las pruebas» | lo que hace: «Buscar vulnerabilidades» |
+| La herramienta hablando de sí misma | «No es un fallo del panel» | hablar del equipo: «en este periodo no ha enviado datos» |
+
+Un id sí se muestra cuando es la forma de referirse a algo que no tiene otro nombre («Análisis
+#12» si no tiene título). Lo que sobra es el id que acompaña a un texto que ya se entiende sin él.
+
+### 12.2 Todo valor de enum pasa por un rótulo
+
+- Un valor que el servidor manda de un conjunto cerrado (estado, tipo, veredicto, categoría) se
+  pinta **siempre** a través de un mapa valor → rótulo en castellano. Nunca `{{ item.status }}`.
+- Un valor que el mapa no conoce cae en un **rótulo genérico** («Anomalía», «Desconocido»), nunca
+  en el crudo. `LABELS[value] || value` es justo lo que no: el día que el servidor añada un valor
+  nuevo, la pantalla tiene que seguir leyéndose en castellano.
+- Un mapa que usan varios componentes vive en un fichero compartido del módulo del SPA
+  (`components/<módulo>/<tema>.js`), no copiado en cada `.vue`. Las copias locales divergen, y
+  cuando se traduce una, la de al lado sigue en inglés. Es la escalera de
+  [§ 6.2](#62-la-escalera-dónde-vive-una-función-según-quién-la-use) aplicada al frontend; ejemplos:
+  `components/hygeia/format.js`, `components/iris/verdict.js`.
+
+### 12.3 El detalle técnico, en segunda capa
+
+Lo que sí le sirve a un usuario técnico —el código exacto de un resultado SPF, el id estable de una
+regla, la fuente de un sensor— no se elimina: baja a una segunda capa que el usuario tiene que pedir
+(el `title` de un elemento, un detalle desplegado). La primera lectura es para todos; la segunda,
+para quien la busca.
+
+### 12.4 Qué queda fuera
+
+- **Vistas de operador** (`ConfigView`, `QueueView`, `LogsView`, `AdminPlansView`,
+  `IrisReplayView`). Las usa quien opera el despliegue, y ahí «workers», «Redis» o «latidos
+  sostenidos» son precisamente lo que se configura.
+- **Lo que el usuario tiene que copiar a otro sistema.** La clave de agente y su fragmento de
+  configuración son el dato, no ruido.
+- **El código.** La regla es sobre lo que ve el usuario: dentro del código, `bucketSec` sigue
+  llamándose `bucketSec` y los comentarios siguen siendo técnicos.
+
+Ningún test la hace cumplir, a propósito: es una regla de significado, no de sintaxis, y una lista
+negra de palabras sobre las plantillas daría una falsa sensación de cobertura (los textos se montan
+tanto en la plantilla como en el script). Se aplica en la revisión.

--- a/README.md
+++ b/README.md
@@ -500,8 +500,8 @@ cd web/app
 npm test                  # all nine suites — this is what CI runs
 
 npm run test:acheron      # schema/label correspondence + crypto interop + CRUD + sync for the Acheron vault client
-npm run test:iris         # file intake (size limit from GET /iris/capabilities, explicit mode, batch drops) and report comparison
-npm run test:hygeia       # metric-formatting tests for the Hygeia dashboard
+npm run test:iris         # file intake (size limit from GET /iris/capabilities, explicit mode, batch drops), report comparison, and the Spanish labels for verdicts, statuses and rule results
+npm run test:hygeia       # metric formatting, chart math, and asset-status/anomaly labels for the Hygeia dashboard
 npm run test:polling      # usePolling composable tests
 npm run test:element-width # useElementWidth composable tests
 npm run test:toast        # toast-store tests

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -15,7 +15,7 @@
     "test:toast": "node test/toastStore.test.mjs",
     "test:quiz": "node test/aegis.quizShuffle.test.mjs",
     "test:logs": "node test/logTransport.test.mjs && node test/logWindows.test.mjs",
-    "test:iris": "node test/iris.intake.test.mjs && node test/iris.compare.test.mjs",
+    "test:iris": "node test/iris.intake.test.mjs && node test/iris.compare.test.mjs && node test/iris.verdict.test.mjs",
     "test:themis": "node test/themis.scanWindow.test.mjs"
   },
   "dependencies": {

--- a/web/app/src/components/hygeia/AssetDetail.vue
+++ b/web/app/src/components/hygeia/AssetDetail.vue
@@ -7,10 +7,10 @@
     <header class="detail-head">
       <div class="head-id">
         <h3 class="detail-host">{{ asset.hostname }}</h3>
-        <p class="detail-seen">Último heartbeat {{ timeAgo(asset.lastSeenAt) }}</p>
+        <p class="detail-seen">Última señal {{ timeAgo(asset.lastSeenAt) }}</p>
       </div>
       <span class="status" :class="`status--${asset.status}`">
-        <span class="status-dot" aria-hidden="true"></span>{{ statusLabel(asset.status) }}
+        <span class="status-dot" aria-hidden="true"></span>{{ assetStatusLabel(asset.status) }}
       </span>
     </header>
 
@@ -198,14 +198,14 @@
         <section v-if="nets.length" class="section">
           <h4 class="section-title">
             Red
-            <span class="hint">el gráfico suma solo las no-loopback</span>
+            <span class="hint">el gráfico no cuenta el tráfico interno del propio equipo</span>
           </h4>
           <ul class="rows">
             <li v-for="n in nets" :key="n.iface" class="row row--net">
               <span class="row-name" :title="n.iface">{{ n.iface }}</span>
               <span class="row-value">↓ {{ rate(n.rxBytesPerSec).text }} <small>{{ rate(n.rxBytesPerSec).unit }}</small></span>
               <span class="row-value">↑ {{ rate(n.txBytesPerSec).text }} <small>{{ rate(n.txBytesPerSec).unit }}</small></span>
-              <span v-if="errorsOf(n)" class="row-note row-note--bad">{{ errorsOf(n) }} err</span>
+              <span v-if="errorsOf(n)" class="row-note row-note--bad">{{ errorsOf(n) }} {{ errorsOf(n) === 1 ? 'error' : 'errores' }}</span>
             </li>
           </ul>
         </section>
@@ -290,13 +290,13 @@
                 <span class="analysis-text">
                   <template v-if="analysisRunning">Analizando el inventario…</template>
                   <template v-else-if="analysis.vulnerableCount">
-                    {{ analysis.vulnerableCount }} {{ analysis.vulnerableCount === 1 ? 'paquete' : 'paquetes' }} con CVE conocida
+                    {{ analysis.vulnerableCount }} {{ analysis.vulnerableCount === 1 ? 'paquete' : 'paquetes' }} con vulnerabilidades conocidas
                   </template>
                   <template v-else>Sin vulnerabilidades conocidas</template>
                 </span>
               </template>
               <span v-else class="analysis-text analysis-text--muted">
-                Sin analizar contra la base de vulnerabilidades
+                Aún no se han buscado vulnerabilidades
               </span>
             </div>
 
@@ -311,7 +311,7 @@
                 @click="$emit(hasAnalysis ? 'reanalyze' : 'analyze')"
               >
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" :class="{ spin: analyzing }"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-                {{ hasAnalysis ? 'Volver a analizar' : 'Analizar con Lybra' }}
+                {{ hasAnalysis ? 'Volver a analizar' : 'Buscar vulnerabilidades' }}
               </button>
             </div>
           </div>
@@ -364,13 +364,15 @@
         <TransitionGroup v-else tag="ul" name="anomaly-row" class="anomalies">
           <li v-for="a in anomalies" :key="a.id" class="anomaly" :class="`anomaly--${a.severity}`">
             <div class="anomaly-top">
-              <span class="anomaly-kind">{{ kindLabel(a.kind) }}</span>
+              <span class="anomaly-kind">{{ anomalyKindLabel(a.kind) }}</span>
               <span class="anomaly-state" :class="`anomaly-state--${a.state}`">{{ stateLabel(a.state) }}</span>
             </div>
 
             <p v-if="a.metric" class="anomaly-reading">
               <span class="reading-value">{{ a.value }}%</span>
-              <span class="reading-ctx">{{ a.metric }} · umbral {{ a.threshold }}%</span>
+              <!-- Sin `a.metric`: es la clave interna (`cpu.usagePct`), y el
+                   tipo de arriba ya dice de qué métrica se trata. -->
+              <span class="reading-ctx">umbral {{ a.threshold }}%</span>
             </p>
 
             <p class="anomaly-time">Abierta {{ timeAgo(a.openedAt) }}</p>
@@ -395,7 +397,8 @@ import AssetTabs from '@/components/hygeia/AssetTabs.vue'
 import { WINDOW_PRESETS, bucketForWindow } from '@/components/hygeia/chartMath'
 import { useUtils } from '@/composables/useUtils'
 import {
-  classifyPower, describePowerPeriod, fmtBytes, fmtPct, fmtRate, fmtWatts, timeAgo,
+  anomalyKindLabel, assetStatusLabel, classifyPower, describePowerPeriod,
+  fmtBytes, fmtPct, fmtRate, fmtWatts, timeAgo,
 } from './format'
 
 const props = defineProps({
@@ -605,17 +608,15 @@ function free(disk) { return fmtBytes(disk.freeBytes) }
 function rate(value) { return fmtRate(value) }
 function errorsOf(iface) { return (iface.errIn ?? 0) + (iface.errOut ?? 0) }
 
-const STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inestable', offline: 'Caído' }
-function statusLabel(status) { return STATUS_LABELS[status] || status }
-
-const KIND_LABELS = {
-  cpu_spike: 'Pico de CPU', mem_high: 'Memoria alta', swap_thrash: 'Swap saturado',
-  disk_full: 'Disco lleno', host_down: 'Host caído',
-}
-function kindLabel(kind) { return KIND_LABELS[kind] || kind }
-
 const STATE_LABELS = { open: 'Abierta', acknowledged: 'Reconocida', resolved: 'Resuelta' }
-function stateLabel(state) { return STATE_LABELS[state] || state }
+
+/**
+ * Rótulo del estado de gestión de una anomalía.
+ *
+ * @param {string|null} state - `open`, `acknowledged` o `resolved`.
+ * @returns {string} El rótulo del estado, o «Desconocido» si no se conoce.
+ */
+function stateLabel(state) { return STATE_LABELS[state] || 'Desconocido' }
 </script>
 
 <style scoped>

--- a/web/app/src/components/hygeia/AssetDetail.vue
+++ b/web/app/src/components/hygeia/AssetDetail.vue
@@ -53,10 +53,10 @@
          role="tabpanel" id="panel-graficas" aria-labelledby="tab-graficas" tabindex="0">
       <section class="section">
         <h4 class="section-title">Constantes</h4>
-        <!-- Silueta de una sola tarjeta de gráfica, con el alto real de la
-             nueva MetricsChart (cabecera, gráfico de 214px, eje X, pie y
-             nota de ventana). Si esa tarjeta cambia de alto, este número
-             deja de cuadrar y vuelve el salto. -->
+        <!-- Silueta de una sola tarjeta de gráfica, con el alto real de
+             MetricsChart (cabecera, gráfico de 214px, eje X, leyenda y pie).
+             Si esa tarjeta cambia de alto, este número deja de cuadrar y
+             vuelve el salto. -->
         <div v-if="metricsLoading" class="vitals-ghost" aria-busy="true" aria-label="Cargando métricas">
           <span class="skeleton vital-ghost" aria-hidden="true"></span>
         </div>
@@ -641,11 +641,12 @@ function stateLabel(state) { return STATE_LABELS[state] || state }
 }
 .status-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 
-/* 380px es el alto medido de una .metric-card de MetricsChart (cabecera,
-   gráfico de 214px, eje X, leyenda, pie y nota de ventana). Si esa tarjeta
-   cambia de alto, este número deja de cuadrar y vuelve el salto. */
+/* 353px es el alto de una .metric-card de MetricsChart (cabecera, gráfico
+   de 214px, eje X, leyenda y pie), sin el aviso de serie recortada, que
+   solo aparece cuando falta parte del periodo. Si esa tarjeta cambia de
+   alto, este número deja de cuadrar y vuelve el salto. */
 .vitals-ghost { display: flex; flex-direction: column; gap: 0.85rem; }
-.vital-ghost { height: 380px; border-radius: 8px; }
+.vital-ghost { height: 353px; border-radius: 8px; }
 .inventory-ghost { display: flex; flex-direction: column; gap: 0.55rem; margin-top: 0.6rem; }
 .status--pending { color: var(--text-muted); }
 .status--online  { color: var(--success); }

--- a/web/app/src/components/hygeia/AssetList.vue
+++ b/web/app/src/components/hygeia/AssetList.vue
@@ -67,7 +67,7 @@
 
     <div v-else-if="!assets.length" class="state-empty">
       <p class="empty-title">Ningún activo todavía</p>
-      <p class="empty-sub">Da de alta el primero para empezar a recibir sus heartbeats.</p>
+      <p class="empty-sub">Da de alta el primero para empezar a vigilarlo.</p>
       <button class="btn-new" @click="$emit('create')">Nuevo activo</button>
     </div>
 
@@ -148,7 +148,7 @@ import { computed, ref } from 'vue'
 import { RouterLink } from 'vue-router'
 import TagBadge from './TagBadge.vue'
 import { hueOf } from './tagColors'
-import { timeAgo } from './format'
+import { assetStatusLabel, timeAgo } from './format'
 
 const props = defineProps({
   assets: { type: Array, default: () => [] },
@@ -203,8 +203,6 @@ function shownTags(asset) {
   return (asset.tags ?? []).slice(0, MAX_ROW_TAGS)
 }
 
-const STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inestable', offline: 'Caído' }
-
 /**
  * Un activo que se apaga a propósito no está "caído": pintarlo en rojo sería
  * exactamente el ruido que su marca elimina. El estado es el mismo (`offline`),
@@ -212,7 +210,7 @@ const STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inest
  */
 function statusLabel(asset) {
   if (asset.status === 'offline' && asset.isPersistent === false) return 'Apagado'
-  return STATUS_LABELS[asset.status] || asset.status
+  return assetStatusLabel(asset.status)
 }
 
 function pulseClass(asset) {

--- a/web/app/src/components/hygeia/InventoryAnalysisModal.vue
+++ b/web/app/src/components/hygeia/InventoryAnalysisModal.vue
@@ -15,20 +15,19 @@
 
             <template v-else>
               <div class="summary-head">
-                <span class="scan-id mono">#{{ analysis.scanId }}</span>
-                <span class="scan-status" :class="analysis.status">{{ STATUS_LABEL[analysis.status] || analysis.status }}</span>
+                <span class="scan-status" :class="analysis.status">{{ STATUS_LABEL[analysis.status] || 'Desconocido' }}</span>
                 <span class="scan-date">{{ fmtDate(analysis.finishedAt || analysis.startedAt) }}</span>
               </div>
 
               <p v-if="isRunning" class="state-msg">
-                El motor está pesando las pruebas… el resumen se actualizará solo al terminar.
+                Analizando el software instalado… el resumen se actualizará solo al terminar.
               </p>
 
               <template v-else>
                 <div class="totals">
                   <div class="total">
                     <span class="total-value">{{ analysis.vulnerableCount ?? 0 }}</span>
-                    <span class="total-label">con CVE conocida</span>
+                    <span class="total-label">con vulnerabilidad conocida</span>
                   </div>
                   <div class="total">
                     <span class="total-value">{{ analysis.confirmedCount ?? 0 }}</span>
@@ -132,7 +131,6 @@ function fmtDate(iso) {
 
 .summary-head { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
 .mono { font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); }
-.scan-id { font-size: var(--fs-md); color: var(--text-muted); }
 .scan-status { font-size: var(--fs-md); font-weight: 600; padding: 0.12rem 0.45rem; border-radius: 5px; }
 .scan-status.finished { color: var(--success); background: var(--success-dim); }
 .scan-status.running, .scan-status.pending { color: var(--info); background: var(--info-dim); }

--- a/web/app/src/components/hygeia/MetricsChart.vue
+++ b/web/app/src/components/hygeia/MetricsChart.vue
@@ -136,7 +136,7 @@
 
     <p v-if="gaps.length || anomalyBands.length" class="plot-legend">
       <span v-if="gaps.length" class="legend-item"><i class="swatch swatch--gap"></i>sin señal</span>
-      <span v-if="anomalyBands.length" class="legend-item"><i class="swatch swatch--hostdown"></i>incidente host_down</span>
+      <span v-if="anomalyBands.length" class="legend-item"><i class="swatch swatch--hostdown"></i>caída detectada</span>
       <!-- Al final y empujada con margin-left:auto, para que quede al borde
            derecho por muchas entradas que tenga la leyenda. -->
       <span v-if="gapSummary" class="legend-total">{{ gapSummary }}</span>
@@ -146,10 +146,14 @@
       <span class="stat"><b>{{ maxLabel }}</b> máx</span>
       <span class="stat"><b>{{ avgLabel }}</b> media</span>
       <span class="stat"><b>{{ minLabel }}</b> mín</span>
-      <span class="stat stat--reads">{{ reads }}</span>
     </footer>
 
-    <p class="metric-window-note">{{ windowNote }}</p>
+    <!-- Cuántos puntos hay o de cuánto es cada cubo es cosa de cómo se
+         dibuja, no del equipo (CONVENCIONES.md § 12): no se cuenta. Lo único
+         que el usuario necesita saber es si le falta parte del periodo. -->
+    <p v-if="truncated" class="metric-window-note">
+      Hay más datos de los que caben: el gráfico muestra solo una parte del periodo.
+    </p>
     <p class="sr-only">{{ srText }}</p>
   </article>
 
@@ -168,7 +172,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useElementWidth } from '@/composables/useElementWidth'
-import { timeAgo } from './format'
+import { anomalyKindLabel, timeAgo } from './format'
 import {
   DEFAULT_WINDOW_MS, detectGaps, fmtDuration, formatTimeTick, formatValue,
   gapThresholdMs, medianDeltaMs, plotWidthForAxis, seriesOf, splitAtRanges, timeTicks,
@@ -313,7 +317,7 @@ const anomalyBands = computed(() =>
         ? Math.min(new Date(a.resolvedAt).getTime(), t1.value)
         : t1.value
       if (!Number.isFinite(start) || end <= start) return null
-      return { start, end, title: `host_down: ${fmtDuration(end - start)}` }
+      return { start, end, title: `Caída detectada · ${fmtDuration(end - start)}` }
     })
     .filter(Boolean)
 )
@@ -341,7 +345,7 @@ const anomalyMarks = computed(() =>
     .map((a) => {
       const at = new Date(a.openedAt).getTime()
       if (!Number.isFinite(at) || at < t0.value || at > t1.value) return null
-      return { at, title: `${a.kind} · ${formatValue(metric.value.fmt(a.value))}` }
+      return { at, title: `${anomalyKindLabel(a.kind)} · ${formatValue(metric.value.fmt(a.value))}` }
     })
     .filter(Boolean)
 )
@@ -359,25 +363,12 @@ const avgLabel = computed(() => formatValue(metric.value.fmt(
   values.value.reduce((a, b) => a + b, 0) / values.value.length,
 )))
 
-const reads = computed(() => {
-  const n = points.value.length
-  if (props.bucketSec) return n === 1 ? '1 cubo' : `${n} cubos`
-  return n === 1 ? '1 lectura' : `${n} lecturas`
-})
-
-const windowNote = computed(() => {
-  const span = fmtDuration(props.windowMs || DEFAULT_WINDOW_MS)
-  const bucket = props.bucketSec ? ` · cubos de ${fmtDuration(props.bucketSec * 1000)}` : ''
-  const cut = props.truncated ? ' · hay más histórico del que cabe' : ''
-  return `${span}${bucket}${cut}`
-})
-
 const srText = computed(() => {
   if (!metric.value || !points.value.length) return ''
   const gapsText = gaps.value.length
     ? `; ${gaps.value.length} tramo${gaps.value.length === 1 ? '' : 's'} sin señal${gapSummary.value ? `, ${gapSummary.value}` : ''}`
     : ''
-  return `${metric.value.name}: ${formatValue(current.value)} ahora, ${maxLabel.value} máximo, ${avgLabel.value} de media, ${minLabel.value} mínimo, sobre ${points.value.length} ${props.bucketSec ? 'cubos' : 'lecturas'}${gapsText}.`
+  return `${metric.value.name}: ${formatValue(current.value)} ahora, ${maxLabel.value} máximo, ${avgLabel.value} de media, ${minLabel.value} mínimo${gapsText}.`
 })
 
 /* ── Estados vacíos ── */
@@ -390,24 +381,25 @@ const srText = computed(() => {
 const hasPlottableData = computed(() => !!metric.value && points.value.length > 0)
 
 const emptyTitle = computed(() =>
-  props.snapshots.length ? `Sin datos de ${metric.value?.name ?? 'esta métrica'}` : 'Sin actividad en este tramo'
+  props.snapshots.length ? `Sin datos de ${metric.value?.name ?? 'esta métrica'}` : 'Sin datos en este periodo'
 )
 
 const emptySub = computed(() => {
   if (!props.snapshots.length) {
     const span = fmtDuration(props.windowMs || DEFAULT_WINDOW_MS)
-    return `El agente no ha reportado ningún heartbeat en las últimas ${span}. No es un fallo del panel: en esta ventana no hay nada que medir.`
+    return `El equipo no ha enviado datos en las últimas ${span}.`
   }
-  return `La métrica «${metric.value?.name ?? ''}» no aparece aquí — algunos agentes no la reportan (p. ej. la carga en Windows).`
+  return `Este equipo no envía «${metric.value?.name ?? ''}»: no todos los sistemas la miden (Windows, por ejemplo, no da la carga).`
 })
 
 /**
  * Pista de salida. Con una última señal conocida, dice cuándo fue; sin ella,
- * el activo nunca ha latido y ampliar la ventana no serviría de nada.
+ * el equipo nunca ha enviado nada, ampliar la ventana no serviría de nada y
+ * lo útil es mirar el agente.
  */
 const lastSeenNote = computed(() => {
   if (props.snapshots.length) return ''
-  if (!props.lastSeenAt) return 'Este activo todavía no ha enviado ningún heartbeat.'
+  if (!props.lastSeenAt) return 'Este equipo todavía no ha enviado ningún dato. Comprueba que el agente está instalado y en marcha.'
   return `Última señal ${timeAgo(props.lastSeenAt)}. Prueba con una ventana más amplia.`
 })
 
@@ -598,7 +590,7 @@ function formatTooltipTime(ts) {
   font-size: var(--fs-sm); color: var(--text-muted);
 }
 .legend-item { display: inline-flex; align-items: center; gap: 0.3rem; }
-/* La cifra se empuja al extremo opuesto, alineada con «N lecturas» del pie. */
+/* La cifra se empuja al extremo opuesto de la leyenda. */
 .legend-total {
   margin-left: auto;
   font-family: var(--font-mono); font-size-adjust: var(--fsa-mono);
@@ -620,8 +612,6 @@ function formatTooltipTime(ts) {
   font-family: var(--font-mono); font-size-adjust: var(--fsa-mono); font-weight: 600;
   color: var(--text-dim); font-variant-numeric: tabular-nums;
 }
-.stat--reads { margin-left: auto; }
-
 .metric-window-note { margin: 0.3rem 0 0; text-align: right; font-size: var(--fs-sm); color: var(--text-muted); }
 
 /* ── Estados vacíos ── */

--- a/web/app/src/components/hygeia/chartMath.js
+++ b/web/app/src/components/hygeia/chartMath.js
@@ -45,9 +45,9 @@ export const SERIES = [
     fixedMax: 100, minSpan: 6,    fmt: PCT },
   // Entrada y salida comparten tono a propósito: son la misma magnitud en
   // dos sentidos, y la paleta no tiene seis matices distintos que repartir.
-  { key: 'net-rx', name: 'Red · in',  field: 'netRxBps',  color: 'var(--success)',
+  { key: 'net-rx', name: 'Red · entrada', field: 'netRxBps', color: 'var(--success)',
     fixedMax: null, minSpan: 8192, fmt: fmtRate },
-  { key: 'net-tx', name: 'Red · out', field: 'netTxBps',
+  { key: 'net-tx', name: 'Red · salida', field: 'netTxBps',
     color: 'color-mix(in srgb, var(--success) 50%, var(--text-muted))',
     fixedMax: null, minSpan: 8192, fmt: fmtRate },
   { key: 'load1',  name: 'Carga',     field: 'load1',     color: 'var(--accent)',

--- a/web/app/src/components/hygeia/format.js
+++ b/web/app/src/components/hygeia/format.js
@@ -239,6 +239,22 @@ export function describePowerPeriod(period) {
   }
 }
 
+const ASSET_STATUS_LABELS = { pending: 'Pendiente', online: 'En línea', stale: 'Inestable', offline: 'Caído' }
+
+/**
+ * Rótulo en castellano del estado de conexión de un activo.
+ *
+ * Solo traduce el estado: el matiz de «Apagado» para un activo que se apaga
+ * a propósito depende también de `isPersistent`, y lo resuelve la lista.
+ *
+ * @param {string|null} status - Estado del servidor: `pending`, `online`,
+ *   `stale` u `offline`.
+ * @returns {string} El rótulo del estado, o «Desconocido» si no se conoce.
+ */
+export function assetStatusLabel(status) {
+  return ASSET_STATUS_LABELS[status] || 'Desconocido'
+}
+
 const ANOMALY_KIND_LABELS = {
   cpu_spike: 'Pico de CPU', mem_high: 'Memoria alta', swap_thrash: 'Swap saturado',
   disk_full: 'Disco lleno', host_down: 'Host caído',

--- a/web/app/src/components/hygeia/format.js
+++ b/web/app/src/components/hygeia/format.js
@@ -239,6 +239,27 @@ export function describePowerPeriod(period) {
   }
 }
 
+const ANOMALY_KIND_LABELS = {
+  cpu_spike: 'Pico de CPU', mem_high: 'Memoria alta', swap_thrash: 'Swap saturado',
+  disk_full: 'Disco lleno', host_down: 'Host caído',
+}
+
+/**
+ * Rótulo en castellano de un tipo de anomalía, para la lista de anomalías y
+ * las marcas de la gráfica.
+ *
+ * Un tipo que el mapa no conoce —uno que el servidor añada antes que el
+ * SPA— cae en el rótulo genérico y no en el identificador crudo: la pantalla
+ * tiene que seguir leyéndose en castellano (CONVENCIONES.md § 12.2).
+ *
+ * @param {string|null} kind - Tipo de anomalía del servidor (`cpu_spike`,
+ *   `mem_high`, `swap_thrash`, `disk_full`, `host_down`…).
+ * @returns {string} El rótulo del tipo, o «Anomalía» si no se conoce.
+ */
+export function anomalyKindLabel(kind) {
+  return ANOMALY_KIND_LABELS[kind] || 'Anomalía'
+}
+
 /**
  * Tiempo encendido en lenguaje natural, con dos unidades de precisión.
  *

--- a/web/app/src/components/iris/IrisArchiveModal.vue
+++ b/web/app/src/components/iris/IrisArchiveModal.vue
@@ -163,10 +163,10 @@
                     </td>
                     <td class="mono col-date">{{ formatDate(item.startedAt) }}</td>
                     <td>
-                      <span class="status-chip" :class="`status--${item.status}`">{{ statusLabel(item.status) }}</span>
+                      <span class="status-chip" :class="`status--${item.status}`">{{ analysisStatusLabel(item.status) }}</span>
                     </td>
                     <td class="col-score">
-                      <div v-if="item.totalScore != null" class="score-rail" :title="`${item.totalScore} · ${item.verdict}`">
+                      <div v-if="item.totalScore != null" class="score-rail" :title="`${item.totalScore} · ${verdictLabel(item.verdict)}`">
                         <span class="rail-track"></span>
                         <span class="rail-tick" :style="{ left: store.thresholds.suspicious + '%' }"></span>
                         <span class="rail-tick" :style="{ left: store.thresholds.legitimate + '%' }"></span>
@@ -216,6 +216,7 @@ import AppPagination from '@/components/shared/AppPagination.vue'
 import IrisCompareModal from '@/components/iris/IrisCompareModal.vue'
 import { useIrisStore } from '@/stores/irisStore'
 import { useModalA11y } from '@/composables/useModalA11y'
+import { analysisStatusLabel, verdictClass, verdictLabel } from '@/components/iris/verdict'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -342,24 +343,6 @@ function sortIndicator(field) {
 function clampScore(score) {
   if (score == null) return 0
   return Math.min(100, Math.max(0, score))
-}
-
-function verdictClass(v) {
-  if (!v) return 'unknown'
-  const l = v.toLowerCase()
-  if (l === 'legitimate') return 'legit'
-  if (l === 'suspicious') return 'susp'
-  if (l === 'phishing') return 'phish'
-  return 'unknown'
-}
-
-function statusLabel(s) {
-  if (s === 'running') return 'En análisis'
-  if (s === 'pending') return 'Pendiente'
-  if (s === 'failed') return 'Fallido'
-  if (s === 'cancelled') return 'Cancelado'
-  if (s === 'finished') return 'Finalizado'
-  return s || ''
 }
 
 function formatDate(iso) {

--- a/web/app/src/components/iris/IrisCompareModal.vue
+++ b/web/app/src/components/iris/IrisCompareModal.vue
@@ -15,7 +15,7 @@
               <section v-for="report in [left, right]" :key="report.analysisId" class="compare-card">
                 <p class="compare-id">#{{ report.analysisId }} · {{ report.title || '(sin título)' }}</p>
                 <p class="compare-verdict" :class="`verdict--${(report.verdict || '').toLowerCase()}`">
-                  {{ VERDICT_LABELS[report.verdict] || report.verdict }} · {{ report.totalScore }}
+                  {{ verdictLabel(report.verdict) }} · {{ report.totalScore }}
                 </p>
                 <p class="compare-meta">
                   Confianza {{ CONFIDENCE_LABELS[report.confidence] || 'sin evaluar' }} ·
@@ -63,6 +63,7 @@ import { computed, ref, watch } from 'vue'
 import { useIrisStore } from '@/stores/irisStore'
 import { useModalA11y } from '@/composables/useModalA11y'
 import { compareReports } from '@/components/iris/compare.js'
+import { ruleVerdictLabel, verdictLabel } from '@/components/iris/verdict'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -79,7 +80,6 @@ const loading = ref(false)
 const error = ref(null)
 const showAll = ref(false)
 
-const VERDICT_LABELS = { Legitimate: 'Legítimo', Suspicious: 'Sospechoso', Phishing: 'Phishing' }
 const CONFIDENCE_LABELS = { high: 'alta', medium: 'media', low: 'baja' }
 
 const comparison = computed(() => (left.value && right.value ? compareReports(left.value, right.value) : null))
@@ -87,8 +87,15 @@ const visibleRules = computed(() =>
   showAll.value ? comparison.value.rules : comparison.value.rules.filter(entry => entry.changed)
 )
 
+/**
+ * Celda de una regla en la tabla comparativa: su resultado y su puntuación.
+ *
+ * @param {{verdict: string, score: number}|null} side - La regla en uno de
+ *   los dos informes, o `null` si ese informe no la tiene.
+ * @returns {string} «Correcto (0)», «Falla (-20)»…, o «—» si falta.
+ */
 function describe(side) {
-  return side ? `${side.verdict} (${side.score})` : '—'
+  return side ? `${ruleVerdictLabel(side.verdict)} (${side.score})` : '—'
 }
 
 watch(() => [props.show, ...props.analysisIds], async () => {

--- a/web/app/src/components/iris/IrisDocumentsModal.vue
+++ b/web/app/src/components/iris/IrisDocumentsModal.vue
@@ -48,7 +48,7 @@
               <div class="doc-info">
                 <span class="doc-status" :class="`status--${doc.status}`">{{ statusLabel(doc.status) }}</span>
                 <span class="doc-id">#{{ doc.documentId }}</span>
-                <span v-if="doc.verdict" class="doc-verdict" :class="`verdict--${verdictClass(doc.verdict)}`">{{ doc.verdict }}</span>
+                <span v-if="doc.verdict" class="doc-verdict" :class="`verdict--${verdictClass(doc.verdict)}`">{{ verdictLabel(doc.verdict) }}</span>
                 <span class="doc-date">{{ formatDate(doc.generatedAt || doc.createdAt) }}</span>
               </div>
               <div class="doc-buttons">
@@ -80,6 +80,7 @@
 
 <script setup>
 import { useUtils } from '@/composables/useUtils'
+import { verdictClass, verdictLabel } from '@/components/iris/verdict'
 
 const { formatDate } = useUtils()
 
@@ -93,19 +94,17 @@ defineProps({
 
 defineEmits(['close', 'refresh', 'generate', 'download', 'delete'])
 
+/**
+ * Rótulo del estado de generación de un documento.
+ *
+ * @param {string|null} status - `running`, `done` o `error`.
+ * @returns {string} «Generando», «Listo», «Error», o «Desconocido» si no se conoce.
+ */
 function statusLabel(status) {
   if (status === 'running') return 'Generando'
   if (status === 'done') return 'Listo'
   if (status === 'error') return 'Error'
-  return status
-}
-
-function verdictClass(v) {
-  const value = v?.toLowerCase() ?? ''
-  if (value === 'legitimate') return 'legit'
-  if (value === 'suspicious') return 'susp'
-  if (value === 'phishing') return 'phish'
-  return 'unknown'
+  return 'Desconocido'
 }
 </script>
 

--- a/web/app/src/components/iris/IrisHistoryStrip.vue
+++ b/web/app/src/components/iris/IrisHistoryStrip.vue
@@ -46,7 +46,7 @@
           <span v-if="item.verdict && item.status === 'finished'" class="strip-verdict" :class="`verdict--${verdictClass(item.verdict)}`">
             {{ item.totalScore }}
           </span>
-          <span v-else-if="item.status === 'running' || item.status === 'pending'" class="strip-status">{{ item.status }}</span>
+          <span v-else-if="item.status === 'running' || item.status === 'pending'" class="strip-status">{{ analysisStatusLabel(item.status) }}</span>
         </button>
 
         <!-- Delete button (visible on hover) -->
@@ -103,11 +103,11 @@
         </div>
         <div class="card-row" v-if="hoverItem.verdict && hoverItem.status === 'finished'">
           <span class="card-label">Veredicto</span>
-          <span class="card-verdict" :class="`v--${verdictClass(hoverItem.verdict)}`">{{ hoverItem.verdict }}</span>
+          <span class="card-verdict" :class="`v--${verdictClass(hoverItem.verdict)}`">{{ verdictLabel(hoverItem.verdict) }}</span>
         </div>
         <div class="card-row" v-else-if="hoverItem.status !== 'finished'">
           <span class="card-label">Estado</span>
-          <span class="card-value card-value--status">{{ statusLabel(hoverItem.status) }}</span>
+          <span class="card-value card-value--status">{{ analysisStatusLabel(hoverItem.status) }}</span>
         </div>
       </div>
     </Transition>
@@ -125,6 +125,7 @@
 
 <script setup>
 import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { analysisStatusLabel, verdictClass, verdictLabel } from '@/components/iris/verdict'
 
 const props = defineProps({
   items: { type: Array, default: () => [] },
@@ -209,14 +210,6 @@ function formatDate(iso) {
   catch { return iso }
 }
 
-function statusLabel(s) {
-  if (s === 'running') return 'En análisis'
-  if (s === 'pending') return 'Pendiente'
-  if (s === 'failed') return 'Fallido'
-  if (s === 'cancelled') return 'Cancelado'
-  return s || ''
-}
-
 function scoreClass(s) {
   if (s == null) return ''
   if (s > 0) return 'score--pos'
@@ -234,15 +227,6 @@ function originLabel(item) {
   const providerNames = { microsoft: 'Microsoft 365', gmail: 'Gmail' }
   const provider = providerNames[item.provider] || item.provider || 'Buzón'
   return item.accountEmail ? `${provider} (${item.accountEmail})` : provider
-}
-
-function verdictClass(v) {
-  if (!v) return 'unknown'
-  const l = v.toLowerCase()
-  if (l === 'legitimate') return 'legit'
-  if (l === 'suspicious') return 'susp'
-  if (l === 'phishing') return 'phish'
-  return 'unknown'
 }
 </script>
 

--- a/web/app/src/components/iris/IrisReportViewer.vue
+++ b/web/app/src/components/iris/IrisReportViewer.vue
@@ -103,7 +103,7 @@
           <span v-if="reportData.winningReason" class="unwrap-wrapper-info">{{ reportData.winningReason }}</span>
           <span v-if="reportData.secondaryContext" class="unwrap-wrapper-info">
             {{ reportData.secondaryContext.contextType === 'wrapper' ? 'Envoltorio' : 'Original' }}:
-            {{ reportData.secondaryContext.verdict }} ({{ reportData.secondaryContext.totalScore }} puntos)
+            {{ verdictLabel(reportData.secondaryContext.verdict) }} ({{ reportData.secondaryContext.totalScore }} puntos)
           </span>
           <span v-if="reportData.wrapperFrom || reportData.wrapperSubject" class="unwrap-wrapper-info">
             Envoltorio: <template v-if="reportData.wrapperFrom">de {{ reportData.wrapperFrom }}</template>
@@ -405,6 +405,7 @@
 <script setup>
 import { ref, computed, watch, nextTick } from 'vue'
 import { useUtils } from '@/composables/useUtils'
+import { verdictLabel } from '@/components/iris/verdict'
 import { useIrisStore } from '@/stores/irisStore'
 import IrisEmailPath from '@/components/iris/IrisEmailPath.vue'
 import IrisDocumentsModal from '@/components/iris/IrisDocumentsModal.vue'

--- a/web/app/src/components/iris/IrisRuleCard.vue
+++ b/web/app/src/components/iris/IrisRuleCard.vue
@@ -3,12 +3,14 @@
     <button type="button" class="rule-header" @click="$emit('toggle')">
       <div class="rule-left">
         <span class="rule-name">{{ rule.ruleName }}</span>
-        <span class="rule-category" v-if="rule.category">{{ rule.category }}</span>
+        <span class="rule-category" v-if="rule.category">{{ ruleCategoryLabel(rule.category) }}</span>
         <span v-if="rule.severity" class="rule-severity" :class="`rule-severity--${rule.severity}`">{{ SEVERITY_LABELS[rule.severity] || rule.severity }}</span>
       </div>
       <div class="rule-right">
         <span class="rule-score" :class="scoreClass(rule.score, rule.verdict)">{{ sign(rule.score) }}{{ rule.score }}</span>
-        <span class="rule-verdict" :class="`verdict-chip--${rule.verdict}`">{{ rule.verdict }}</span>
+        <!-- El código exacto (`softfail`, `bestguess`…) es lo que busca un
+             técnico: se queda en el tooltip, no en la primera lectura. -->
+        <span class="rule-verdict" :class="`verdict-chip--${rule.verdict}`" :title="`Código: ${rule.verdict}`">{{ ruleVerdictLabel(rule.verdict) }}</span>
         <svg class="rule-chevron" :class="{ rotated: expanded }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
       </div>
     </button>
@@ -68,6 +70,8 @@
 </template>
 
 <script setup>
+import { ruleCategoryLabel, ruleVerdictLabel } from '@/components/iris/verdict'
+
 defineProps({
   rule: { type: Object, required: true },
   expanded: { type: Boolean, default: false },
@@ -93,7 +97,7 @@ function evidenceLabel(item) {
   if (item.kind === 'attachment') return 'Adjunto'
   if (item.kind === 'body') return 'Cuerpo'
   if (item.kind === 'mime_part') return 'Parte MIME'
-  return item.kind
+  return 'Evidencia'
 }
 
 function sign(s) {

--- a/web/app/src/components/iris/IrisVerdictHero.vue
+++ b/web/app/src/components/iris/IrisVerdictHero.vue
@@ -5,7 +5,7 @@
       <span class="score-unit">/ máx</span>
     </div>
     <div class="rv-hero-verdict">
-      <span class="verdict-badge" :class="`verdict--${verdictClass}`">{{ verdict }}</span>
+      <span class="verdict-badge" :class="`verdict--${verdictClass}`">{{ verdictLabel(verdict) }}</span>
       <span class="verdict-status">{{ statusLabel }}</span>
       <span v-if="confidenceLabel" class="verdict-confidence" :class="`confidence--${confidence}`">
         Confianza {{ confidenceLabel }} · {{ coverageLabel }}
@@ -21,6 +21,7 @@
  * sección del informe, así que no hace falta duplicar nada en el padre.
  */
 import { computed } from 'vue'
+import { verdictClass as toVerdictClass, verdictLabel } from '@/components/iris/verdict'
 
 const props = defineProps({
   score: { type: [Number, null], default: null },
@@ -38,13 +39,7 @@ const coverageLabel = computed(() =>
   props.coverageMode === 'headers_only' ? 'solo cabeceras' : 'mensaje completo'
 )
 
-const verdictClass = computed(() => {
-  const v = props.verdict?.toLowerCase() ?? ''
-  if (v === 'legitimate') return 'legit'
-  if (v === 'suspicious') return 'susp'
-  if (v === 'phishing') return 'phish'
-  return 'unknown'
-})
+const verdictClass = computed(() => toVerdictClass(props.verdict))
 
 const statusLabel = computed(() => {
   const v = props.verdict?.toLowerCase() ?? ''

--- a/web/app/src/components/iris/verdict.js
+++ b/web/app/src/components/iris/verdict.js
@@ -1,0 +1,93 @@
+/**
+ * Rótulos en castellano de los valores cerrados que Iris recibe del servidor:
+ * veredicto y estado de un análisis, y categoría y resultado de cada regla.
+ *
+ * Viven aquí y no en cada componente porque los pintan la tira del
+ * historial, el archivo, el comparador, los documentos, los casos y el
+ * informe: con un mapa por fichero, al traducir uno el de al lado seguía en
+ * inglés (CONVENCIONES.md § 12.2). Todos caen en un rótulo genérico ante un
+ * valor desconocido, nunca en el crudo.
+ */
+
+const VERDICT_LABELS = { legitimate: 'Legítimo', suspicious: 'Sospechoso', phishing: 'Phishing' }
+const VERDICT_CLASSES = { legitimate: 'legit', suspicious: 'susp', phishing: 'phish' }
+
+/**
+ * Rótulo del veredicto de un análisis.
+ *
+ * @param {string|null} verdict - Veredicto del servidor (`Legitimate`,
+ *   `Suspicious` o `Phishing`); no distingue mayúsculas.
+ * @returns {string} «Legítimo», «Sospechoso», «Phishing», o «Sin veredicto»
+ *   si falta o no se conoce.
+ */
+export function verdictLabel(verdict) {
+  return VERDICT_LABELS[verdict?.toLowerCase()] || 'Sin veredicto'
+}
+
+/**
+ * Sufijo de clase CSS con el que se colorea un veredicto.
+ *
+ * @param {string|null} verdict - Veredicto del servidor; no distingue mayúsculas.
+ * @returns {'legit'|'susp'|'phish'|'unknown'} El tono del veredicto, o
+ *   `'unknown'` si falta o no se conoce.
+ */
+export function verdictClass(verdict) {
+  return VERDICT_CLASSES[verdict?.toLowerCase()] || 'unknown'
+}
+
+const ANALYSIS_STATUS_LABELS = {
+  pending: 'Pendiente', running: 'En análisis', finished: 'Finalizado',
+  failed: 'Fallido', cancelled: 'Cancelado',
+}
+
+/**
+ * Rótulo del estado de un análisis.
+ *
+ * @param {string|null} status - `pending`, `running`, `finished`, `failed` o `cancelled`.
+ * @returns {string} El rótulo del estado, o «Desconocido» si no se conoce.
+ */
+export function analysisStatusLabel(status) {
+  return ANALYSIS_STATUS_LABELS[status] || 'Desconocido'
+}
+
+const RULE_CATEGORY_LABELS = {
+  authentication: 'Autenticación', header_analysis: 'Cabeceras', content_analysis: 'Contenido',
+}
+
+/**
+ * Rótulo de la categoría de una regla.
+ *
+ * @param {string|null} category - `authentication`, `header_analysis` o `content_analysis`.
+ * @returns {string} El rótulo de la categoría, o «Otra» si no se conoce.
+ */
+export function ruleCategoryLabel(category) {
+  return RULE_CATEGORY_LABELS[category] || 'Otra'
+}
+
+/**
+ * Resultados de regla. Muchos son los resultados estándar de SPF, DKIM y
+ * DMARC (`softfail`, `bestguess`…); el código exacto no se pierde, pasa al
+ * tooltip de la tarjeta (CONVENCIONES.md § 12.3).
+ */
+const RULE_VERDICT_LABELS = {
+  pass: 'Correcto', fail: 'Falla', softfail: 'Falla leve', suspicious: 'Sospechoso',
+  neutral: 'Neutro', missing: 'Ausente', error: 'Error', trusted: 'De confianza',
+  // DMARC: sin registro, pero pasaría si lo tuviera / política aplicada / sin política.
+  bestguess: 'Estimado', policy: 'Política aplicada', none: 'Sin política',
+  spoof: 'Suplantación',
+  // Destinatarios: ni To ni Cc / solo en copia / «undisclosed recipients».
+  empty: 'Sin destinatarios', empty_to: 'Solo en copia', undisclosed: 'Destinatarios ocultos',
+  // Cabecera Date.
+  future: 'Fecha futura', past: 'Fecha antigua', unparseable: 'Fecha ilegible',
+}
+
+/**
+ * Rótulo del resultado de una regla.
+ *
+ * @param {string|null} verdict - Resultado que emite la regla (`pass`,
+ *   `fail`, `softfail`, `bestguess`, `empty_to`…).
+ * @returns {string} El rótulo del resultado, o «Otro» si no se conoce.
+ */
+export function ruleVerdictLabel(verdict) {
+  return RULE_VERDICT_LABELS[verdict] || 'Otro'
+}

--- a/web/app/src/views/HygeiaHubView.vue
+++ b/web/app/src/views/HygeiaHubView.vue
@@ -46,12 +46,12 @@ const online = ref(0)
 
 const features = [
   {
-    kicker: 'Push, no pull',
-    title: 'El agente empuja, tú no sondeas',
-    desc: 'Un agente ligero envía heartbeats cada pocos segundos — funciona detrás de NAT, sin abrir ningún puerto en el activo.',
+    kicker: 'Sin abrir puertos',
+    title: 'El equipo avisa, tú no preguntas',
+    desc: 'Un agente ligero informa cada pocos segundos, también detrás del router de la oficina, sin abrir ningún puerto en el equipo.',
   },
   {
-    kicker: 'Umbrales con histéresis',
+    kicker: 'Alertas sin ruido',
     title: 'Una alerta, no un aluvión',
     desc: 'CPU, memoria, disco y swap se vigilan con umbrales configurables; una anomalía se abre una vez y se resuelve sola al normalizarse.',
   },

--- a/web/app/src/views/HygeiaView.vue
+++ b/web/app/src/views/HygeiaView.vue
@@ -90,7 +90,7 @@
     <ConfirmModal
       :show="!!pendingDeleteId"
       title="Eliminar activo"
-      message="Se eliminará el activo y se revocará su clave de agente. Los heartbeats que llegue con esa clave dejarán de aceptarse."
+      message="Se eliminará el activo y se revocará su clave de agente. El agente instalado en ese equipo dejará de poder enviar datos."
       confirm-label="Eliminar"
       danger
       @confirm="handleDeleteConfirm"
@@ -430,7 +430,7 @@ async function handleAnalyze() {
   if (!id) return
   const scanId = await store.analyzeInventory(id)
   toast.show(
-    scanId ? `Análisis iniciado (escaneo ${scanId}). El resumen se actualizará al terminar.`
+    scanId ? 'Análisis iniciado. El resumen se actualizará al terminar.'
            : (store.state.analysisError || 'No se pudo lanzar el análisis.'),
     scanId ? 'success' : 'error',
   )

--- a/web/app/src/views/IrisCasesView.vue
+++ b/web/app/src/views/IrisCasesView.vue
@@ -115,7 +115,7 @@
               <button type="button" class="link-btn" @click="openAnalysis(analysis.analysisId)">
                 #{{ analysis.analysisId }} · {{ analysis.title || '(sin título)' }}
               </button>
-              <span class="case-meta">{{ analysis.verdict || analysis.status }} · {{ analysis.totalScore ?? '—' }}</span>
+              <span class="case-meta">{{ analysis.verdict ? verdictLabel(analysis.verdict) : analysisStatusLabel(analysis.status) }} · {{ analysis.totalScore ?? '—' }}</span>
               <button type="button" class="ghost-btn ghost-btn--small" @click="store.unlinkCaseAnalysis(detail.caseId, analysis.analysisId)">Quitar</button>
             </li>
           </ul>
@@ -148,6 +148,7 @@ import Topbar from '@/components/shared/Topbar.vue'
 import StarBackground from '@/components/shared/StarBackground.vue'
 import { useIrisStore } from '@/stores/irisStore'
 import { useUtils } from '@/composables/useUtils'
+import { analysisStatusLabel, verdictLabel } from '@/components/iris/verdict'
 
 const store = useIrisStore()
 const router = useRouter()

--- a/web/app/test/hygeia.format.test.mjs
+++ b/web/app/test/hygeia.format.test.mjs
@@ -10,6 +10,7 @@
 import {
   fmtBytes, fmtRate, fmtUptime, fmtPct, fmtLoad1,
   fmtWatts, classifyPower, fmtEnergy, fmtCost, describePowerPeriod,
+  anomalyKindLabel,
 } from '../src/components/hygeia/format.js'
 
 let passed = 0
@@ -121,6 +122,11 @@ eq('periodo proyectado', describePowerPeriod({
   kwh: 30, cost: 4.5, currency: 'EUR', classification: 'projected', coverageFraction: null,
 }).classificationLabel, 'Proyección')
 eq('periodo nulo no rompe', describePowerPeriod(null), null)
+
+console.log('\nanomalyKindLabel')
+eq('tipo conocido', anomalyKindLabel('host_down'), 'Host caído')
+eq('tipo desconocido: rótulo genérico, nunca el identificador crudo', anomalyKindLabel('disk_io_high'), 'Anomalía')
+eq('sin tipo', anomalyKindLabel(null), 'Anomalía')
 
 console.log(`\n${passed} pasados, ${failed} fallidos\n`)
 process.exit(failed === 0 ? 0 : 1)

--- a/web/app/test/hygeia.format.test.mjs
+++ b/web/app/test/hygeia.format.test.mjs
@@ -10,7 +10,7 @@
 import {
   fmtBytes, fmtRate, fmtUptime, fmtPct, fmtLoad1,
   fmtWatts, classifyPower, fmtEnergy, fmtCost, describePowerPeriod,
-  anomalyKindLabel,
+  anomalyKindLabel, assetStatusLabel,
 } from '../src/components/hygeia/format.js'
 
 let passed = 0
@@ -127,6 +127,10 @@ console.log('\nanomalyKindLabel')
 eq('tipo conocido', anomalyKindLabel('host_down'), 'Host caído')
 eq('tipo desconocido: rótulo genérico, nunca el identificador crudo', anomalyKindLabel('disk_io_high'), 'Anomalía')
 eq('sin tipo', anomalyKindLabel(null), 'Anomalía')
+
+console.log('\nassetStatusLabel')
+eq('estado conocido', assetStatusLabel('stale'), 'Inestable')
+eq('estado desconocido: rótulo genérico, nunca el valor crudo', assetStatusLabel('degraded'), 'Desconocido')
 
 console.log(`\n${passed} pasados, ${failed} fallidos\n`)
 process.exit(failed === 0 ? 0 : 1)

--- a/web/app/test/iris.verdict.test.mjs
+++ b/web/app/test/iris.verdict.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * Test de los rótulos de Iris (`components/iris/verdict.js`).
+ *
+ * Fija que los valores que el servidor manda en inglés salen en castellano, y
+ * que un valor desconocido cae en un rótulo genérico en vez de llegar crudo a
+ * la pantalla (CONVENCIONES.md § 12.2).
+ *
+ *   node web/app/test/iris.verdict.test.mjs
+ */
+
+import {
+  verdictLabel, verdictClass, analysisStatusLabel, ruleCategoryLabel, ruleVerdictLabel,
+} from '../src/components/iris/verdict.js'
+
+let passed = 0
+let failed = 0
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  ✓ ${name}`) }
+  else { failed++; console.error(`  ✗ ${name}${detail ? ' — ' + detail : ''}`) }
+}
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  check(name, a === e, `esperado ${e}, obtenido ${a}`)
+}
+
+console.log('\nverdictLabel / verdictClass')
+eq('veredicto del servidor, en castellano', verdictLabel('Suspicious'), 'Sospechoso')
+eq('no distingue mayúsculas', verdictLabel('legitimate'), 'Legítimo')
+eq('sin veredicto', verdictLabel(null), 'Sin veredicto')
+eq('veredicto desconocido: genérico, nunca el crudo', verdictLabel('Spam'), 'Sin veredicto')
+eq('tono del veredicto', verdictClass('Phishing'), 'phish')
+eq('tono desconocido', verdictClass(undefined), 'unknown')
+
+console.log('\nanalysisStatusLabel')
+eq('en curso', analysisStatusLabel('running'), 'En análisis')
+eq('estado desconocido', analysisStatusLabel('queued'), 'Desconocido')
+
+console.log('\nruleCategoryLabel / ruleVerdictLabel')
+eq('categoría', ruleCategoryLabel('content_analysis'), 'Contenido')
+eq('categoría desconocida', ruleCategoryLabel('reputation'), 'Otra')
+eq('resultado SPF', ruleVerdictLabel('softfail'), 'Falla leve')
+eq('resultado desconocido', ruleVerdictLabel('temperror'), 'Otro')
+
+console.log(`\n${passed} pasados, ${failed} fallidos\n`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Resumen

Varias pantallas del SPA le enseñaban al usuario **cómo funciona Ellysia por dentro** en vez de lo que le importa de su equipo o de su correo. El caso que lo destapó es la gráfica de constantes de Hygeia, que en una ventana de 24 h decía «235 cubos», «cubos de 5 min» e «incidente host_down». Un *cubo* es el tramo en el que el servidor agrupa las lecturas para que una ventana larga quepa en el gráfico, y `host_down` es el identificador interno con el que registra una caída. Ninguna de las dos cosas le dice nada a un cliente, técnico o no.

Este PR hace dos cosas:

1. **Deja la regla escrita** en `CONVENCIONES.md` (nueva § 12, «Textos de la interfaz»), para que la próxima interfaz nazca ya con ella.
2. **Aplica la regla** en Hygeia (la gráfica y el resto de la vista) y en Iris, donde el veredicto y el estado de un análisis llegaban del servidor en inglés y varias pantallas los pintaban tal cual.

## Issue relacionado

Closes #602

## Implementación

### 1. La regla (`CONVENCIONES.md` § 12)

Se resume en una pregunta: **¿el texto describe algo del usuario, o describe cómo funciona Ellysia?**

- Lo del usuario se queda, con su nombre estándar. «CPU», «swap», «kernel», el PID de un proceso o «SPF» son hechos de lo que el usuario vigila, y un técnico los busca por ese nombre.
- Lo de Ellysia no llega a la pantalla: cómo agrega o transporta los datos, sus ids internos, sus enums y el nombre de sus motores.

La sección añade tres normas prácticas:

- Todo valor de un conjunto cerrado que manda el servidor (estado, tipo, veredicto…) se pinta a través de un rótulo en castellano. Un valor desconocido cae en un texto genérico, nunca en el crudo.
- Los rótulos que usan varios componentes viven en un fichero compartido del módulo, no copiados en cada `.vue`.
- El detalle técnico útil (el código exacto de un resultado SPF, por ejemplo) no se elimina: baja a una segunda capa, como un tooltip o un detalle desplegado.

Quedan fuera, a propósito, las vistas de operador (configuración, cola, logs, planes, replay) y lo que el usuario tiene que copiar a otro sistema, como la clave del agente.

Va como § 12 y no como § 11 porque `API/tests/unit/test_code_conventions.py` cita la «§ 11.2», y renumerar habría obligado a tocar un test del backend por un cambio de documentación.

### 2. La gráfica de Hygeia

- Fuera el recuento de puntos («235 cubos», y también «N lecturas» en las ventanas cortas) y el tamaño del tramo. La nota inferior solo aparece cuando falta parte del periodo.
- La banda roja se rotula «caída detectada», en la leyenda y en el tooltip.
- Las marcas de otras anomalías usan el rótulo humano del tipo («Pico de CPU») en vez del enum (`cpu_spike`).
- Pestañas «Red · entrada / salida» en vez de «in / out».
- Los estados vacíos hablan del equipo («El equipo no ha enviado datos en las últimas 24 h») y no del transporte («heartbeat») ni de la herramienta («no es un fallo del panel»).
- El esqueleto de carga, cuya altura fija tiene que coincidir con la de la tarjeta, se ajusta de 380 a 353 px.

### 3. El resto de Hygeia

- «Última señal» en vez de «Último heartbeat». La lista vacía, la confirmación de borrado y la portada del módulo dejan de hablar de *heartbeats*. De paso se corrige la errata «llegue» por «lleguen» del borrado.
- La sección Red explica que el gráfico no cuenta el tráfico interno del equipo, en vez de «suma solo las no-loopback»; «err» pasa a «error/errores».
- La tarjeta de anomalía deja de enseñar la clave interna de la métrica (`cpu.usagePct`): el tipo de anomalía ya dice de qué métrica se trata.
- «Buscar vulnerabilidades» en vez de «Analizar con Lybra» (Lybra es el motor de Themis y, desde Hygeia, no dice qué hace el botón). «Vulnerabilidades conocidas» en vez de «CVE conocida».
- El modal del análisis y su aviso dejan de mostrar el id interno del escaneo y la frase «el motor está pesando las pruebas».
- El rótulo del estado del activo estaba copiado en la lista y en el detalle; sube a `format.js` (`assetStatusLabel`), junto a `anomalyKindLabel`.

### 4. Iris

- Nuevo `components/iris/verdict.js` con los rótulos del veredicto, del estado del análisis, de la categoría y del resultado de cada regla, más el tono CSS del veredicto. Sustituye a cuatro copias locales de `verdictClass` y tres de `statusLabel` que ya no coincidían entre sí: una conocía el estado `finished` y otra no.
- La tira del historial, el modal de documentos, la vista de casos, el aviso de correo reenviado, el comparador y la insignia principal del informe dicen «Sospechoso» / «En análisis» en vez de `Suspicious` / `running`.
- La tarjeta de regla dice «Contenido» en vez de `content_analysis` y «Falla leve» en vez de `softfail`. El código exacto se queda en el tooltip, para quien lo busca.

## Validación

- **Tests del SPA**: pasan las ocho suites que no dependen del cliente de Acheron (`test:hygeia`, `polling`, `element-width`, `toast`, `quiz`, `logs`, `iris`, `themis`). Hay casos nuevos en `hygeia.format.test.mjs` y un fichero nuevo, `iris.verdict.test.mjs`, añadido a `test:iris`. Ambos fijan, entre otras cosas, que un valor desconocido no llega crudo a la pantalla.
- **Compilación de los componentes**: los catorce `.vue` tocados se han compilado uno a uno con `@vue/compiler-sfc` (plantilla y script) sin errores.
- **Lo que no he podido ejecutar en local**: `npm run build`, la suite `test:acheron` y, por tanto, `npm test` completo. Los tres dependen de `@projectellysia/acheron-core-web`, un paquete del registro privado de GitHub Packages que no está instalado en esta máquina. El fallo es de entorno y no tiene relación con el cambio. El CI, que sí tiene acceso al registro, es quien lo confirma.
- **Sin verificación visual**: el SPA necesita la API, y aquí no había ninguna levantada. Los 353 px del esqueleto están calculados (380 px menos la línea eliminada: 0,8 rem × 1,7 de interlineado + 0,3 rem de margen ≈ 27 px), no medidos en pantalla. Si al cargar se nota un salto, ese es el número que hay que retocar.

## Notas

- **Fuera del plan, pero en un fichero que ya se tocaba**: en la portada de Hygeia, además de *heartbeats*, se reescribió la tarjeta «Push, no pull / El agente empuja, tú no sondeas / funciona detrás de NAT», y la etiqueta «Umbrales con histéresis» pasó a «Alertas sin ruido». Las dos describían la arquitectura en vez de la ventaja para el usuario.
- **Quedan tres rótulos con salida cruda**, del mismo patrón pero fuera del alcance acordado: `MailboxConnectionList` (Iris), `CampaignModal` (Aegis) y `AgentScansPanel` (Themis). Solo se ven si el servidor manda un estado que el mapa no conoce.
- **Asimetría en el recorte de la serie de Hygeia** (backend, no se toca aquí): cuando la serie supera el máximo de puntos, la serie cruda conserva lo más reciente, pero la agregada conserva lo más antiguo. Hoy no llega a pasar, porque la ventana agregada más larga son 336 tramos frente a un máximo de 1.000, y por eso el nuevo aviso de recorte no dice qué parte falta.
- **Fuera de alcance** (explicado en el issue): traducir los textos que el servidor genera en inglés, como los nombres de las reglas de Iris, y unificar «activo», «equipo» y «host» en Hygeia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
